### PR TITLE
feat(parser): M-SYNTAX-AI-FORGIVING — forgiving statement separators (R1 ;-in-=-body, R2 newline-in-blocks)

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,26 @@
 
 ## [Unreleased]
 
+### Added — Forgiving statement separators: `;`-sequences in `=` bodies (M-SYNTAX-AI-FORGIVING R1)
+
+- The parser now accepts a `;`-separated statement sequence directly in an
+  equation-form (`=`) function body — `func f() = s1; s2; e` — the form small
+  models naturally write. This eliminates the **PAR017** parse-failure class
+  (~32% of small-model failures, directional) *without changing the model*.
+- Additive and **backward-compatible**: a multi-statement `=`-body parses to the
+  same `ast.Block` a braced `{ ... }` body produces, so elaboration and typing are
+  unchanged; a single-expression `=`-body is unchanged. The sequence stops at a
+  top-level declaration boundary (`export | type | import | extern | @ | pure |
+  func IDENT | EOF`), while an anonymous-function expression `func ( ... )` in the
+  body is never cut (M-TAINT guard).
+- Implementation: `parseEquationBody()` + `peekIsDeclBoundary()` in
+  `internal/parser/parser_func.go`. Backward-compatibility is enforced by a corpus
+  AST-diff fuzz gate (`internal/parser/corpus_astdiff_test.go`, run with
+  `AILANG_CORPUS_FUZZ=1`): every currently-valid `benchmarks/**/*.ail` +
+  `examples/**/*.ail` file (389 valid of 399) produces a byte-identical AST under
+  the new parser. Example: `examples/runnable/syntax_ai_forgiving.ail`.
+- Design: [`m-syntax-ai-forgiving.md`](../design_docs/planned/v0_29_0/m-syntax-ai-forgiving.md).
+
 ### Fixed — Windows CI: riglock dead-holder steal used Unix-only PID probe
 
 - `internal/riglock` split its holder-liveness probe into platform files:

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,29 @@
 
 ## [Unreleased]
 
+### Added — Forgiving statement separators: newline-as-soft-separator in blocks (M-SYNTAX-AI-FORGIVING R2)
+
+- A **newline** before a statement-starter (`let` / `letrec` / `if` / `match` /
+  identifier) now separates statements inside a `{ }` block, not only `;` — the
+  form small models naturally write. This relaxes the **PAR020** "missing ;"
+  failure class to the genuinely ambiguous same-line case *without changing the
+  model*.
+- Additive and **backward-compatible**: a newline-separated block parses to the
+  same `ast.Block` the `;`-separated block does. The rule is line-aware
+  (`peek.Line > cur.Line`, the M-GAP2 precedent) AND requires a statement-starter,
+  so multi-line *expressions* (`{ 1\n+ 2 }`, operator continuations) are never
+  split. Record literals / record-updates use commas and are detected up front, so
+  the newline rule never reaches a record body.
+- **Systemic fix**: patched all block statement-loops — `parseFunctionBody`,
+  `parseBlockOrExpression`, and both loops in `parseRecordLiteral` (the LBRACE-
+  prefix path that `if/then` blocks and `\`-lambda bodies take). **PAR020** is
+  preserved for the genuine same-line no-`;` case at both guard sites.
+- Enforced by the same corpus AST-diff fuzz gate (`AILANG_CORPUS_FUZZ=1`): every
+  currently-valid `benchmarks/**/*.ail` + `examples/**/*.ail` file (389 of 400)
+  produces a byte-identical AST under R2. Follow-up: a canonical formatter is
+  deferred to [`m-ailang-fmt.md`](../design_docs/planned/v0_29_0/m-ailang-fmt.md).
+- Design: [`m-syntax-ai-forgiving.md`](../design_docs/planned/v0_29_0/m-syntax-ai-forgiving.md).
+
 ### Added — Forgiving statement separators: `;`-sequences in `=` bodies (M-SYNTAX-AI-FORGIVING R1)
 
 - The parser now accepts a `;`-separated statement sequence directly in an

--- a/cmd/ailang/prompts/agent/dialect-traps.md
+++ b/cmd/ailang/prompts/agent/dialect-traps.md
@@ -8,13 +8,15 @@ obey these. They are the exact mistakes that break AILANG solutions:
    `nth(xs, 0)` (returns `Option`) or pattern-match `match xs { [x, ...rest] => ... }`.
    `import std/list (nth, head)`.
 
-2. **`=`-body holds ONE expression — no `let x = ...;` after `=`.** The reflex
-   `func f() -> T = let x = e; rest` is the single most common failure here. Fix it
-   one of two ways:
-   - **brace block** (drop the `=`): `func f() -> T { let x = e; rest }` — `;` is legal here
-   - **let-in** (keep the `=`): `func f() -> T = let x = e in rest`
-   `;` is valid ONLY inside `{ }`. For recursion use a named top-level `func` (there is
-   no top-level `let rec`).
+2. **Statement separators are forgiving (v0.29+).** All of these now parse and mean
+   the same thing — write whichever is natural:
+   - `;`-sequence in a `=`-body: `func f() -> T = let x = e; rest`
+   - brace block: `func f() -> T { let x = e; rest }` (`;` OR a **newline** separates
+     statements: `{ let x = e\n rest }` also works)
+   - let-in: `func f() -> T = let x = e in rest`
+   A `;` is still the last-statement rule: the block's/`=`-body's **final** expression
+   is the return value — no `;` after it. For recursion use a named top-level `func`
+   (there is no top-level `let rec`).
 
 3. **`match x { Pat => expr, ... }`** — NOT `match x with` (that's Haskell/OCaml).
    Arms use `=>` and are separated by **commas**.

--- a/cmd/astdump/main.go
+++ b/cmd/astdump/main.go
@@ -1,0 +1,57 @@
+// Command astdump parses a single .ail file and prints a deep, deterministic dump
+// of the resulting AST (or the parse errors). It exists to support the
+// M-SYNTAX-AI-FORGIVING corpus AST-diff fuzz gate (internal/parser/corpus_astdiff_test.go),
+// which builds this command from both the pre-change (old) parser and the current
+// (new) parser and diffs the output over the whole .ail corpus.
+//
+// Usage: astdump <file.ail>
+//
+// Output contract (stable, line-based):
+//
+//	ERRORS\n<one error per line>   — if the file does not parse cleanly
+//	AST\n<spew dump>               — if it parses cleanly
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/sunholo-data/ailang/internal/lexer"
+	"github.com/sunholo-data/ailang/internal/parser"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: astdump <file.ail>")
+		os.Exit(2)
+	}
+	path := os.Args[1]
+	src, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read %s: %v\n", path, err)
+		os.Exit(2)
+	}
+
+	p := parser.New(lexer.New(string(src), path))
+	prog := p.Parse()
+
+	if errs := p.Errors(); len(errs) > 0 {
+		fmt.Println("ERRORS")
+		for _, e := range errs {
+			fmt.Println(e.Error())
+		}
+		return
+	}
+
+	cfg := &spew.ConfigState{
+		Indent:                  "  ",
+		DisablePointerAddresses: true,
+		DisableCapacities:       true,
+		DisableMethods:          true, // dump full struct, not Stringer output
+		SortKeys:                true,
+		SpewKeys:                true,
+	}
+	fmt.Println("AST")
+	fmt.Print(cfg.Sdump(prog))
+}

--- a/design_docs/planned/v0_29_0/m-ailang-fmt.md
+++ b/design_docs/planned/v0_29_0/m-ailang-fmt.md
@@ -1,0 +1,54 @@
+# M-AILANG-FMT: `ailang fmt` — canonical AILANG formatter (deferred follow-up)
+
+**Status**: Planned (deferred / stub)
+**Target**: TBD (post-v0.29.x)
+**Split from**: [m-syntax-ai-forgiving.md](m-syntax-ai-forgiving.md) (sprint discrepancy D1)
+
+> This is a **placeholder** doc capturing the formatter deferred out of the
+> M-SYNTAX-AI-FORGIVING sprint, so the canonical-form erosion risk is tracked rather
+> than dropped. It is intentionally minimal; flesh it out when the formatter is scheduled.
+
+## Why this exists
+
+The M-SYNTAX-AI-FORGIVING sprint plan assumed `ailang fmt` existed and needed only
+"~0.5d of canonicalization." It **does not exist** — there is no `fmt` subcommand in
+`cmd/ailang/main.go` and no formatter package. A from-scratch AST-reprinting
+formatter (idempotence, round-trip, comment preservation, a CI gate) is a multi-day
+item that would blow the parser sprint's budget and smuggle a formatter into a parser
+change. The sprint therefore **split it here** (plan option b).
+
+M-SYNTAX-AI-FORGIVING made the parser **accept** several statement-separator forms
+that all produce the same AST:
+
+- `=`-body `;`-sequence: `func f() = s1; s2; e`  (R1)
+- braced `;`-sequence: `func f() { s1; s2; e }`
+- braced newline-sequence: `func f() { s1\n s2\n e }` (R2)
+- `let … in`: `func f() = let x = e in rest`
+
+Acceptance is the v1.0 gate (bar v2 clause 3), and it is satisfied. But with multiple
+accepted spellings and **no formatter**, source style can drift. In-sprint this is
+mitigated by (1) the corpus AST-diff fuzz gate (same AST → same result — presentation
+determinism / Axiom A1 is untouched, since A1 is about execution/trace determinism)
+and (2) documented canonical-form guidance (`prompts/agent/dialect-traps.md`). A
+formatter is a *convenience* on top of that, not a correctness requirement.
+
+## Scope (when scheduled)
+
+- `ailang fmt [--write] [--check] <files...>` — reprint AST to a canonical form.
+- **Canonical separator choice** (deferred decision from the parent doc): pick ONE of
+  `;`-on-line vs newline-per-statement as the emitted form. Recommendation: **newline
+  per statement inside `{ }`** (matches what models write and reads cleanest), with
+  the last expression bare (no trailing `;`); keep `let … in` only where explicit.
+- Idempotence (`fmt(fmt(x)) == fmt(x)`), comment preservation, round-trip on the
+  corpus, and a CI `--check` gate.
+- Reuse the deep-AST infrastructure from `cmd/astdump` where useful.
+
+## Non-goals
+
+- Any change to what the parser *accepts* (that shipped in M-SYNTAX-AI-FORGIVING).
+- Semantic rewrites — `fmt` is presentation-only.
+
+## Open questions
+
+- Comment attachment model (leading/trailing/floating) — the usual formatter hard part.
+- Whether `fmt --check` becomes a `make verify-examples`-adjacent CI gate or opt-in.

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -62,6 +62,11 @@ Single-expression branches don't need braces. See the
   `match x { pat => expr }`.
 - **Multi-statement block expressions** — `{ e1; e2; e3 }` sequencing works fully; the old
   `let _ = … in` workaround is no longer needed.
+- **Forgiving statement separators (v0.29+, M-SYNTAX-AI-FORGIVING)** — a `;`-separated
+  sequence is now accepted directly in a `=`-body (`func f() = s1; s2; e`), and a
+  **newline** is a soft statement separator inside `{ }` blocks (`{ let x = e\n rest }`).
+  Both parse to the same AST as the `;`-in-braces form; a `;` is only *required* to
+  separate two statements on the **same line**. Records still use commas.
 - **String interpolation** — `"Value: ${x}"` → `Value: 42` (v0.12.1); `++` is now list-only
   (string `++` is a type error, v0.13.0).
 - **Pattern guards** — `match x { n if n > 100 => …, n if n > 0 => …, _ => … }` (v0.6.2).

--- a/examples/runnable/syntax_ai_forgiving.ail
+++ b/examples/runnable/syntax_ai_forgiving.ail
@@ -1,0 +1,26 @@
+-- syntax_ai_forgiving.ail
+-- Demonstrates M-SYNTAX-AI-FORGIVING R1: a `;`-separated statement sequence is
+-- accepted directly in a `=` function body, without wrapping it in `{ }`. This is
+-- the form small models naturally write; it produces exactly the same AST as the
+-- braced form, so behaviour is identical.
+module examples/runnable/syntax_ai_forgiving
+
+import std/io (println)
+
+-- R1: `;`-sequence in a `=` body (no braces needed).
+pure func classify(n: int) -> string =
+  let doubled = n * 2;
+  let big = doubled > 10;
+  if big then "big" else "small"
+
+-- The canonical braced form parses to the same AST — shown here for contrast.
+pure func classifyBraced(n: int) -> string {
+  let doubled = n * 2;
+  let big = doubled > 10;
+  if big then "big" else "small"
+}
+
+export func main() -> () ! {IO} =
+  println(classify(3));
+  println(classify(8));
+  println(classifyBraced(8))

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	firebase.google.com/go/v4 v4.21.0
 	github.com/BurntSushi/toml v1.6.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.32.0
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/fatih/color v1.19.0
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/google/go-cmp v0.7.0
@@ -65,7 +66,6 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/internal/diag/footgun_fixtures_test.go
+++ b/internal/diag/footgun_fixtures_test.go
@@ -112,12 +112,17 @@ export func main() -> int { 1 }
 `,
 	},
 	{
-		name:   "semicolon_in_expr_func",
+		// M-SYNTAX-AI-FORGIVING R1 made a well-formed `;`-sequence in a `=`-body
+		// VALID (`= let x = 1; x` now parses). PAR017 now fires only for a genuinely
+		// MISPLACED `;` — here a stray double `;` where an expression was expected.
+		// The diagnostic (and its "only valid inside" fix text) is preserved for that
+		// real error; the previously-rejected valid form is not.
+		name:   "misplaced_semicolon_in_expr_func",
 		code:   "PAR017",
 		fix:    "only valid inside",
 		status: "covered", // promoted by m-diagnostic-coverage (M-DIAG-FIXTURE-PROMOTION)
 		src: `module benchmark/solution
-export func f() -> int = let x = 1; x
+export func f() -> int = let x = 1;; x
 export func main() -> int { f() }
 `,
 	},

--- a/internal/parser/corpus_astdiff_test.go
+++ b/internal/parser/corpus_astdiff_test.go
@@ -1,0 +1,237 @@
+package parser
+
+// M-SYNTAX-AI-FORGIVING corpus AST-diff fuzz gate.
+//
+// The hand-picked fixtures in syntax_ai_forgiving_test.go prove the new forms are
+// ACCEPTED. This gate proves the change is BACKWARD-COMPATIBLE: for every currently
+// valid .ail file in the corpus (benchmarks/**/*.ail + examples/**/*.ail), the NEW
+// parser must produce a byte-identical AST to the OLD (pre-change) parser. A single
+// meaning-diff on a currently-valid program fails the gate.
+//
+// Precedent (M-TAINT): a 2-token lookahead that passed hand-picked tests still
+// mis-parsed ~14 real programs. The corpus diff — not the fixtures — is the merge gate.
+//
+// Mechanism: build the astdump command (cmd/astdump) from BOTH a git worktree at the
+// pre-change base commit (the "old" parser) and the current worktree (the "new"
+// parser), run both over every corpus file, and diff their output. Files the OLD
+// parser rejected are skipped (they are not "currently valid"); the new parser is
+// allowed to newly ACCEPT them — that is the whole point of the feature.
+//
+// This test is heavy (it compiles the toolchain twice and parses ~400 files). It is
+// gated behind AILANG_CORPUS_FUZZ=1 so it does not run on every `go test` invocation,
+// but IS the explicit M2 (R1) and M4 (R2) merge gate.
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// corpusBaseEnv names the git ref of the pre-change parser. The sprint plan pins
+// the base at the sprint-plan commit; override for local runs if the base moves.
+const corpusBaseEnv = "AILANG_CORPUS_BASE"
+
+func TestCorpusASTDiff(t *testing.T) {
+	if os.Getenv("AILANG_CORPUS_FUZZ") != "1" {
+		t.Skip("set AILANG_CORPUS_FUZZ=1 to run the corpus AST-diff fuzz gate")
+	}
+
+	base := os.Getenv(corpusBaseEnv)
+	if base == "" {
+		base = "a7bd8257c" // sprint-plan commit (pre M-SYNTAX-AI-FORGIVING)
+	}
+
+	repoRoot := repoRootDir(t)
+
+	// Build the NEW-parser dumper from the current tree.
+	newBin := buildAstdump(t, repoRoot, "new")
+
+	// Materialise the OLD tree in a temp git worktree and build the OLD dumper.
+	oldRoot := t.TempDir()
+	gitRun(t, repoRoot, "worktree", "add", "--detach", oldRoot, base)
+	t.Cleanup(func() {
+		// Best-effort removal; ignore errors so a leftover worktree never fails CI.
+		_ = exec.Command("git", "-C", repoRoot, "worktree", "remove", "--force", oldRoot).Run()
+	})
+	// The base commit predates cmd/astdump — copy it in so both trees share the dumper.
+	copyAstdumpInto(t, repoRoot, oldRoot)
+	oldBin := buildAstdump(t, oldRoot, "old")
+
+	// Collect the corpus.
+	files := collectCorpus(t, repoRoot)
+	if len(files) == 0 {
+		t.Fatal("empty corpus — glob is wrong")
+	}
+	t.Logf("corpus: %d files", len(files))
+
+	var (
+		checked   int
+		newlyOK   int
+		stillFail int
+	)
+	for _, f := range files {
+		oldOut := runDump(t, oldBin, f)
+		newOut := runDump(t, newBin, f)
+
+		oldValid := !strings.HasPrefix(oldOut, "ERRORS")
+		newValid := !strings.HasPrefix(newOut, "ERRORS")
+
+		if !oldValid {
+			// Not a currently-valid program. The feature is allowed to newly accept
+			// it; we don't gate on files the old parser already rejected.
+			if newValid {
+				newlyOK++
+			} else {
+				stillFail++
+			}
+			continue
+		}
+
+		checked++
+		if oldOut != newOut {
+			rel, _ := filepath.Rel(repoRoot, f)
+			t.Errorf("AST DIFF on currently-valid file %s\n%s", rel, firstDiff(oldOut, newOut))
+		}
+	}
+
+	t.Logf("checked=%d identical; newly-accepted=%d; still-invalid=%d",
+		checked, newlyOK, stillFail)
+}
+
+// --- helpers -----------------------------------------------------------------
+
+func repoRootDir(t *testing.T) string {
+	t.Helper()
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse --show-toplevel: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func gitRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+func buildAstdump(t *testing.T, root, tag string) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "astdump_"+tag)
+	cmd := exec.Command("go", "build", "-o", bin, "./cmd/astdump")
+	cmd.Dir = root
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build astdump (%s) in %s: %v\n%s", tag, root, err, out)
+	}
+	return bin
+}
+
+// copyAstdumpInto copies cmd/astdump/main.go from the new tree into the old tree so
+// the old (pre-change) source can be compiled with the same dumper entrypoint.
+func copyAstdumpInto(t *testing.T, srcRoot, dstRoot string) {
+	t.Helper()
+	src := filepath.Join(srcRoot, "cmd", "astdump", "main.go")
+	dstDir := filepath.Join(dstRoot, "cmd", "astdump")
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dstDir, err)
+	}
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read %s: %v", src, err)
+	}
+	if err := os.WriteFile(filepath.Join(dstDir, "main.go"), data, 0o644); err != nil {
+		t.Fatalf("write astdump into old tree: %v", err)
+	}
+}
+
+func collectCorpus(t *testing.T, root string) []string {
+	t.Helper()
+	var files []string
+	for _, dir := range []string{"benchmarks", "examples"} {
+		err := filepath.Walk(filepath.Join(root, dir), func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if !info.IsDir() && strings.HasSuffix(path, ".ail") {
+				files = append(files, path)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", dir, err)
+		}
+	}
+	return files
+}
+
+func runDump(t *testing.T, bin, file string) string {
+	t.Helper()
+	out, err := exec.Command(bin, file).Output()
+	if err != nil {
+		// A non-zero exit means the dumper itself failed (bad usage / read error),
+		// not a parse error (those are reported on stdout with exit 0).
+		t.Fatalf("astdump %s: %v", file, err)
+	}
+	return string(out)
+}
+
+// firstDiff returns a short context around the first differing line, to keep
+// failure output actionable rather than dumping two full ASTs.
+func firstDiff(a, b string) string {
+	al := strings.Split(a, "\n")
+	bl := strings.Split(b, "\n")
+	n := len(al)
+	if len(bl) < n {
+		n = len(bl)
+	}
+	for i := 0; i < n; i++ {
+		if al[i] != bl[i] {
+			start := i - 2
+			if start < 0 {
+				start = 0
+			}
+			var sb strings.Builder
+			sb.WriteString("first diff at line ")
+			sb.WriteString(itoa(i + 1))
+			sb.WriteString(":\n")
+			for j := start; j <= i; j++ {
+				sb.WriteString("  old: " + al[j] + "\n")
+			}
+			sb.WriteString("  ---\n")
+			for j := start; j <= i; j++ {
+				sb.WriteString("  new: " + bl[j] + "\n")
+			}
+			return sb.String()
+		}
+	}
+	if len(al) != len(bl) {
+		return "outputs differ in length (old=" + itoa(len(al)) + " new=" + itoa(len(bl)) + " lines)"
+	}
+	return "(identical prefix; trailing whitespace differs)"
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/internal/parser/par020_block_semicolon_test.go
+++ b/internal/parser/par020_block_semicolon_test.go
@@ -12,16 +12,20 @@ import (
 // produce an actionable PAR020 error naming the fix, not a bare
 // "expected }, got X". This is the #1 unactionable thrash-causer on small models
 // — config_file_parser burned 66 agent turns on a generic "expected }, got if".
+//
+// M-SYNTAX-AI-FORGIVING R2 narrowed PAR020's scope: a NEWLINE between statements is
+// now an accepted soft separator (no error). PAR020 therefore fires only for the
+// genuine SAME-LINE, no-`;` case — where the tokens are ambiguous and a `;` really
+// is required. The fixtures below use same-line inputs accordingly.
 func TestPAR020_MissingBlockSemicolon(t *testing.T) {
-	t.Run("func body missing semicolon (the 66-turn pattern)", func(t *testing.T) {
+	t.Run("same-line missing semicolon before if (the 66-turn pattern)", func(t *testing.T) {
 		input := "module t\n" +
 			"pure func f(n: int) -> int {\n" +
-			"  let x = n\n" + // <-- missing ';'
-			"  if x > 0 then 1 else 0\n" +
+			"  let x = n if x > 0 then 1 else 0\n" + // <-- same line, missing ';'
 			"}\n"
 		err := firstParserErrorWithCode(t, input, "PAR020")
 		if err == nil {
-			t.Fatal("expected PAR020 for a missing ';' between block statements")
+			t.Fatal("expected PAR020 for a same-line missing ';' between block statements")
 		}
 		msg := err.Error()
 		if !strings.Contains(msg, "missing ';'") {
@@ -35,15 +39,25 @@ func TestPAR020_MissingBlockSemicolon(t *testing.T) {
 		}
 	})
 
-	t.Run("missing semicolon before another let", func(t *testing.T) {
+	t.Run("same-line missing semicolon before another let", func(t *testing.T) {
 		input := "module t\n" +
 			"pure func f(n: int) -> int {\n" +
-			"  let x = n\n" + // <-- missing ';'
+			"  let x = n let y = x y\n" + // <-- same line, missing ';'
+			"}\n"
+		if firstParserErrorWithCode(t, input, "PAR020") == nil {
+			t.Error("expected PAR020 when a same-line let-statement is followed by another without ';'")
+		}
+	})
+
+	t.Run("newline-separated statements do NOT trigger PAR020 (R2)", func(t *testing.T) {
+		input := "module t\n" +
+			"pure func f(n: int) -> int {\n" +
+			"  let x = n\n" + // newline is a soft separator now — no error
 			"  let y = x\n" +
 			"  y\n" +
 			"}\n"
-		if firstParserErrorWithCode(t, input, "PAR020") == nil {
-			t.Error("expected PAR020 when a let-statement is followed by another without ';'")
+		if err := firstParserErrorWithCode(t, input, "PAR020"); err != nil {
+			t.Errorf("newline-separated statements must not trigger PAR020 after R2: %s", err.Error())
 		}
 	})
 

--- a/internal/parser/parser_expr.go
+++ b/internal/parser/parser_expr.go
@@ -420,18 +420,19 @@ func (p *Parser) parseBlockOrExpression() ast.Expr {
 	exprs := []ast.Expr{}
 	exprs = append(exprs, p.parseExpression(LOWEST))
 
-	// Keep parsing while we see semicolons
-	for p.peekTokenIs(lexer.SEMICOLON) {
-		p.nextToken() // move to SEMICOLON
-
-		// Check for trailing semicolon (next token is RBRACE)
-		// Keep cursor at semicolon so peek is RBRACE for expectPeek below
-		if p.peekTokenIs(lexer.RBRACE) {
-			break
+	// Keep parsing while statements are separated by `;` OR (R2) by a newline
+	// before a statement-starter (peekStartsNewlineBlockStatement, parser_func.go).
+	for p.peekTokenIs(lexer.SEMICOLON) || p.peekStartsNewlineBlockStatement() {
+		if p.peekTokenIs(lexer.SEMICOLON) {
+			p.nextToken() // move to SEMICOLON
+			// Trailing `;`: keep cursor at it so peek is RBRACE for expectPeek below.
+			if p.peekTokenIs(lexer.RBRACE) {
+				break
+			}
+			p.nextToken() // move past SEMICOLON
+		} else {
+			p.nextToken() // R2: newline separator — advance onto the next statement
 		}
-
-		p.nextToken() // move past SEMICOLON
-
 		exprs = append(exprs, p.parseExpression(LOWEST))
 	}
 

--- a/internal/parser/parser_func.go
+++ b/internal/parser/parser_func.go
@@ -180,22 +180,25 @@ func (p *Parser) parseFunctionDeclaration(isPure bool, isExport bool) *ast.FuncD
 
 	// Check if we're already at LBRACE (block-form) or ASSIGN (equation-form)
 	if p.peekTokenIs(lexer.ASSIGN) {
-		// Equation-form: consume = and parse expression
+		// Equation-form: consume = and parse the body.
+		// M-SYNTAX-AI-FORGIVING R1: accept `;`-separated statement sequences in the
+		// `=` body (`func f() = s1; s2; e`), the form small models naturally write.
+		// This eliminates the PAR017 parse-failure class. A single-expression body
+		// is unchanged (still wrapped in a 1-expr Block, identical to before). The
+		// sequence stops at a top-level declaration boundary so back-to-back decls
+		// (`func f() = e func g() = ...`) split correctly, while an anonymous-func
+		// expression (`func (`) stays inside the body (M-TAINT guard).
 		p.nextToken() // move to ASSIGN
 		p.nextToken() // move past ASSIGN to start of expression
 
-		body := p.parseExpression(LOWEST)
+		body := p.parseEquationBody()
 		if body == nil {
 			// parseExpression already recorded the underlying error (e.g. an
 			// unsupported construct such as index access `x[i]` in the body);
 			// don't nil-deref on .Position(). Matches the return nil below.
 			return nil
 		}
-		// Wrap single expression in a block for uniform handling
-		fn.Body = &ast.Block{
-			Exprs: []ast.Expr{body},
-			Pos:   body.Position(),
-		}
+		fn.Body = body
 	} else {
 		// Block-form: expect LBRACE
 		if !p.curTokenIs(lexer.LBRACE) {
@@ -366,6 +369,75 @@ func (p *Parser) parseFunctionBody() ast.Expr {
 	return &ast.Block{
 		Exprs: exprs,
 		Pos:   startPos,
+	}
+}
+
+// parseEquationBody parses the body of an equation-form function (`func f() = ...`).
+//
+// M-SYNTAX-AI-FORGIVING R1: the body is a `;`-separated statement sequence
+// (`s1; s2; e`), not just a single expression. The result is ALWAYS wrapped in an
+// ast.Block — identical to the pre-R1 single-expression wrapping and to what a
+// braced `{ ... }` body produces — so elaboration and typing are unchanged.
+//
+// The sequence continues past a `;` unless the following token begins a new
+// top-level declaration (peekIsDeclBoundary). This makes back-to-back decls
+// (`func f() = e; func g() = ...`, or without the `;`) split at `func g`, while an
+// anonymous-function expression `func ( ... )` in the body is never treated as a
+// boundary. Assumes cursor is AT the first token of the body.
+func (p *Parser) parseEquationBody() ast.Expr {
+	first := p.parseExpression(LOWEST)
+	if first == nil {
+		return nil
+	}
+	exprs := []ast.Expr{first}
+	startPos := first.Position()
+
+	// Continue while we see `;` and the next statement is not a declaration boundary.
+	for p.peekTokenIs(lexer.SEMICOLON) {
+		p.nextToken() // move to SEMICOLON
+
+		// Trailing `;` before a real declaration boundary (or EOF): stop, leaving the
+		// boundary token in peek so the top-level loop picks up the next declaration.
+		if p.peekIsDeclBoundary() {
+			break
+		}
+
+		p.nextToken() // move past SEMICOLON to next statement
+
+		next := p.parseExpression(LOWEST)
+		if next == nil {
+			return nil
+		}
+		exprs = append(exprs, next)
+	}
+
+	return &ast.Block{
+		Exprs: exprs,
+		Pos:   startPos,
+	}
+}
+
+// peekIsDeclBoundary reports whether the peek token begins a new top-level
+// declaration, which ends the current equation-form body (M-SYNTAX-AI-FORGIVING R1).
+//
+// Boundary = `export | type | import | extern | @ (annotation) | EOF`, or `func` /
+// `pure` that begins a NAMED declaration (`func IDENT` / `pure func`). A bare
+// `func (` (or `func [`) is an anonymous-function EXPRESSION and is NOT a boundary
+// — it stays inside the body (M-TAINT guard against cutting a funclit argument).
+func (p *Parser) peekIsDeclBoundary() bool {
+	switch p.peekToken.Type {
+	case lexer.EXPORT, lexer.TYPE, lexer.IMPORT, lexer.EXTERN, lexer.AT, lexer.EOF:
+		return true
+	case lexer.PURE:
+		// `pure func ...` is a declaration; a bare `pure` is not a valid expr start
+		// here, so treating it as a boundary is safe and matches top-level dispatch.
+		return true
+	case lexer.FUNC:
+		// `func IDENT ...` is a named declaration boundary; `func (`/`func [` is an
+		// anonymous-function expression that must remain inside the body.
+		return p.peek2TokenIs(lexer.IDENT)
+	default:
+		return false
 	}
 }
 

--- a/internal/parser/parser_func.go
+++ b/internal/parser/parser_func.go
@@ -342,17 +342,24 @@ func (p *Parser) parseFunctionBody() ast.Expr {
 		exprs = append(exprs, expr)
 	}
 
-	// Continue parsing while we see semicolons
-	for p.peekTokenIs(lexer.SEMICOLON) {
-		p.nextToken() // move to SEMICOLON
+	// Continue parsing while statements are separated by `;` OR (R2) by a newline
+	// before a statement-starting token. See peekStartsNewlineBlockStatement.
+	for p.peekTokenIs(lexer.SEMICOLON) || p.peekStartsNewlineBlockStatement() {
+		if p.peekTokenIs(lexer.SEMICOLON) {
+			p.nextToken() // move to SEMICOLON
 
-		// Check for trailing semicolon (next token is RBRACE)
-		// Don't advance past it so caller can consume the RBRACE
-		if p.peekTokenIs(lexer.RBRACE) {
-			break
+			// Check for trailing semicolon (next token is RBRACE)
+			// Don't advance past it so caller can consume the RBRACE
+			if p.peekTokenIs(lexer.RBRACE) {
+				break
+			}
+
+			p.nextToken() // move past SEMICOLON
+		} else {
+			// R2 soft separator: no `;` to consume — the newline before the next
+			// statement-starter IS the separator. Advance onto that starter.
+			p.nextToken()
 		}
-
-		p.nextToken() // move past SEMICOLON
 
 		expr = p.parseExpression(LOWEST)
 		if expr != nil {
@@ -370,6 +377,25 @@ func (p *Parser) parseFunctionBody() ast.Expr {
 		Exprs: exprs,
 		Pos:   startPos,
 	}
+}
+
+// peekStartsNewlineBlockStatement reports whether the peek token begins a new block
+// statement that is separated from the current statement by a NEWLINE (rather than a
+// `;`). This is M-SYNTAX-AI-FORGIVING R2: a newline is accepted as a soft statement
+// separator inside `{ }` blocks, the form small models naturally write.
+//
+// It is deliberately conservative — it requires BOTH:
+//   - peek is on a LATER line than cur (`p.peekToken.Line > p.curToken.Line`), the
+//     same line-awareness the M-GAP2 LPAREN fix uses; AND
+//   - peek is an unambiguous statement-starter (let/letrec/if/match/identifier), via
+//     peekStartsBlockStatement.
+//
+// Because operators, literals, `(`, etc. are NOT statement-starters, a multi-line
+// expression (`= 1\n+ 2`, `{ 1\n+ 2 }`) is never split. Same-line adjacency
+// (`{ let x = 1 let y = 2 }`) fails the line check and still yields the PAR020
+// "missing ;" error at the guard sites.
+func (p *Parser) peekStartsNewlineBlockStatement() bool {
+	return p.peekToken.Line > p.curToken.Line && p.peekStartsBlockStatement()
 }
 
 // parseEquationBody parses the body of an equation-form function (`func f() = ...`).

--- a/internal/parser/parser_literals.go
+++ b/internal/parser/parser_literals.go
@@ -502,15 +502,19 @@ func (p *Parser) parseRecordLiteral() ast.Expr {
 		// for the outer block's `}`. Resulting bug: `{ stmt; {a:1} }` parsed as
 		// the inner record-only block, leaving the outer `}` unconsumed and the
 		// caller (e.g. if-then-else) failing to find its `else` token.
-		for p.peekTokenIs(lexer.SEMICOLON) {
-			p.nextToken() // move to SEMICOLON
-
-			// Trailing semicolon support: `{ a; b; }`
-			if p.peekTokenIs(lexer.RBRACE) {
-				break
+		// R2 (M-SYNTAX-AI-FORGIVING): a newline before a statement-starter is a soft
+		// separator too, not only `;` (peekStartsNewlineBlockStatement, parser_func.go).
+		for p.peekTokenIs(lexer.SEMICOLON) || p.peekStartsNewlineBlockStatement() {
+			if p.peekTokenIs(lexer.SEMICOLON) {
+				p.nextToken() // move to SEMICOLON
+				// Trailing semicolon support: `{ a; b; }`
+				if p.peekTokenIs(lexer.RBRACE) {
+					break
+				}
+				p.nextToken() // move past SEMICOLON to the next expression
+			} else {
+				p.nextToken() // R2: newline separator — advance onto the next statement
 			}
-
-			p.nextToken() // move past SEMICOLON to the next expression
 			expr := p.parseExpression(LOWEST)
 			block.Exprs = append(block.Exprs, expr)
 		}
@@ -537,6 +541,13 @@ func (p *Parser) parseRecordLiteral() ast.Expr {
 			if p.peekTokenIs(lexer.SEMICOLON) {
 				p.nextToken() // move to SEMICOLON
 				p.nextToken() // move past SEMICOLON
+				continue
+			}
+
+			// R2 (M-SYNTAX-AI-FORGIVING): a newline before a statement-starter is a
+			// soft separator — advance onto the next statement and continue.
+			if p.peekStartsNewlineBlockStatement() {
+				p.nextToken()
 				continue
 			}
 

--- a/internal/parser/syntax_ai_forgiving_test.go
+++ b/internal/parser/syntax_ai_forgiving_test.go
@@ -1,0 +1,183 @@
+package parser
+
+// Tests for M-SYNTAX-AI-FORGIVING: the parser accepts the two statement-separator
+// forms small models naturally write, eliminating the PAR017/PAR020 parse-failure
+// class without changing the model.
+//
+//   R1 — `;`-separated statement sequences in `=` function bodies.
+//   R2 — a newline as a soft statement separator inside `{ }` blocks.
+//
+// Both are additive and backward-compatible: no currently-valid program changes
+// meaning (proven structurally here and in corpus_astdiff_test.go).
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/sunholo-data/ailang/internal/ast"
+	"github.com/sunholo-data/ailang/internal/lexer"
+)
+
+// ignorePos ignores all positional data so two ASTs can be compared purely
+// structurally (an `=`-body and a `{ }`-body differ only in columns/spans).
+var ignorePos = cmpopts.IgnoreTypes(ast.Pos{}, ast.Span{})
+
+// parseOK parses input, fails the test on any parse error, and returns the File.
+func parseOK(t *testing.T, input string) *ast.File {
+	t.Helper()
+	p := New(lexer.New(input, "test://unit"))
+	prog := p.Parse()
+	if errs := p.Errors(); len(errs) > 0 {
+		t.Fatalf("unexpected parse errors for %q:\n%v", input, errs)
+	}
+	if prog == nil || prog.File == nil {
+		t.Fatalf("nil program/file for %q", input)
+	}
+	return prog.File
+}
+
+// funcBody returns the body of the first FuncDecl in the file.
+func funcBody(t *testing.T, f *ast.File) ast.Expr {
+	t.Helper()
+	if len(f.Funcs) == 0 {
+		t.Fatalf("no function declarations in file")
+	}
+	return f.Funcs[0].Body
+}
+
+// --- R1: `;`-sequences in `=` function bodies ---------------------------------
+
+// TestR1_EqBodyMatchesBracedBody is the core structural guarantee: an `=`-body
+// `;`-sequence produces the SAME AST as the equivalent braced `{ }` body, so
+// elaboration and typing are unchanged.
+func TestR1_EqBodyMatchesBracedBody(t *testing.T) {
+	cases := []struct {
+		name  string
+		eq    string
+		brace string
+	}{
+		{
+			"near_miss_let_seq",
+			"func g() -> int = let x = 5; x + 1",
+			"func g() -> int { let x = 5; x + 1 }",
+		},
+		{
+			"three_stmt_seq",
+			"func g() = let a = 1; let b = 2; a + b",
+			"func g() { let a = 1; let b = 2; a + b }",
+		},
+		{
+			"validate_version_shape",
+			`pure func validateVersion(v: string) -> bool = let parts = split(v, "."); length(parts) == 3`,
+			`pure func validateVersion(v: string) -> bool { let parts = split(v, "."); length(parts) == 3 }`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			eqBody := funcBody(t, parseOK(t, tc.eq))
+			brBody := funcBody(t, parseOK(t, tc.brace))
+			if diff := cmp.Diff(brBody, eqBody, ignorePos); diff != "" {
+				t.Errorf("=-body AST differs from braced-body AST (-brace +eq):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestR1_MultiStmtIsBlock confirms a multi-statement `=`-body parses as an
+// N-expression Block (not a single expression).
+func TestR1_MultiStmtIsBlock(t *testing.T) {
+	body := funcBody(t, parseOK(t, "func g() = let a = 1; let b = 2; a + b"))
+	block, ok := body.(*ast.Block)
+	if !ok {
+		t.Fatalf("expected *ast.Block, got %T", body)
+	}
+	if len(block.Exprs) != 3 {
+		t.Fatalf("expected 3 exprs in block, got %d", len(block.Exprs))
+	}
+}
+
+// TestR1_SingleExprUnchanged is the regression guard: a single-expression
+// `=`-body still parses as a 1-expr Block (identical to pre-R1 behaviour).
+func TestR1_SingleExprUnchanged(t *testing.T) {
+	body := funcBody(t, parseOK(t, "func g() = x * 2"))
+	block, ok := body.(*ast.Block)
+	if !ok {
+		t.Fatalf("expected *ast.Block (1-expr wrapper), got %T", body)
+	}
+	if len(block.Exprs) != 1 {
+		t.Fatalf("expected 1 expr in block, got %d", len(block.Exprs))
+	}
+	if _, ok := block.Exprs[0].(*ast.BinaryOp); !ok {
+		t.Fatalf("expected BinaryOp body, got %T", block.Exprs[0])
+	}
+}
+
+// TestR1_DeclBoundaries verifies the `=`-body sequence ends at the right
+// top-level declaration boundary, producing the correct number of decls.
+func TestR1_DeclBoundaries(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		wantFuncs int
+		wantDecls int // Funcs + type/other decls in file.Decls
+	}{
+		// back-to-back function decls (no `;`): body of f ends at `func g`.
+		{"back_to_back_no_semi", "func f() = 1\nfunc g() = 2", 2, 2},
+		// back-to-back with a trailing `;`: `func g` is still the boundary.
+		{"back_to_back_trailing_semi", "func f() = 1;\nfunc g() = 2", 2, 2},
+		// body followed by `export func`: body ends at `export`.
+		{"export_boundary", "func f() = 1\nexport func g() = 2", 2, 2},
+		// body followed by a type declaration.
+		{"type_boundary", "func f() = 1\ntype T = int", 1, 2},
+		// body at EOF.
+		{"eof_boundary", "func f() = let x = 1; x", 1, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := parseOK(t, tc.input)
+			if len(f.Funcs) != tc.wantFuncs {
+				t.Errorf("funcs: got %d, want %d", len(f.Funcs), tc.wantFuncs)
+			}
+			if len(f.Decls) != tc.wantDecls {
+				t.Errorf("decls: got %d, want %d", len(f.Decls), tc.wantDecls)
+			}
+		})
+	}
+}
+
+// TestR1_FuncLitInBody is the M-TAINT guard: an anonymous-function expression
+// `func ( ... )` inside a call in the `=`-body must NOT be cut at `func(`.
+func TestR1_FuncLitInBody(t *testing.T) {
+	f := parseOK(t, "func f() -> int = g(func(x) -> int { x + 1 }, xs)")
+	if len(f.Funcs) != 1 {
+		t.Fatalf("expected 1 func (funclit stays inside body), got %d", len(f.Funcs))
+	}
+	body := funcBody(t, f)
+	// Body is a single-expr Block wrapping the whole call.
+	block, ok := body.(*ast.Block)
+	if !ok || len(block.Exprs) != 1 {
+		t.Fatalf("expected single-expr Block wrapping the call, got %T", body)
+	}
+	if _, ok := block.Exprs[0].(*ast.FuncCall); !ok {
+		t.Fatalf("expected the call FuncCall as the body, got %T", block.Exprs[0])
+	}
+}
+
+// TestR1_BackslashLambdaInBody: a backslash-lambda argument parses in the body.
+func TestR1_BackslashLambdaInBody(t *testing.T) {
+	parseOK(t, `func f() = map(\x. x * 2, xs)`)
+}
+
+// TestR1_OperatorLineContinuation: `= 1\n+ 2` is ONE expression (operator is not
+// a statement start), unchanged by R1.
+func TestR1_OperatorLineContinuation(t *testing.T) {
+	body := funcBody(t, parseOK(t, "func f() = 1\n+ 2"))
+	block, ok := body.(*ast.Block)
+	if !ok || len(block.Exprs) != 1 {
+		t.Fatalf("expected single-expr Block (operator continuation), got %T", body)
+	}
+	if _, ok := block.Exprs[0].(*ast.BinaryOp); !ok {
+		t.Fatalf("expected BinaryOp (1 + 2), got %T", block.Exprs[0])
+	}
+}

--- a/internal/parser/syntax_ai_forgiving_test.go
+++ b/internal/parser/syntax_ai_forgiving_test.go
@@ -181,3 +181,134 @@ func TestR1_OperatorLineContinuation(t *testing.T) {
 		t.Fatalf("expected BinaryOp (1 + 2), got %T", block.Exprs[0])
 	}
 }
+
+// --- R2: newline-as-soft-separator in `{ }` blocks ----------------------------
+
+// errsHaveCode reports whether any of errs is a *ParserError with the given code.
+func errsHaveCode(errs []error, code string) bool {
+	for _, e := range errs {
+		if pe, ok := e.(*ParserError); ok && pe.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+// TestR2_NewlineMatchesSemicolon: a newline-separated block produces the SAME AST
+// as the `;`-separated block, across all three block-parsing paths.
+//
+//	parseFunctionBody       — `func f() { ... }`
+//	parseBlockOrExpression  — typed funclit body / match-case body
+//	parseRecordLiteral      — `{ }` in expression position (if/then blocks, \-lambda)
+func TestR2_NewlineMatchesSemicolon(t *testing.T) {
+	cases := []struct {
+		name    string
+		newline string
+		semi    string
+	}{
+		{
+			"func_body",
+			"func f(s) { let n = length(s)\n countOccurrences(s, \".\") }",
+			"func f(s) { let n = length(s); countOccurrences(s, \".\") }",
+		},
+		{
+			"if_then_block", // parseRecordLiteral else-block path (D6 systemic-fix proof)
+			"func f(x) { if x > 0 then { let a = x\n a + 1 } else { 0 } }",
+			"func f(x) { if x > 0 then { let a = x; a + 1 } else { 0 } }",
+		},
+		{
+			"typed_funclit_body", // parseBlockOrExpression path
+			"func f() { g(func(x) -> int { let y = x\n y * 2 }) }",
+			"func f() { g(func(x) -> int { let y = x; y * 2 }) }",
+		},
+		{
+			"backslash_lambda_body", // parseRecordLiteral IDENT-first / else path
+			"func f() = (\\x. { let a = x\n a + 1 })(3)",
+			"func f() = (\\x. { let a = x; a + 1 })(3)",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			nl := funcBody(t, parseOK(t, tc.newline))
+			sc := funcBody(t, parseOK(t, tc.semi))
+			if diff := cmp.Diff(sc, nl, ignorePos); diff != "" {
+				t.Errorf("newline-block AST differs from ;-block AST (-semi +newline):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestR2_MixedSeparators: a block mixing `;` and newline separators parses.
+func TestR2_MixedSeparators(t *testing.T) {
+	body := funcBody(t, parseOK(t, "func f() { let a = 1; let b = 2\n let c = 3; a + b + c }"))
+	block, ok := body.(*ast.Block)
+	if !ok || len(block.Exprs) != 4 {
+		t.Fatalf("expected 4-expr Block, got %T (%d exprs)", body, blockLen(body))
+	}
+}
+
+// TestR2_SingleExprBlockUnchanged: a single-expression block is not falsely split.
+func TestR2_SingleExprBlockUnchanged(t *testing.T) {
+	body := funcBody(t, parseOK(t, "func f() { x * 2 }"))
+	if _, ok := body.(*ast.BinaryOp); !ok {
+		t.Fatalf("expected bare BinaryOp (single-expr block unwrapped), got %T", body)
+	}
+}
+
+// TestR2_MultiLineRecordStillRecord: a comma-separated multi-line record literal
+// and record update still parse as records — the newline rule never reaches a
+// record body (up-front record detection stays ahead of the block loop).
+func TestR2_MultiLineRecordStillRecord(t *testing.T) {
+	// Record literal spanning lines (comma-separated).
+	f := parseOK(t, "func f() { let r = { name: \"a\",\n age: 2 } in r }")
+	_ = f
+	// Record update spanning lines.
+	parseOK(t, "func g(base) { let r = { base | x: 1,\n y: 2 } in r }")
+}
+
+// TestR2_MatchArmsUnaffected: a multi-line match inside a block keeps comma-
+// separated arms (the match arm list is not the block statement loop).
+func TestR2_MatchArmsUnaffected(t *testing.T) {
+	parseOK(t, "func f(x) { match x {\n Some(v) => v,\n None => 0\n } }")
+}
+
+// TestR2_OperatorLineContinuationInBlock: `{ 1\n+ 2 }` is one expression (operator
+// is not a statement-starter), never split — matches the documented `= 1\n+ 2` rule.
+func TestR2_OperatorLineContinuationInBlock(t *testing.T) {
+	// Pure operator continuation: one expression.
+	body := funcBody(t, parseOK(t, "func f() { 1\n+ 2 }"))
+	if _, ok := body.(*ast.BinaryOp); !ok {
+		t.Fatalf("expected single BinaryOp (operator continuation not split), got %T", body)
+	}
+	// A statement then an operator-continued expression: 2 statements, the 2nd whole.
+	body2 := funcBody(t, parseOK(t, "func f() { let a = 1\n a + 2 }"))
+	block, ok := body2.(*ast.Block)
+	if !ok || len(block.Exprs) != 2 {
+		t.Fatalf("expected 2-expr Block, got %T", body2)
+	}
+}
+
+// TestR2_SameLineNoSemicolonStillPAR020: the actionable "missing ;" error is
+// preserved for the genuine same-line-no-`;` case (line-check false), at BOTH the
+// funcbody guard and the block-expression guard.
+func TestR2_SameLineNoSemicolonStillPAR020(t *testing.T) {
+	cases := []string{
+		"func f() { let x = 1 let y = 2 }",                       // parseFunctionBody guard
+		"func f() { g(func(z) -> int { let a = 1 let b = 2 }) }", // parseBlockOrExpression guard
+	}
+	for _, src := range cases {
+		p := New(lexer.New(src, "test://unit"))
+		p.Parse()
+		if !errsHaveCode(p.Errors(), "PAR020") {
+			t.Errorf("expected PAR020 for same-line-no-; %q, got: %v", src, p.Errors())
+		}
+	}
+}
+
+// blockLen returns the number of exprs if e is a Block, else -1 (test diagnostics).
+func blockLen(e ast.Expr) int {
+	if b, ok := e.(*ast.Block); ok {
+		return len(b.Exprs)
+	}
+	return -1
+}

--- a/prompts/agent/dialect-traps.md
+++ b/prompts/agent/dialect-traps.md
@@ -8,13 +8,15 @@ obey these. They are the exact mistakes that break AILANG solutions:
    `nth(xs, 0)` (returns `Option`) or pattern-match `match xs { [x, ...rest] => ... }`.
    `import std/list (nth, head)`.
 
-2. **`=`-body holds ONE expression — no `let x = ...;` after `=`.** The reflex
-   `func f() -> T = let x = e; rest` is the single most common failure here. Fix it
-   one of two ways:
-   - **brace block** (drop the `=`): `func f() -> T { let x = e; rest }` — `;` is legal here
-   - **let-in** (keep the `=`): `func f() -> T = let x = e in rest`
-   `;` is valid ONLY inside `{ }`. For recursion use a named top-level `func` (there is
-   no top-level `let rec`).
+2. **Statement separators are forgiving (v0.29+).** All of these now parse and mean
+   the same thing — write whichever is natural:
+   - `;`-sequence in a `=`-body: `func f() -> T = let x = e; rest`
+   - brace block: `func f() -> T { let x = e; rest }` (`;` OR a **newline** separates
+     statements: `{ let x = e\n rest }` also works)
+   - let-in: `func f() -> T = let x = e in rest`
+   A `;` is still the last-statement rule: the block's/`=`-body's **final** expression
+   is the return value — no `;` after it. For recursion use a named top-level `func`
+   (there is no top-level `let rec`).
 
 3. **`match x { Pat => expr, ... }`** — NOT `match x with` (that's Haskell/OCaml).
    Arms use `=>` and are separated by **commas**.


### PR DESCRIPTION
## Summary

Mission iteration 9 (queue #10, bar v2 clause 3). The parser now **accepts the two statement-separator forms small models naturally write**, eliminating the PAR017/PAR020 parse-failure class (~32% of small-model failures, directional) without changing the model:

- **R1** — `;`-separated statement sequences in `=` function bodies (`func f() = s1; s2; e`) → kills **PAR017**
- **R2** — newline as a soft statement separator inside `{ }` blocks → narrows **PAR020** to the genuine same-line-no-`;` case (actionable error preserved)

Both additive + backward-compatible: **corpus AST-diff fuzz gate = zero re-parse diffs over all 389 currently-valid `.ail` files** (400-file corpus, `AILANG_CORPUS_FUZZ=1`, old parser built from pinned base via temp git worktree + new `cmd/astdump` dumper).

**Systemic fix beyond the plan**: R2 patched **four** block statement-loops, not the planned two — `if/then` blocks and `\`-lambda bodies route through `parseRecordLiteral`'s block paths, which the plan (D6) missed; the plan's own if/then fixture caught it.

## Evaluation (Fable, independent)

**PASS 96/100 round 1** — evaluator re-ran the fuzz gate from scratch, rebuilt the binary from worktree sources, re-produced all acceptance transcripts (R1/R2 accept; same-line-no-`;` still PAR020; comma-less records error as records, never statement-split), and proved non-vacuity (v0.29.2-2-g07aa1062f emits PAR017/PAR020 on the exact fixtures this branch accepts). Sole `make test` red = known flake #338, non-regression proven 4/4 standalone. `verify-examples` 183/5/5 — failures exactly = pre-existing issue #341 set; +1 pass is the new gated example.

Deferred (per plan): `ailang fmt` → `m-ailang-fmt.md` stub (D1); rig A/B compile_error Δ = post-merge GPU step for the mission controller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)