### PR TITLE
Update release binary naming for Gemini CLI compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,26 +44,28 @@ jobs:
     strategy:
       matrix:
         include:
+          # Naming follows Gemini CLI convention: {platform}.{arch}.{name}
+          # See: https://geminicli.com/docs/extensions/extension-releasing/
           - os: ubuntu-latest
             goos: linux
             goarch: amd64
             binary_name: ailang
-            artifact_name: ailang-linux-amd64
+            artifact_name: linux.x64.ailang
           - os: macos-latest
             goos: darwin
             goarch: amd64
             binary_name: ailang
-            artifact_name: ailang-darwin-amd64
+            artifact_name: darwin.x64.ailang
           - os: macos-latest
             goos: darwin
             goarch: arm64
             binary_name: ailang
-            artifact_name: ailang-darwin-arm64
+            artifact_name: darwin.arm64.ailang
           - os: windows-latest
             goos: windows
             goarch: amd64
             binary_name: ailang.exe
-            artifact_name: ailang-windows-amd64
+            artifact_name: win32.x64.ailang
 
     steps:
     - name: Checkout code
@@ -147,15 +149,15 @@ jobs:
         echo "" >> changelog.md
         echo '```bash' >> changelog.md
         echo '# macOS (Intel)' >> changelog.md
-        echo 'curl -L https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.VERSION }}/ailang-darwin-amd64.tar.gz | tar -xz' >> changelog.md
+        echo 'curl -L https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.VERSION }}/darwin.x64.ailang.tar.gz | tar -xz' >> changelog.md
         echo 'sudo mv ailang /usr/local/bin/' >> changelog.md
         echo '' >> changelog.md
         echo '# macOS (Apple Silicon)' >> changelog.md
-        echo 'curl -L https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.VERSION }}/ailang-darwin-arm64.tar.gz | tar -xz' >> changelog.md
+        echo 'curl -L https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.VERSION }}/darwin.arm64.ailang.tar.gz | tar -xz' >> changelog.md
         echo 'sudo mv ailang /usr/local/bin/' >> changelog.md
         echo '' >> changelog.md
         echo '# Linux' >> changelog.md
-        echo 'curl -L https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.VERSION }}/ailang-linux-amd64.tar.gz | tar -xz' >> changelog.md
+        echo 'curl -L https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.VERSION }}/linux.x64.ailang.tar.gz | tar -xz' >> changelog.md
         echo 'sudo mv ailang /usr/local/bin/' >> changelog.md
         echo '```' >> changelog.md
         echo '' >> changelog.md


### PR DESCRIPTION
## Summary

Updates binary naming convention to follow Gemini CLI's extension format, enabling direct installation via `gemini extensions install sunholo-data/ailang`.

### Changes

| Old Name | New Name |
|----------|----------|
| `ailang-darwin-amd64.tar.gz` | `darwin.x64.ailang.tar.gz` |
| `ailang-darwin-arm64.tar.gz` | `darwin.arm64.ailang.tar.gz` |
| `ailang-linux-amd64.tar.gz` | `linux.x64.ailang.tar.gz` |
| `ailang-windows-amd64.zip` | `win32.x64.ailang.zip` |

### Why

Gemini CLI automatically selects the correct platform binary when the naming follows their convention:
- Format: `{platform}.{arch}.{name}.{extension}`
- Platforms: `darwin`, `linux`, `win32`
- Architectures: `x64`, `arm64`

Reference: https://geminicli.com/docs/extensions/extension-releasing/

### After Merge

Users can install AILANG directly:
```bash
gemini extensions install sunholo-data/ailang
```

## Test plan

- [ ] Merge and tag a new release
- [ ] Verify new asset names in release
- [ ] Test `gemini extensions install sunholo-data/ailang`

🤖 Generated with [Claude Code](https://claude.com/claude-code)