### PR TITLE
docs(mission): record iteration 15 (m-match-xcheck-error-quality LANDED)

### DIFF
--- a/design_docs/v1-mission-log.md
+++ b/design_docs/v1-mission-log.md
@@ -1213,3 +1213,77 @@ scope-params release-gate re-score; frontier-failure validation of the 8 + 4 ske
 triage; rig A/B for m-syntax-ai-forgiving (GPU). Carry forward: %-row + m-record-update-local-resolution
 doc-status re-check; the two dev-health flakies (`PipedStdoutFlushesPerLine`; 5 effect-row example
 failures — candidate dev-health issue, sibling of #341).
+
+## 16 — 2026-07-12 — Iteration 15: m-match-xcheck-error-quality BUILT + LANDED — foreign-ctor errors now enumerate transitively-known constructors
+
+**Picked**: queue #14 `m-match-xcheck-error-quality` (top DOC-READY of the clause-3 accessibility
+cluster; iteration-14's **Next** named it as the cheapest 0.5d starter). A P2 diagnostic-quality
+paper-cut: `MatchForeignConstructorError` correctly names both ADTs + the offending constructor, but
+the `<scrutinee ADT>'s constructors are:` suggestion line was EMPTY when the scrutinee's ADT was
+known only transitively.
+
+**Reality check**: Gate-1 origin-sync caught local dev 4 commits BEHIND origin/dev (`f72313e33` vs
+`363164dab` — iteration 14 had landed via PR #350). Read all mission state from origin. dev CI green
+per-workflow (CI/Build/Docs all success @ 363164dab) — no red outranking the queue. Item REAL and
+UNBUILT: not in `implemented/`, no merged PR. Reproduced live at origin/dev HEAD in a worktree
+(rebuilt binary): a module importing only `std/json`+`std/result` (NOT `std/option`), matching
+`asNumber(jnum(3.0))` with `Ok/Err`, printed `Option's constructors are: ` (empty) while
+`Result's constructors are: Err, Ok` was populated. Design doc's cited code (`lookupADTConstructors`,
+`pipeline_module_imports.go` M-CTOR-AUTO block) verified present; **Option A** chosen per the doc's
+own recommendation.
+
+**Shipped**: full build loop headless in an origin/dev worktree → **PR #352 → squash-merge `5aaaff2ed`**,
+design doc + sprint plan → `implemented/v0_30_0/`.
+- Opus sprint-planner → 2-milestone plan + JSON, with root-cause verified in code (topo-order
+  deps-first compile ⇒ every transitive iface registered in `modLinker.GetLoadedModules()` before the
+  root type-checks) and the `types` cannot import `link` cycle noted (⇒ pass a plain `map[string]string`).
+- Opus executor (worktree, commits `3ded459cc` M1 / `f5498ca0e` M2 / `ecca08b3b` hardening):
+  a **diagnostic-only** `Constructor→ADT` registry (`moduleImports.AllCtorTypes`) built from all
+  loaded ifaces, plumbed via new `SetDiagnosticConstructorTypes`, consulted by `lookupADTConstructors`
+  ONLY when the primary direct/local scan is empty — so it never enters scope. Strengthened the
+  existing function-call repro test to assert `Some`+`None` now appear; non-vacuity proven by
+  disabling the fallback (line reverts to empty). CHANGELOG + doc-move.
+- Independent Opus evaluator: **round-1 PASS 96/100**, no blockers. Re-proved non-vacuity with a
+  BASE origin/dev binary (empty on base, `None, Some` on fix), confirmed `Some` stays uncallable
+  without importing `std/option` (no scope leak — identical on base+fix), confirmed the error-message
+  format string is byte-identical (out-of-scope respected), and that direct/local ctors always win.
+  Two −2 deductions (benign same-name-ctor collision undocumented; scope invariant not locked into
+  CI) → BOTH addressed in the `ecca08b3b` hardening commit (added
+  `TestSchemeImport_DiagnosticRegistryDoesNotLeakIntoScope` + a collision note in the design doc).
+- Gate 3b: PR #352 auto-merge on green required checks; bounded 29-min CI poll observed `CI: completed success` on the PR head (`ecca08b3b`) — the required-check green that gated auto-merge; post-merge dev CI re-running on `5aaaff2ed` at record time.
+  Queue #14 → `[LANDED]`.
+
+**Routing evidence**: model=opus task-class=plan (2-milestone, correct scope, root-cause code-verified
+before planning) rounds=1 corrections=0. model=opus task-class=execute round1-quality=high (clean
+Option-A impl; proactively hardened per the evaluator's two non-blocking deductions) rounds=1
+corrections=0. model=opus task-class=evaluate round1-score=96 rounds=1 (consecutive round-1 pass
+continues). Evaluator-independence caveat holds (Opus judges Opus) — mitigated as before: the
+evaluator built a base-origin/dev binary and independently reproduced the empty-vs-populated delta,
+the scope-non-leak invariant, and the format-unchanged claim; nothing rested on the executor's report.
+
+**Ruled out**:
+- "Bringing transitive constructors into `constructorTypes` would fix the message" — REJECTED by
+  design: that would put `Some`/`None` in scope (auto-import), the doc's explicit out-of-scope
+  hazard. Kept a SEPARATE diagnostic map consulted only for error text.
+- "`types` can reach the linker to enumerate ifaces at error time" — REFUTED: `internal/types` is
+  below `internal/link`; importing it is a cycle. The registry is passed down as a plain
+  `map[string]string` (the doc's "slimmed-down ADT registry").
+- "The strengthened test might be vacuous" — REFUTED twice: executor disabled the fallback (line
+  empty); evaluator ran the identical repro on a base binary (empty) vs fix (`None, Some`).
+
+**Retro lane**: **none** (no skill or process edit). One iteration, zero corrections, clean round-1
+PASS — no ≥2-friction pattern to route. The only friction (local dev 4 commits behind origin/dev) is
+EXACTLY the case Gate 1's origin-sync step already handles, and it worked as designed (caught it
+before any stale-state work) — the process fix from iteration 12/13 is paying off, no further change
+warranted.
+
+**Next**: Iteration 16 — continue the clause-3 accessibility cluster. Remaining DOC-READY/small
+diagnostics: m-dx-json-bool-coercion (0.5d) · m-dx-split-argument-warning (1d). Then the NEW-DOC
+footgun fixes (m-dx-match-hof R4a, m-poly-arith-lambda R4b, m-arity-style-diagnostic R4c) each need
+design-doc-creator first (Conflict Surface mandatory — incl. the error-code + mechanism verification
+gates added iter 14). Also VERIFY-then-route: m-dx-record-cons-pattern, m-dx-tapp-trecord-unification
+(may be ghosts — run the repro FIRST). PARKED for human (cumulative, unchanged): tier-assignment
+ratification (release gate); feedback-gate production ops; haiku causal re-run; scope-params
+release-gate re-score; frontier-failure validation of the 8 + 4 sketches; issue #341 triage; rig A/B
+for m-syntax-ai-forgiving (GPU). Carry forward: %-row + m-record-update-local-resolution doc-status
+re-check; the two dev-health flakies (`PipedStdoutFlushesPerLine`; 5 effect-row example failures).

--- a/design_docs/v1-mission.md
+++ b/design_docs/v1-mission.md
@@ -49,6 +49,23 @@ routing table: while on Opus, evaluation is model-homogeneous (Opus judges Opus)
 available (distinct-model skeptic evaluator) but left off. To go back to Fable EARLY (more quota
 sooner): `rm ~/.ailang/state/mission-model`. To extend Opus: bump the epoch in that file.
 
+## STATUS 2026-07-12 — ITERATION 15: m-match-xcheck-error-quality BUILT + LANDED (queue #14, clause 3 — foreign-ctor errors now enumerate transitively-known constructors)
+
+`MatchForeignConstructorError` used to print an EMPTY `<scrutinee ADT>'s constructors are:` line
+whenever the scrutinee's ADT was known only *transitively* (e.g. `std/json` returns `Option` but the
+module imported only `std/result`). Now it enumerates them (`Option's constructors are: None, Some` +
+a `did you mean` hint). Full build loop headless, round-1 clean: Gate-1 origin-sync caught local dev
+4 commits behind (iter 14 landed via #350) — read state from origin; reproduced the empty line live;
+**Option A** (design doc's recommendation) — a diagnostic-only `Constructor→ADT` registry from all
+transitively-loaded ifaces, consulted only when the primary scan is empty, never entering scope. Opus
+plan → Opus execute (worktree) → independent Opus evaluator **PASS 96/100 round 1**, no blockers
+(base-binary non-vacuity proof + scope-non-leak verified); 2 non-blocking deductions folded into a
+hardening commit (scope-leak regression test + collision note). PR #352 → `5aaaff2ed`, required checks
+green (auto-merge). Design → implemented/v0_30_0. Retro: no skill/process change (clean round-1, the
+sole friction was the already-handled stale-local-dev case). SonarCloud PR gate red = advisory
+(non-required; merge succeeded) — flagged for sonarcloud-triage. Next: m-dx-json-bool-coercion /
+m-dx-split-argument-warning. Detail: log entry 16.
+
 ## STATUS 2026-07-12 — ITERATION 14: m-module-less-run-fail-loud BUILT + LANDED (queue #13, clause 3 — footgun burn-down opened, MOD014)
 
 Module-less `.ail` files (top-level decls, no `module`) now **FAIL LOUDLY** with `MOD014` on both
@@ -530,11 +547,27 @@ with design-doc-creator; existing-doc items start at reality-check.)*
     base-origin/dev binary proving test non-vacuity + pre-existing-failure claims. PR #349 →
     merge `c2ffd1b5c`, post-merge dev CI green per-workflow. Design → implemented/v0_30_0. Module-less
     files now FAIL LOUDLY (CP2). Skill-fix: design-doc-creator error-code + mechanism verification gates)
+14. [LANDED 2026-07-12] m-match-xcheck-error-quality (iteration 15: full build loop headless, round-1
+    clean — Gate-1 origin-sync caught local dev 4 commits behind origin/dev (iter 14 landed via #350),
+    read state from origin; reproduced the empty `Option's constructors are: ` line live at HEAD →
+    **Option A** (design doc's own recommendation): a diagnostic-only `Constructor→ADT` registry
+    (`moduleImports.AllCtorTypes`) built from ALL transitively-loaded ifaces via
+    `modLinker.GetLoadedModules()`, plumbed via new `SetDiagnosticConstructorTypes`, consulted by
+    `lookupADTConstructors` ONLY when the primary direct/local scan is empty — never enters scope
+    (`types` can't import `link` → passed as a plain `map[string]string`). Opus plan → Opus execute
+    (worktree, commits `3ded459cc`/`f5498ca0e`/`ecca08b3b`) → independent Opus evaluator **PASS 96/100
+    round 1** w/ base-binary non-vacuity proof + scope-non-leak + format-unchanged checks; 2
+    non-blocking deductions folded into the hardening commit
+    (`TestSchemeImport_DiagnosticRegistryDoesNotLeakIntoScope` + collision note). PR #352 →
+    squash-merge `5aaaff2ed`, required checks green (auto-merge). Design → implemented/v0_30_0.
+    Foreign-ctor errors now enumerate transitively-known constructors (`None, Some` + did-you-mean).
+    SonarCloud PR gate red = advisory/non-required (merge succeeded) — flagged for sonarcloud-triage)
 **[NEXT]** clause-3 accessibility cluster (the bulk of v1.0). Loop ordering within a group:
 P0/unblockers first, then cheapest impact-per-day → cheapest remaining DOC-READY/small diagnostics:
-m-match-xcheck-error-quality (0.5d) · m-dx-json-bool-coercion (0.5d) · m-dx-split-argument-warning
-(1d); the NEW-DOC footgun fixes (m-dx-match-hof R4a, m-poly-arith-lambda R4b, …) each need design-doc-
-creator first (Conflict Surface mandatory — incl. the new error-code + mechanism verification gates).
+m-dx-json-bool-coercion (0.5d) · m-dx-split-argument-warning (1d); the NEW-DOC footgun fixes
+(m-dx-match-hof R4a, m-poly-arith-lambda R4b, …) each need design-doc-creator first (Conflict Surface
+mandatory — incl. the error-code + mechanism verification gates). *(m-match-xcheck-error-quality
+LANDED iter 15 → implemented/v0_30_0.)*
 
 *(SCOPE EXPANDED 2026-07-12, Mark — full-v1.0 triage of the 69 non-gating docs. The clause-3
 accessibility cluster, BOTH DX tooling investments, and the FULL clause-4 orchestration surface
@@ -549,7 +582,7 @@ triage evidence = log entry 10.)*
 - **VERIFY-then-route** (agents split ghost-vs-open; run the doc repro FIRST — may be ghosts):
   m-dx-record-cons-pattern · m-dx-tapp-trecord-unification
 - **Diagnostics** (DOC-READY / small): ~~m-module-less-run-fail-loud (MOD014)~~ **[LANDED iter 14 →
-  implemented/v0_30_0]** · m-match-xcheck-error-quality (0.5d) ·
+  implemented/v0_30_0]** · ~~m-match-xcheck-error-quality~~ **[LANDED iter 15 → implemented/v0_30_0]** ·
   m-dx-split-argument-warning (1d) · m-dx-json-bool-coercion (0.5d)
 - **Prelude / discovery**: m-prelude-option-result (Some/None no-import, 1.5d) · m-dx-ai-discovery
   (2d) · m-dx-examples-coverage (1d) · 20251013_auto_caps (infer caps, 2d) ·


### PR DESCRIPTION
Bookkeeping for mission iteration 15 (sprint landed in #352, `5aaaff2ed`).

- Log entry 16 appended to `v1-mission-log.md`.
- Queue item 14 → `[LANDED]`; `[NEXT]` advanced to m-dx-json-bool-coercion / m-dx-split-argument-warning; STATUS stamp added.

Foreign-constructor errors now enumerate transitively-known constructors (Option A: diagnostic-only registry, never enters scope). Independent evaluator round-1 PASS 96/100, no blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)