### PR TITLE
Update v0.5.11 prompt with record pattern documentation

### DIFF
--- a/cmd/ailang/prompts/v0.5.11.md
+++ b/cmd/ailang/prompts/v0.5.11.md
@@ -303,29 +303,7 @@ match result {
   Some(x) => x,
   None => defaultValue
 }
-
--- On Records (destructuring)
-match person {
-  {name, age} => name ++ " is " ++ show(age)
-}
-
--- Record with renaming
-match config {
-  {host, port: p} => host ++ ":" ++ show(p)
-}
-
--- Nested record patterns
-match data {
-  {user: {email: e}} => e
-}
 ```
-
-**Record pattern syntax:**
-- `{name}` - shorthand, binds field "name" to variable "name"
-- `{name: n}` - renaming, binds field "name" to variable "n"
-- `{name, age}` - multiple fields
-- `{user: {name}}` - nested records
-- `{name, ...}` - rest pattern (matches some fields, ignores others)
 
 **Option type with findFirst and mapOption:**
 ```ailang

--- a/cmd/ailang/prompts/v0.5.11.md
+++ b/cmd/ailang/prompts/v0.5.11.md
@@ -303,7 +303,29 @@ match result {
   Some(x) => x,
   None => defaultValue
 }
+
+-- On Records (destructuring)
+match person {
+  {name, age} => name ++ " is " ++ show(age)
+}
+
+-- Record with renaming
+match config {
+  {host, port: p} => host ++ ":" ++ show(p)
+}
+
+-- Nested record patterns
+match data {
+  {user: {email: e}} => e
+}
 ```
+
+**Record pattern syntax:**
+- `{name}` - shorthand, binds field "name" to variable "name"
+- `{name: n}` - renaming, binds field "name" to variable "n"
+- `{name, age}` - multiple fields
+- `{user: {name}}` - nested records
+- `{name, ...}` - rest pattern (matches some fields, ignores others)
 
 **Option type with findFirst and mapOption:**
 ```ailang

--- a/cmd/ailang/prompts/v0.6.2.md
+++ b/cmd/ailang/prompts/v0.6.2.md
@@ -1,4 +1,4 @@
-# AILANG v0.5.11 - AI Teaching Prompt
+# AILANG v0.6.2 - AI Teaching Prompt
 
 AILANG is a **pure functional language** with Hindley-Milner type inference and algebraic effects. Write code using **recursion** (no loops), **pattern matching**, and **explicit effect declarations**.
 

--- a/cmd/ailang/prompts/v0.6.2.md
+++ b/cmd/ailang/prompts/v0.6.2.md
@@ -303,7 +303,29 @@ match result {
   Some(x) => x,
   None => defaultValue
 }
+
+-- On Records (destructuring)
+match person {
+  {name, age} => name ++ " is " ++ show(age)
+}
+
+-- Record with renaming
+match config {
+  {host, port: p} => host ++ ":" ++ show(p)
+}
+
+-- Nested record patterns
+match data {
+  {user: {email: e}} => e
+}
 ```
+
+**Record pattern syntax:**
+- `{name}` - shorthand, binds field "name" to variable "name"
+- `{name: n}` - renaming, binds field "name" to variable "n"
+- `{name, age}` - multiple fields
+- `{user: {name}}` - nested records
+- `{name, ...}` - rest pattern (matches some fields, ignores others)
 
 **Option type with findFirst and mapOption:**
 ```ailang

--- a/cmd/ailang/prompts/versions.json
+++ b/cmd/ailang/prompts/versions.json
@@ -366,7 +366,7 @@
     },
     "v0.6.2": {
       "file": "prompts/v0.6.2.md",
-      "hash": "57c2f652ebac44b2c532e367621c6dc9756f3c1f420287f1cb644a52edc99949",
+      "hash": "2bd5dd2236cf7bf7eaddf6ec7ff8e80bbd58340cc4c5866902b6e6aca16cb143",
       "description": "Add record pattern matching (M-RECORD-PATTERNS)",
       "created": "2025-12-25",
       "tags": [

--- a/cmd/ailang/prompts/versions.json
+++ b/cmd/ailang/prompts/versions.json
@@ -354,7 +354,7 @@
     },
     "v0.5.11": {
       "file": "prompts/v0.5.11.md",
-      "hash": "dd7a2357c5c28a3c2c1c994434e2f8621a6288cf33aef09b8cf9eb70f0935f58",
+      "hash": "57c2f652ebac44b2c532e367621c6dc9756f3c1f420287f1cb644a52edc99949",
       "description": "Add Semantic Caching Doctrine + Embeddings Doctrine for AI agents",
       "created": "2025-12-16",
       "tags": [

--- a/cmd/ailang/prompts/versions.json
+++ b/cmd/ailang/prompts/versions.json
@@ -354,19 +354,30 @@
     },
     "v0.5.11": {
       "file": "prompts/v0.5.11.md",
-      "hash": "57c2f652ebac44b2c532e367621c6dc9756f3c1f420287f1cb644a52edc99949",
+      "hash": "dd7a2357c5c28a3c2c1c994434e2f8621a6288cf33aef09b8cf9eb70f0935f58",
       "description": "Add Semantic Caching Doctrine + Embeddings Doctrine for AI agents",
       "created": "2025-12-16",
       "tags": [
         "production",
-        "latest",
         "semantic-caching",
         "embeddings"
       ],
       "notes": "Major additions: (1) Semantic Caching Doctrine - SharedMem/SharedIndex as cognitive working memory, namespace conventions, canonical patterns (cache-or-compute, deduplication, multi-agent CAS). (2) Embeddings Doctrine - when/what/how to use neural embeddings for paraphrase detection, hybrid retrieval pattern. All v0.5.10 features included."
+    },
+    "v0.6.2": {
+      "file": "prompts/v0.6.2.md",
+      "hash": "57c2f652ebac44b2c532e367621c6dc9756f3c1f420287f1cb644a52edc99949",
+      "description": "Add record pattern matching (M-RECORD-PATTERNS)",
+      "created": "2025-12-25",
+      "tags": [
+        "production",
+        "latest",
+        "record-patterns"
+      ],
+      "notes": "Record pattern matching for destructuring records in match expressions. Syntax: {name}, {name: var}, {name, age}, {user: {name}} for nested patterns, {name, ...} for rest patterns. All v0.5.11 features included."
     }
   },
-  "active": "v0.5.11",
+  "active": "v0.6.2",
   "notes": [
     "Hash is SHA256 of the prompt file contents",
     "Use 'active' field to specify default prompt version",

--- a/prompts/v0.6.2.md
+++ b/prompts/v0.6.2.md
@@ -1,4 +1,4 @@
-# AILANG v0.5.11 - AI Teaching Prompt
+# AILANG v0.6.2 - AI Teaching Prompt
 
 AILANG is a **pure functional language** with Hindley-Milner type inference and algebraic effects. Write code using **recursion** (no loops), **pattern matching**, and **explicit effect declarations**.
 

--- a/prompts/v0.6.2.md
+++ b/prompts/v0.6.2.md
@@ -303,7 +303,29 @@ match result {
   Some(x) => x,
   None => defaultValue
 }
+
+-- On Records (destructuring)
+match person {
+  {name, age} => name ++ " is " ++ show(age)
+}
+
+-- Record with renaming
+match config {
+  {host, port: p} => host ++ ":" ++ show(p)
+}
+
+-- Nested record patterns
+match data {
+  {user: {email: e}} => e
+}
 ```
+
+**Record pattern syntax:**
+- `{name}` - shorthand, binds field "name" to variable "name"
+- `{name: n}` - renaming, binds field "name" to variable "n"
+- `{name, age}` - multiple fields
+- `{user: {name}}` - nested records
+- `{name, ...}` - rest pattern (matches some fields, ignores others)
 
 **Option type with findFirst and mapOption:**
 ```ailang

--- a/prompts/versions.json
+++ b/prompts/versions.json
@@ -366,7 +366,7 @@
     },
     "v0.6.2": {
       "file": "prompts/v0.6.2.md",
-      "hash": "57c2f652ebac44b2c532e367621c6dc9756f3c1f420287f1cb644a52edc99949",
+      "hash": "2bd5dd2236cf7bf7eaddf6ec7ff8e80bbd58340cc4c5866902b6e6aca16cb143",
       "description": "Add record pattern matching (M-RECORD-PATTERNS)",
       "created": "2025-12-25",
       "tags": [

--- a/prompts/versions.json
+++ b/prompts/versions.json
@@ -354,7 +354,7 @@
     },
     "v0.5.11": {
       "file": "prompts/v0.5.11.md",
-      "hash": "dd7a2357c5c28a3c2c1c994434e2f8621a6288cf33aef09b8cf9eb70f0935f58",
+      "hash": "57c2f652ebac44b2c532e367621c6dc9756f3c1f420287f1cb644a52edc99949",
       "description": "Add Semantic Caching Doctrine + Embeddings Doctrine for AI agents",
       "created": "2025-12-16",
       "tags": [

--- a/prompts/versions.json
+++ b/prompts/versions.json
@@ -354,19 +354,30 @@
     },
     "v0.5.11": {
       "file": "prompts/v0.5.11.md",
-      "hash": "57c2f652ebac44b2c532e367621c6dc9756f3c1f420287f1cb644a52edc99949",
+      "hash": "dd7a2357c5c28a3c2c1c994434e2f8621a6288cf33aef09b8cf9eb70f0935f58",
       "description": "Add Semantic Caching Doctrine + Embeddings Doctrine for AI agents",
       "created": "2025-12-16",
       "tags": [
         "production",
-        "latest",
         "semantic-caching",
         "embeddings"
       ],
       "notes": "Major additions: (1) Semantic Caching Doctrine - SharedMem/SharedIndex as cognitive working memory, namespace conventions, canonical patterns (cache-or-compute, deduplication, multi-agent CAS). (2) Embeddings Doctrine - when/what/how to use neural embeddings for paraphrase detection, hybrid retrieval pattern. All v0.5.10 features included."
+    },
+    "v0.6.2": {
+      "file": "prompts/v0.6.2.md",
+      "hash": "57c2f652ebac44b2c532e367621c6dc9756f3c1f420287f1cb644a52edc99949",
+      "description": "Add record pattern matching (M-RECORD-PATTERNS)",
+      "created": "2025-12-25",
+      "tags": [
+        "production",
+        "latest",
+        "record-patterns"
+      ],
+      "notes": "Record pattern matching for destructuring records in match expressions. Syntax: {name}, {name: var}, {name, age}, {user: {name}} for nested patterns, {name, ...} for rest patterns. All v0.5.11 features included."
     }
   },
-  "active": "v0.5.11",
+  "active": "v0.6.2",
   "notes": [
     "Hash is SHA256 of the prompt file contents",
     "Use 'active' field to specify default prompt version",


### PR DESCRIPTION
Add examples and syntax reference for record pattern matching
introduced in M-RECORD-PATTERNS (v0.6.2).