### PR TITLE
test(diag): promote 4 footgun rows to covered with CI fixtures (M-DIAG-FIXTURE-PROMOTION)

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,21 @@
 
 ## [Unreleased]
 
+### Added — Footgun coverage: 4 fix-carrying diagnostics promoted to `covered` with CI fixtures (M-DIAG-FIXTURE-PROMOTION)
+
+Promoted four footgun rows from `inventoried` to `covered` in the coverage table
+(`internal/diag/footguns.md`) by adding CI fixtures in
+`internal/diag/footgun_fixtures_test.go` that assert each diagnostic's code **and**
+its fix-carrying substring: reserved-keyword-as-name (`PAR_RESERVED_KEYWORD`),
+hyphen-in-module-path (`PAR_HYPHEN_IN_MODULE`), `;`-in-expression-body-func
+(`PAR017`), and stdlib-func-used-without-import (the `ImportSuggester` "exported by
+std/…; add the matching import" hint). The stdlib-import fixture wires
+`AILANG_STDLIB_PATH` + `types.ImportSuggester` via a `TestMain` so it exercises the
+same hint an agent's `ailang check` sees. The `%`/Fractional row is held at
+`inventoried`: its table-claimed diagnostic is not reachable via `ailang check` on
+an `.ail` snippet (only via the internal `InstanceEnv.Lookup` unit test), so it is
+not fixturable without new diagnostic work. Part of m-diagnostic-coverage (R1.1).
+
 ### Fixed — contract codegen emitted uncompilable Go on Windows (path escapes in panic literals)
 
 `internal/gen/golang/contracts.go` interpolated `Contract.Message`/`Contract.Location`

--- a/design_docs/planned/v0_29_0/m-diagnostic-coverage.md
+++ b/design_docs/planned/v0_29_0/m-diagnostic-coverage.md
@@ -1,6 +1,14 @@
 # M-DIAGNOSTIC-COVERAGE: The footgun coverage table — error-time teaching with CI-enforced fix-carrying diagnostics (R1.1)
 
-**Status**: Planned
+**Status**: Partially implemented — M1–M3 SHIPPED 2026-07-09 (found stale-status at mission
+iteration 4 reality-check, 2026-07-10): footgun table (14 rows) at `internal/diag/footguns.md`,
+CI fixture mechanism at `internal/diag/footgun_fixtures_test.go`, first three diagnostics
+(#325 `PAR_IMPORT_PLACEMENT`, #327 interim truth-telling hint, `++` gold standard fixtured) —
+commits ff58a3259 / e59197554; #327's REAL fix (M2_RECORD_UPDATE_FIX, 01fb8676a) shipped in the
+same sprint, so the interim-hint retirement condition is already met (audit pending).
+OPEN: fixture-promotion of the 5 fix-carrying rows (sprint M-DIAG-FIXTURE-PROMOTION,
+2026-07-10), then the A/B-gated deletion pass + haiku causal re-run (see dated note above
+Solution Design).
 **Target**: v0.29.0 (Phase 1 of the strategy review routing table)
 **Priority**: P0 (the cheapest cost-per-success lever with fresh causal evidence: one missing diagnostic cost a full mid-tier benchmark cell)
 **Estimated**: 3–4 days for the mechanism + first three diagnostics (table+CI 1d, diagnostics 1.5d, prompt-deletion pass + rig A/B 1d)
@@ -94,6 +102,16 @@ Touches `internal/parser/` (for #325's placement diagnostic) and error-message p
    on old strings — the eval harness's `CategorizeErrorWithCode` patterns must be
    updated in the same PR; grep for affected `errorRule` entries).
 
+## Deferred-step note (2026-07-10, mission iteration 4)
+
+The deletion pass (step 4) is **deliberately deferred, not skipped**: with only M1–M3 shipped,
+the deletable surface is ~35 lines (`++` section ≈18 + scattered singles) — far below the ≥100
+gate — so a rig A/B now would be poorly amortized (hours of GPU eval to clear a 35-line
+deletion). Sequencing: widen `covered` first (fixture-promotion sprint, then future target
+diagnostics), THEN one A/B clears a ≥100-line deletion in a single gate. The haiku causal
+re-run (success criterion 3) is API-billed and cannot run from the headless mission loop
+(billing guard strips API keys) — it needs a supervised session or explicit human ops.
+
 ## Solution Design
 
 1. **Inventory** (~0.5d): sweep `prompts/v0.16.2.md` Common Mistakes + `docs/LIMITATIONS.md`
@@ -108,10 +126,10 @@ Touches `internal/parser/` (for #325's placement diagnostic) and error-message p
    prompt-size A/B per R3.1 tooling, merge only on no-loss.
 
 ## Success Criteria
-- [ ] Table with ≥ 10 inventoried entries, each row live-verified
-- [ ] 3 diagnostics shipped, fixtures green in CI
-- [ ] haiku re-run on `legal_obligation_engine` AILANG: the #325 cell flips (the causal test of the whole thesis)
-- [ ] ≥ 100 prompt lines deleted, rig A/B no-loss, KPI reported
+- [x] Table with ≥ 10 inventoried entries, each row live-verified (14 rows, live-verified 2026-07-09)
+- [x] 3 diagnostics shipped, fixtures green in CI (ff58a3259/e59197554; `go test ./internal/diag/` green on dev 22b3f0c62, re-verified 2026-07-10)
+- [ ] haiku re-run on `legal_obligation_engine` AILANG: the #325 cell flips (the causal test of the whole thesis) — API-billed; blocked headless, needs supervised session
+- [ ] ≥ 100 prompt lines deleted, rig A/B no-loss, KPI reported — deferred pending wider coverage (see dated note above)
 
 ## Verification Log
 

--- a/internal/diag/footgun_fixtures_test.go
+++ b/internal/diag/footgun_fixtures_test.go
@@ -14,11 +14,31 @@
 package diag
 
 import (
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/sunholo-data/ailang/internal/pipeline"
+	"github.com/sunholo-data/ailang/internal/stdlibindex"
+	"github.com/sunholo-data/ailang/internal/types"
 )
+
+// TestMain wires the stdlib import-suggestion path exactly as the CLI does
+// (cmd/ailang/diagnostics_wiring.go) so the stdlib_import_hint fixture below
+// sees the same fix-carrying diagnostic an agent's `ailang check` sees. Two
+// steps are required and BOTH must run before any fixture executes:
+//
+//  1. AILANG_STDLIB_PATH must point at the on-disk stdlib (../../std relative to
+//     this package's CWD) — stdlibindex scans it lazily via sync.Once, so the
+//     env var must be set before stdlibindex.Modules is first called.
+//  2. types.ImportSuggester must be wired to stdlibindex.Modules — it is nil in
+//     pure library code (only the CLI init() sets it), so without this the hint
+//     is empty and the fixture is silently red with a bare "undefined variable".
+func TestMain(m *testing.M) {
+	_ = os.Setenv("AILANG_STDLIB_PATH", "../../std")
+	types.ImportSuggester = stdlibindex.Modules
+	os.Exit(m.Run())
+}
 
 // footgunFixture is one CI-enforced row of footguns.md.
 type footgunFixture struct {
@@ -71,6 +91,47 @@ export func main() -> int { 1 }
 func helper(x: int) -> int { x }
 import std/string (join)
 export func main() -> int { 1 }
+`,
+	},
+	{
+		name:   "reserved_keyword",
+		code:   "PAR_RESERVED_KEYWORD",
+		fix:    "'exists' is reserved for existential types",
+		status: "covered", // promoted by m-diagnostic-coverage (M-DIAG-FIXTURE-PROMOTION)
+		src: `module benchmark/solution
+export func main() -> int { let exists = 1 in exists }
+`,
+	},
+	{
+		name:   "hyphen_in_module",
+		code:   "PAR_HYPHEN_IN_MODULE",
+		fix:    "Use underscores instead",
+		status: "covered", // promoted by m-diagnostic-coverage (M-DIAG-FIXTURE-PROMOTION)
+		src: `module benchmark/my-solution
+export func main() -> int { 1 }
+`,
+	},
+	{
+		name:   "semicolon_in_expr_func",
+		code:   "PAR017",
+		fix:    "only valid inside",
+		status: "covered", // promoted by m-diagnostic-coverage (M-DIAG-FIXTURE-PROMOTION)
+		src: `module benchmark/solution
+export func f() -> int = let x = 1; x
+export func main() -> int { f() }
+`,
+	},
+	{
+		// TYPE error (not parse) — the fix substring comes from the ImportSuggester
+		// hint wired in TestMain above. Assert a STABLE substring ("exported by
+		// std/list"), NOT the full "std/list, std/option, std/result" comma list,
+		// which shifts as stdlib exports change.
+		name:   "stdlib_import_hint",
+		code:   "undefined variable: map",
+		fix:    "exported by std/list",
+		status: "covered", // promoted by m-diagnostic-coverage (M-DIAG-FIXTURE-PROMOTION)
+		src: `module benchmark/solution
+export func main() -> list[int] { map(\x. x, [1,2,3]) }
 `,
 	},
 }

--- a/internal/diag/footguns.md
+++ b/internal/diag/footguns.md
@@ -27,7 +27,11 @@ current and target diagnostic, and tracks whether the diagnostic is a tested con
 Every "current diagnostic" below was **live-verified** by running the sprint binary
 (`ailang check`) on a temp `.ail` file reproducing the footgun (2026-07-09,
 `v0.28.0-33-g` + this branch). Diagnostics are quoted verbatim (module-path MOD010
-temp-dir warnings elided).
+temp-dir warnings elided). The 4 rows promoted to `covered` on 2026-07-10
+(reserved keyword, hyphen-in-module, `;`-in-expr-func, stdlib-import hint) and the
+`%`/Fractional non-reachability were re-verified live that day via the fixture
+pipeline (`internal/diag/footgun_fixtures_test.go`, driving `pipeline.Run` in
+`ModeCheck`).
 
 ## Coverage table
 
@@ -38,20 +42,35 @@ temp-dir warnings elided).
 | local func in record-update field (#327) | `{ s \| dls: extendFm(s.dls, ...) }` where `extendFm` is a module-local func | `undefined variable: extendFm at ... (extendFm is defined in this module but not resolvable in this position — known bug #327; workaround: bind it with let first)` | truth-telling + workaround (interim); real fix in `m-record-update-local-resolution` retires this | `internal/types/local_resolution_hint_test.go` | (none — this is a bug, not a prompt line) | shipped-this-sprint |
 | `println(42)` / `print(42)` (needs string) | `println(42)` | `type error: ... No instance for Num[string] in scope. Arithmetic operators (+, -, *, /) need numbers, but this is a string. Use ++ to concatenate strings, or stringToInt to convert a string to a number.` | should name the print-arg-must-be-string rule + suggest `show(42)`; current message is about arithmetic, misdirecting | (future) | `prompts/v0.16.2.md:2338` | inventoried |
 | `import "std/io"` (quoted path) | `import "std/io"` | `IMP012_UNSUPPORTED_NAMESPACE at ...: namespace imports not yet supported` + suggestion `Use selective import: import module/path (symbol1, symbol2) / Or module alias: import std/list as List` | should detect the quoted-path shape and suggest dropping the quotes: `import std/io (println)` | (future) | `prompts/v0.16.2.md:190`, `:2339` | inventoried |
-| `%` / division on wrong numeric type | `3.5 % 2.0` | `type error: ... No instance for Fractional[int] in scope. Float division (/) needs floats; int is not Fractional. Convert ints with intToFloat, e.g. intToFloat(x) / intToFloat(y).` | carries a fix (intToFloat); message wording keyed to `/` even when trigger is `%` — tighten to name the actual operator | (future) | `prompts/v0.16.2.md:1094` (defaulting note) | inventoried |
-| reserved keyword as name | `let exists = 1` | `PAR_RESERVED_KEYWORD at ...: expected identifier, got reserved keyword 'exists'` + suggestions incl. `'exists' is reserved for existential types (future feature)` and `Try: let found = ... or let doesExist = ...` | (already fix-carrying — promote to `covered` once fixtured) | (future) | `prompts/v0.16.2.md:2346`, Reserved Keywords Common-mistake block (≈2259–2266) | inventoried |
+| `%` / division on wrong numeric type | `3.5 % 2.0` **type-checks clean** (floats satisfy the operator — no diagnostic fires); the nearest mismatch `func f(a:int,b:int)->float{a/b}` yields a plain `cannot unify int vs float`, not the Fractional hint | the `No instance for Fractional[int] ... intToFloat` message (`internal/types/instances.go`) is **NOT reachable via `ailang check` on an .ail snippet** — it only fires through the internal `InstanceEnv.Lookup` path exercised by `instances_test.go` (live-verified 2026-07-10). Kept for the record; not fixturable | carries a fix (intToFloat) once reachable; would also need to name the actual operator (`%` vs `/`) | (not fixturable — see current-diagnostic cell) | `prompts/v0.16.2.md:1094` (defaulting note) | inventoried |
+| reserved keyword as name | `let exists = 1` | `PAR_RESERVED_KEYWORD at ...: expected identifier, got reserved keyword 'exists'` + suggestions incl. `'exists' is reserved for existential types (future feature)` and `Try: let found = ... or let doesExist = ...` | (met — fix-carrying) | `footgun_fixtures_test.go:reserved_keyword` | `prompts/v0.16.2.md:2346`, Reserved Keywords Common-mistake block (≈2259–2266) | covered |
 | bare assignment (missing `let`) | `x = 1` | `PAR015 at ...: bare assignment not supported (missing 'let' keyword)` + suggestion `Use: let x = ... in` (preceded by a `PAR_UNEXPECTED_TOKEN` on `=`) | collapse the leading `PAR_UNEXPECTED_TOKEN` so only the fix-carrying PAR015 shows | (future) | `prompts/v0.16.2.md:188` | inventoried |
 | `const` keyword (JS/TS) | `const x = 1` | `PAR020 at ...: missing ';' between block statements (found 'x' ...)` (block context masks the const-specific PAR014 at top level) | recognise `const` in block-statement position and emit the PAR014 const→let fix | (future) | `prompts/v0.16.2.md:188` | inventoried |
-| hyphen in module/import path | `module benchmark/my-solution` | `PAR_HYPHEN_IN_MODULE at ...: hyphens in module paths are parsed as subtraction (in 'benchmark/my')` + suggestion `Use underscores instead: module benchmark/my_solution` | (already fix-carrying — promote to `covered` once fixtured) | (future) | (none in prompt) | inventoried |
+| hyphen in module/import path | `module benchmark/my-solution` | `PAR_HYPHEN_IN_MODULE at ...: hyphens in module paths are parsed as subtraction (in 'benchmark/my')` + suggestion `Use underscores instead: module benchmark/my_solution` | (met — fix-carrying) | `footgun_fixtures_test.go:hyphen_in_module` | (none in prompt) | covered |
 | `\|` as bitwise OR | `1 \| 2` | `PAR016 at ...: '\|' is reserved for pattern alternatives in 'match', not a binary operator` + De Morgan / `\|\|` suggestions (preceded by `PAR_UNEXPECTED_TOKEN`) | collapse the leading `PAR_UNEXPECTED_TOKEN` so only PAR016 shows | (future) | (none in prompt) | inventoried |
-| `;` in expression-body func | `func f() -> int = let x = 1; x` | `PAR017 at ...: ';' is only valid inside '{ ... }' block bodies, not in expression-body functions` + `let .. in ..` vs `{ }` suggestions | (already fix-carrying — promote to `covered` once fixtured) | (future) | `prompts/v0.16.2.md:2349` | inventoried |
-| stdlib func used without import | `map(\x. x, [1,2,3])` (no `import std/list`) | ``undefined variable: map at ... — `map` is exported by std/list, std/option, std/result; add the matching import`` | (already fix-carrying via ImportSuggester — promote to `covered` once fixtured) | (future) | `prompts/v0.16.2.md:2347` (transitive-imports line) | inventoried |
+| `;` in expression-body func | `func f() -> int = let x = 1; x` | `PAR017 at ...: ';' is only valid inside '{ ... }' block bodies, not in expression-body functions` + `let .. in ..` vs `{ }` suggestions | (met — fix-carrying) | `footgun_fixtures_test.go:semicolon_in_expr_func` | `prompts/v0.16.2.md:2349` | covered |
+| stdlib func used without import | `map(\x. x, [1,2,3])` (no `import std/list`) | ``undefined variable: map at ... — `map` is exported by std/list, std/option, std/result; add the matching import`` | (met — fix-carrying via ImportSuggester) | `footgun_fixtures_test.go:stdlib_import_hint` (needs `AILANG_STDLIB_PATH` + `types.ImportSuggester` wired in TestMain — the CLI wires these in `init()`) | `prompts/v0.16.2.md:2347` (transitive-imports line) | covered |
 | `list.map(f)` (method syntax) | `list.map(f)` | (field-access / type error — method-call syntax does not exist) | detect `x.method(args)` where `method` is a known stdlib function and suggest `method(x, args)` | (future) | `prompts/v0.16.2.md:2340` | inventoried |
 
-**Count:** 14 rows (≥ 10 required). 3 CI-fixtured (1 covered + 2 shipped-this-sprint entries;
-`import_placement` has two fixtures). 5 rows already carry a fix and are promote-to-`covered`
-candidates once fixtured (reserved keyword, hyphen, `;`-in-expr-func, stdlib-import hint, plus
-the `%`/Fractional case).
+**Count:** 14 rows (≥ 10 required).
+
+- **Fixtured footgun rows: 7** — `++` (covered), import-after-decl (shipped-this-sprint, contributes
+  **2** fixtures: `import_placement` + `import_placement_rule_stated`), and the 4 promoted this sprint
+  (reserved keyword, hyphen, `;`-in-expr-func, stdlib-import hint). So the fixture *row* count (7)
+  equals the fixture *entry* count in `footgunFixtures` — but it maps to **6 distinct footgun rows**
+  in this table because import-after-decl has two fixtures.
+- **CI-fixtured footgun rows in this table: 6** (1 `covered` `++` + 1 `shipped-this-sprint`
+  import-after-decl + 4 promoted-this-sprint `covered`). The #327-interim row is `shipped-this-sprint`
+  but its contract lives in `internal/types/local_resolution_hint_test.go`, not `footgunFixtures`.
+- **Promote-to-`covered` candidates remaining: 1** (down from 5) — only `%`/Fractional, and it is
+  **blocked**: its claimed diagnostic is not reachable via `ailang check` on an .ail snippet (see its
+  current-diagnostic cell), so it cannot be fixtured without new diagnostic work (out of scope).
+
+> **Follow-up (not this sprint):** the #327 interim truth-telling hint (`internal/types/import_hint.go:43`,
+> aka `localResolutionHint`) is a **dead-code retirement candidate** now that the real record-update
+> resolver fix shipped (`01fb8676a`, `M2_RECORD_UPDATE_FIX`). Its own comment says it "becomes dead code
+> and is removed the moment the resolver fix ships." Confirming deadness needs reproducing the original
+> cross-module repro — tracked separately, NOT retired here.
 
 ## Deletion gate (do NOT skip)
 


### PR DESCRIPTION
Mission iteration 4 (m-diagnostic-coverage remainder). Full inner loop headless: Fable reality-check → Opus plan → Opus execute (isolated worktree) → Fable evaluation **PASS 96/100 round 1**.

## What
- **M1**: 4 new CI fixtures in `internal/diag/footgun_fixtures_test.go` promoting fix-carrying diagnostics to tested contracts: `PAR_RESERVED_KEYWORD`, `PAR_HYPHEN_IN_MODULE`, `PAR017` (`;` in expr-body func), and the stdlib `ImportSuggester` hint (with `TestMain` wiring `AILANG_STDLIB_PATH` + `types.ImportSuggester`, mirroring CLI `init()`).
- **M2**: `footguns.md` — 4 rows → `covered`; `%`/Fractional row corrected to the live truth (its claimed diagnostic is **unreachable** via `ailang check`; stays `inventoried`); #327 interim-hint retirement flagged as follow-up (real fix `01fb8676a` shipped).
- **M3**: CHANGELOG entry.
- **Bookkeeping**: `m-diagnostic-coverage.md` stale-status correction (M1–M3 had shipped 2026-07-09 while the doc said Planned) + deferred-step rationale for the A/B-gated deletion pass.

## Verification
- `go test ./internal/diag/ -count=1`: 7 fixtures + conflict-surface test PASS
- `go test ./internal/types/ ./internal/parser/ ./internal/pipeline/`: no collateral
- Non-vacuity proven twice (executor inverted `stdlib_import_hint`, evaluator independently inverted `reserved_keyword` — both FAIL as required, restored → PASS)
- gofmt clean, `golangci-lint run internal/diag/` 0 issues, no conflict markers

Planner/executor attestations: claude-opus-4-8; evaluator: claude-fable-5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)