### PR TITLE
fix(dx): verify + regression-guard record-cons & nested-record-list ghosts (M-DX-RECORD-CONS, M-DX-TAPP-TRECORD)

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,25 @@
 
 ## [Unreleased]
 
+### Fixed — record patterns in cons & nested-record-list extraction verified + regression-guarded (M-DX-RECORD-CONS, M-DX-TAPP-TRECORD)
+
+- Two long-standing DX bugs from the `docparse-demo` feedback (Feb 2026) were **verified fixed at
+  HEAD and closed as ghosts** (mission iteration 18), then locked in with CI-enforced regression
+  guards so they cannot silently regress:
+  - **M-DX-RECORD-CONS** — a record literal as the head of a `::` cons pattern
+    (`{text: s, bold: b} :: rest`) once failed with `PAT_INVALID_CONS`. It now type-checks in both
+    the infix and canonical `::({…}, rest)` forms. Guards:
+    `internal/parser/list_cons_pattern_test.go::TestListConsPatternWithRecord` and the runnable
+    example `examples/record_cons_pattern.ail`.
+  - **M-DX-TAPP-TRECORD** — a helper taking a nested list of a record-type alias
+    (`makeTable(rows: [[TableCell]]) -> Block`) once failed inference with `cannot unify type
+    application with *types.TRecord` when the same body type-checked inline. It now type-checks in
+    both the `func` and `let … = \rows. …` forms. Guard: the runnable example
+    `examples/record_list_extraction.ail`.
+- No language/runtime change — the underlying fixes shipped earlier with record-pattern / `::`-sugar
+  and type-unification work; this iteration is verification + regression coverage. Both design docs
+  moved to `design_docs/implemented/v0_30_0/` with resolution notes.
+
 ### Added — compile-time warning for reversed `split` arguments (M-DX-SPLIT-ARG)
 
 - The compiler now emits a **non-blocking** warning when it detects the reversed

--- a/design_docs/implemented/v0_30_0/m-dx-record-cons-pattern.md
+++ b/design_docs/implemented/v0_30_0/m-dx-record-cons-pattern.md
@@ -1,9 +1,28 @@
 # M-DX-RECORD-CONS: Record Literal + :: Cons Pattern Bug
 
-**Status**: Planned
+**Status**: Resolved — ghost (verified fixed, no change needed; closed mission iteration 18, 2026-07-13)
 **Priority**: Low
 **Source**: DX feedback from docparse-demo (Feb 2026)
-**Milestone**: v0.8.0
+**Milestone**: v0.8.0 (closed in the v0.30.0 line)
+
+## Resolution (2026-07-13, mission iteration 18)
+
+VERIFY-then-route reality-check: the bug **no longer reproduces at HEAD** (`v0.29.2`). All three
+forms type-check cleanly (`ailang check`):
+
+- infix record head — `{text: s, bold: b} :: rest => s` ✓
+- canonical form — `::({text: s, bold: b}, rest) => s` ✓
+- baseline var head — `first :: rest` ✓ (was never broken)
+
+The parser cursor-position mismatch described below was fixed by subsequent record-pattern /
+`::`-sugar work (`internal/parser/parser_pattern.go`); no code change was required this iteration.
+The doc's own noted gap — *"Missing: Cons with record patterns (no test)"* — is now closed with a
+CI-enforced regression guard so it cannot silently regress:
+
+- `internal/parser/list_cons_pattern_test.go::TestListConsPatternWithRecord` (infix + canonical)
+- `examples/record_cons_pattern.ail` (top-level example, type-checked + run by `verify-examples-toplevel` in CI)
+
+*(Everything below is the original 2026-02 analysis, retained for provenance.)*
 
 ## Problem
 

--- a/design_docs/implemented/v0_30_0/m-dx-tapp-trecord-unification.md
+++ b/design_docs/implemented/v0_30_0/m-dx-tapp-trecord-unification.md
@@ -1,9 +1,30 @@
 # M-DX-TAPP-TRECORD: Type Inference Bug with Nested [[RecordType]]
 
-**Status**: Planned
+**Status**: Resolved — ghost (verified fixed, no change needed; closed mission iteration 18, 2026-07-13)
 **Priority**: High
 **Source**: DX feedback from docparse-demo (Feb 2026)
-**Milestone**: v0.8.0
+**Milestone**: v0.8.0 (closed in the v0.30.0 line)
+
+## Resolution (2026-07-13, mission iteration 18)
+
+VERIFY-then-route reality-check: the bug **no longer reproduces at HEAD** (`v0.29.2`). A helper
+`makeTable(rows: [[TableCell]]) -> Block` — the exact "fails when extracted to a function" case —
+type-checks cleanly in both the modern `func` form and the doc's original
+`let makeTable: [[TableCell]] -> Block = \rows. …` lambda-binding form.
+
+The doc cited the error `cannot unify type application with *types.TRecord` from
+`internal/types/unification_types.go:unifyTypeApps()`. That `%T`-formatted string was reworded to
+`.String()` in commit `5cf6287bf`; the remaining fallback (`cannot unify type application %s with
+%s`) fires only for genuinely-unrelated type applications, not for `[[RecordAlias]]` element
+unification — `unifyTypeApps` decomposes `TApp ~ TApp` and recursively unifies element types
+(alias expansion resolves the record alias before comparison). No code change was required.
+
+CI-enforced regression guard added:
+
+- `examples/record_list_extraction.ail` — top-level example whose `[[TableCell]]` extraction is
+  type-checked (and run, printing `headers: 2`) by `verify-examples-toplevel` in CI.
+
+*(Everything below is the original 2026-02 analysis, retained for provenance.)*
 
 ## Problem
 

--- a/examples/record_cons_pattern.ail
+++ b/examples/record_cons_pattern.ail
@@ -1,0 +1,22 @@
+-- Record-literal head in a :: cons pattern.
+-- Regression guard for M-DX-RECORD-CONS: destructuring a record directly in the
+-- head of a cons pattern (`{field} :: rest`) once failed with PAT_INVALID_CONS.
+-- Verified fixed / closed as a ghost in mission iteration 18 (2026-07-13).
+module examples/record_cons_pattern
+
+import std/io (println)
+
+type Row = { text: string, bold: bool }
+
+-- The head of the cons pattern is a record literal, destructured inline.
+pure func firstText(rows: [Row]) -> string {
+  match rows {
+    {text: s, bold: _} :: _ => s,
+    [] => "(empty)"
+  }
+}
+
+export func main() -> () ! {IO} {
+  let rows = [{text: "hello", bold: true}, {text: "world", bold: false}];
+  println(firstText(rows))
+}

--- a/examples/record_list_extraction.ail
+++ b/examples/record_list_extraction.ail
@@ -1,0 +1,36 @@
+-- Extracting a helper that takes a nested list of a record-type alias.
+-- Regression guard for M-DX-TAPP-TRECORD: a function parameter typed
+-- `[[RecordAlias]]` once failed type inference with
+-- "cannot unify type application with *types.TRecord" when the same body
+-- type-checked inline. Verified fixed / closed as a ghost in mission
+-- iteration 18 (2026-07-13).
+module examples/record_list_extraction
+
+import std/io (println)
+import std/list (length)
+
+type TableCell = { text: string, bold: bool }
+
+type Block = TableBlock({ rows: [[TableCell]], headers: [TableCell] }) | EmptyBlock
+
+-- The [[TableCell]] parameter is the crux: nested list of a record alias,
+-- unified across the function boundary against the pattern-inferred record type.
+pure func makeTable(rows: [[TableCell]]) -> Block {
+  match rows {
+    firstRow :: dataRows => TableBlock({ rows: dataRows, headers: firstRow }),
+    [] => EmptyBlock
+  }
+}
+
+pure func headerCount(b: Block) -> int {
+  match b {
+    TableBlock({ rows: _, headers: hs }) => length(hs),
+    EmptyBlock => 0
+  }
+}
+
+export func main() -> () ! {IO} {
+  let cell = {text: "h", bold: true};
+  let table = makeTable([[cell, cell], [cell]]);
+  println("headers: ${show(headerCount(table))}")
+}

--- a/internal/parser/list_cons_pattern_test.go
+++ b/internal/parser/list_cons_pattern_test.go
@@ -197,6 +197,61 @@ func firstSome(xs: List[Option]) -> int {
 	}
 }
 
+// TestListConsPatternWithRecord is the regression guard for M-DX-RECORD-CONS.
+// A record-literal pattern as the head of an infix :: cons pattern used to fail
+// with PAT_INVALID_CONS (a parser cursor-position mismatch after the record
+// pattern). Verified fixed and closed as a ghost in mission iteration 18
+// (2026-07-13); this test locks it in — both the infix and canonical forms.
+func TestListConsPatternWithRecord(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{
+			name: "infix record head",
+			input: `module test
+
+func firstText(rows: List[{text: string, bold: bool}]) -> string {
+  match rows {
+    {text: s, bold: b} :: rest => s,
+    [] => ""
+  }
+}`,
+		},
+		{
+			name: "canonical record head",
+			input: `module test
+
+func firstText(rows: List[{text: string, bold: bool}]) -> string {
+  match rows {
+    ::({text: s, bold: b}, rest) => s,
+    [] => ""
+  }
+}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			l := lexer.New(tc.input, "test.ail")
+			p := New(l)
+			program := p.Parse()
+
+			if len(p.Errors()) != 0 {
+				t.Log("Parser errors:")
+				for _, err := range p.Errors() {
+					t.Logf("  %s", err)
+				}
+				t.Fatal("REGRESSION: record-literal head in :: cons pattern rejected (M-DX-RECORD-CONS)")
+			}
+
+			if program == nil || program.File == nil {
+				t.Fatal("Expected file to parse successfully")
+			}
+		})
+	}
+}
+
 // TestListConsPatternInvalidNoArgs tests error when :: has no arguments
 func TestListConsPatternInvalidNoArgs(t *testing.T) {
 	input := `module test


### PR DESCRIPTION
## Mission iteration 18 — VERIFY-then-route

Reality-checked the two clause-3 **VERIFY-then-route** backlog items. Both **reproduced clean at HEAD (v0.29.2)** → they are **ghosts** (already fixed by prior record-pattern / `::`-sugar and type-unification work; no code change needed). Closed with **CI-enforced regression guards** so they can't silently regress.

### M-DX-RECORD-CONS (record literal head in `::` cons pattern)
- `{text: s, bold: b} :: rest` and canonical `::({…}, rest)` both type-check ✓
- Guards: `internal/parser/list_cons_pattern_test.go::TestListConsPatternWithRecord` + `examples/record_cons_pattern.ail` (runs → `hello`)
- The doc's own noted gap (*"Missing: Cons with record patterns (no test)"*) is now closed.

### M-DX-TAPP-TRECORD (nested-record-list `[[TableCell]]` extraction)
- `makeTable(rows: [[TableCell]]) -> Block` type-checks in both `func` and `let … = \rows. …` forms ✓
- Guard: `examples/record_list_extraction.ail` (runs → `headers: 2`)
- The cited `cannot unify type application with *types.TRecord` (`%T`) error was reworded to `.String()` in `5cf6287bf`; the remaining fallback only fires for genuinely-unrelated type applications.

### Bookkeeping
- Both design docs → `design_docs/implemented/v0_30_0/` with resolution notes
- CHANGELOG updated

### Local verification
- `verify-examples-toplevel`: 36 type-checked, 33 ran clean (incl. both new examples)
- `internal/parser` package tests green; `gofmt`/`go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)