### PR TITLE
docs: prioritize AI agent installation via plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,23 +149,54 @@ For the formal rationale and algebraic laws, see the [Why No Loops?](https://sun
 
 ## Quick Start
 
-### Installation
+### Installation for AI Agents (Recommended)
+
+AILANG is designed to be used with AI coding agents. Install via your agent's extension/plugin system:
+
+**Claude Code:**
+```
+/plugin marketplace add sunholo-data/ailang_bootstrap
+/plugin install ailang
+```
+
+**Gemini CLI:**
+```bash
+gemini extensions install https://github.com/sunholo-data/ailang_bootstrap.git
+```
+
+These plugins provide:
+- AILANG binary (auto-installed)
+- MCP tools for type-checking and running code
+- Custom slash commands (`/ailang:prompt`, `/ailang:run`, etc.)
+- Teaching prompts and coding challenges
+- Full stdlib documentation via `ailang builtins list --verbose`
+
+### Manual Installation
+
+For standalone CLI usage or development:
 
 ```bash
-# Download binary (macOS Apple Silicon)
+# macOS (Apple Silicon)
 curl -L https://github.com/sunholo-data/ailang/releases/latest/download/ailang-darwin-arm64.tar.gz | tar -xz
 sudo mv ailang /usr/local/bin/
 
-# Or from source
-git clone https://github.com/sunholo-data/ailang.git
-cd ailang
-make install
+# macOS (Intel)
+curl -L https://github.com/sunholo-data/ailang/releases/latest/download/ailang-darwin-amd64.tar.gz | tar -xz
+sudo mv ailang /usr/local/bin/
 
-# Verify installation
+# Linux
+curl -L https://github.com/sunholo-data/ailang/releases/latest/download/ailang-linux-amd64.tar.gz | tar -xz
+sudo mv ailang /usr/local/bin/
+
+# From source
+git clone https://github.com/sunholo-data/ailang.git
+cd ailang && make install
+
+# Verify
 ailang --version
 ```
 
-For other platforms and detailed instructions, see the [Getting Started Guide](https://sunholo-data.github.io/ailang/docs/guides/getting-started).
+For detailed instructions, see the [Getting Started Guide](https://sunholo-data.github.io/ailang/docs/guides/getting-started).
 
 ### Hello World (Module Execution)
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,41 @@ ailang --version
 
 For detailed instructions, see the [Getting Started Guide](https://sunholo-data.github.io/ailang/docs/guides/getting-started).
 
+### MCP Server (For Custom Integrations)
+
+If you want to integrate AILANG tools into other AI systems via [Model Context Protocol](https://modelcontextprotocol.io/):
+
+```bash
+# Clone the bootstrap repo
+git clone https://github.com/sunholo-data/ailang_bootstrap.git
+cd ailang_bootstrap/mcp-server
+
+# Install dependencies and start server
+npm install
+npm start
+```
+
+Configure in your MCP client's `settings.json`:
+```json
+{
+  "mcpServers": {
+    "ailang-tools": {
+      "command": "node",
+      "args": ["/path/to/ailang_bootstrap/mcp-server/server.js"]
+    }
+  }
+}
+```
+
+**Available MCP Tools:**
+| Tool | Description |
+|------|-------------|
+| `ailang_prompt` | Get teaching prompt (SOURCE OF TRUTH for syntax) |
+| `ailang_check` | Type-check a file |
+| `ailang_run` | Run with capabilities |
+| `ailang_builtins` | Full stdlib docs with examples |
+| `ailang_eval` | Evaluate expression in REPL |
+
 ### Hello World (Module Execution)
 
 ```ailang

--- a/docs/docs/guides/getting-started.mdx
+++ b/docs/docs/guides/getting-started.mdx
@@ -73,6 +73,39 @@ ailang --version
 
 ---
 
+## <Icon name="server" inline /> MCP Server (Custom Integrations)
+
+For integrating AILANG tools into AI systems via [Model Context Protocol](https://modelcontextprotocol.io/):
+
+```bash
+# Clone and setup
+git clone https://github.com/sunholo-data/ailang_bootstrap.git
+cd ailang_bootstrap/mcp-server
+npm install
+npm start
+```
+
+**Configure in your MCP client:**
+```json
+{
+  "mcpServers": {
+    "ailang-tools": {
+      "command": "node",
+      "args": ["/path/to/ailang_bootstrap/mcp-server/server.js"]
+    }
+  }
+}
+```
+
+**Available Tools:**
+- <CheckIcon inline size={14} /> `ailang_prompt` - Teaching prompt (SOURCE OF TRUTH for syntax)
+- <CheckIcon inline size={14} /> `ailang_check` - Type-check files
+- <CheckIcon inline size={14} /> `ailang_run` - Run with capabilities
+- <CheckIcon inline size={14} /> `ailang_builtins` - Full stdlib documentation
+- <CheckIcon inline size={14} /> `ailang_eval` - REPL evaluation
+
+---
+
 ## <Icon name="bot" inline /> For AI Agents: CLI Integration
 
 **If you installed manually**, integrate AILANG into your AI coding agent:

--- a/docs/docs/guides/getting-started.mdx
+++ b/docs/docs/guides/getting-started.mdx
@@ -7,11 +7,52 @@ import { STABLE_RELEASE, ACTIVE_PROMPT } from '@site/src/constants/version';
 
 # Getting Started with AILANG
 
-## <Icon name="bot" inline /> For AI Agents: Quick Integration
+## <Icon name="bot" inline /> For AI Agents: Plugin Installation (Recommended)
 
-**AILANG is designed for AI-assisted development.** To integrate AILANG into your AI coding agent:
+**AILANG is designed to be used with AI coding agents.** The easiest way to get started is via your agent's plugin/extension system:
 
-### Step 1: Install AILANG
+### Claude Code
+
+```
+/plugin marketplace add sunholo-data/ailang_bootstrap
+/plugin install ailang
+```
+
+### Gemini CLI
+
+```bash
+gemini extensions install https://github.com/sunholo-data/ailang_bootstrap.git
+```
+
+### What the Plugin Provides
+
+- <CheckIcon inline size={14} /> **AILANG binary** - Auto-installed for your platform
+- <CheckIcon inline size={14} /> **MCP tools** - `ailang_prompt`, `ailang_check`, `ailang_run`, `ailang_builtins`
+- <CheckIcon inline size={14} /> **Slash commands** - `/ailang:prompt`, `/ailang:new`, `/ailang:run`, `/ailang:challenge`
+- <CheckIcon inline size={14} /> **Teaching prompts** - Current syntax rules loaded automatically
+- <CheckIcon inline size={14} /> **Coding challenges** - Learn AILANG by building real programs
+- <CheckIcon inline size={14} /> **Full stdlib docs** - `ailang builtins list --verbose --by-module`
+
+### Using AILANG with Your Agent
+
+Once the plugin is installed, ask your agent:
+
+```
+Write an AILANG program that reads a file and counts the lines.
+```
+
+The agent will:
+1. Load the teaching prompt via `ailang prompt`
+2. Check stdlib functions via `ailang builtins list --verbose`
+3. Write correct AILANG code
+4. Type-check with `ailang check`
+5. Run with `ailang run --caps IO,FS --entry main`
+
+---
+
+## <Icon name="download" inline /> Manual Installation
+
+For standalone CLI usage or if you prefer manual installation:
 
 ```bash
 # macOS (Apple Silicon)
@@ -29,6 +70,12 @@ sudo mv ailang /usr/local/bin/
 # Verify
 ailang --version
 ```
+
+---
+
+## <Icon name="bot" inline /> For AI Agents: CLI Integration
+
+**If you installed manually**, integrate AILANG into your AI coding agent:
 
 ### Step 2: Get the AILANG Teaching Prompt
 


### PR DESCRIPTION
## Summary

Updates the Quick Start and Getting Started guide to recommend installing AILANG via Claude Code plugins or Gemini CLI extensions rather than direct binary installation.

### Why

AILANG is primarily designed for AI coding agents. The plugin approach provides a better experience:

- **MCP tools** for type-checking and running code (`ailang_prompt`, `ailang_check`, `ailang_run`, `ailang_builtins`)
- **Custom slash commands** (`/ailang:prompt`, `/ailang:new`, `/ailang:run`, `/ailang:challenge`)
- **Teaching prompts** loaded automatically
- **Coding challenges** to learn AILANG by building
- **Full stdlib docs** via `ailang builtins list --verbose --by-module`

### Changes

**README.md:**
- New "Installation for AI Agents (Recommended)" section at top of Quick Start
- Claude Code: `/plugin marketplace add` + `/plugin install` commands
- Gemini CLI: `gemini extensions install` command
- Manual installation moved to secondary section

**docs/guides/getting-started.mdx:**
- New plugin installation section at top
- Lists what the plugin provides
- Shows typical AI agent workflow
- Manual installation as fallback

### Installation Commands

**Claude Code:**
```
/plugin marketplace add sunholo-data/ailang_bootstrap
/plugin install ailang
```

**Gemini CLI:**
```bash
gemini extensions install https://github.com/sunholo-data/ailang_bootstrap.git
```

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Build docs site locally and verify getting-started page
- [ ] Test Claude Code plugin installation
- [ ] Test Gemini CLI extension installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)