### PR TITLE
Fixes a typo in the main README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Further reading on answering common misconceptions:
 - AILANG is not trying to be a "better python"
 - AILANG as a Semantic Control Surface
 
-Read more about [AILANG vs Agents](docs/docs/roadmpa/ailang-vs-agents.md) concepts.
+Read more about [AILANG vs Agents](docs/docs/roadmap/ailang-vs-agents.md) concepts.
 
 ## 🏗️ Architecture
 


### PR DESCRIPTION
There was a link to compare AI Lang to agents that had a typo. This fixes the typo.