### PR TITLE
ci: install z3 + assert binary-gated integration tests actually run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,31 @@ jobs:
       # checks the real motoko core via MOTOKO_REPO.)
       run: tools/ci/motoko_smoke.sh
 
+    # Without z3, every SMT/contract-verification integration test
+    # (internal/smt TestSolve_*_Z3, internal/bestof TestZ3VerifyEndToEnd, …)
+    # t.Skip()s — they had silently never run in CI until 2026-07-10.
+    - name: Install z3 (SMT solver for contract-verification tests)
+      run: sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends z3
+
     - name: Run tests with timeout (M-DX11)
       run: go test -timeout 60s ./...
+
+    # `go test ./...` output is non-verbose: a t.Skip is invisible and CI
+    # stays green while integration coverage silently evaporates (e.g. if
+    # the "Build binaries" or "Install z3" steps above are ever removed or
+    # reordered after the test step). Re-run one fast representative test
+    # per external-binary gate (ailang via bin/, ailang via PATH, z3)
+    # verbosely and require an explicit PASS — a skip or rename fails here.
+    - name: Assert binary-gated integration tests ran (no silent skips)
+      run: |
+        go test -count=1 -v -run '^(TestRunSmokeInTempDir_Pass|TestPromptCommand_Piping|TestZ3VerifyEndToEnd)$' \
+          ./internal/pkg ./cmd/ailang ./internal/bestof 2>&1 | tee gated_integration.log
+        for t in TestRunSmokeInTempDir_Pass TestPromptCommand_Piping TestZ3VerifyEndToEnd; do
+          grep -q -- "--- PASS: $t" gated_integration.log || {
+            echo "::error::$t did not PASS — a binary-gated integration test is being skipped (missing/stale ailang or z3?) or was renamed (then update this step)."
+            exit 1
+          }
+        done
 
     - name: Run parser tests
       run: make test-parser
@@ -258,6 +281,21 @@ jobs:
       # If a test is genuinely Windows-incompatible (not just slow), fix it or
       # skip it with a `// TODO(windows-ci): <reason>` + tracked GH issue.
       run: go test -timeout 300s ./...
+
+    # Same anti-silent-skip gate as the Linux job (minus z3, which isn't
+    # installed here): tests that shell out to ailang t.Skip when it's
+    # missing, invisibly in non-verbose `go test ./...`. Require an explicit
+    # PASS from one representative test per discovery path (bin/ vs PATH).
+    - name: Assert binary-gated integration tests ran (no silent skips)
+      shell: pwsh
+      run: |
+        go test -count=1 -v -run '^(TestRunSmokeInTempDir_Pass|TestPromptCommand_Piping)$' ./internal/pkg ./cmd/ailang 2>&1 | Tee-Object -FilePath gated_integration.log
+        foreach ($t in 'TestRunSmokeInTempDir_Pass','TestPromptCommand_Piping') {
+          if (-not (Select-String -Path gated_integration.log -SimpleMatch "--- PASS: $t" -Quiet)) {
+            Write-Error "$t did not PASS - a binary-gated integration test is being skipped (missing/stale ailang?) or was renamed (then update this step)."
+            exit 1
+          }
+        }
 
   build:
     runs-on: ubuntu-latest

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,28 @@
 
 ## [Unreleased]
 
+### Added — CI: z3 on the runner + anti-silent-skip gate for binary-shelling integration tests
+
+An audit of the last green dev CI log (run 29092834899's predecessor) confirmed the
+ailang-binary-gated integration tests (internal/pkg smoke runner, cmd/ailang prompt/pipe,
+internal/gen/golang contract violations, eval_harness runner, …) already **run and PASS** in
+CI — `make install` (Linux) / `go install` (Windows) precede `go test ./...` and the runner's
+PATH includes GOPATH/bin. What actually never ran: every **Z3-dependent** test
+(internal/smt `TestSolve_*_Z3`/`TestZ3Version`, internal/bestof `TestZ3VerifyEndToEnd`/
+`TestZ3CatchesRuntimePassingButUnprovable`) skipped with "Z3 not installed" in every run —
+the contract-verification tier (M-CONTRACT-GUIDED-EVAL) had zero CI signal.
+
+- ci.yml (Linux test job): install `z3` via apt before the test step, so the SMT/contract
+  integration tests execute for real.
+- ci.yml (both jobs): new "Assert binary-gated integration tests ran" step — re-runs one fast
+  representative test per external-binary gate (`TestRunSmokeInTempDir_Pass`,
+  `TestPromptCommand_Piping`, `TestZ3VerifyEndToEnd`; Windows minus z3) verbosely and fails
+  unless each shows `--- PASS`. `go test ./...` is non-verbose, so without this a skip is
+  invisible and CI stays green while integration coverage silently evaporates (e.g. if the
+  build/install steps are removed or reordered). Also arms the staleness guard landing in
+  `internal/testutil` (ailangbin.go): if it ever misfires in CI, this step turns the silent
+  skip into a red build.
+
 ### Added — Feedback cost & abuse gate on the cloud dispatch path (M-FEEDBACK-TRIAGE-GATE)
 
 A deterministic-first cost & abuse gate between the coordinator's cloud Pub/Sub pickup


### PR DESCRIPTION
## What

An audit of the latest green dev CI log established that the ailang-binary-gated integration tests (internal/pkg smoke runner, cmd/ailang prompt/pipe, internal/gen/golang contract violations, eval_harness runner, cmd/registry-validator, …) **already run and PASS in CI**: `make install` (Linux) / `go install` (Windows) precede `go test ./...`, and the runner PATH includes GOPATH/bin (the install step even logs "Your PATH is correctly configured"). Zero tests in the whole run skip for a missing ailang binary.

What genuinely never ran is the **Z3 family**: internal/smt `TestSolve_*_Z3` / `TestZ3Version` / `TestFindZ3` and internal/bestof `TestZ3VerifyEndToEnd` / `TestZ3CatchesRuntimePassingButUnprovable` all skip with `Z3 not installed` in every CI run — the contract-verification tier (M-CONTRACT-GUIDED-EVAL) had zero CI signal.

## Changes

1. **Linux test job: install z3** (apt) before the test step → the SMT/contract integration tests execute for real.
2. **Both jobs: anti-silent-skip assert step** — re-runs one fast (~2s total) representative test per external-binary gate (`TestRunSmokeInTempDir_Pass`, `TestPromptCommand_Piping`, `TestZ3VerifyEndToEnd`; Windows minus z3) with `-v` and fails unless each shows `--- PASS`. Since `go test ./...` is non-verbose, a `t.Skip` is otherwise invisible and CI stays green while integration coverage silently evaporates (e.g. if the build/install steps are ever removed or reordered). This also arms the `internal/testutil` staleness guard (in-flight on another branch): a guard misfire in CI becomes a red build instead of silent skips.

## Verification

- Locally: all three representative tests + full smt/bestof Z3 suite PASS with a fresh binary and z3 on PATH; the assert loop exits 1 on a SKIP-only log and with no binary on PATH the gated tests do skip (negative path exercised).
- On this PR's CI run: check the `Assert binary-gated integration tests ran` steps (both jobs) are green, and that `TestZ3VerifyEndToEnd` / `TestSolve_*_Z3` now show **PASS** in the verbose coverage-gate step where they previously showed SKIP.
- Risk to watch: apt's z3 is older than the locally-tested 4.16.0 — if the CI run shows Z3 test failures (not skips), the z3 version needs pinning.
- CI time impact: apt install ~15–30s + ~2s assert on Linux, ~2s on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)