### PR TITLE
docs(mission): record iteration 18 (record-cons + tapp-trecord GHOSTS, verified-closed)

### DIFF
--- a/design_docs/v1-mission-log.md
+++ b/design_docs/v1-mission-log.md
@@ -1464,3 +1464,80 @@ causal re-run; scope-params release-gate re-score; frontier-failure validation o
 issue #341 triage; rig A/B for m-syntax-ai-forgiving (GPU). Carry forward: %-row +
 m-record-update-local-resolution doc-status re-check; the two dev-health flakies
 (`PipedStdoutFlushesPerLine`; 5 effect-row example failures).
+
+## 19 — 2026-07-13 — Iteration 18: m-dx-record-cons-pattern + m-dx-tapp-trecord-unification BOTH GHOSTS — verified-closed + regression-guarded
+
+**Picked**: the clause-3 **VERIFY-then-route** pair (`m-dx-record-cons-pattern`,
+`m-dx-tapp-trecord-unification`) — iteration-17's **Next** named it as the recommended next step
+("run the doc repro FIRST — may be ghosts, a ghost is a near-zero-cost close"). Both are existing
+docs → started at reality-check, not design-doc-creator. Bookkeeping-double allowed under Standing
+rule 1 (both are the one VERIFY-then-route batch).
+
+**Reality check**: Gate-1 origin-sync clean (local dev == origin/dev @ `8f505e633`); dev CI green
+per-workflow (CI/Build/Docs all success @ 8f505e633). Inbox: one `eval-suite` partial (19/27, 70.4%)
+— routine status, not a regression/directive, ack'd, did NOT outrank the queue. Rebuilt both binaries
+(`v0.29.2-106-g8f505e633`; `-dirty` only from a sibling's 5 pre-existing uncommitted doc/skill edits
+in the main tree — NOT touched, Critical Principle 0). Ran each doc's repro LIVE at HEAD:
+- **m-dx-record-cons-pattern = GHOST.** `{text: s, bold: b} :: rest => s` type-checks (`✓ No errors`);
+  canonical `::({…}, rest)` and baseline `first :: rest` also clean. (First repro attempt FALSE-failed
+  because I wrote match arms with a leading `|` — corrected against a real example: AILANG arms have
+  NO `|` prefix. The doc's `PAT_INVALID_CONS` bug itself does not reproduce.)
+- **m-dx-tapp-trecord-unification = GHOST.** `makeTable(rows: [[TableCell]]) -> Block` type-checks in
+  both the modern `func` form AND the doc's original `let makeTable: [[TableCell]] -> Block = \rows. …`
+  lambda-binding form (`✓ No errors`). The doc's cited error `cannot unify type application with
+  *types.TRecord` (`%T`) was reworded to `.String()` in `5cf6287bf`; the remaining fallback
+  (`unification_types.go:250`) fires only for genuinely-unrelated type apps — `unifyTypeApps`
+  decomposes `TApp~TApp` and recursively unifies element types, alias-expanding the record alias.
+
+**Shipped** (durable close, NOT just markdown — the record-cons doc flagged its OWN gap: *"Missing:
+Cons with record patterns (no test)"*). One worktree off origin/dev, one commit:
+- **`adde9e9d0`** (squash of `7e1881586`) — parser regression test
+  `internal/parser/list_cons_pattern_test.go::TestListConsPatternWithRecord` (table: infix + canonical);
+  two runnable top-level examples `examples/record_cons_pattern.ail` (→ `hello`) and
+  `examples/record_list_extraction.ail` (→ `headers: 2`) — both **CI-gated** by
+  `verify-examples-toplevel`; both design docs → `implemented/v0_30_0/` with resolution notes;
+  CHANGELOG entry.
+- **No inner-loop skills invoked** (no design-doc-creator/planner/executor/evaluator): Gate 2's
+  "already done → bookkeeping" path. The deliverable is verification + a CI-enforced regression guard,
+  not a feature — the full sprint machinery would be overkill for a 4-file additive change (2 examples,
+  1 test func, 2 doc moves + CHANGELOG). Zero Go production-code change.
+- **Local gates green in-worktree**: `internal/parser` package tests; `verify-examples-toplevel`
+  (36 type-checked, 33 ran clean, incl. both new examples); `gofmt`/`go vet` clean.
+
+**Routing evidence**: model=controller(opus) task-class=verify+bookkeeping. NO plan/execute/evaluate
+roles used this iteration — it was a reality-check that resolved to two ghosts, so the routing table's
+sprint roles didn't apply. No routing-policy change (this is 1 evidence row, not the ≥3 required, and
+it's a null case — no sprint executed).
+
+**Ruled out**:
+- "m-dx-record-cons-pattern is an open parser bug (doc status: Planned)" — REFUTED live: record head
+  in `::` type-checks in all three forms at HEAD. Ghost.
+- "m-dx-tapp-trecord-unification is an open High-pri type-inference bug (doc status: Planned)" —
+  REFUTED live: `[[TableCell]]` extraction type-checks in both `func` and `let`-lambda forms. Ghost.
+- "The `cannot unify type application with *types.TRecord` error still guards this case" — REFUTED:
+  the `%T` form was reworded (`5cf6287bf`); the surviving fallback is for unrelated type apps only.
+- (Self-correction, not a code claim) "match arms take a leading `|`" — REFUTED by
+  `examples/first_non_repeat.ail`: AILANG arms are `pat => expr,` with NO `|`. My first repro
+  false-failed on this; re-ran correctly before concluding.
+
+**Gate 3b**: PR #358 squash auto-merge on green required checks; bounded CI poll in two ~7-8 min
+chunks (30-min hard deadline, never open-ended) observed all required checks pass → merge `adde9e9d0`;
+origin/dev advanced `8f505e633..adde9e9d0`. Post-merge dev CI: the `CI` job's **Install dependencies**
+step hit a transient `proxy.golang.org` flake (`golang.org/x/tools@v0.47.0` "stream ID 1;
+INTERNAL_ERROR" during `make deps` — NOT code; no dependency change in this PR, parent `8f505e633`
+was green). Fix-forward = one `gh run rerun --failed` → **all 3 workflows green** on `adde9e9d0`
+(CI/Build/Docs). The PR's required checks had already passed pre-merge on identical content, so this
+was an environmental red on the post-merge re-run only, not a real regression.
+
+**Next**: Iteration 19 — clause-3 continues. VERIFY-then-route backlog is now EXHAUSTED (both ghosts
+closed). All remaining clause-3 starters are heavier NEW-DOC footgun fixes needing design-doc-creator
+first (Conflict Surface mandatory + the error-code/mechanism verification gates): **m-dx-match-hof**
+(R4a, 2–3d) · **m-poly-arith-lambda** (R4b, 2–3d) · **m-arity-style-diagnostic** (R4c, 1–2d) ·
+m-lambda-open-record-pattern (1d) · m-xmod-alias-poly (1–2d). Recommend R4c (arity-style, cheapest)
+or R4a next. These are full inner-loop sprints (design→plan→execute→evaluate), NOT bookkeeping.
+PARKED for human/coordinator (cumulative, unchanged): M-DX-JSON-BOOL Phase-1 firestore-package fix in
+`ailang-packages`; tier-assignment ratification (release gate); feedback-gate production ops; haiku
+causal re-run; scope-params release-gate re-score; frontier-failure validation of the 8 + 4 sketches;
+issue #341 triage; rig A/B for m-syntax-ai-forgiving (GPU). Carry forward: %-row +
+m-record-update-local-resolution doc-status re-check; the two dev-health flakies
+(`PipedStdoutFlushesPerLine`; 5 effect-row example failures).

--- a/design_docs/v1-mission.md
+++ b/design_docs/v1-mission.md
@@ -49,6 +49,25 @@ routing table: while on Opus, evaluation is model-homogeneous (Opus judges Opus)
 available (distinct-model skeptic evaluator) but left off. To go back to Fable EARLY (more quota
 sooner): `rm ~/.ailang/state/mission-model`. To extend Opus: bump the epoch in that file.
 
+## STATUS 2026-07-13 — ITERATION 18: m-dx-record-cons-pattern + m-dx-tapp-trecord-unification BOTH GHOSTS — verified-closed + CI-regression-guarded (clause 3, VERIFY-then-route)
+
+The clause-3 **VERIFY-then-route** pair. Ran each doc's repro LIVE at HEAD (`v0.29.2`): both bugs are
+**ghosts** — already fixed by prior record-pattern/`::`-sugar + type-unification work. `{text: s, bold:
+b} :: rest` type-checks (infix + canonical); `makeTable(rows: [[TableCell]]) -> Block` type-checks in
+both `func` and `let`-lambda forms. The doc's `cannot unify type application with *types.TRecord` (`%T`)
+error was reworded to `.String()` (`5cf6287bf`); the surviving fallback is for unrelated type apps only.
+NO inner-loop skills invoked — Gate 2 "already done → bookkeeping" path; deliverable is verification +
+a CI-enforced regression guard (the record-cons doc flagged its OWN missing-test gap). Shipped one
+worktree commit: parser test `TestListConsPatternWithRecord` + two runnable examples
+`record_cons_pattern.ail` (→ `hello`) / `record_list_extraction.ail` (→ `headers: 2`), both gated by
+`verify-examples-toplevel` in CI; both docs → implemented/v0_30_0; CHANGELOG. Zero Go production-code
+change. PR #358 → squash-merge `adde9e9d0`, required checks green (bounded 2-chunk poll, 30-min cap);
+post-merge dev CI green (one `gh run rerun --failed` cleared a transient `proxy.golang.org` deps
+flake in the `CI` job's install step — NOT code; all 3 workflows green on `adde9e9d0`). Retro: no
+skill/process edit (see log 19). VERIFY-then-route
+backlog now EXHAUSTED. Next: NEW-DOC footgun fixes (R4c arity-style / R4a match-hof) via
+design-doc-creator — full inner-loop sprints. Detail: log entry 19.
+
 ## STATUS 2026-07-12 — ITERATION 17: m-dx-split-argument-warning BUILT + LANDED (clause 3 — compile-time non-blocking warning for the reversed-`split` footgun)
 
 Full build loop headless, round-1 clean. Reality-check verified the footgun live (`split("/", name)` →
@@ -601,16 +620,18 @@ with design-doc-creator; existing-doc items start at reality-check.)*
     Foreign-ctor errors now enumerate transitively-known constructors (`None, Some` + did-you-mean).
     SonarCloud PR gate red = advisory/non-required (merge succeeded) — flagged for sonarcloud-triage)
 **[NEXT]** clause-3 accessibility cluster (the bulk of v1.0). Loop ordering within a group:
-P0/unblockers first, then cheapest impact-per-day. The DOC-READY/small diagnostics are now EXHAUSTED
-(module-less/xcheck/json-bool/split-arg all landed iters 14–17). Remaining clause-3 starters:
-(a) **VERIFY-then-route** — m-dx-record-cons-pattern · m-dx-tapp-trecord-unification: run the doc repro
-FIRST (may be ghosts, cheap if so); (b) the **NEW-DOC footgun fixes** (m-dx-match-hof R4a,
-m-poly-arith-lambda R4b, m-arity-style-diagnostic R4c) each need design-doc-creator first (Conflict
-Surface mandatory — incl. the error-code + mechanism verification gates). Recommend (a) next: a ghost
-is a near-zero-cost close and clears the VERIFY-then-route backlog before the heavier NEW-DOC work.
+P0/unblockers first, then cheapest impact-per-day. The DOC-READY/small diagnostics AND the
+VERIFY-then-route backlog are now EXHAUSTED (module-less/xcheck/json-bool/split-arg landed iters
+14–17; both VERIFY-then-route items closed as ghosts iter 18). Remaining clause-3 starters are all
+**NEW-DOC footgun fixes** — each needs design-doc-creator first (Conflict Surface mandatory, incl.
+the error-code + mechanism verification gates): m-dx-match-hof (R4a, 2–3d) · m-poly-arith-lambda
+(R4b, 2–3d) · m-arity-style-diagnostic (R4c, 1–2d) · m-lambda-open-record-pattern (1d) ·
+m-xmod-alias-poly (1–2d). Recommend R4c (cheapest) or R4a next — these are full inner-loop sprints,
+NOT bookkeeping.
 *(m-match-xcheck-error-quality LANDED iter 15; m-dx-json-bool-coercion in-repo half LANDED iter 16
 [`std/json.asBoolLoose`; Phase-1 firestore fix PARKED out-of-repo]; m-dx-split-argument-warning LANDED
-iter 17 — all → implemented/v0_30_0.)*
+iter 17; m-dx-record-cons-pattern + m-dx-tapp-trecord-unification GHOSTS/verified-closed iter 18 —
+all → implemented/v0_30_0.)*
 
 *(SCOPE EXPANDED 2026-07-12, Mark — full-v1.0 triage of the 69 non-gating docs. The clause-3
 accessibility cluster, BOTH DX tooling investments, and the FULL clause-4 orchestration surface
@@ -622,8 +643,11 @@ triage evidence = log entry 10.)*
 - **Parser/type footgun fixes** (NEW-DOC, Conflict Surface mandatory): m-dx-match-hof (R4a, 2–3d) ·
   m-poly-arith-lambda (R4b, 2–3d) · m-arity-style-diagnostic (R4c, 1–2d) ·
   m-lambda-open-record-pattern (1d) · m-xmod-alias-poly (1–2d)
-- **VERIFY-then-route** (agents split ghost-vs-open; run the doc repro FIRST — may be ghosts):
-  m-dx-record-cons-pattern · m-dx-tapp-trecord-unification
+- **VERIFY-then-route** (ran the doc repro FIRST — both were ghosts): ~~m-dx-record-cons-pattern~~
+  **[LANDED/GHOST iter 18 → implemented/v0_30_0; `{…} :: rest` type-checks; guard
+  `TestListConsPatternWithRecord` + `examples/record_cons_pattern.ail`, PR #358 → `adde9e9d0`]** ·
+  ~~m-dx-tapp-trecord-unification~~ **[LANDED/GHOST iter 18 → implemented/v0_30_0; `[[TableCell]]`
+  extraction type-checks; guard `examples/record_list_extraction.ail`, PR #358 → `adde9e9d0`]**
 - **Diagnostics** (DOC-READY / small): ~~m-module-less-run-fail-loud (MOD014)~~ **[LANDED iter 14 →
   implemented/v0_30_0]** · ~~m-match-xcheck-error-quality~~ **[LANDED iter 15 → implemented/v0_30_0]** ·
   ~~m-dx-json-bool-coercion~~ **[in-repo half LANDED iter 16 → implemented/v0_30_0 (`std/json.asBoolLoose`);


### PR DESCRIPTION
Mission bookkeeping for iteration 18. Both clause-3 **VERIFY-then-route** items (`m-dx-record-cons-pattern`, `m-dx-tapp-trecord-unification`) reproduced clean at HEAD → **ghosts** (already fixed by prior record-pattern/`::`-sugar + type-unification work). Closed durably with CI-enforced regression guards in PR #358 → `adde9e9d0`.

- Log entry 19 + STATUS stamp + queue tags ([LANDED/GHOST], VERIFY-then-route backlog exhausted)
- No skill/process edit (retro clean)

Companion to #358 (the code/test/example change). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)