### PR TITLE
feat(stdlib): std/net URL parsing — parseUrl + parseQuery (m-stdlib-url-parse)

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -30,6 +30,35 @@
   `examples/regex_log_orchestration.ail` (the orchestration use case — parse +
   route structured log/LLM lines).
 
+### Added — `std/net`: RFC-3986 URL parsing (`parseUrl` / `parseQuery`) (M-STDLIB-URL-PARSE)
+
+- `std/net` gains two **pure** URL-parsing functions backed by Go's `net/url`
+  (the reference RFC-3986 parser) — the *inverse complement* of the existing
+  `urlEncode`/`urlEncodeForm`. This closes the **URL-parse half** of the v1.0
+  orchestration bar (clause 4); the regex half shipped alongside (above).
+- `parseUrl(s) -> Result[Url, string]` splits a URL into a flat record
+  `Url = {scheme, host, port, path, query, fragment : string}`. `port` is `""`
+  when absent (Go `url.Port()` semantics — no `-1`/`0` sentinel); `host` is the
+  hostname only (no port, **no brackets for IPv6**: `http://[::1]:80/` →
+  `host="::1"`); `path`/`fragment` are percent-decoded; `query` is the raw
+  substring after `?` (still encoded — feed to `parseQuery`). Malformed input
+  (invalid `%`-escape, control char, bad port) returns `Err(message)`, **never a
+  panic** (CP2) — one fallible boundary, the record fields are then total.
+- `parseQuery(s) -> [{name, value}]` decodes a query string into
+  order-preserving `{name,value}` pairs (values percent-**DECODED**) — the inverse
+  of `urlEncodeForm`. Deliberately **not** Go's `url.ParseQuery` (a sorted map):
+  it parses the raw string to **preserve source order and duplicate keys**
+  (`a=1&a=2` → two entries). A bare key (`flag`) → `{name:"flag", value:""}`;
+  the empty string → `[]`. Total — never fails.
+- Both `pure` (`! {}`, `IsPure: true`) — **no `Net` capability** despite living in
+  `std/net` (parsing reaches no network); usable in contracts and pure code.
+  `parseQuery(urlEncodeForm(pairs))` round-trips (modulo `urlEncodeForm`'s
+  alphabetical key sort). Axiom net **+8**.
+- Examples: `examples/url_parse_basics.ail` (parse + all six fields),
+  `examples/url_route_dispatch.ail` (the orchestration use case — route on host,
+  dispatch on path, branch on a query param).
+- Design: [`m-stdlib-url-parse.md`](../design_docs/planned/v0_30_0/m-stdlib-url-parse.md).
+
 ### Added — Forgiving statement separators: newline-as-soft-separator in blocks (M-SYNTAX-AI-FORGIVING R2)
 
 - A **newline** before a statement-starter (`let` / `letrec` / `if` / `match` /

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -71,6 +71,13 @@ Single-expression branches don't need braces. See the
 - **String interpolation** — `"Value: ${x}"` → `Value: 42` (v0.12.1); `++` is now list-only
   (string `++` is a type error, v0.13.0).
 - **Pattern guards** — `match x { n if n > 100 => …, n if n > 0 => …, _ => … }` (v0.6.2).
+- **URL parsing** (v0.30.0, M-STDLIB-URL-PARSE) — `std/net` now parses URLs, not just builds them.
+  `parseUrl(s) -> Result[Url, string]` splits a URL into `{scheme, host, port, path, query, fragment}`
+  (RFC-3986, backed by Go `net/url`; `Err` on malformed input, never a panic), and
+  `parseQuery(s) -> [{name, value}]` decodes a query string into order-preserving, percent-decoded
+  pairs (the inverse of `urlEncodeForm`). Both **pure** — no `Net` capability. Previously an author
+  had to hand-roll a `std/string.split` chain (order-sensitive, RFC-ignorant); that workaround is no
+  longer needed.
 
 ## Reporting New Limitations
 

--- a/docs/docs/reference/stability.md
+++ b/docs/docs/reference/stability.md
@@ -102,6 +102,7 @@ May change in a 1.x minor with a CHANGELOG entry.
 | `std/ai` | AI as a typed effect (`call`, `callJson`, `step`) | surface still evolving with the agent loop |
 | `std/ai/streaming` | Streaming AI responses | new; narrow usage |
 | `std/net` | Network operations | ⚠ proposed — widely used (13 examples) but security/format-sensitive; held Experimental pending a network-surface review |
+| `std/net` — `parseUrl` / `parseQuery` | Pure RFC-3986 URL parsing (URL → `Url` record; query string → `{name,value}` pairs) | new (v0.30.0); pure, no `Net` capability; `Url` record shape may evolve; `parseQuery` is order-preserving (deliberately not Go's sorted `url.ParseQuery`) |
 | `std/stream` | Async stream sources / `selectEvents` | concurrency-adjacent; evolving |
 | `std/secret` | Gated secret resolution (M-SECRET-EFFECT, v0.26.0) | new effect (v0.26.0) |
 | `std/cognition` | Cognitive-OS message fabric (M-COG-RUNTIME) | named Experimental in design doc |

--- a/examples/url_parse_basics.ail
+++ b/examples/url_parse_basics.ail
@@ -1,0 +1,36 @@
+-- url_parse_basics.ail — take a URL apart with std/net.parseUrl / parseQuery
+--
+-- parseUrl splits an RFC-3986 URL into scheme/host/port/path/query/fragment.
+-- parseQuery decodes the query string into order-preserving {name,value} pairs.
+-- Both are PURE (no Net capability) — they reach no network, they just parse.
+--
+-- Run: ailang run --caps IO --entry main examples/url_parse_basics.ail
+
+module examples/url_parse_basics
+
+import std/net (parseUrl, parseQuery)
+import std/result (Result, Ok, Err)
+import std/list (nth_or)
+import std/io (println)
+
+export func main() -> () ! {IO} {
+  match parseUrl("https://user@api.example.com:8443/v1/users?q=hello%20world&r=2#top") {
+    Err(e) => println("bad url: ${e}"),
+    Ok(u) => {
+      -- Direct .field access on the Url record — no accessor boilerplate.
+      println("scheme:   ${u.scheme}");     -- https
+      println("host:     ${u.host}");       -- api.example.com  (no userinfo, no port)
+      println("port:     ${u.port}");       -- 8443
+      println("path:     ${u.path}");       -- /v1/users
+      println("query:    ${u.query}");      -- q=hello%20world&r=2  (raw, still encoded)
+      println("fragment: ${u.fragment}");   -- top
+
+      -- Decode the query into {name,value} pairs (values percent-DECODED).
+      let params = parseQuery(u.query);
+      let q = nth_or(params, 0, {name: "", value: ""});
+      let r = nth_or(params, 1, {name: "", value: ""});
+      println("param 0:  ${q.name}=${q.value}");   -- q=hello world
+      println("param 1:  ${r.name}=${r.value}")     -- r=2
+    }
+  }
+}

--- a/examples/url_route_dispatch.ail
+++ b/examples/url_route_dispatch.ail
@@ -1,0 +1,47 @@
+-- url_route_dispatch.ail — the orchestration use case for std/net URL parsing
+--
+-- Step zero of consuming any redirect / webhook / link: parse the URL, then
+-- ROUTE on the host, DISPATCH on the path, and BRANCH on a query param — instead
+-- of a hand-rolled std/string.split chain that mishandles ://, ? vs #, and :port.
+--
+-- Run: ailang run --caps IO --entry main examples/url_route_dispatch.ail
+
+module examples/url_route_dispatch
+
+import std/net (parseUrl, parseQuery)
+import std/result (Result, Ok, Err)
+import std/list (nth_or)
+import std/io (println)
+
+-- Read a single query parameter's value by name, or a default if absent.
+-- Linear scan over the {name,value} list (parseQuery's primitive shape).
+export func getParam(pairs: [{name: string, value: string}], key: string, dflt: string) -> string {
+  match pairs {
+    [] => dflt,
+    [p, ...rest] => if p.name == key then p.value else getParam(rest, key, dflt)
+  }
+}
+
+-- Route a parsed request URL to a handler label based on host + path + a param.
+export func route(u: {scheme: string, host: string, port: string, path: string, query: string, fragment: string}) -> string {
+  let params = parseQuery(u.query);
+  let fmt = getParam(params, "fmt", "html");
+  if u.host == "api.example.com"
+  then if u.path == "/v1/users"
+       then "handler: users-api (fmt=${fmt})"
+       else "handler: api-fallback (${u.path})"
+  else "handler: web (${u.host}${u.path})"
+}
+
+export func dispatch(rawUrl: string) -> () ! {IO} {
+  match parseUrl(rawUrl) {
+    Err(e) => println("reject: ${e}"),
+    Ok(u)  => println("${rawUrl}\n  -> ${route(u)}")
+  }
+}
+
+export func main() -> () ! {IO} {
+  dispatch("https://api.example.com:8443/v1/users?id=42&fmt=json");
+  dispatch("https://api.example.com/v1/orders?id=7");
+  dispatch("https://docs.example.com/guide/intro#start")
+}

--- a/internal/builtins/net.go
+++ b/internal/builtins/net.go
@@ -18,6 +18,8 @@ func init() {
 	registerNetHTTPRequestBytes()
 	registerNetURLEncode()
 	registerNetURLEncodeForm()
+	registerNetURLParse()
+	registerNetURLParseQuery()
 }
 
 // registerNetHTTPRequest registers the _net_httpRequest builtin
@@ -323,6 +325,210 @@ func netURLEncodeFormImpl(_ *effects.EffContext, args []eval.Value) (eval.Value,
 		values.Add(nameStr.Value, valueStr.Value)
 	}
 	return &eval.StringValue{Value: values.Encode()}, nil
+}
+
+// registerNetURLParse registers the _net_url_parse builtin.
+// Parses an RFC-3986 URL into a Url record (scheme/host/port/path/query/fragment).
+// Backed by Go net/url.Parse — pure, no Net capability. Fallible: Err on malformed input.
+func registerNetURLParse() {
+	err := RegisterEffectBuiltin(BuiltinSpec{
+		Module:  "std/net",
+		Name:    "_net_url_parse",
+		NumArgs: 1,
+		IsPure:  true,
+		Effect:  "",
+		Type:    makeNetURLParseType,
+		Impl:    netURLParseImpl,
+
+		Metadata: &BuiltinMetadata{
+			Description: "Parse an RFC-3986 URL into a {scheme,host,port,path,query,fragment} record",
+			LongDesc: `Parses a URL string into its structured components using Go's net/url
+(the reference RFC-3986 parser). Returns Result[Url, string]: Ok(record) with
+scheme/host/port/path/query/fragment fields, or Err(message) for malformed
+input (control chars, invalid %-escape, bad port) — never a silent fallback.
+
+Fields are all strings. port is "" when absent (Go url.Port() semantics); host
+is the hostname only (no port, no IPv6 brackets); path and fragment are percent-
+DECODED; query is the raw substring after ? (still encoded — feed to parseQuery).
+
+Pure function: no Net capability needed. It reaches no network; it only takes a
+URL apart. The inverse of urlEncode/urlEncodeForm.`,
+			Params: []ParamDoc{
+				{Name: "s", Description: "The URL string to parse"},
+			},
+			Returns: "Result[Url, string] where Url = {scheme, host, port, path, query, fragment : string}",
+			Examples: []Example{
+				{
+					Code:        `_net_url_parse("https://user@host:8443/a/b?q=1#frag")`,
+					Description: `Ok({scheme:"https", host:"host", port:"8443", path:"/a/b", query:"q=1", fragment:"frag"})`,
+				},
+			},
+			SeeAlso:   []string{"_net_url_parse_query", "_net_url_encode", "_net_url_encode_form"},
+			Since:     "v0.30.0",
+			Stability: StabilityExperimental,
+			Tags:      []string{"url", "parse", "http", "web", "orchestration"},
+			Category:  "network",
+		},
+	})
+	if err != nil {
+		panic(fmt.Sprintf("failed to register _net_url_parse: %v", err))
+	}
+}
+
+// makeNetURLParseType: string -> Result[Url, string]
+func makeNetURLParseType() types.Type {
+	T := types.NewBuilder()
+	return T.Func(T.String()).Returns(
+		T.App("Result", urlRecordType(T), T.String()),
+	).Build()
+}
+
+// urlRecordType returns the Url record type:
+// {scheme, host, port, path, query, fragment : string}. All fields are strings.
+func urlRecordType(T *types.Builder) types.Type {
+	return T.Record(
+		types.Field("scheme", T.String()),
+		types.Field("host", T.String()),
+		types.Field("port", T.String()),
+		types.Field("path", T.String()),
+		types.Field("query", T.String()),
+		types.Field("fragment", T.String()),
+	)
+}
+
+// netURLParseImpl parses its argument with net/url.Parse and marshals the
+// *url.URL into a Url RecordValue wrapped in Ok(...). On parse error it returns
+// Err(err.Error()) — no silent fallback on the structural fields (CP2).
+//
+// Field mapping (all decoded string fields — no byte offsets exposed):
+//
+//	scheme   = u.Scheme      ("" if scheme-relative)
+//	host     = u.Hostname()  (no port, no IPv6 brackets)
+//	port     = u.Port()      ("" when absent)
+//	path     = u.Path        (percent-decoded)
+//	query    = u.RawQuery    (raw, still percent-encoded — feed to parseQuery)
+//	fragment = u.Fragment    (decoded; "" when absent)
+func netURLParseImpl(_ *effects.EffContext, args []eval.Value) (eval.Value, error) {
+	s, ok := args[0].(*eval.StringValue)
+	if !ok {
+		return nil, fmt.Errorf("_net_url_parse: expected String, got %T", args[0])
+	}
+	u, err := url.Parse(s.Value)
+	if err != nil {
+		return wrapErr(err.Error()), nil
+	}
+	rec := &eval.RecordValue{
+		Fields: map[string]eval.Value{
+			"scheme":   &eval.StringValue{Value: u.Scheme},
+			"host":     &eval.StringValue{Value: u.Hostname()},
+			"port":     &eval.StringValue{Value: u.Port()},
+			"path":     &eval.StringValue{Value: u.Path},
+			"query":    &eval.StringValue{Value: u.RawQuery},
+			"fragment": &eval.StringValue{Value: u.Fragment},
+		},
+	}
+	return wrapOk(rec), nil
+}
+
+// registerNetURLParseQuery registers the _net_url_parse_query builtin.
+// Parses a query string ("a=1&b=2") into order-preserving {name,value} pairs.
+// Values are percent-DECODED (inverse of urlEncodeForm). Total — never panics.
+func registerNetURLParseQuery() {
+	err := RegisterEffectBuiltin(BuiltinSpec{
+		Module:  "std/net",
+		Name:    "_net_url_parse_query",
+		NumArgs: 1,
+		IsPure:  true,
+		Effect:  "",
+		Type:    makeNetURLParseQueryType,
+		Impl:    netURLParseQueryImpl,
+
+		Metadata: &BuiltinMetadata{
+			Description: "Parse a query string into order-preserving, percent-decoded {name,value} pairs",
+			LongDesc: `Parses a query string ("a=1&b=2") into a list of {name: String, value: String}
+records — the inverse of urlEncodeForm. Values are percent-DECODED.
+
+Unlike Go's url.ParseQuery (which returns a sorted map, lossy for order and
+duplicate keys), this parses the raw string itself: it splits on &, each pair on
+the FIRST =, url.QueryUnescape's both halves, and PRESERVES source order and
+duplicate keys (?a=1&a=2 -> two entries). A bare key (?flag) yields
+{name:"flag", value:""}. An empty string yields []. Total: never panics.
+
+Pure function: no Net capability needed.`,
+			Params: []ParamDoc{
+				{Name: "s", Description: "The query string to parse (the raw substring after ?, no leading ?)"},
+			},
+			Returns: "List[{name: String, value: String}] in source order, values percent-decoded",
+			Examples: []Example{
+				{
+					Code:        `_net_url_parse_query("q=hello%20world&r=2")`,
+					Description: `[{name:"q", value:"hello world"}, {name:"r", value:"2"}]`,
+				},
+			},
+			SeeAlso:   []string{"_net_url_parse", "_net_url_encode_form"},
+			Since:     "v0.30.0",
+			Stability: StabilityExperimental,
+			Tags:      []string{"url", "parse", "query", "http", "web"},
+			Category:  "network",
+		},
+	})
+	if err != nil {
+		panic(fmt.Sprintf("failed to register _net_url_parse_query: %v", err))
+	}
+}
+
+// makeNetURLParseQueryType: string -> List[{name: String, value: String}]
+func makeNetURLParseQueryType() types.Type {
+	T := types.NewBuilder()
+	return T.Func(T.String()).Returns(T.List(httpHeaderType(T))).Build()
+}
+
+// netURLParseQueryImpl parses a raw query string into order-preserving
+// {name,value} records with percent-decoded values. It deliberately does NOT
+// use url.ParseQuery (which sorts and dedups); it splits the raw string to
+// preserve source order and duplicate keys — the inverse of netURLEncodeFormImpl.
+//
+// Rules: empty string -> []; split on "&" (empty segments skipped); each segment
+// on the FIRST "="; both halves url.QueryUnescape'd (best-effort: on decode error
+// the raw half is kept, matching url.ParseQuery leniency, never panics); a bare
+// key with no "=" -> {name:key, value:""}.
+func netURLParseQueryImpl(_ *effects.EffContext, args []eval.Value) (eval.Value, error) {
+	s, ok := args[0].(*eval.StringValue)
+	if !ok {
+		return nil, fmt.Errorf("_net_url_parse_query: expected String, got %T", args[0])
+	}
+	elems := []eval.Value{}
+	if s.Value != "" {
+		for _, pair := range strings.Split(s.Value, "&") {
+			if pair == "" {
+				continue
+			}
+			var rawKey, rawVal string
+			if idx := strings.IndexByte(pair, '='); idx >= 0 {
+				rawKey, rawVal = pair[:idx], pair[idx+1:]
+			} else {
+				rawKey, rawVal = pair, ""
+			}
+			name := queryUnescapeLenient(rawKey)
+			value := queryUnescapeLenient(rawVal)
+			elems = append(elems, &eval.RecordValue{
+				Fields: map[string]eval.Value{
+					"name":  &eval.StringValue{Value: name},
+					"value": &eval.StringValue{Value: value},
+				},
+			})
+		}
+	}
+	return &eval.ListValue{Elements: elems}, nil
+}
+
+// queryUnescapeLenient percent-decodes a query half, falling back to the raw
+// input if decoding fails so the parser stays total (never panics, never errors).
+func queryUnescapeLenient(raw string) string {
+	if decoded, err := url.QueryUnescape(raw); err == nil {
+		return decoded
+	}
+	return raw
 }
 
 // httpResponseType returns the HttpResponse record type with body (string view)

--- a/internal/builtins/net_url_parse_test.go
+++ b/internal/builtins/net_url_parse_test.go
@@ -1,0 +1,240 @@
+package builtins
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/sunholo-data/ailang/internal/eval"
+)
+
+// callURLParse drives netURLParseImpl and returns the resulting TaggedValue
+// (Ok(record) or Err(string)).
+func callURLParse(t *testing.T, s string) *eval.TaggedValue {
+	t.Helper()
+	v, err := netURLParseImpl(nil, []eval.Value{&eval.StringValue{Value: s}})
+	require.NoError(t, err, "_net_url_parse must not return a Go error")
+	tv, ok := v.(*eval.TaggedValue)
+	require.True(t, ok, "_net_url_parse should return a Result TaggedValue, got %T", v)
+	return tv
+}
+
+// unwrapOkURL asserts the parse succeeded and returns the Url field map.
+func unwrapOkURL(t *testing.T, tv *eval.TaggedValue) map[string]string {
+	t.Helper()
+	require.Equal(t, "Ok", tv.CtorName, "expected Ok, got %s", tv.CtorName)
+	require.Len(t, tv.Fields, 1)
+	rec, ok := tv.Fields[0].(*eval.RecordValue)
+	require.True(t, ok, "Ok field should be a RecordValue, got %T", tv.Fields[0])
+	out := map[string]string{}
+	for _, f := range []string{"scheme", "host", "port", "path", "query", "fragment"} {
+		sv, ok := rec.Fields[f].(*eval.StringValue)
+		require.True(t, ok, "field %q should be a StringValue, got %T", f, rec.Fields[f])
+		out[f] = sv.Value
+	}
+	require.Len(t, rec.Fields, 6, "Url record must have exactly 6 fields")
+	return out
+}
+
+// callParseQuery drives netURLParseQueryImpl and returns ordered (name,value) pairs.
+func callParseQuery(t *testing.T, s string) [][2]string {
+	t.Helper()
+	v, err := netURLParseQueryImpl(nil, []eval.Value{&eval.StringValue{Value: s}})
+	require.NoError(t, err, "_net_url_parse_query must not return a Go error")
+	list, ok := v.(*eval.ListValue)
+	require.True(t, ok, "_net_url_parse_query should return a ListValue, got %T", v)
+	out := make([][2]string, 0, len(list.Elements))
+	for i, e := range list.Elements {
+		rec, ok := e.(*eval.RecordValue)
+		require.True(t, ok, "element %d should be a RecordValue, got %T", i, e)
+		name, ok := rec.Fields["name"].(*eval.StringValue)
+		require.True(t, ok, "element %d 'name' should be a StringValue", i)
+		value, ok := rec.Fields["value"].(*eval.StringValue)
+		require.True(t, ok, "element %d 'value' should be a StringValue", i)
+		out = append(out, [2]string{name.Value, value.Value})
+	}
+	return out
+}
+
+func TestNetURLParse_FullURL(t *testing.T) {
+	got := unwrapOkURL(t, callURLParse(t, "https://user@host:8443/a/b?q=1#frag"))
+	assert.Equal(t, "https", got["scheme"])
+	assert.Equal(t, "host", got["host"])
+	assert.Equal(t, "8443", got["port"])
+	assert.Equal(t, "/a/b", got["path"])
+	assert.Equal(t, "q=1", got["query"])
+	assert.Equal(t, "frag", got["fragment"])
+}
+
+func TestNetURLParse_SchemeRelative(t *testing.T) {
+	// "//host/path" has no scheme.
+	got := unwrapOkURL(t, callURLParse(t, "//host/path"))
+	assert.Equal(t, "", got["scheme"])
+	assert.Equal(t, "host", got["host"])
+	assert.Equal(t, "", got["port"])
+	assert.Equal(t, "/path", got["path"])
+}
+
+func TestNetURLParse_NoPort(t *testing.T) {
+	got := unwrapOkURL(t, callURLParse(t, "https://example.com/x"))
+	assert.Equal(t, "example.com", got["host"])
+	assert.Equal(t, "", got["port"], "absent port must be empty string, not a sentinel")
+}
+
+func TestNetURLParse_IPv6Host(t *testing.T) {
+	// Go url.Hostname() strips the [] brackets from an IPv6 literal.
+	got := unwrapOkURL(t, callURLParse(t, "http://[::1]:80/"))
+	assert.Equal(t, "::1", got["host"], "IPv6 host must have no brackets")
+	assert.Equal(t, "80", got["port"])
+	assert.Equal(t, "/", got["path"])
+}
+
+func TestNetURLParse_Userinfo(t *testing.T) {
+	// Userinfo is not exposed as a field; host must not include it.
+	got := unwrapOkURL(t, callURLParse(t, "https://user@host/"))
+	assert.Equal(t, "host", got["host"])
+	assert.Equal(t, "/", got["path"])
+}
+
+func TestNetURLParse_PathOnly(t *testing.T) {
+	got := unwrapOkURL(t, callURLParse(t, "/just/a/path"))
+	assert.Equal(t, "", got["scheme"])
+	assert.Equal(t, "", got["host"])
+	assert.Equal(t, "/just/a/path", got["path"])
+}
+
+func TestNetURLParse_EmptyQueryAndFragment(t *testing.T) {
+	got := unwrapOkURL(t, callURLParse(t, "https://example.com/x"))
+	assert.Equal(t, "", got["query"])
+	assert.Equal(t, "", got["fragment"])
+}
+
+func TestNetURLParse_PathDecoded(t *testing.T) {
+	// u.Path is the decoded path — %20 becomes a space.
+	got := unwrapOkURL(t, callURLParse(t, "https://example.com/a%20b"))
+	assert.Equal(t, "/a b", got["path"])
+}
+
+func TestNetURLParse_QueryRawEncoded(t *testing.T) {
+	// query is RawQuery — still percent-encoded (feed to parseQuery to decode).
+	got := unwrapOkURL(t, callURLParse(t, "https://example.com/?q=hello%20world"))
+	assert.Equal(t, "q=hello%20world", got["query"])
+}
+
+func TestNetURLParse_ErrorNeverPanics(t *testing.T) {
+	// A control char / invalid escape makes url.Parse error. Must be Err, never panic.
+	for _, bad := range []string{"http://%zz", "http://foo\x7f.com", "://noscheme"} {
+		tv := callURLParse(t, bad)
+		if tv.CtorName == "Err" {
+			require.Len(t, tv.Fields, 1)
+			_, ok := tv.Fields[0].(*eval.StringValue)
+			assert.True(t, ok, "Err payload must be a StringValue")
+		}
+		// If Go leniently accepts it (Ok), that is also fine — the point is no panic.
+	}
+	// Assert at least one of these is a genuine Err (invalid %-escape is a hard error).
+	assert.Equal(t, "Err", callURLParse(t, "http://%zz").CtorName)
+}
+
+func TestNetURLParse_RejectsNonString(t *testing.T) {
+	_, err := netURLParseImpl(nil, []eval.Value{&eval.IntValue{Value: 42}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected String")
+}
+
+func TestNetURLParseQuery_PercentDecoded(t *testing.T) {
+	got := callParseQuery(t, "q=hello%20world&r=2")
+	assert.Equal(t, [][2]string{{"q", "hello world"}, {"r", "2"}}, got)
+}
+
+func TestNetURLParseQuery_PlusIsSpace(t *testing.T) {
+	// url.QueryUnescape decodes + as space (form semantics) — round-trips urlEncodeForm.
+	got := callParseQuery(t, "q=hello+world")
+	assert.Equal(t, [][2]string{{"q", "hello world"}}, got)
+}
+
+func TestNetURLParseQuery_OrderPreserved(t *testing.T) {
+	// Deliberately NOT alphabetical — url.ParseQuery would sort; we must not.
+	got := callParseQuery(t, "zeta=1&alpha=2&mu=3")
+	assert.Equal(t, [][2]string{{"zeta", "1"}, {"alpha", "2"}, {"mu", "3"}}, got)
+}
+
+func TestNetURLParseQuery_DuplicateKeys(t *testing.T) {
+	got := callParseQuery(t, "a=1&a=2")
+	assert.Equal(t, [][2]string{{"a", "1"}, {"a", "2"}}, got, "duplicate keys must be kept as separate entries")
+}
+
+func TestNetURLParseQuery_BareKey(t *testing.T) {
+	got := callParseQuery(t, "flag")
+	assert.Equal(t, [][2]string{{"flag", ""}}, got)
+}
+
+func TestNetURLParseQuery_EmptyString(t *testing.T) {
+	got := callParseQuery(t, "")
+	assert.Equal(t, [][2]string{}, got, "empty query string must yield an empty list")
+}
+
+func TestNetURLParseQuery_EmptyValue(t *testing.T) {
+	got := callParseQuery(t, "k=")
+	assert.Equal(t, [][2]string{{"k", ""}}, got)
+}
+
+func TestNetURLParseQuery_EmptyKey(t *testing.T) {
+	got := callParseQuery(t, "=v")
+	assert.Equal(t, [][2]string{{"", "v"}}, got)
+}
+
+func TestNetURLParseQuery_ValueWithEquals(t *testing.T) {
+	// Split on the FIRST '=' only; the rest is part of the value.
+	got := callParseQuery(t, "expr=a=b")
+	assert.Equal(t, [][2]string{{"expr", "a=b"}}, got)
+}
+
+func TestNetURLParseQuery_SkipsEmptySegments(t *testing.T) {
+	got := callParseQuery(t, "a=1&&b=2")
+	assert.Equal(t, [][2]string{{"a", "1"}, {"b", "2"}}, got)
+}
+
+func TestNetURLParseQuery_LenientOnBadEscape(t *testing.T) {
+	// A malformed %-escape must not panic; the raw half is kept.
+	got := callParseQuery(t, "q=%zz")
+	require.Len(t, got, 1)
+	assert.Equal(t, "q", got[0][0])
+	assert.Equal(t, "%zz", got[0][1])
+}
+
+func TestNetURLParseQuery_RejectsNonString(t *testing.T) {
+	_, err := netURLParseQueryImpl(nil, []eval.Value{&eval.IntValue{Value: 42}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected String")
+}
+
+// TestNetURLParseRoundTrip proves parseQuery(urlEncodeForm(pairs)) recovers the
+// pairs (modulo urlEncodeForm's alphabetical key sort).
+func TestNetURLParseRoundTrip(t *testing.T) {
+	encoded := callURLEncodeForm(t,
+		[2]string{"q", "hello world"},
+		[2]string{"n", "42"},
+	)
+	// urlEncodeForm sorts keys: "n=42&q=hello+world".
+	got := callParseQuery(t, encoded)
+	assert.Equal(t, [][2]string{{"n", "42"}, {"q", "hello world"}}, got)
+}
+
+// TestNetURLParse_RegisteredPureNoNetCap asserts both new builtins surface through
+// the registry as PURE with no effect row — usable without the Net capability (CP2 /
+// design success-criterion "no Net capability required").
+func TestNetURLParse_RegisteredPureNoNetCap(t *testing.T) {
+	for _, name := range []string{"_net_url_parse", "_net_url_parse_query"} {
+		t.Run(name, func(t *testing.T) {
+			spec, ok := GetSpec(name)
+			require.True(t, ok, "%s should be registered", name)
+			assert.Equal(t, "std/net", spec.Module)
+			assert.Equal(t, 1, spec.NumArgs)
+			assert.True(t, spec.IsPure, "%s must be pure", name)
+			assert.Equal(t, "", spec.Effect, "%s must have no effect row (no Net capability)", name)
+			require.NotNil(t, spec.Type)
+			require.NotNil(t, spec.Impl)
+		})
+	}
+}

--- a/internal/pipeline/testdata/builtin_types.golden
+++ b/internal/pipeline/testdata/builtin_types.golden
@@ -174,6 +174,8 @@ _net_httpRequest : (string, string, list[{name: string, value: string}], string)
 _net_httpRequestBytes : (string, string, list[{name: string, value: string}], bytes) -> Result[{body: string, bodyBytes: bytes, headers: list[{name: string, value: string}], ok: bool, status: int}, NetError] ! {Net}
 _net_url_encode : string -> string
 _net_url_encode_form : list[{name: string, value: string}] -> string
+_net_url_parse : string -> Result[{fragment: string, host: string, path: string, port: string, query: string, scheme: string}, string]
+_net_url_parse_query : string -> list[{name: string, value: string}]
 _ollama_embed : (string, string) -> list[float] ! {IO}
 _pkg_asset_path : (string, string) -> Result[string, string] ! {FS}
 _process_close_stdin : ProcessHandle -> () ! {Process}

--- a/std/net.ail
+++ b/std/net.ail
@@ -228,3 +228,53 @@ export func urlEncode(s: string) -> string {
 export func urlEncodeForm(params: List[{name: string, value: string}]) -> string {
   _net_url_encode_form(params)
 }
+
+-- A parsed URL as a plain record for direct field access.
+--
+-- `port` is a string ("" when absent, matching Go url.Port()); `host` is the
+-- hostname only (no port, no brackets for IPv6). `path` and `fragment` are
+-- percent-DECODED. `query` is the raw substring after `?` (still percent-encoded
+-- — feed it to parseQuery to decode it into pairs).
+export type Url = {
+  scheme: string,     -- "https"        ("" if the URL is scheme-relative)
+  host: string,       -- "example.com"  (hostname only, no port, no brackets for IPv6)
+  port: string,       -- "8443"         ("" when no explicit port)
+  path: string,       -- "/a/b"         (percent-decoded)
+  query: string,      -- "q=1&r=2"      (raw, still percent-encoded — feed to parseQuery)
+  fragment: string    -- "frag"         (decoded; "" when absent)
+}
+
+-- Parse an RFC-3986 URL into its components (scheme/host/port/path/query/fragment).
+--
+-- Backed by Go's net/url — the reference RFC-3986 parser. Returns Err(message)
+-- for malformed input (control chars, invalid %-escape, bad port) — never a
+-- silent fallback (all record fields are then total).
+--
+-- Pure function: no Net capability needed. It takes a URL apart; it reaches no
+-- network. The inverse of urlEncode/urlEncodeForm.
+--
+-- Example:
+--   match parseUrl("https://api.example.com:8443/v1/users?id=42#top") {
+--     Err(e) => println("bad url: ${e}"),
+--     Ok(u)  => println("${u.host}:${u.port}${u.path}")  -- api.example.com:8443/v1/users
+--   }
+export func parseUrl(s: string) -> Result[Url, string] {
+  _net_url_parse(s)
+}
+
+-- Parse a query string ("a=1&b=2") into order-preserving {name,value} pairs.
+--
+-- Values are percent-DECODED (the inverse of urlEncodeForm). Unlike Go's
+-- url.ParseQuery (a sorted map), this PRESERVES source order and duplicate keys
+-- (`a=1&a=2` yields two entries). A bare key (`flag`) yields
+-- {name:"flag", value:""}. An empty string yields []. Total: never fails.
+--
+-- Pure function: no Net capability needed. Pass a Url's `query` field, or any
+-- raw query string (no leading `?`).
+--
+-- Example:
+--   parseQuery("q=hello%20world&r=2")
+--   -- [{name:"q", value:"hello world"}, {name:"r", value:"2"}]
+export func parseQuery(s: string) -> [{name: string, value: string}] {
+  _net_url_parse_query(s)
+}


### PR DESCRIPTION
Implements design doc `design_docs/planned/v0_30_0/m-stdlib-url-parse.md` (mission queue #12, v1.0 bar clause 4 — orchestration flagship). The URL-parse complement to the shipped regex half (#343) and the existing `urlEncode`/`urlEncodeForm`.

## What
Two **pure** builtins (`IsPure: true`, `Effect: ""`, **no Net capability**) wrapping Go `net/url`, exported from `std/net`:

- `parseUrl(s: string) -> Result[Url, string]` — RFC-3986 parse into a flat `Url` record (`scheme, host, port, path, query, fragment` — all strings). `Err` on malformed input, **never a silent fallback / panic** (CP2). `port` is `""` when absent (Go `url.Port()` semantics — no `0`/`-1` sentinel).
- `parseQuery(s: string) -> [{name, value}]` — order-preserving, duplicate-key-safe, percent-**decoded** inverse of `urlEncodeForm`. Parses the raw string (not Go's sorting `url.ParseQuery`), so `?a=1&a=2` → two entries and round-trips with the encode side.
- `export type Url` in `std/net`.

## Files
- `internal/builtins/net.go` (+206) — 2 builtins, 2 type specs, `urlRecordType` + `queryUnescapeLenient` helpers, `init()` registration.
- `internal/builtins/net_url_parse_test.go` (new, 26 tests) — full/IPv6 `[::1]:80`/no-port/userinfo/error-never-panics/decode/order/dupes/bare-key/empty/purity/round-trip.
- `internal/pipeline/testdata/builtin_types.golden` — regenerated for the 2 new builtins.
- `std/net.ail` (+50) — `Url` type + wrappers.
- `examples/url_parse_basics.ail`, `examples/url_route_dispatch.ail` (new).
- `changelogs/v0.18-current.md`, `docs/LIMITATIONS.md`, `docs/docs/reference/stability.md` (Experimental tier).

## Verification
- `go test ./internal/builtins/... ./internal/pipeline/...` green; new tests non-vacuous, impl functions 100% covered.
- Both examples run (`--caps IO`) with output matching the design doc.
- `golangci-lint run ./internal/builtins/` → 0 issues; `gofmt` clean.
- `make verify-examples` — no new regression (5 pre-existing #341 failures only).
- `make test` green except the pre-existing flaky `TestRunCommand_PipedStdoutFlushesPerLine` (passes 3/3 in isolation; sprint touches zero `cmd/`/stdout code).

Purely additive — namespace-only, zero collisions, existing `std/net` consumers unchanged.

Sprint loop: Opus executor → independent Opus evaluator (round 1: 80/100 FAIL on the stale golden; round 2: golden regenerated → 100/100 PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)