### PR TITLE
feat(dx): compile-time warning for reversed split() arguments (M-DX-SPLIT-ARG)

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,37 @@
 
 ## [Unreleased]
 
+### Added — compile-time warning for reversed `split` arguments (M-DX-SPLIT-ARG)
+
+- The compiler now emits a **non-blocking** warning when it detects the reversed
+  `split` footgun: `split("/", name)` where the first arg is a short (1–3 rune)
+  string literal and the second arg is not a literal. `split(s, delimiter)` is
+  **data-first**, so `split("/", name)` silently splits the literal `"/"` by the
+  contents of `name` and returns the 1-element list `["/"]` instead of the parts.
+- The warning names the exact call site and suggests the fix:
+  ```
+  warning: split(s, delimiter) takes the string first, delimiter second.
+    --> app.ail:8:20
+    = hint: did you mean split(name, "/")?
+    = note: split("/", name) splits "/" by name, which likely returns ["/"]
+  ```
+- Both `ailang run` and `ailang check` surface it (and `check` now renders pipeline
+  warnings, which it previously dropped). The program **still compiles and runs** —
+  this turns a silent wrong result into a visible diagnostic (A11 Structured Failure).
+- **Why models get this wrong**: `join(delimiter, xs)` is separator-first while
+  `split(s, delimiter)` is data-first — inverse operations with **opposite** arg
+  orders — and both args are `string`, so the type system can't catch a swap.
+  Observed twice in AI-generated AILANG code.
+- **Extensible**: the detector is a `swapTraps` table keyed by imported symbol
+  (`internal/pipeline/warn_split_args.go`); only `std/string.split` is armed today.
+  A user-defined local `split` never triggers (module-guarded on the resolved
+  `std/string.split` reference).
+- New runnable example **`examples/runnable/split_argument_order.ail`** demonstrates
+  the wrong-vs-right call end-to-end (the reversed call yields 1 part, the correct
+  call yields 3) with the join-vs-split ordering teaching in its header.
+- Implements the split heuristic without a runtime or type-system change; see
+  `design_docs/planned/v0_29_0/m-dx-split-argument-warning.md`.
+
 ### Added — `std/json.asBoolLoose`: boundary-tolerant boolean decode (M-DX-JSON-BOOL)
 
 - New helper **`asBoolLoose(j: Json) -> Option[bool]`** for the *system-boundary*

--- a/cmd/ailang/check.go
+++ b/cmd/ailang/check.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sunholo-data/ailang/internal/elaborate"
 	"github.com/sunholo-data/ailang/internal/pipeline"
 	"github.com/sunholo-data/ailang/internal/telemetry"
 	"go.opentelemetry.io/otel"
@@ -239,7 +240,19 @@ func runCheckWithContext(ctx context.Context, cfg pipeline.Config, src pipeline.
 			Errors:     []checkJSONError{},
 		})
 	} else if !quietFlag {
+		printCheckWarnings(result.Warnings)
 		fmt.Printf("\n%s No errors found!\n", green("✓"))
+	}
+}
+
+// printCheckWarnings renders non-blocking pipeline warnings (exhaustiveness,
+// split-arg-order, ...) to stderr. Warnings never fail the check.
+func printCheckWarnings(warnings []elaborate.Warning) {
+	for _, w := range warnings {
+		if w == nil {
+			continue
+		}
+		fmt.Fprintf(os.Stderr, "%s\n", yellow(w.String()))
 	}
 }
 
@@ -327,6 +340,7 @@ func runCheckWithTimeoutAndContext(ctx context.Context, cfg pipeline.Config, src
 				Errors:     []checkJSONError{},
 			})
 		} else if !quietFlag {
+			printCheckWarnings(r.result.Warnings)
 			fmt.Printf("\n%s No errors found!\n", green("✓"))
 		}
 

--- a/design_docs/planned/v0_29_0/m-dx-split-argument-warning-sprint-plan.md
+++ b/design_docs/planned/v0_29_0/m-dx-split-argument-warning-sprint-plan.md
@@ -1,0 +1,100 @@
+# Sprint Plan: M-DX-SPLIT-ARG — Compile-Time Warning for Reversed `split` Arguments
+
+**Design doc**: [m-dx-split-argument-warning.md](./m-dx-split-argument-warning.md)
+**Sprint ID**: M-DX-SPLIT-ARG
+**Duration**: 1 day (~6h)
+**Risk**: Low
+**Created**: 2026-07-12 (mission-control iteration 17)
+
+---
+
+## Goal
+
+Emit a **compile-time, non-blocking warning** when `split` is called with a short string literal
+first arg and a non-literal second arg (the reversed-argument footgun — silently returns the
+unsplit string). Design the warning surface to be **extensible** to other same-typed-arg swap traps.
+
+## Reality-check discoveries (verified live at HEAD c94c67417, ailang v0.29.2)
+
+1. **Footgun is real & reproducible**: `split("/", name)` → `["/"]` (silently wrong);
+   `split(name, "/")` → `["api","keys","user123"]`. `split` is data-first `split(s, delimiter)`.
+2. **No `warn_split` pass exists** — genuinely unimplemented.
+3. **CONFLICT SURFACE (doc premise stale)**: the ONLY warning infra is exhaustiveness-specific.
+   `result.Warnings` is `[]*elaborate.ExhaustivenessWarning` (pipeline.go:125,
+   pipeline_module_compile.go:21), sourced from `elaborator.GetWarnings()`
+   (internal/elaborate/core.go:233), rendered in **2 sites** that already call `warning.String()`
+   (cmd/ailang/main_run_exec.go:272, internal/repl/planning.go:97). → generalize the slice element
+   to an interface `Warning { String() string }`; render sites stay untouched.
+4. **Detection point**: run on the **elaborated Core** where `split` is
+   `App{Func: VarGlobal{Ref: {Module:"std/string", Name:"split"}}, Args:[…]}` — *before*
+   lowering rewrites it to the `_str_split` builtin. Confirm module == "std/string" AND name ==
+   "split" so a user function named `split` never triggers. Warning location = `App.OriginalSpan()`.
+5. Core literal: `core.Lit{Kind: core.StringLit, Value: string}`. Heuristic: arg0 is a
+   `StringLit` of 1–3 runes AND arg1 is NOT a `StringLit`.
+
+## Milestones
+
+### M1 — Generalize the warning surface (interface) — ~70 LOC + tests
+
+- Add `internal/elaborate` interface `Warning interface { String() string }`.
+- Make `*ExhaustivenessWarning` satisfy it (already has `String()` — no change needed).
+- Change `pipeline.Result.Warnings` and `pipeline_module_compile.go` `Warnings` field from
+  `[]*elaborate.ExhaustivenessWarning` to `[]elaborate.Warning`. Update the 3 append sites
+  (pipeline_module.go:337, pipeline_module_compile.go:296, pipeline_single.go:189).
+- Render sites (main_run_exec.go:272, repl/planning.go:97) call `.String()` → unchanged; verify.
+- **Acceptance**: `make build` green; exhaustiveness warnings still render identically
+  (regression check with a known non-exhaustive-match fixture).
+
+### M2 — Split-arg detection pass — ~150 LOC + tests
+
+- New file `internal/pipeline/warn_split_args.go`: a **extensible** post-elaboration walk.
+  - A small table `swapTraps` keyed by `{Module, Name}` → detector fn, seeded with std/string.split
+    (extensible per the doc's systemic-audit table; only split is armed now).
+  - Walk the elaborated Core program (`unit.Core` / elaborated decls), find `App` nodes whose
+    `Func` is `*core.VarGlobal` with `Ref.Module=="std/string" && Ref.Name=="split"`, `len(Args)==2`.
+  - Heuristic: `Args[0]` is `*core.Lit{Kind:StringLit}` with 1–3 runes AND `Args[1]` is NOT a
+    `*core.Lit{Kind:StringLit}` → emit `ArgOrderWarning{Location, Got, Suggestion, Note}`.
+  - `ArgOrderWarning.String()` renders the doc's message format (hint: did you mean `split(x, "/")`?
+    + note explaining what the reversed call does).
+- Register the pass in the module pipeline (`pipeline_module_compile.go`, appending its warnings
+  into `result.Warnings` next to the exhaustiveness collection) AND the single-file pipeline
+  (`pipeline_single.go`) so both `run` and `check` surface it.
+- **Acceptance (test plan from doc §Test Plan)**:
+  - Triggers: `split(",", name)`, `split("/", path)`, `split("\n", text)`, `split("::", q)`.
+  - No false positives: `split(name, ",")`, `split("hello world", " ")`, `split(a, b)`,
+    `split(",", ",")`.
+  - User-defined `split(x, y)` (own module) does NOT trigger (module-guard non-vacuity test).
+  - Warning does **not** block compilation — program still runs (exit 0 + correct output).
+
+### M3 — Docs + runnable example — ~40 LOC
+
+- CHANGELOG.md entry (Added / DX).
+- `examples/runnable/split_argument_order.ail`: demonstrates the wrong vs right call end-to-end,
+  header comment carries the Phase-2 teaching (join vs split ordering). **Do NOT edit the embedded
+  teaching prompt** — prompt-diet gate; teaching lives in the example header.
+- LIMITATIONS.md: add a one-line note only if a real limitation exists (heuristic is best-effort,
+  won't catch `split(delimVar, s)` where delim is a variable) — document the heuristic's bounds.
+- Design doc → `implemented/v0_30_0/` on landing (executor leaves in planned/; controller moves).
+- **Acceptance**: example type-checks + runs; `make verify-examples` unaffected; CHANGELOG present.
+
+## Out of scope
+
+- Phase 3 (`join` argument reorder) — separate breaking-change doc.
+- Editing the embedded teaching prompt (prompt-diet gated).
+- Arming other swap-trap functions (find/contains) — table is extensible; only split armed now.
+
+## Success metrics
+
+- 8+ table-driven test cases (4 trigger, 4 no-false-positive) + 1 module-guard non-vacuity test.
+- Exhaustiveness-warning regression fixture still passes (M1 didn't break existing warnings).
+- 1 runnable example verified.
+- No new CI file-size violations; `make test` + `make lint` green.
+
+## Risk factors
+
+- **Low**: The generalization touches a small, well-mapped surface (5 sites). The detection pass is
+  additive and read-only over Core. Main risk = false positives → mitigated by the tight heuristic
+  (1–3 rune literal + module-guard) and explicit no-false-positive tests.
+
+SPRINT_PLAN_PATH: design_docs/planned/v0_29_0/m-dx-split-argument-warning-sprint-plan.md
+SPRINT_JSON_PATH: .ailang/state/sprints/sprint_M-DX-SPLIT-ARG.json

--- a/docs/docs/reference/limitations.md
+++ b/docs/docs/reference/limitations.md
@@ -327,7 +327,7 @@ rune) **string literal** and the second is not a literal, e.g. `split("/", name)
 It intentionally does **not** flag `split(sep, s)` when the delimiter is a
 variable (`let sep = "/"; split(sep, name)`) — there is no literal delimiter to
 key on, and both arguments are `string` so the type system cannot distinguish
-them. The warning is non-blocking and never produces false negatives on the
+them. The warning is non-blocking and never produces false positives on the
 correct data-first order `split(s, delimiter)`. Prefer data-first and treat the
 warning as a backstop for the literal-delimiter case.
 

--- a/docs/docs/reference/limitations.md
+++ b/docs/docs/reference/limitations.md
@@ -317,6 +317,22 @@ Suggestion: Add ')' to close grouped expression
 
 ---
 
+## Diagnostic Heuristic Bounds (By Design)
+
+### Reversed-`split`-argument warning is best-effort
+
+The compile-time warning for reversed `split` arguments (M-DX-SPLIT-ARG) is a
+**best-effort heuristic**: it fires only when the first argument is a short (1–3
+rune) **string literal** and the second is not a literal, e.g. `split("/", name)`.
+It intentionally does **not** flag `split(sep, s)` when the delimiter is a
+variable (`let sep = "/"; split(sep, name)`) — there is no literal delimiter to
+key on, and both arguments are `string` so the type system cannot distinguish
+them. The warning is non-blocking and never produces false negatives on the
+correct data-first order `split(s, delimiter)`. Prefer data-first and treat the
+warning as a backstop for the literal-delimiter case.
+
+---
+
 ## Reporting New Limitations
 
 Found a limitation not listed here? Please file an issue at:

--- a/examples/runnable/split_argument_order.ail
+++ b/examples/runnable/split_argument_order.ail
@@ -1,0 +1,47 @@
+-- split_argument_order.ail
+--
+-- TEACHING: split() is DATA-FIRST. It takes the string to split FIRST, and the
+-- delimiter SECOND:
+--
+--     split(s, delimiter)   -- data first  ->  split("a/b/c", "/") = ["a","b","c"]
+--
+-- This is the OPPOSITE order from join(), which is SEPARATOR-FIRST:
+--
+--     join(delimiter, xs)   -- separator first  ->  join("/", ["a","b","c"]) = "a/b/c"
+--
+-- Because both split arguments are strings, the type system cannot catch a swap.
+-- Calling split with the arguments reversed is a silent footgun:
+--
+--     split("/", name)      -- WRONG: splits the literal "/" BY the contents of
+--                           -- `name`. Since "/" does not contain `name`, this
+--                           -- returns the 1-element list ["/"], NOT the parts.
+--
+-- The AILANG compiler emits a NON-BLOCKING warning (M-DX-SPLIT-ARG) when it sees
+-- a short (1-3 char) string literal as the first arg and a non-literal second
+-- arg, e.g. `split("/", name)`. The program still compiles and runs.
+--
+-- LIMITATION (best-effort heuristic): the warning fires only when the delimiter
+-- is a SHORT STRING LITERAL. It cannot catch `split(delim, s)` where `delim` is
+-- a variable (e.g. `let sep = "/"; split(sep, name)`) — there is no literal to
+-- key on. Prefer the data-first order and let the warning backstop literals.
+--
+-- Run me:  ailang run --caps IO --entry main examples/runnable/split_argument_order.ail
+
+module examples/runnable/split_argument_order
+
+import std/string (split)
+import std/list (length)
+import std/io (println)
+
+export func main() -> () ! {IO} {
+  let name = "api/keys/user123";
+
+  -- CORRECT: string first, delimiter second -> ["api", "keys", "user123"]
+  let right = split(name, "/");
+  let _ = println("correct  split(name, \"/\") -> ${show(length(right))} parts");
+
+  -- WRONG (reversed): splits "/" by `name` -> ["/"] (1 element).
+  -- The compiler warns about this line but does NOT block the run.
+  let wrong = split("/", name);
+  println("reversed split(\"/\", name) -> ${show(length(wrong))} part(s)")
+}

--- a/internal/elaborate/warnings.go
+++ b/internal/elaborate/warnings.go
@@ -1,0 +1,17 @@
+package elaborate
+
+// Warning is the common interface for all non-blocking compile-time warnings
+// surfaced through the pipeline (pipeline.Result.Warnings).
+//
+// Historically the pipeline only carried exhaustiveness warnings
+// (*ExhaustivenessWarning). This interface generalizes the warning surface so
+// additional diagnostic passes (e.g. the split-argument-order DX warning in
+// internal/pipeline/warn_split_args.go) can contribute warnings without the
+// pipeline needing to know their concrete types. Render sites only rely on
+// String(), so they remain unchanged.
+//
+// *ExhaustivenessWarning already satisfies this interface via its String()
+// method.
+type Warning interface {
+	String() string
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -121,8 +121,8 @@ type Result struct {
 	Value          eval.Value
 	Type           types.Type
 	Constraints    []types.Constraint
-	Errors         []error                            // TODO: Use structured errors
-	Warnings       []*elaborate.ExhaustivenessWarning // Exhaustiveness warnings
+	Errors         []error             // TODO: Use structured errors
+	Warnings       []elaborate.Warning // Compile-time warnings (exhaustiveness, split-arg-order, ...)
 	Artifacts      Artifacts
 	Interface      *iface.Iface                    // Module interface (for modules only)
 	Modules        map[string]*loader.LoadedModule // Loaded modules with Core (for module execution)

--- a/internal/pipeline/pipeline_module.go
+++ b/internal/pipeline/pipeline_module.go
@@ -370,6 +370,24 @@ func runModuleWithContext(ctx context.Context, cfg Config, src Source) (Result, 
 		compiledUnits[string(modID)] = unit
 	}
 
+	// M-DX-SPLIT-ARG: same-typed-arg swap warnings (e.g. reversed split args).
+	// Runs over every compiled unit's final Core. In user code, a call to an
+	// imported std/string.split stays as App{Func: VarGlobal{std/string.split}}
+	// even after lowering (the _str_split builtin substitution happens only
+	// inside std/string itself), so this correctly detects on both freshly
+	// compiled AND cache-hit-loaded modules. Non-blocking: warnings only.
+	// The VarGlobal module-guard means std library internals and user-defined
+	// local `split` functions never trigger. Iterate in sorted module order so
+	// warning output is deterministic.
+	argOrderModIDs := make([]string, 0, len(compiledUnits))
+	for modID := range compiledUnits {
+		argOrderModIDs = append(argOrderModIDs, modID)
+	}
+	sort.Strings(argOrderModIDs)
+	for _, modID := range argOrderModIDs {
+		result.Warnings = append(result.Warnings, DetectArgOrderWarnings(compiledUnits[modID].Core)...)
+	}
+
 	// Register $adt module after all modules are loaded and their interfaces are built
 	// This allows $adt to collect all constructors from all loaded modules
 	link.RegisterAdtModule(modLinker)

--- a/internal/pipeline/pipeline_module_compile.go
+++ b/internal/pipeline/pipeline_module_compile.go
@@ -18,7 +18,7 @@ import (
 type moduleCompileResult struct {
 	TypeChecker   *types.CoreTypeChecker
 	DebugSink     *types.VerboseDebugSink
-	Warnings      []*elaborate.ExhaustivenessWarning
+	Warnings      []elaborate.Warning
 	ModuleTypeEnv *types.TypeEnv // Accumulated type environment for interface building
 }
 
@@ -292,8 +292,9 @@ func typeCheckAndLowerModule(
 	}
 
 	// Collect exhaustiveness warnings
-	warnings := elaborator.GetWarnings()
-	result.Warnings = append(result.Warnings, warnings...)
+	for _, w := range elaborator.GetWarnings() {
+		result.Warnings = append(result.Warnings, w)
+	}
 	result.ModuleTypeEnv = moduleTypeEnv
 
 	return result, nil

--- a/internal/pipeline/pipeline_single.go
+++ b/internal/pipeline/pipeline_single.go
@@ -191,6 +191,12 @@ func runSingleWithContext(ctx context.Context, cfg Config, src Source) (Result, 
 		result.Warnings = append(result.Warnings, w)
 	}
 
+	// M-DX-SPLIT-ARG: same-typed-arg swap warnings on the elaborated Core
+	// (before lowering). In the single-file/REPL pipeline imports are not
+	// resolved to VarGlobal, so this is effectively a no-op today; wired for
+	// consistency and future extensibility. Non-blocking.
+	result.Warnings = append(result.Warnings, DetectArgOrderWarnings(coreProg)...)
+
 	// Record Core stats on span
 	elabSpan.SetAttributes(attribute.Int("core.decls", len(coreProg.Decls)))
 	elabSpan.End()

--- a/internal/pipeline/pipeline_single.go
+++ b/internal/pipeline/pipeline_single.go
@@ -186,7 +186,10 @@ func runSingleWithContext(ctx context.Context, cfg Config, src Source) (Result, 
 	}
 
 	// Collect exhaustiveness warnings
-	result.Warnings = elaborator.GetWarnings()
+	result.Warnings = nil
+	for _, w := range elaborator.GetWarnings() {
+		result.Warnings = append(result.Warnings, w)
+	}
 
 	// Record Core stats on span
 	elabSpan.SetAttributes(attribute.Int("core.decls", len(coreProg.Decls)))

--- a/internal/pipeline/warn_split_args.go
+++ b/internal/pipeline/warn_split_args.go
@@ -1,0 +1,215 @@
+package pipeline
+
+import (
+	"fmt"
+	"unicode/utf8"
+
+	"github.com/sunholo-data/ailang/internal/ast"
+	"github.com/sunholo-data/ailang/internal/core"
+	"github.com/sunholo-data/ailang/internal/elaborate"
+)
+
+// M-DX-SPLIT-ARG: Compile-time, non-blocking warning for reversed same-typed
+// arguments.
+//
+// The "same-typed argument swap" bug class: when both arguments of a function
+// share a type, the type system provides no guardrail against passing them in
+// the wrong order. The canonical case is `split(s, delimiter)` (data-first):
+// `split("/", name)` silently returns `["/"]` (it splits the literal "/" by the
+// contents of `name`) instead of splitting `name` by "/".
+//
+// This pass runs over the *elaborated* Core program, BEFORE lowering rewrites
+// `split` into the `_str_split` builtin. At that stage a call to an imported
+// `std/string.split` is `App{Func: VarGlobal{Module:"std/string", Name:"split"},
+// Args:[a, b]}`. A user-defined local `split` elaborates to a plain
+// `*core.Var{Name:"split"}` (never a VarGlobal), so matching on VarGlobal with a
+// module guard structurally excludes user functions.
+//
+// The pass is extensible: swapTraps is a table keyed by the imported symbol.
+// Only std/string.split is armed today.
+
+// argOrderDetector inspects a matched 2-arg call and returns a warning if the
+// heuristic fires, or nil otherwise.
+type argOrderDetector func(app *core.App) *ArgOrderWarning
+
+// swapTrap describes a function whose same-typed arguments are prone to being
+// swapped, and how to detect a likely swap.
+type swapTrap struct {
+	module string
+	name   string
+	detect argOrderDetector
+}
+
+// swapTraps is the extensible registry of same-typed-arg swap traps.
+// Only std/string.split is armed. Add more entries (find, contains, ...) here.
+var swapTraps = []swapTrap{
+	{
+		module: "std/string",
+		name:   "split",
+		detect: detectSplitReversed,
+	},
+}
+
+// swapTrapIndex is a fast lookup from GlobalRef{module,name} to its detector,
+// built once from swapTraps.
+var swapTrapIndex = buildSwapTrapIndex()
+
+func buildSwapTrapIndex() map[core.GlobalRef]argOrderDetector {
+	idx := make(map[core.GlobalRef]argOrderDetector, len(swapTraps))
+	for _, t := range swapTraps {
+		idx[core.GlobalRef{Module: t.module, Name: t.name}] = t.detect
+	}
+	return idx
+}
+
+// ArgOrderWarning is a non-blocking warning that a same-typed-argument function
+// was likely called with its arguments reversed. It satisfies elaborate.Warning.
+type ArgOrderWarning struct {
+	Location   ast.Pos // Surface location of the offending call
+	FuncName   string  // e.g. "split"
+	Delimiter  string  // the short literal that was passed as arg0
+	Arg1String string  // String() rendering of the (non-literal) arg1
+}
+
+// compile-time assertion that ArgOrderWarning satisfies the warning interface.
+var _ elaborate.Warning = (*ArgOrderWarning)(nil)
+
+// Position exposes 1-indexed line/col for LSP diagnostic placement.
+func (w *ArgOrderWarning) Position() (line, col int) {
+	return w.Location.Line, w.Location.Column
+}
+
+// String renders the warning in the design-doc format (hint + note).
+func (w *ArgOrderWarning) String() string {
+	return fmt.Sprintf(
+		"warning: %s(s, delimiter) takes the string first, delimiter second.\n"+
+			"  --> %s\n"+
+			"  = hint: did you mean %s(%s, %q)?\n"+
+			"  = note: %s(%q, %s) splits %q by %s, which likely returns [%q]",
+		w.FuncName,
+		w.Location.String(),
+		w.FuncName, w.Arg1String, w.Delimiter,
+		w.FuncName, w.Delimiter, w.Arg1String, w.Delimiter, w.Arg1String, w.Delimiter,
+	)
+}
+
+// detectSplitReversed applies the split heuristic to a 2-arg split call:
+// arg0 is a StringLit of 1-3 runes AND arg1 is NOT a StringLit.
+func detectSplitReversed(app *core.App) *ArgOrderWarning {
+	if len(app.Args) != 2 {
+		return nil
+	}
+	lit, ok := app.Args[0].(*core.Lit)
+	if !ok || lit.Kind != core.StringLit {
+		return nil
+	}
+	s, ok := lit.Value.(string)
+	if !ok {
+		return nil
+	}
+	// Short literal (1-3 runes) is a likely delimiter, not data.
+	if n := utf8.RuneCountInString(s); n < 1 || n > 3 {
+		return nil
+	}
+	// arg1 a string literal too => can't tell (edge case), don't warn.
+	if lit1, ok := app.Args[1].(*core.Lit); ok && lit1.Kind == core.StringLit {
+		return nil
+	}
+	return &ArgOrderWarning{
+		Location:   app.OriginalSpan(),
+		FuncName:   "split",
+		Delimiter:  s,
+		Arg1String: app.Args[1].String(),
+	}
+}
+
+// DetectArgOrderWarnings walks an elaborated Core program and returns any
+// same-typed-arg swap warnings. It is read-only over Core and must be called
+// BEFORE lowering (while split is still an imported VarGlobal).
+func DetectArgOrderWarnings(prog *core.Program) []elaborate.Warning {
+	if prog == nil {
+		return nil
+	}
+	var out []elaborate.Warning
+	for _, decl := range prog.Decls {
+		walkArgOrder(decl, &out)
+	}
+	return out
+}
+
+// walkArgOrder recursively visits every Core expression, applying swap-trap
+// detectors to matching App nodes.
+func walkArgOrder(e core.CoreExpr, out *[]elaborate.Warning) {
+	if e == nil {
+		return
+	}
+	switch n := e.(type) {
+	case *core.App:
+		if vg, ok := n.Func.(*core.VarGlobal); ok {
+			if detect, ok := swapTrapIndex[vg.Ref]; ok {
+				if w := detect(n); w != nil {
+					*out = append(*out, w)
+				}
+			}
+		}
+		walkArgOrder(n.Func, out)
+		for _, a := range n.Args {
+			walkArgOrder(a, out)
+		}
+	case *core.Lambda:
+		walkArgOrder(n.Body, out)
+	case *core.Let:
+		walkArgOrder(n.Value, out)
+		walkArgOrder(n.Body, out)
+	case *core.LetRec:
+		for _, b := range n.Bindings {
+			walkArgOrder(b.Value, out)
+		}
+		walkArgOrder(n.Body, out)
+	case *core.If:
+		walkArgOrder(n.Cond, out)
+		walkArgOrder(n.Then, out)
+		walkArgOrder(n.Else, out)
+	case *core.Match:
+		walkArgOrder(n.Scrutinee, out)
+		for _, arm := range n.Arms {
+			walkArgOrder(arm.Guard, out)
+			walkArgOrder(arm.Body, out)
+		}
+	case *core.BinOp:
+		walkArgOrder(n.Left, out)
+		walkArgOrder(n.Right, out)
+	case *core.UnOp:
+		walkArgOrder(n.Operand, out)
+	case *core.Intrinsic:
+		for _, a := range n.Args {
+			walkArgOrder(a, out)
+		}
+	case *core.Record:
+		for _, v := range n.Fields {
+			walkArgOrder(v, out)
+		}
+	case *core.RecordAccess:
+		walkArgOrder(n.Record, out)
+	case *core.RecordUpdate:
+		walkArgOrder(n.Base, out)
+		for _, v := range n.Updates {
+			walkArgOrder(v, out)
+		}
+	case *core.List:
+		for _, el := range n.Elements {
+			walkArgOrder(el, out)
+		}
+	case *core.Array:
+		for _, el := range n.Elements {
+			walkArgOrder(el, out)
+		}
+	case *core.Tuple:
+		for _, el := range n.Elements {
+			walkArgOrder(el, out)
+		}
+	default:
+		// Atomic nodes (Var, VarGlobal, Lit) and any unhandled leaf: nothing to
+		// recurse into.
+	}
+}

--- a/internal/pipeline/warn_split_args_test.go
+++ b/internal/pipeline/warn_split_args_test.go
@@ -1,0 +1,239 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/core"
+	"github.com/sunholo-data/ailang/internal/elaborate"
+	"github.com/sunholo-data/ailang/internal/lexer"
+	"github.com/sunholo-data/ailang/internal/parser"
+)
+
+// elaborateForTest parses and elaborates a source string with std/string.split
+// resolved to its VarGlobal (mirroring what the module pipeline does via
+// SetGlobalEnv). It returns the elaborated Core program (pre-lowering).
+func elaborateForTest(t *testing.T, src string) *core.Program {
+	t.Helper()
+	l := lexer.New(src, "test.ail")
+	p := parser.New(l)
+	f := p.ParseFile()
+	if len(p.Errors()) > 0 {
+		t.Fatalf("parse errors: %v", p.Errors())
+	}
+	el := elaborate.NewElaborator()
+	el.AddBuiltinsToGlobalEnv()
+	// Simulate `import std/string (split)`.
+	el.MergeGlobalEnv(map[string]core.GlobalRef{
+		"split": {Module: "std/string", Name: "split"},
+	})
+	prog, err := el.ElaborateFile(f)
+	if err != nil {
+		t.Fatalf("elaboration error: %v", err)
+	}
+	return prog
+}
+
+// wrapMain wraps a split expression body inside a minimal module so it parses.
+func wrapMain(body string) string {
+	return "module test/m\n" +
+		"import std/string (split)\n" +
+		"export func main() -> [string] {\n" +
+		body + "\n}\n"
+}
+
+func TestDetectArgOrderWarnings_Split(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     string
+		wantWarn bool
+	}{
+		// Triggers: short literal delimiter as arg0, non-literal as arg1.
+		{"comma_var", `let name = "a,b,c"; split(",", name)`, true},
+		{"slash_var", `let path = "a/b/c"; split("/", path)`, true},
+		{"newline_var", `let text = "a\nb"; split("\n", text)`, true},
+		{"double_colon_var", `let q = "a::b"; split("::", q)`, true},
+
+		// No false positives.
+		{"correct_order", `let name = "a,b,c"; split(name, ",")`, false},
+		{"long_first_arg", `split("hello world", " ")`, false},
+		{"both_literals", `split(",", ",")`, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prog := elaborateForTest(t, wrapMain(tc.body))
+			warns := DetectArgOrderWarnings(prog)
+			got := len(warns) > 0
+			if got != tc.wantWarn {
+				t.Fatalf("body %q: wantWarn=%v got=%v (warns=%d)", tc.body, tc.wantWarn, got, len(warns))
+			}
+			if tc.wantWarn {
+				aw, ok := warns[0].(*ArgOrderWarning)
+				if !ok {
+					t.Fatalf("expected *ArgOrderWarning, got %T", warns[0])
+				}
+				// Warning satisfies elaborate.Warning and renders hint + note.
+				var _ elaborate.Warning = aw
+				s := aw.String()
+				if !strings.Contains(s, "hint:") || !strings.Contains(s, "note:") {
+					t.Errorf("warning missing hint/note: %q", s)
+				}
+				if !strings.Contains(s, "split") {
+					t.Errorf("warning missing func name: %q", s)
+				}
+			}
+		})
+	}
+}
+
+// TestDetectArgOrderWarnings_BothVarsNoWarn covers split(a, b) where both are
+// variables — the pass cannot tell, so it must not warn. Kept separate because
+// it needs two bound vars.
+func TestDetectArgOrderWarnings_BothVarsNoWarn(t *testing.T) {
+	body := `let a = ","; let b = "x,y"; split(a, b)`
+	prog := elaborateForTest(t, wrapMain(body))
+	if warns := DetectArgOrderWarnings(prog); len(warns) != 0 {
+		t.Fatalf("split(a, b) should not warn, got %d: %v", len(warns), warns)
+	}
+}
+
+// TestDetectArgOrderWarnings_ModuleGuard proves non-vacuity: a user-defined
+// local `split(x, y)` (NOT imported from std/string) must NOT trigger, because
+// it elaborates to a plain *core.Var, not the std/string.split VarGlobal.
+func TestDetectArgOrderWarnings_ModuleGuard(t *testing.T) {
+	src := "module test/userdef\n" +
+		"export func split(x: string, y: string) -> [string] { [x, y] }\n" +
+		"export func main() -> [string] {\n" +
+		"  let name = \"a/b/c\";\n" +
+		"  split(\"/\", name)\n" +
+		"}\n"
+
+	// Elaborate WITHOUT the std/string import mapping: `split` is a local func.
+	l := lexer.New(src, "test.ail")
+	p := parser.New(l)
+	f := p.ParseFile()
+	if len(p.Errors()) > 0 {
+		t.Fatalf("parse errors: %v", p.Errors())
+	}
+	el := elaborate.NewElaborator()
+	el.AddBuiltinsToGlobalEnv()
+	prog, err := el.ElaborateFile(f)
+	if err != nil {
+		t.Fatalf("elaboration error: %v", err)
+	}
+
+	// Sanity: assert the call really is a plain Var, not a std/string VarGlobal.
+	if hasStdStringSplitVarGlobal(prog) {
+		t.Fatal("test setup invalid: user-defined split resolved to std/string VarGlobal")
+	}
+	if warns := DetectArgOrderWarnings(prog); len(warns) != 0 {
+		t.Fatalf("user-defined split must not warn, got %d: %v", len(warns), warns)
+	}
+}
+
+// TestSplitArgWarning_Integration exercises the full module pipeline end-to-end:
+// the reversed-split warning must be surfaced in result.Warnings AND must NOT
+// block compilation (no error). A correct-order call must not warn.
+func TestSplitArgWarning_Integration(t *testing.T) {
+	dir := t.TempDir()
+
+	writeMod := func(name, body string) string {
+		p := filepath.Join(dir, name)
+		src := "module " + strings.TrimSuffix(name, ".ail") + "\n" +
+			"import std/string (split)\n" +
+			"import std/list (length)\n" +
+			"export func main() -> int {\n" +
+			body + "\n}\n"
+		if err := os.WriteFile(p, []byte(src), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		return p
+	}
+
+	countWarns := func(warns []elaborate.Warning) int {
+		n := 0
+		for _, w := range warns {
+			if _, ok := w.(*ArgOrderWarning); ok {
+				n++
+			}
+		}
+		return n
+	}
+
+	t.Run("reversed_warns_non_blocking", func(t *testing.T) {
+		p := writeMod("rev.ail", `  let name = "a/b/c";
+  length(split("/", name))`)
+		b, _ := os.ReadFile(p)
+		cfg := Config{RelaxModules: true, NoCache: true}
+		res, err := Run(cfg, Source{Code: string(b), Filename: p})
+		if err != nil {
+			t.Fatalf("pipeline error (warning must not block): %v", err)
+		}
+		if len(res.Errors) != 0 {
+			t.Fatalf("unexpected errors: %v", res.Errors)
+		}
+		if got := countWarns(res.Warnings); got != 1 {
+			t.Fatalf("expected 1 ArgOrderWarning, got %d (all=%d)", got, len(res.Warnings))
+		}
+	})
+
+	t.Run("correct_order_no_warn", func(t *testing.T) {
+		p := writeMod("ok.ail", `  let name = "a/b/c";
+  length(split(name, "/"))`)
+		b, _ := os.ReadFile(p)
+		cfg := Config{RelaxModules: true, NoCache: true}
+		res, err := Run(cfg, Source{Code: string(b), Filename: p})
+		if err != nil {
+			t.Fatalf("pipeline error: %v", err)
+		}
+		if got := countWarns(res.Warnings); got != 0 {
+			t.Fatalf("expected 0 ArgOrderWarning, got %d", got)
+		}
+	})
+}
+
+// hasStdStringSplitVarGlobal reports whether any App in prog calls the
+// std/string.split VarGlobal (used to validate module-guard test setup).
+func hasStdStringSplitVarGlobal(prog *core.Program) bool {
+	found := false
+	var walk func(e core.CoreExpr)
+	walk = func(e core.CoreExpr) {
+		if e == nil || found {
+			return
+		}
+		switch n := e.(type) {
+		case *core.App:
+			if vg, ok := n.Func.(*core.VarGlobal); ok {
+				if vg.Ref.Module == "std/string" && vg.Ref.Name == "split" {
+					found = true
+					return
+				}
+			}
+			walk(n.Func)
+			for _, a := range n.Args {
+				walk(a)
+			}
+		case *core.Lambda:
+			walk(n.Body)
+		case *core.Let:
+			walk(n.Value)
+			walk(n.Body)
+		case *core.LetRec:
+			for _, b := range n.Bindings {
+				walk(b.Value)
+			}
+			walk(n.Body)
+		case *core.If:
+			walk(n.Cond)
+			walk(n.Then)
+			walk(n.Else)
+		}
+	}
+	for _, d := range prog.Decls {
+		walk(d)
+	}
+	return found
+}


### PR DESCRIPTION
## M-DX-SPLIT-ARG — reversed-`split`-argument warning (mission iteration 17)

Closes the clause-3 accessibility item: a **compile-time, non-blocking** warning when `split` is called with a short (1–3 rune) string literal as arg0 and a non-literal as arg1 — the reversed-argument footgun where `split("/", name)` silently returns `["/"]` instead of splitting `name`.

### What shipped
- **M1** `3cfcc8a6a` — generalized `pipeline.Result.Warnings` to an `elaborate.Warning { String() string }` interface (`*ExhaustivenessWarning` already satisfies it; render sites untouched).
- **M2** `9dcaa01ce` — extensible `swapTraps` detection pass (`internal/pipeline/warn_split_args.go`): walks final module Core for `App{VarGlobal{std/string.split}, [lit, non-lit]}`, emits `ArgOrderWarning` (hint + note). Module-guarded — a user-defined `split` never triggers. Covers cold **and** cache-hit compiles; surfaced by both `run` and `check`.
- **M3** `56e716953` — CHANGELOG, `examples/runnable/split_argument_order.ail` (teaching in header — prompt-diet respected, no embedded-prompt edit), LIMITATIONS heuristic-bounds note.

### Verification
- Independent Opus evaluator: **round-1 PASS 97/100**, no blockers. Reproduced non-vacuity two ways (heuristic flip breaks trigger tests; user-`Var` match breaks the module-guard test).
- 11/11 new tests pass; `go test ./...` clean; `gofmt`/`vet`/`golangci-lint` clean; new files ≤239 lines.
- Live: reversed → warning on stderr + program still runs (exit 0); correct/long-literal/both-vars/both-literals/user-`split` → no warning.

Design doc → `implemented/v0_30_0/` on landing (controller bookkeeping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)