### PR TITLE
feat(stdlib): std/json.asBoolLoose — boundary-tolerant boolean decode (M-DX-JSON-BOOL)

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,26 @@
 
 ## [Unreleased]
 
+### Added — `std/json.asBoolLoose`: boundary-tolerant boolean decode (M-DX-JSON-BOOL)
+
+- New helper **`asBoolLoose(j: Json) -> Option[bool]`** for the *system-boundary*
+  case where an external API may hand a boolean back as either a JSON boolean or a
+  stringified `"true"`/`"false"`. It accepts `JBool(b)` **or** `JString "true"/"false"`;
+  anything else is `None` — a **structured failure, never a silent default** (CP2).
+- **Why**: booleans must be encoded with `jb(b)` (→ JSON `true`), *not* `js("true")`
+  (→ JSON `"true"`). The two are different JSON values, and `asBool` only accepts the
+  real boolean, so a value written the wrong way — or normalised by an API like
+  Firestore's `booleanValue` — reads back as `None` and is silently treated as false.
+  `asBoolLoose` is the liberal-in-what-you-accept decoder for exactly that boundary;
+  keep using `asBool` for values you control.
+- New runnable example **`examples/runnable/json_bool_encoding.ail`** demonstrates the
+  `jb` vs `js` footgun and the `asBool`/`asBoolLoose` distinction end-to-end.
+- Regression test `internal/repl/json_asboolloose_test.go` reproduces the Firestore
+  `{"field":{"booleanValue": …}}` round-trip for both boolean and stringified shapes.
+- **Scope note**: this landed the in-repo half of M-DX-JSON-BOOL. The original
+  package-level encoder bug (`sunholo/firestore/fields` using `js("true")`) lives in
+  the separate `ailang-packages` repo and is parked for a coordinator task there.
+
 ### Fixed — foreign-constructor error now lists transitively-known constructors (M-MATCH-XCHECK-ERROR-QUALITY)
 
 - When a `match` arm uses the wrong ADT's constructor, the error already named

--- a/design_docs/implemented/v0_30_0/m-dx-json-bool-coercion.md
+++ b/design_docs/implemented/v0_30_0/m-dx-json-bool-coercion.md
@@ -1,13 +1,36 @@
 # M-DX-JSON-BOOL: JSON Boolean Coercion and Firestore Encoding Consistency
 
-**Status**: Planned
-**Target**: v0.9.5
+**Status**: Implemented (in-repo half — v0.30.0, mission iteration 16); Phase 1 PARKED (out-of-repo)
+**Target**: v0.9.5 → landed v0.30.0
 **Priority**: P3 (DX — package-level bug with std/json implications)
 **Estimated**: 0.5 days
 **Dependencies**: M-DX-XPKG-RESOLVE (the asString cross-package bug blocks testing this fix)
 **Milestone ID**: M-DX-JSON-BOOL
 **Created**: 2026-03-25
 **Source**: DocParse agent message `eafa7e06` (boolVal encoding inconsistency)
+
+---
+
+## Outcome (mission iteration 16, 2026-07-12)
+
+Reality-check against the repo split this doc into an in-repo half and an out-of-repo half:
+
+- **`std/json` already had the correct primitives** — `jb(b)` (JBool) and `asBool` (JBool → Option)
+  exist and round-trip correctly. `asBool(jb(true)) == Some(true)` was verified live. So the core
+  encoder/decoder are not broken; the bug is *use of the wrong constructor* at the package layer.
+- **Phase 2 LANDED**: added **`asBoolLoose(j) -> Option[bool]`** (accepts `JBool` OR
+  `JString "true"/"false"`, else `None` — structured failure, never a silent default). This is the
+  "system boundary" resilience helper (A12). Shipped with runnable example
+  `examples/runnable/json_bool_encoding.ail` and Go regression test
+  `internal/repl/json_asboolloose_test.go` (7 cases incl. the Firestore `booleanValue` round-trip;
+  non-vacuity proven — the same test fails on stringified booleans if `asBool` is substituted).
+- **Phase 3 (teaching prompt)** folded into the example's header comment (`jb` vs `js` footgun)
+  rather than editing the embedded prompt — prompt-budget is GATED in the v1 mission (prompt-diet).
+- **Phase 1 (the actual data-integrity bug) PARKED**: `sunholo/firestore/fields.ail` lives in the
+  **separate `ailang-packages` repo**, absent from this checkout, and the doc's own dependency
+  M-DX-XPKG-RESOLVE gates testing it. The one-line encoder fix (`js("true")` → `jb(b)`) plus the
+  decoder swap to `asBoolLoose` is a coordinator/human task in that repo — see the mission log
+  iteration 16 and GH issue #329. `asBoolLoose` now exists so that decoder fix is a drop-in.
 
 ---
 

--- a/examples/runnable/json_bool_encoding.ail
+++ b/examples/runnable/json_bool_encoding.ail
@@ -1,0 +1,50 @@
+-- json_bool_encoding.ail - Encoding booleans as JSON, and reading them back (v0.30.0)
+--
+-- FOOTGUN: encode a boolean with jb(), NOT js("true").
+--   jb(true)      -- correct: JBool(true)  -> JSON  true
+--   js("true")    -- WRONG for booleans: JString("true") -> JSON "true"
+-- The two are different JSON values. asBool() only accepts the real JSON
+-- boolean, so a value written as js("true") reads back as None (silently
+-- wrong when a caller then treats None as false).
+--
+-- SYSTEM BOUNDARY: some external APIs normalise a boolean on write but hand
+-- it back as the OTHER shape (e.g. Firestore stores {"booleanValue": true}
+-- but a naive encoder may have sent the string). asBoolLoose() tolerates
+-- both JBool(b) and JString "true"/"false"; use it ONLY at that boundary.
+module examples/runnable/json_bool_encoding
+
+import std/json (jb, js, asBool, asBoolLoose, jo, kv, encode, Json)
+import std/option (Option, Some, None)
+import std/io (println)
+
+-- Render an Option[bool] for display
+func showOpt(o: Option[bool]) -> string =
+  match o {
+    Some(v) => "Some(${v})",
+    None => "None"
+  }
+
+-- Correct encoder: booleans use jb()
+func encodeFlag(b: bool) -> Json =
+  jo([kv("enabled", jb(b))])
+
+export func main() -> () ! {IO} = {
+  -- Correct roundtrip: jb() then asBool() is inverse
+  println("encode(jb(true))            = ${encode(jb(true))}");
+  println("asBool(jb(true))           = ${showOpt(asBool(jb(true)))}");
+
+  -- The footgun: js("true") is a JSON STRING, not a boolean
+  println("encode(js(\"true\"))         = ${encode(js("true"))}");
+  println("asBool(js(\"true\"))         = ${showOpt(asBool(js("true")))}");
+
+  -- At a system boundary, asBoolLoose() accepts either shape
+  println("asBoolLoose(js(\"true\"))    = ${showOpt(asBoolLoose(js("true")))}");
+  println("asBoolLoose(js(\"false\"))   = ${showOpt(asBoolLoose(js("false")))}");
+  println("asBoolLoose(jb(false))     = ${showOpt(asBoolLoose(jb(false)))}");
+
+  -- Non-boolean input is structured failure, never a silent default
+  println("asBoolLoose(js(\"maybe\"))   = ${showOpt(asBoolLoose(js("maybe")))}");
+
+  -- A correctly-encoded object
+  println("encodeFlag(true)           = ${encode(encodeFlag(true))}")
+}

--- a/internal/repl/json_asboolloose_test.go
+++ b/internal/repl/json_asboolloose_test.go
@@ -1,0 +1,109 @@
+package repl
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/eval"
+)
+
+// TestAsBoolLoose_FirestoreBooleanField reproduces the M-DX-JSON-BOOL data-
+// integrity scenario at the std/json boundary.
+//
+// The bug: a package encodes a boolean as js("true") (a JSON *string*) while
+// the external API (Firestore) normalises and returns it as a JSON *boolean*.
+// asBool() only accepts JBool, so a value that round-trips through the API
+// reads back as None and is silently treated as false.
+//
+// asBoolLoose() is the system-boundary fix: it accepts BOTH the real JSON
+// boolean AND the stringified "true"/"false", while still returning None
+// (structured failure, never a silent default) for genuinely non-boolean input.
+//
+// This mirrors sunholo/firestore/fields.ail's asBoolField decoder using the
+// nested {"field": {"booleanValue": ...}} envelope shape.
+func TestAsBoolLoose_FirestoreBooleanField(t *testing.T) {
+	reg := NewModuleRegistry()
+
+	for _, modName := range []string{"option", "result", "list", "math", "json"} {
+		path := filepath.Join("..", "..", "std", modName+".ail")
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("Failed to read std/%s.ail: %v", modName, err)
+		}
+		if _, err := reg.LoadModule("std/"+modName, string(content)); err != nil {
+			t.Fatalf("Failed to load std/%s: %v", modName, err)
+		}
+	}
+
+	// A Firestore-style boolean-field decoder built on asBoolLoose.
+	pkgCode := `
+module pkg/test/boolfields
+
+import std/json (get, asBoolLoose, decode)
+import std/option (Some, None)
+import std/result (Ok, Err)
+
+-- Decode a Firestore {"field": {"booleanValue": <bool|string>}} envelope.
+-- Uses asBoolLoose so a boolean survives whether the API returns it as a JSON
+-- boolean OR a stringified "true"/"false".
+export func asBoolField(fields: Json, fieldName: string) -> string =
+  match get(fields, fieldName) {
+    None => "MISSING",
+    Some(field) =>
+      match get(field, "booleanValue") {
+        None => "MISSING",
+        Some(bv) => match asBoolLoose(bv) {
+          Some(b) => if b then "true" else "false",
+          None => "NOT_BOOL"
+        }
+      }
+  }
+
+export func readFlag(jsonStr: string, fieldName: string) -> string =
+  match decode(jsonStr) {
+    Ok(fields) => asBoolField(fields, fieldName),
+    Err(_) => "DECODE_ERROR"
+  }
+`
+	if _, err := reg.LoadModule("pkg/test/boolfields", pkgCode); err != nil {
+		t.Fatalf("Failed to load pkg/test/boolfields: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		json string
+		want string
+	}{
+		// Firestore-normalised real JSON booleans (the shape the API returns).
+		{"real_bool_true", `{"active":{"booleanValue":true}}`, "true"},
+		{"real_bool_false", `{"active":{"booleanValue":false}}`, "false"},
+		// Stringified booleans (a naive js("true") encoder) — the bug, now tolerated.
+		{"string_true", `{"active":{"booleanValue":"true"}}`, "true"},
+		{"string_false", `{"active":{"booleanValue":"false"}}`, "false"},
+		// Genuinely non-boolean input is structured failure, never a silent false.
+		{"number_not_bool", `{"active":{"booleanValue":42}}`, "NOT_BOOL"},
+		{"string_not_bool", `{"active":{"booleanValue":"maybe"}}`, "NOT_BOOL"},
+		// Absent field.
+		{"missing_field", `{"other":{"booleanValue":true}}`, "MISSING"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := reg.InvokeExport("pkg/test/boolfields", "readFlag", []eval.Value{
+				&eval.StringValue{Value: tc.json},
+				&eval.StringValue{Value: "active"},
+			})
+			if err != nil {
+				t.Fatalf("InvokeExport readFlag failed: %v", err)
+			}
+			strVal, ok := result.(*eval.StringValue)
+			if !ok {
+				t.Fatalf("Expected StringValue, got %T: %v", result, result)
+			}
+			if strVal.Value != tc.want {
+				t.Errorf("readFlag(%s) = %q, want %q", tc.json, strVal.Value, tc.want)
+			}
+		})
+	}
+}

--- a/std/json.ail
+++ b/std/json.ail
@@ -122,6 +122,23 @@ export func asBool(j: Json) -> Option[bool] {
   }
 }
 
+-- Extract boolean value, tolerating a stringified boolean.
+-- System-boundary helper (A12): some external APIs normalise a boolean
+-- written as JSON true/false but return "true"/"false" as a JSON string
+-- (e.g. Firestore's booleanValue). Accepts JBool(b) OR JString "true"/"false";
+-- anything else is None. Prefer asBool for values you control — reach for
+-- asBoolLoose only at the boundary with an API that may hand back either shape.
+export func asBoolLoose(j: Json) -> Option[bool] {
+  match j {
+    JBool(b) => Some(b),
+    JString(s) =>
+      if s == "true" then Some(true)
+      else if s == "false" then Some(false)
+      else None,
+    _ => None
+  }
+}
+
 -- Extract array value
 export func asArray(j: Json) -> Option[List[Json]] {
   match j {


### PR DESCRIPTION
## M-DX-JSON-BOOL — in-repo half (mission iteration 16)

`std/json` already round-trips booleans correctly (`jb()` → JSON `true`, `asBool` accepts it). The real M-DX-JSON-BOOL bug is encoding a boolean as `js("true")` (a JSON **string**) — which `asBool` reads back as `None` (silently false). Some external APIs (e.g. Firestore's `booleanValue`) also normalise a boolean but may hand it back stringified.

### What landed
- **`std/json.asBoolLoose(j) -> Option[bool]`** — the system-boundary decoder (A12): accepts `JBool(b)` **or** `JString "true"/"false"`, else `None` (structured failure, never a silent default — CP2). Use `asBool` for values you control; `asBoolLoose` only at the API boundary.
- **`examples/runnable/json_bool_encoding.ail`** — demonstrates the `jb` vs `js` footgun + the `asBool`/`asBoolLoose` distinction end-to-end.
- **`internal/repl/json_asboolloose_test.go`** — 7-case Firestore `{"field":{"booleanValue": …}}` round-trip regression covering real-bool, stringified-bool, and non-bool inputs. **Non-vacuity proven**: the same test fails on stringified booleans if `asBool` is substituted for `asBoolLoose`.
- Design doc → `implemented/v0_30_0/` with a reality-check outcome section; CHANGELOG updated.

### Parked (out-of-repo)
Phase 1 (the actual data-integrity bug: `sunholo/firestore/fields.ail` encoding booleans with `js("true")`) lives in the **separate `ailang-packages` repo**, absent from this checkout, and is gated on dependency M-DX-XPKG-RESOLVE. `asBoolLoose` makes that decoder swap a drop-in. Flagged for a coordinator task in that repo — see issue #329.

### Verification
- Independent Opus evaluator: **PASS 92/100**, no blockers (build, 7/7 test, non-vacuity reproduced, example output verified, CP2 semantics confirmed, scope honesty verified).
- `go test ./internal/repl/ ./internal/pipeline/ ./internal/loader/` green; gofmt clean; example type-checks + runs.
- std/json.ail is not in the frozen STDLIB manifest — no golden to regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)