### PR TITLE
Fix operator precedence handling and list parsing

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -27,8 +27,7 @@ type (
 
 // Precedence levels
 const (
-	_ int = iota
-	LOWEST
+	LOWEST int = iota
 	LOGICAL_OR    // ||
 	LOGICAL_AND   // &&
 	EQUALS        // ==, !=
@@ -409,10 +408,17 @@ func (p *Parser) parseListLiteral() ast.Expr {
 	for !p.curTokenIs(lexer.RBRACKET) {
 		list.Elements = append(list.Elements, p.parseExpression(LOWEST))
 		
-		if !p.peekTokenIs(lexer.RBRACKET) {
-			p.expectPeek(lexer.COMMA)
+		if p.peekTokenIs(lexer.RBRACKET) {
 			p.nextToken()
+			break
 		}
+		
+		p.expectPeek(lexer.COMMA)
+		p.nextToken()
+	}
+
+	if !p.curTokenIs(lexer.RBRACKET) {
+		p.expectPeek(lexer.RBRACKET)
 	}
 
 	return list
@@ -917,7 +923,7 @@ func (p *Parser) curPos() ast.Pos {
 }
 
 func (p *Parser) peekPrecedence() int {
-	return p.curToken.Precedence()
+	return p.peekToken.Precedence()
 }
 
 func (p *Parser) curPrecedence() int {


### PR DESCRIPTION
## Summary
- correct the Pratt parser's lowest precedence level so chained operators like logical OR parse correctly
- update list literal parsing to consume the closing bracket instead of looping indefinitely
- base peek-precedence checks on the upcoming token to respect operator precedence rules

## Testing
- go test ./internal/parser -run TestOperatorPrecedenceParsing -count=1 -v
- go test ./internal/parser -run TestListLiteral -count=1 -v

------
https://chatgpt.com/codex/tasks/task_e_68d64dc45b60832d8f77ddde8a9c9ced