### PR TITLE
fix(docs): align react with react-dom 19 (unblock npm install)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -16,7 +16,7 @@
         "clsx": "^2.0.0",
         "lucide-react": "^1.14.0",
         "prism-react-renderer": "^2.3.0",
-        "react": "^18.0.0",
+        "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "recharts": "^3.8.1"
       },
@@ -15996,12 +15996,10 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/docs/package.json
+++ b/docs/package.json
@@ -26,7 +26,7 @@
     "clsx": "^2.0.0",
     "lucide-react": "^1.14.0",
     "prism-react-renderer": "^2.3.0",
-    "react": "^18.0.0",
+    "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "recharts": "^3.8.1"
   },


### PR DESCRIPTION
## Summary

- Bumps \`react\` from \`^18.0.0\` to \`^19.2.6\` in \`docs/package.json\` to match \`react-dom\` (which #208 already bumped to 19).
- Updates \`docs/package-lock.json\` accordingly.

## Why

PR #208 merged \`react-dom 18→19.2.6\` cleanly (CI was green) but left \`react\` pinned at \`^18.0.0\`. The runtime tolerated the mismatch — react-dom@19 accepts react@18 at the peer-optional layer — but **npm's installer doesn't**, so every subsequent PR that triggers \`npm install\` in \`/docs\` now fails with:

\`\`\`
npm error While resolving: react-dom@19.2.6
npm error Found: react@18.3.1
npm error peerOptional react@">= 16.8.0 < 20.0.0" from @docsearch/core@4.6.2
\`\`\`

This was caught immediately on the next Dependabot PR I tried to merge (#220 \`cloud.google.com/go/trace\` — Go-only, but blocked on the docs install step).

## Test plan

- [x] \`docs/package.json\` updated
- [x] \`docs/package-lock.json\` regenerated via \`npm install --package-lock-only\`
- [ ] CI green on this PR
- [ ] After merge: re-merge #220 (and any other Dependabot PRs blocked on the same issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)