### PR TITLE
Add design doc: M-EVAL-OLLAMA local model evaluation

### DIFF
--- a/design_docs/planned/v0_6_2/m-eval-ollama-local-models.md
+++ b/design_docs/planned/v0_6_2/m-eval-ollama-local-models.md
@@ -1,0 +1,352 @@
+# M-EVAL-OLLAMA: Local Model Evaluation via Ollama
+
+**Status:** Planned
+**Target:** v0.6.2
+**Priority:** P1 (Medium)
+**Estimated:** 2 days
+**Dependencies:** None (Ollama already integrated for embeddings)
+**Created:** 2024-12-24
+
+## Problem Statement
+
+Currently, the AILANG eval harness only supports cloud-based LLMs (OpenAI, Anthropic, Google). This has several limitations:
+
+1. **Cost**: Running benchmarks across all 46 AILANG tasks costs $2-5 per run, limiting iteration speed
+2. **Privacy**: Some users want to evaluate code generation without sending code to cloud APIs
+3. **Offline development**: Can't run evals without internet connectivity
+4. **New model testing**: Can't quickly test open-weight models (Llama, Mistral, CodeLlama, DeepSeek, etc.)
+5. **Reproducibility**: Cloud model versions change; local models are fully deterministic
+
+**Existing Infrastructure:**
+- Ollama already integrated for semantic caching (`internal/messaging/embedder.go`)
+- `_ollama_embed` builtin works (`internal/builtins/ollama_embed.go`)
+- Uses official `github.com/ollama/ollama/api` package
+- Configuration pattern exists in `~/.ailang/config.yaml`
+
+## Goals
+
+**Primary Goal:** Enable running AILANG eval benchmarks against local Ollama models with zero additional dependencies.
+
+**Success Metrics:**
+- [ ] `ailang eval-suite --models ollama:codellama` works end-to-end
+- [ ] 100% parity with cloud model output format (same JSON schema)
+- [ ] <5% overhead vs direct Ollama API calls
+- [ ] Clear error messages when Ollama isn't running
+
+## Solution Design
+
+### Overview
+
+Add `ollama` as a new provider in the eval harness, reusing the existing Ollama client infrastructure from embeddings.
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    eval_harness/                            │
+├─────────────────────────────────────────────────────────────┤
+│  ai_agent.go         - Add callOllama() method              │
+│  api_ollama.go (NEW) - Ollama API implementation            │
+│  models.go           - Add "ollama" provider support        │
+│  models.yml          - Add local model definitions          │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│  github.com/ollama/ollama/api (already imported)            │
+│  - api.ClientFromEnvironment()                              │
+│  - client.Chat() / client.Generate()                        │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Implementation Plan
+
+#### Phase 1: Core Ollama Provider (~4 hours)
+
+**1.1 Create `internal/eval_harness/api_ollama.go`**
+
+```go
+package eval_harness
+
+import (
+    "context"
+    "fmt"
+    "os"
+    "strings"
+
+    "github.com/ollama/ollama/api"
+)
+
+// callOllama makes a request to a local Ollama model
+func (a *AIAgent) callOllama(ctx context.Context, prompt string) (*GenerateResult, error) {
+    // Use OLLAMA_HOST from env or default
+    if endpoint := os.Getenv("OLLAMA_HOST"); endpoint == "" {
+        os.Setenv("OLLAMA_HOST", "http://localhost:11434")
+    }
+
+    client, err := api.ClientFromEnvironment()
+    if err != nil {
+        return nil, fmt.Errorf("failed to create Ollama client: %w", err)
+    }
+
+    // Extract model name from "ollama:modelname" format
+    modelName := strings.TrimPrefix(a.model, "ollama:")
+
+    // Use Chat API for better instruction following
+    var response strings.Builder
+    err = client.Chat(ctx, &api.ChatRequest{
+        Model: modelName,
+        Messages: []api.Message{
+            {
+                Role:    "system",
+                Content: "You are a programming assistant. Generate ONLY code without explanations or markdown formatting.",
+            },
+            {
+                Role:    "user",
+                Content: prompt,
+            },
+        },
+        Options: map[string]interface{}{
+            "temperature": 0.0,  // Deterministic for reproducibility
+            "seed":        a.seed,
+        },
+    }, func(resp api.ChatResponse) error {
+        response.WriteString(resp.Message.Content)
+        return nil
+    })
+
+    if err != nil {
+        return nil, fmt.Errorf("Ollama chat failed: %w", err)
+    }
+
+    // Extract code from response
+    code := extractCode(response.String())
+
+    return &GenerateResult{
+        Code:         code,
+        RawResponse:  response.String(),
+        InputTokens:  0,  // Ollama doesn't report tokens in same way
+        OutputTokens: 0,
+    }, nil
+}
+```
+
+**1.2 Update `ai_agent.go` to route to Ollama**
+
+```go
+// In Generate() method, add:
+case "ollama":
+    return a.callOllama(ctx, prompt)
+```
+
+**1.3 Update `models.go` to handle dynamic Ollama models**
+
+```go
+// Add to guessProvider():
+case "oll":
+    return "ollama"
+
+// Add to ResolveModelName():
+if strings.HasPrefix(name, "ollama:") {
+    modelName := strings.TrimPrefix(name, "ollama:")
+    return modelName, "ollama", nil
+}
+```
+
+#### Phase 2: Model Configuration (~2 hours)
+
+**2.1 Add local models to `models.yml`**
+
+```yaml
+  # === LOCAL MODELS (via Ollama) ===
+
+  ollama-codellama:
+    api_name: "codellama:7b"
+    provider: "ollama"
+    description: "CodeLlama 7B - local code generation"
+    env_var: ""  # No API key needed
+    pricing:
+      input_per_1k: 0.0
+      output_per_1k: 0.0
+    notes: |
+      Local model via Ollama. Requires: ollama run codellama:7b
+      Best for: Quick iteration, offline development
+
+  ollama-deepseek-coder:
+    api_name: "deepseek-coder:6.7b"
+    provider: "ollama"
+    description: "DeepSeek Coder 6.7B - strong code model"
+    env_var: ""
+    pricing:
+      input_per_1k: 0.0
+      output_per_1k: 0.0
+    notes: |
+      Local model via Ollama. Requires: ollama run deepseek-coder:6.7b
+      Competitive with GPT-3.5 on coding benchmarks.
+
+  ollama-qwen-coder:
+    api_name: "qwen2.5-coder:7b"
+    provider: "ollama"
+    description: "Qwen 2.5 Coder 7B - excellent for code"
+    env_var: ""
+    pricing:
+      input_per_1k: 0.0
+      output_per_1k: 0.0
+    notes: |
+      Local model via Ollama. Requires: ollama run qwen2.5-coder:7b
+      Top-tier open model for code generation.
+
+# Add local model suite
+local_models:
+  - "ollama-codellama"
+  - "ollama-deepseek-coder"
+  - "ollama-qwen-coder"
+```
+
+**2.2 Support dynamic `ollama:modelname` syntax**
+
+Allow any Ollama model without pre-configuration:
+
+```bash
+# Pre-configured (in models.yml)
+ailang eval-suite --models ollama-codellama
+
+# Dynamic (any model Ollama has pulled)
+ailang eval-suite --models ollama:mistral:7b
+ailang eval-suite --models ollama:llama3.2:3b
+ailang eval-suite --models ollama:phi3:mini
+```
+
+#### Phase 3: Testing & Polish (~2 hours)
+
+**3.1 Add connection check**
+
+```go
+// CheckOllamaConnection verifies Ollama is running
+func CheckOllamaConnection() error {
+    client, err := api.ClientFromEnvironment()
+    if err != nil {
+        return fmt.Errorf("cannot create Ollama client: %w", err)
+    }
+
+    ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+    defer cancel()
+
+    _, err = client.List(ctx)
+    if err != nil {
+        return fmt.Errorf("Ollama not running at %s: %w",
+            os.Getenv("OLLAMA_HOST"), err)
+    }
+    return nil
+}
+```
+
+**3.2 Add helpful error messages**
+
+```
+Error: Ollama not running at http://localhost:11434
+
+To start Ollama:
+  1. Install: https://ollama.ai/download
+  2. Start:   ollama serve
+  3. Pull model: ollama pull codellama:7b
+  4. Retry:   ailang eval-suite --models ollama:codellama
+```
+
+**3.3 Unit tests**
+
+- `api_ollama_test.go` - Mock Ollama responses
+- Integration test (skipped if Ollama not running)
+
+### Files to Modify
+
+| File | Change | LOC |
+|------|--------|-----|
+| `internal/eval_harness/api_ollama.go` | NEW - Ollama provider | ~120 |
+| `internal/eval_harness/ai_agent.go` | Add callOllama routing | ~10 |
+| `internal/eval_harness/models.go` | Add ollama: prefix handling | ~15 |
+| `internal/eval_harness/models.yml` | Add local model definitions | ~60 |
+| `internal/eval_harness/api_ollama_test.go` | NEW - Unit tests | ~100 |
+| **Total** | | **~305** |
+
+## Examples
+
+### Running Local Eval
+
+```bash
+# Ensure Ollama is running
+ollama serve &
+
+# Pull a code model
+ollama pull qwen2.5-coder:7b
+
+# Run eval against local model
+ailang eval-suite --models ollama:qwen2.5-coder:7b --output eval_results/local
+
+# Compare local vs cloud
+ailang eval-compare eval_results/local eval_results/baselines/v0.6.1
+```
+
+### Mixed Local + Cloud
+
+```bash
+# Compare local model against cloud baselines
+ailang eval-suite --models ollama:codellama,claude-haiku-4-5
+```
+
+### Offline Development
+
+```bash
+# No internet needed after model is pulled
+export OLLAMA_HOST=http://localhost:11434
+ailang eval-suite --models ollama:deepseek-coder:6.7b
+```
+
+## Axiom Compliance
+
+| Axiom | Score | Rationale |
+|-------|-------|-----------|
+| A1: Determinism | +1 | Local models with seed=fixed are fully reproducible |
+| A2: Replayability | +1 | Traces work identically for local models |
+| A3: Effect Legibility | 0 | No change to effect system |
+| A7: Machines First | +1 | Same JSON output format, machine-readable |
+| A9: Cost Visibility | +1 | Explicit $0.00 pricing for local models |
+
+**Net Score: +4** (Accept)
+
+## Success Criteria
+
+- [ ] `ailang eval-suite --models ollama:codellama` completes successfully
+- [ ] Results JSON has same schema as cloud model results
+- [ ] Clear error when Ollama not running
+- [ ] Can mix local and cloud models in same run
+- [ ] Documentation updated with local model setup guide
+- [ ] All existing tests still pass
+
+## Timeline
+
+| Day | Tasks |
+|-----|-------|
+| 1 | Phase 1 (api_ollama.go, routing) + Phase 2 (models.yml) |
+| 2 | Phase 3 (testing, error messages, docs) |
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Ollama API changes | Low | Medium | Pin to specific ollama/api version in go.mod |
+| Model quality variance | High | Low | Document expected quality; users choose models |
+| Response format differences | Medium | Medium | Robust code extraction with fallbacks |
+
+## Related Documents
+
+- [DX-15: Semantic Caching MVP](../implemented/v0_6_0/DX-15-semantic-caching-MVP.md) - Ollama integration for embeddings
+- [M-EVAL-AGENT](./M-EVAL-AGENT.md) - Agent-based evaluation (different approach)
+- [models.yml](../../internal/eval_harness/models.yml) - Current model configuration
+
+## Future Extensions
+
+1. **GPU acceleration**: Document CUDA/Metal setup for faster inference
+2. **Model comparison dashboard**: Add local models to benchmark dashboard
+3. **Quantization options**: Support different quantization levels (Q4, Q8, FP16)
+4. **Batch inference**: Use Ollama's batch API for faster multi-benchmark runs

--- a/design_docs/planned/v0_6_2/m-eval-ollama-local-models.md
+++ b/design_docs/planned/v0_6_2/m-eval-ollama-local-models.md
@@ -1,72 +1,80 @@
-# M-EVAL-OLLAMA: Local Model Evaluation via Ollama
+# M-AI-OLLAMA: Unified Ollama Provider for Local Models
 
 **Status:** Planned
 **Target:** v0.6.2
 **Priority:** P1 (Medium)
-**Estimated:** 2 days
-**Dependencies:** None (Ollama already integrated for embeddings)
+**Estimated:** 2-3 days (includes eval harness migration)
+**Dependencies:** M-UNIFIED-AI-PROVIDERS (v0.5.10) - partially implemented (CLI done, eval harness NOT migrated)
 **Created:** 2024-12-24
+**Updated:** 2024-12-24
 
 ## Problem Statement
 
-Currently, the AILANG eval harness only supports cloud-based LLMs (OpenAI, Anthropic, Google). This has several limitations:
+The unified AI provider system (`internal/ai/`) supports OpenAI, Anthropic, and Google - but **no local models**. This creates gaps:
 
-1. **Cost**: Running benchmarks across all 46 AILANG tasks costs $2-5 per run, limiting iteration speed
-2. **Privacy**: Some users want to evaluate code generation without sending code to cloud APIs
-3. **Offline development**: Can't run evals without internet connectivity
-4. **New model testing**: Can't quickly test open-weight models (Llama, Mistral, CodeLlama, DeepSeek, etc.)
-5. **Reproducibility**: Cloud model versions change; local models are fully deterministic
+**⚠️ CRITICAL FINDING:** The eval harness (`internal/eval_harness/`) does NOT use the unified `internal/ai/` package! It has its own duplicated implementations:
+- `api_openai.go` - ~120 LOC duplicate
+- `api_anthropic.go` - ~100 LOC duplicate
+- `api_google.go` - ~150 LOC duplicate
+
+This means adding a new provider requires changes in TWO places, defeating the purpose of unification. **This design doc will fix that** by migrating the eval harness to use `internal/ai/`.
+
+**Current gaps:**
+
+1. **Cost**: Cloud API calls for every eval run ($2-5 per benchmark suite)
+2. **Privacy**: Code sent to cloud APIs for processing
+3. **Offline**: No AI capabilities without internet
+4. **Open models**: Can't use Llama, Mistral, DeepSeek, Qwen, etc.
+5. **Reproducibility**: Cloud model versions change silently
 
 **Existing Infrastructure:**
-- Ollama already integrated for semantic caching (`internal/messaging/embedder.go`)
-- `_ollama_embed` builtin works (`internal/builtins/ollama_embed.go`)
-- Uses official `github.com/ollama/ollama/api` package
-- Configuration pattern exists in `~/.ailang/config.yaml`
+- Unified `internal/ai/` package with `Provider` interface (v0.5.10)
+- Ollama integration for embeddings (`internal/messaging/embedder.go`)
+- `github.com/ollama/ollama/api` package already imported
+- Config pattern in `~/.ailang/config.yaml`
 
 ## Goals
 
-**Primary Goal:** Enable running AILANG eval benchmarks against local Ollama models with zero additional dependencies.
+**Primary Goal:** Add Ollama as a first-class provider in `internal/ai/`, enabling local models across ALL touchpoints.
+
+**Touchpoints that automatically gain Ollama support:**
+- ✅ `ailang eval-suite --models ollama:codellama`
+- ✅ `ailang run --caps AI --ai ollama:qwen2.5-coder file.ail`
+- ✅ AILANG programs using `std/ai` effect
+- ✅ Any future AI-powered features
 
 **Success Metrics:**
-- [ ] `ailang eval-suite --models ollama:codellama` works end-to-end
-- [ ] 100% parity with cloud model output format (same JSON schema)
-- [ ] <5% overhead vs direct Ollama API calls
-- [ ] Clear error messages when Ollama isn't running
+- [ ] `internal/ai/ollama/` implements `Provider` interface
+- [ ] All three touchpoints work with local models
+- [ ] Same JSON output format as cloud providers
+- [ ] Clear error when Ollama not running
 
 ## Solution Design
-
-### Overview
-
-Add `ollama` as a new provider in the eval harness, reusing the existing Ollama client infrastructure from embeddings.
 
 ### Architecture
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│                    eval_harness/                            │
-├─────────────────────────────────────────────────────────────┤
-│  ai_agent.go         - Add callOllama() method              │
-│  api_ollama.go (NEW) - Ollama API implementation            │
-│  models.go           - Add "ollama" provider support        │
-│  models.yml          - Add local model definitions          │
-└─────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────┐
-│  github.com/ollama/ollama/api (already imported)            │
-│  - api.ClientFromEnvironment()                              │
-│  - client.Chat() / client.Generate()                        │
-└─────────────────────────────────────────────────────────────┘
+internal/ai/
+├── provider.go          # Provider interface (exists)
+├── config.go            # ProviderType enum (add ProviderOllama)
+├── handler.go           # Effect handler wrapper (exists)
+│
+├── openai/              # OpenAI (exists)
+├── gemini/              # Google (exists)
+├── anthropic/           # Anthropic (exists)
+│
+└── ollama/              # NEW - Local models via Ollama
+    ├── client.go        # HTTP client, connection check
+    ├── generate.go      # Chat completion (implements Provider)
+    ├── handler.go       # implements effects.AIHandler
+    └── client_test.go   # Unit tests
 ```
 
-### Implementation Plan
-
-#### Phase 1: Core Ollama Provider (~4 hours)
-
-**1.1 Create `internal/eval_harness/api_ollama.go`**
+### Provider Interface Implementation
 
 ```go
-package eval_harness
+// internal/ai/ollama/client.go
+package ollama
 
 import (
     "context"
@@ -74,88 +82,141 @@ import (
     "os"
     "strings"
 
-    "github.com/ollama/ollama/api"
+    ollamaapi "github.com/ollama/ollama/api"
+    "github.com/sunholo/ailang/internal/ai"
 )
 
-// callOllama makes a request to a local Ollama model
-func (a *AIAgent) callOllama(ctx context.Context, prompt string) (*GenerateResult, error) {
-    // Use OLLAMA_HOST from env or default
-    if endpoint := os.Getenv("OLLAMA_HOST"); endpoint == "" {
-        os.Setenv("OLLAMA_HOST", "http://localhost:11434")
-    }
+// Client implements ai.Provider for local Ollama models
+type Client struct {
+    client   *ollamaapi.Client
+    endpoint string
+}
 
-    client, err := api.ClientFromEnvironment()
+// NewClient creates a new Ollama client
+func NewClient() (*Client, error) {
+    endpoint := os.Getenv("OLLAMA_HOST")
+    if endpoint == "" {
+        endpoint = "http://localhost:11434"
+    }
+    os.Setenv("OLLAMA_HOST", endpoint)
+
+    client, err := ollamaapi.ClientFromEnvironment()
     if err != nil {
         return nil, fmt.Errorf("failed to create Ollama client: %w", err)
     }
 
-    // Extract model name from "ollama:modelname" format
-    modelName := strings.TrimPrefix(a.model, "ollama:")
+    return &Client{client: client, endpoint: endpoint}, nil
+}
 
-    // Use Chat API for better instruction following
+// Generate implements ai.Provider
+func (c *Client) Generate(ctx context.Context, req *ai.Request) (*ai.Response, error) {
     var response strings.Builder
-    err = client.Chat(ctx, &api.ChatRequest{
-        Model: modelName,
-        Messages: []api.Message{
-            {
-                Role:    "system",
-                Content: "You are a programming assistant. Generate ONLY code without explanations or markdown formatting.",
-            },
-            {
-                Role:    "user",
-                Content: prompt,
-            },
+
+    // Use Chat API for instruction following
+    err := c.client.Chat(ctx, &ollamaapi.ChatRequest{
+        Model: req.Model,
+        Messages: []ollamaapi.Message{
+            {Role: "system", Content: req.SystemPrompt},
+            {Role: "user", Content: req.UserPrompt},
         },
         Options: map[string]interface{}{
-            "temperature": 0.0,  // Deterministic for reproducibility
-            "seed":        a.seed,
+            "temperature": req.Temperature,
+            "seed":        42, // Deterministic by default
         },
-    }, func(resp api.ChatResponse) error {
+    }, func(resp ollamaapi.ChatResponse) error {
         response.WriteString(resp.Message.Content)
         return nil
     })
 
     if err != nil {
-        return nil, fmt.Errorf("Ollama chat failed: %w", err)
+        return nil, ai.NewProviderError("ollama", 0, err.Error(), err)
     }
 
-    // Extract code from response
-    code := extractCode(response.String())
-
-    return &GenerateResult{
-        Code:         code,
-        RawResponse:  response.String(),
-        InputTokens:  0,  // Ollama doesn't report tokens in same way
+    return &ai.Response{
+        Text:         response.String(),
+        Model:        req.Model,
+        InputTokens:  0,  // Ollama doesn't report tokens the same way
         OutputTokens: 0,
     }, nil
 }
-```
 
-**1.2 Update `ai_agent.go` to route to Ollama**
-
-```go
-// In Generate() method, add:
-case "ollama":
-    return a.callOllama(ctx, prompt)
-```
-
-**1.3 Update `models.go` to handle dynamic Ollama models**
-
-```go
-// Add to guessProvider():
-case "oll":
+// Name implements ai.Provider
+func (c *Client) Name() string {
     return "ollama"
+}
 
-// Add to ResolveModelName():
-if strings.HasPrefix(name, "ollama:") {
-    modelName := strings.TrimPrefix(name, "ollama:")
-    return modelName, "ollama", nil
+// CheckConnection verifies Ollama is running
+func (c *Client) CheckConnection(ctx context.Context) error {
+    _, err := c.client.List(ctx)
+    if err != nil {
+        return fmt.Errorf("Ollama not running at %s: %w\n\n"+
+            "To start Ollama:\n"+
+            "  1. Install: https://ollama.ai/download\n"+
+            "  2. Start:   ollama serve\n"+
+            "  3. Pull:    ollama pull codellama:7b",
+            c.endpoint, err)
+    }
+    return nil
 }
 ```
 
-#### Phase 2: Model Configuration (~2 hours)
+### Integration Points
 
-**2.1 Add local models to `models.yml`**
+**1. Add ProviderOllama to config.go:**
+
+```go
+// internal/ai/config.go
+const (
+    ProviderOpenAI    ProviderType = "openai"
+    ProviderAnthropic ProviderType = "anthropic"
+    ProviderGoogle    ProviderType = "google"
+    ProviderOllama    ProviderType = "ollama"  // NEW
+)
+
+func GuessProvider(modelName string) ProviderType {
+    // Add at top - highest priority for explicit prefix
+    if strings.HasPrefix(modelName, "ollama:") {
+        return ProviderOllama
+    }
+    // ... existing logic
+}
+```
+
+**2. Update CLI ai_handlers.go:**
+
+```go
+// cmd/ailang/ai_handlers.go
+import "github.com/sunholo/ailang/internal/ai/ollama"
+
+func setupAIHandler(effCtx *effects.EffContext, model string) error {
+    provider := ai.GuessProvider(model)
+
+    var handler effects.AIHandler
+    switch provider {
+    case ai.ProviderOllama:
+        modelName := strings.TrimPrefix(model, "ollama:")
+        client, err := ollama.NewClient()
+        if err != nil {
+            return err
+        }
+        // Check connection before proceeding
+        if err := client.CheckConnection(ctx); err != nil {
+            return err
+        }
+        handler = ai.NewHandler(client, modelName)
+    // ... existing providers
+    }
+
+    effCtx.AI = effects.NewAIContext(handler)
+    return nil
+}
+```
+
+**3. Update eval harness (minimal change):**
+
+The eval harness already uses the unified providers via `ai.GuessProvider()`. Just need to ensure it routes correctly.
+
+**4. Add to models.yml:**
 
 ```yaml
   # === LOCAL MODELS (via Ollama) ===
@@ -169,184 +230,199 @@ if strings.HasPrefix(name, "ollama:") {
       input_per_1k: 0.0
       output_per_1k: 0.0
     notes: |
-      Local model via Ollama. Requires: ollama run codellama:7b
+      Local model via Ollama. Requires: ollama pull codellama:7b
       Best for: Quick iteration, offline development
 
   ollama-deepseek-coder:
     api_name: "deepseek-coder:6.7b"
     provider: "ollama"
-    description: "DeepSeek Coder 6.7B - strong code model"
+    description: "DeepSeek Coder 6.7B - competitive with GPT-3.5"
     env_var: ""
     pricing:
       input_per_1k: 0.0
       output_per_1k: 0.0
-    notes: |
-      Local model via Ollama. Requires: ollama run deepseek-coder:6.7b
-      Competitive with GPT-3.5 on coding benchmarks.
 
   ollama-qwen-coder:
     api_name: "qwen2.5-coder:7b"
     provider: "ollama"
-    description: "Qwen 2.5 Coder 7B - excellent for code"
+    description: "Qwen 2.5 Coder 7B - top-tier open model"
     env_var: ""
     pricing:
       input_per_1k: 0.0
       output_per_1k: 0.0
-    notes: |
-      Local model via Ollama. Requires: ollama run qwen2.5-coder:7b
-      Top-tier open model for code generation.
 
-# Add local model suite
+# Add to suites
 local_models:
   - "ollama-codellama"
   - "ollama-deepseek-coder"
   - "ollama-qwen-coder"
 ```
 
-**2.2 Support dynamic `ollama:modelname` syntax**
+### Implementation Plan
 
-Allow any Ollama model without pre-configuration:
+#### Phase 1: Migrate Eval Harness to Unified Package (~4 hours)
 
-```bash
-# Pre-configured (in models.yml)
-ailang eval-suite --models ollama-codellama
+**Critical prerequisite:** Eval harness must use `internal/ai/` before we can add Ollama.
 
-# Dynamic (any model Ollama has pulled)
-ailang eval-suite --models ollama:mistral:7b
-ailang eval-suite --models ollama:llama3.2:3b
-ailang eval-suite --models ollama:phi3:mini
-```
-
-#### Phase 3: Testing & Polish (~2 hours)
-
-**3.1 Add connection check**
+- [ ] Update `internal/eval_harness/ai_agent.go` to use `ai.Provider`
+- [ ] Create thin wrapper: `GenerateResult` → `ai.Response`
+- [ ] Delete `internal/eval_harness/api_openai.go` (~120 LOC)
+- [ ] Delete `internal/eval_harness/api_anthropic.go` (~100 LOC)
+- [ ] Delete `internal/eval_harness/api_google.go` (~150 LOC)
+- [ ] Run full eval baseline to verify no regression
 
 ```go
-// CheckOllamaConnection verifies Ollama is running
-func CheckOllamaConnection() error {
-    client, err := api.ClientFromEnvironment()
+// internal/eval_harness/ai_agent.go (after migration)
+import (
+    "github.com/sunholo/ailang/internal/ai"
+    "github.com/sunholo/ailang/internal/ai/openai"
+    "github.com/sunholo/ailang/internal/ai/anthropic"
+    "github.com/sunholo/ailang/internal/ai/gemini"
+)
+
+func (a *AIAgent) GenerateCode(ctx context.Context, prompt string) (*GenerateResult, error) {
+    provider := a.getProvider()
+
+    resp, err := provider.Generate(ctx, &ai.Request{
+        Model:        a.model,
+        SystemPrompt: "You are a programming assistant...",
+        UserPrompt:   prompt,
+    })
     if err != nil {
-        return fmt.Errorf("cannot create Ollama client: %w", err)
+        return nil, err
     }
 
-    ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-    defer cancel()
-
-    _, err = client.List(ctx)
-    if err != nil {
-        return fmt.Errorf("Ollama not running at %s: %w",
-            os.Getenv("OLLAMA_HOST"), err)
-    }
-    return nil
+    return &GenerateResult{
+        Code:         extractCodeFromMarkdown(resp.Text),
+        RawResponse:  resp.Text,
+        InputTokens:  resp.InputTokens,
+        OutputTokens: resp.OutputTokens,
+    }, nil
 }
 ```
 
-**3.2 Add helpful error messages**
+#### Phase 2: Add Ollama Provider (~3 hours)
 
-```
-Error: Ollama not running at http://localhost:11434
+- [ ] Create `internal/ai/ollama/client.go` (~80 LOC)
+- [ ] Create `internal/ai/ollama/generate.go` (~60 LOC)
+- [ ] Create `internal/ai/ollama/client_test.go` (~100 LOC)
+- [ ] Add `ProviderOllama` to `internal/ai/config.go` (~10 LOC)
+- [ ] Update `GuessProvider()` for `ollama:` prefix
 
-To start Ollama:
-  1. Install: https://ollama.ai/download
-  2. Start:   ollama serve
-  3. Pull model: ollama pull codellama:7b
-  4. Retry:   ailang eval-suite --models ollama:codellama
-```
+#### Phase 3: Integration (~2 hours)
 
-**3.3 Unit tests**
+- [ ] Update `cmd/ailang/ai_handlers.go` to route to Ollama
+- [ ] Add local models to `models.yml`
+- [ ] Test all three touchpoints:
+  - [ ] `ailang run --ai ollama:codellama`
+  - [ ] `ailang eval-suite --models ollama:codellama`
+  - [ ] AILANG program with `std/ai` effect
 
-- `api_ollama_test.go` - Mock Ollama responses
-- Integration test (skipped if Ollama not running)
+#### Phase 4: Polish (~1 hour)
+
+- [ ] Add connection check with helpful error message
+- [ ] Add `--suite local_models` flag
+- [ ] Update documentation
 
 ### Files to Modify
 
 | File | Change | LOC |
 |------|--------|-----|
-| `internal/eval_harness/api_ollama.go` | NEW - Ollama provider | ~120 |
-| `internal/eval_harness/ai_agent.go` | Add callOllama routing | ~10 |
-| `internal/eval_harness/models.go` | Add ollama: prefix handling | ~15 |
-| `internal/eval_harness/models.yml` | Add local model definitions | ~60 |
-| `internal/eval_harness/api_ollama_test.go` | NEW - Unit tests | ~100 |
-| **Total** | | **~305** |
+| **Phase 1: Migrate Eval Harness** | | |
+| `internal/eval_harness/ai_agent.go` | Use `ai.Provider` interface | ~50 (refactor) |
+| `internal/eval_harness/api_openai.go` | DELETE | -120 |
+| `internal/eval_harness/api_anthropic.go` | DELETE | -100 |
+| `internal/eval_harness/api_google.go` | DELETE | -150 |
+| **Phase 2: Add Ollama Provider** | | |
+| `internal/ai/ollama/client.go` | NEW - Ollama client | ~80 |
+| `internal/ai/ollama/generate.go` | NEW - Provider impl | ~60 |
+| `internal/ai/ollama/client_test.go` | NEW - Tests | ~100 |
+| `internal/ai/config.go` | Add ProviderOllama | ~15 |
+| **Phase 3: Integration** | | |
+| `cmd/ailang/ai_handlers.go` | Add Ollama routing | ~20 |
+| `internal/eval_harness/models.yml` | Add local models | ~50 |
+| **Net Change** | Delete 370 LOC, Add 375 LOC | **~+5 net** |
+
+**Key win:** By migrating eval harness first, we DELETE ~370 LOC of duplicate code while adding ~375 LOC of new functionality. Net code is roughly the same, but architecture is unified.
 
 ## Examples
 
-### Running Local Eval
+### CLI with Local Model
 
 ```bash
-# Ensure Ollama is running
-ollama serve &
+# Run AILANG program with local AI
+ailang run --caps IO,AI --ai ollama:qwen2.5-coder:7b program.ail
 
-# Pull a code model
-ollama pull qwen2.5-coder:7b
-
-# Run eval against local model
-ailang eval-suite --models ollama:qwen2.5-coder:7b --output eval_results/local
-
-# Compare local vs cloud
-ailang eval-compare eval_results/local eval_results/baselines/v0.6.1
+# Dynamic model - any Ollama model works
+ailang run --caps AI --ai ollama:llama3.2:3b program.ail
 ```
 
-### Mixed Local + Cloud
+### Eval Suite
 
 ```bash
-# Compare local model against cloud baselines
-ailang eval-suite --models ollama:codellama,claude-haiku-4-5
+# Run benchmarks against local model
+ailang eval-suite --models ollama:codellama
+
+# Mix local and cloud
+ailang eval-suite --models ollama:deepseek-coder,claude-haiku-4-5
+
+# Use local suite
+ailang eval-suite --suite local_models
 ```
 
-### Offline Development
+### AILANG Program
 
-```bash
-# No internet needed after model is pulled
-export OLLAMA_HOST=http://localhost:11434
-ailang eval-suite --models ollama:deepseek-coder:6.7b
+```ailang
+-- Works with ANY provider now including Ollama
+import std/ai as AI
+
+func ask(question: string) -> string ! {AI} =
+    AI.call(question)
+
+-- Run with: ailang run --caps AI --ai ollama:codellama --entry main file.ail
 ```
 
 ## Axiom Compliance
 
 | Axiom | Score | Rationale |
 |-------|-------|-----------|
-| A1: Determinism | +1 | Local models with seed=fixed are fully reproducible |
-| A2: Replayability | +1 | Traces work identically for local models |
-| A3: Effect Legibility | 0 | No change to effect system |
-| A7: Machines First | +1 | Same JSON output format, machine-readable |
-| A9: Cost Visibility | +1 | Explicit $0.00 pricing for local models |
+| A1: Determinism | +1 | Local models with seed=fixed are reproducible |
+| A3: Effect Legibility | 0 | Uses existing AI effect - no change |
+| A7: Machines First | +1 | Same JSON format, machine-readable |
+| A9: Cost Visibility | +1 | Explicit $0.00 pricing |
+| A10: Composability | +1 | Composes with existing Provider interface |
 
 **Net Score: +4** (Accept)
 
 ## Success Criteria
 
-- [ ] `ailang eval-suite --models ollama:codellama` completes successfully
-- [ ] Results JSON has same schema as cloud model results
+- [ ] `internal/ai/ollama/` package implements `Provider` interface
+- [ ] `ailang run --ai ollama:codellama` works (CLI)
+- [ ] `ailang eval-suite --models ollama:codellama` works (evals)
+- [ ] AILANG programs with `std/ai` work with Ollama
+- [ ] Same JSON output schema as cloud providers
 - [ ] Clear error when Ollama not running
-- [ ] Can mix local and cloud models in same run
-- [ ] Documentation updated with local model setup guide
-- [ ] All existing tests still pass
-
-## Timeline
-
-| Day | Tasks |
-|-----|-------|
-| 1 | Phase 1 (api_ollama.go, routing) + Phase 2 (models.yml) |
-| 2 | Phase 3 (testing, error messages, docs) |
+- [ ] All existing tests pass
 
 ## Risks & Mitigations
 
 | Risk | Likelihood | Impact | Mitigation |
 |------|------------|--------|------------|
-| Ollama API changes | Low | Medium | Pin to specific ollama/api version in go.mod |
-| Model quality variance | High | Low | Document expected quality; users choose models |
-| Response format differences | Medium | Medium | Robust code extraction with fallbacks |
+| Ollama API changes | Low | Medium | Pin ollama/api version |
+| Model quality variance | High | Low | Document expected quality |
+| No token counting | Medium | Low | Return 0, note in docs |
+| Streaming differences | Low | Low | Use callback pattern |
 
 ## Related Documents
 
-- [DX-15: Semantic Caching MVP](../implemented/v0_6_0/DX-15-semantic-caching-MVP.md) - Ollama integration for embeddings
-- [M-EVAL-AGENT](./M-EVAL-AGENT.md) - Agent-based evaluation (different approach)
-- [models.yml](../../internal/eval_harness/models.yml) - Current model configuration
+- [M-UNIFIED-AI-PROVIDERS](../implemented/v0_5_10/m-unified-ai-providers.md) - Provider architecture
+- [DX-15: Semantic Caching](../implemented/v0_6_0/DX-15-semantic-caching-MVP.md) - Existing Ollama use
+- [M-EVAL-AGENT](./M-EVAL-AGENT.md) - Agent-based evaluation
 
 ## Future Extensions
 
-1. **GPU acceleration**: Document CUDA/Metal setup for faster inference
-2. **Model comparison dashboard**: Add local models to benchmark dashboard
-3. **Quantization options**: Support different quantization levels (Q4, Q8, FP16)
-4. **Batch inference**: Use Ollama's batch API for faster multi-benchmark runs
+1. **Token counting**: Parse Ollama response metrics for accurate counts
+2. **Model preloading**: `ailang ollama warmup codellama` before benchmarks
+3. **GPU config**: Document CUDA/Metal setup
+4. **Streaming**: Add `GenerateStream()` implementation
+5. **Tool calling**: Support Ollama's function calling for agents


### PR DESCRIPTION
Design document for adding Ollama as an eval provider, enabling:
- Local model evaluation (CodeLlama, DeepSeek, Qwen, etc.)
- Zero-cost benchmark iteration
- Offline development support
- Dynamic ollama:modelname syntax

Reuses existing Ollama infrastructure from semantic caching.
Estimated: 2 days, ~305 LOC.