### PR TITLE
chore(mission): version the never-committed iteration-13 bounded-wait safety fix

### DIFF
--- a/.claude/skills/mission-control/SKILL.md
+++ b/.claude/skills/mission-control/SKILL.md
@@ -139,12 +139,30 @@ into sprint-sized design docs (≤3–4 days each), queued individually.
 
 ## Gate 3b — CI GREEN (an item is not LANDED until remote CI passes on its merge)
 
-After any push to dev: `gh run watch $(gh run list --branch dev --workflow CI --limit 1 --json
-databaseId --jq '.[0].databaseId') --exit-status` (or poll `gh run list` if watch is
-unavailable). Local `make test`/`make lint` do NOT cover the remote-only gates (fmt-check,
-govulncheck, check-file-sizes, docs build). Red → fix-forward immediately if small; otherwise
-revert the merge and park the item with the CI log excerpt. Only a green run upgrades the queue
-tag to [LANDED].
+After any push to dev, wait for CI **with a hard deadline** (Standing rule 6). A headless run has
+no human to notice a hang, and a bare `gh run watch … --exit-status` blocks FOREVER if the run
+never leaves `queued` (no runner). Iteration 13 (2026-07-12) wedged 4h in exactly this class of
+unbounded poll — an `until COND; do sleep 30; done` whose condition never came true — before the
+6h driver watchdog reclaimed the slot. Use a BOUNDED poll that fails loudly on expiry (portable;
+there is no GNU `timeout` on the rig):
+
+```bash
+rid=$(gh run list --branch dev --workflow CI --limit 1 --json databaseId --jq '.[0].databaseId')
+[ -n "$rid" ] || echo "Gate 3b: no CI run for HEAD yet — re-list a few times, still bounded"
+deadline=$(( $(date +%s) + 1800 ))            # 30-min cap; CI is ~15-20m — never open-ended
+while :; do
+  st=$(gh run view "$rid" --json status,conclusion --jq '.status + " " + (.conclusion // "")')
+  case "$st" in "completed "*) echo "CI: $st"; break ;; esac
+  [ "$(date +%s)" -ge "$deadline" ] && { echo "Gate 3b TIMEOUT after 30m (status=$st) — PARK, do not hang"; break; }
+  sleep 30
+done
+```
+
+On timeout, do NOT keep waiting: park the item `needs-human-review` with the last status and
+report (Gate 5), same as for a red run — a timed-out wait is NOT green. Local `make test`/`make
+lint` do NOT cover the remote-only gates (fmt-check, govulncheck, check-file-sizes, docs build).
+Red → fix-forward immediately if small; otherwise revert the merge and park the item with the CI
+log excerpt. Only an OBSERVED green run upgrades the queue tag to [LANDED].
 
 ## Gate 4 — RECORD (append-only; the log is the mission's memory)
 
@@ -180,3 +198,12 @@ mission doc's queue tags ([LANDED], [PARKED], etc.) and STATUS stamp.
    mid-iteration because one is annoying. If a skill blocks you, that IS the retro finding.
 5. **Data before conclusions** (PROGRAM.md invariant): no fix without a measured/reproduced
    failure; record refuted hypotheses in the log's Ruled out field.
+6. **Every wait is bounded** (added 2026-07-12 after iteration 13 hung 4h in an unbounded
+   `until COND; do sleep 30; done` — no worktree, no commit, claude idle at 0% CPU with a live
+   `sleep` grandchild, until the 6h driver watchdog reclaimed the slot). ANY poll/wait you issue
+   — CI (Gate 3b), a coordinator task, a background agent, an eval, a `make` step — MUST carry a
+   hard ceiling: a `date +%s` deadline OR a max-iteration counter. On expiry, FAIL LOUDLY and
+   park/report — never keep sleeping. Forbidden: a bare `gh run watch`, `while true`, or
+   `until COND; do sleep …; done` with no cutoff. A headless iteration has no human to notice, so
+   one unbounded wait burns the entire 6h slot. Default cap ≤30 min; treat expiry as a parkable
+   failure, not an error to retry in place.

--- a/design_docs/v1-mission-log.md
+++ b/design_docs/v1-mission-log.md
@@ -1541,3 +1541,77 @@ causal re-run; scope-params release-gate re-score; frontier-failure validation o
 issue #341 triage; rig A/B for m-syntax-ai-forgiving (GPU). Carry forward: %-row +
 m-record-update-local-resolution doc-status re-check; the two dev-health flakies
 (`PipedStdoutFlushesPerLine`; 5 effect-row example failures).
+
+## 20 — 2026-07-13 — Iteration 19: versioned the never-committed iteration-13 bounded-wait safety fix (unversioned 6 iters) — clause-3 queue untouched, R4c next
+
+**Picked**: NOT the queue's `[NEXT]` (clause-3 R4c/R4a NEW-DOC sprints). The Gate-1/Gate-2
+reality-check surfaced a higher-priority **infrastructure liability that outranks feature work**
+(analogous to the mission's "a red dev outranks the queue" rule): the mission's OWN iteration-13
+anti-wedge remediation was never committed to git — SKILL.md Gate 3b bounded-poll rewrite +
+Standing rule 6 ("Every wait is bounded"), and the `mission-control.sh` `_mc_stalled` stall
+watchdog (idle-tree + long-lived-child fingerprint → early kill before HARD_TIMEOUT). Live for 6
+iterations only because launchd reads the on-disk working tree; one `git checkout`/`reset`/`clean`
+from permanent loss of the very mechanism that prevents a repeat of iteration-13's 4h loop-wide
+wedge.
+
+**Reality check**: Gate-1 origin-sync: local dev STALE at `8f505e633`, **2 commits behind**
+origin/dev `76d15aeea` (iters 17/18 landed via #358/#359; the local ref never advanced —
+iteration-12 stale-local class) → read all mission state from origin. dev CI **green per-workflow**
+(CI/Build success @ `76d15aeea`, Docs @ `adde9e9d0`). Inbox: one routine `eval-suite` start
+(3 local models × 3 benchmarks, 27 jobs) — not a regression/directive, did NOT outrank the queue.
+Classified the 7 dirty main-tree files:
+- **mission-log.md + mission.md** — uncommitted but byte-identical to origin/dev (already-merged
+  iter-18 content; the local ref is just stale). Harmless.
+- **SKILL.md + mission-control.sh** — the iteration-13 fix. Confirmed **never in git history**:
+  `git log --all -S "Every wait is bounded" -- SKILL.md` and `-S "_mc_stalled" -- mission-control.sh`
+  BOTH empty; `git show origin/dev:` greps = 0. Lives ONLY as uncommitted working-tree state.
+- **3 auto-generated docs** (`docs/docs/design-docs.md` index, `docs/docs/prompts/current.md`
+  v0.16.1→v0.16.2 sync, `docs/docs/roadmap/index.md`) — build-artifact drift, regenerated locally
+  but never committed. Left untouched (lower-risk than the safety tooling; a future iteration
+  commits them or confirms the docs build regenerates them).
+- No sibling mission-control process running (only PID 82573 = this run); the other `claude`
+  processes are unrelated ccd-cli desktop/remote sessions. So these are accumulated cross-iteration
+  drift, NOT a sibling's active in-progress work — refuting iteration 18's assumption.
+
+**Shipped**: worktree off origin/dev, branch `mission/iter19-bounded-wait-versioning`, **PR #360**.
+- commit `de26d6a7a` — versions the exact live on-disk SKILL.md (+39) + mission-control.sh (+74);
+  `bash -n` clean; **no behavioral change** (already-live content made durable + reviewable).
+- commit (this entry) — iteration-19 log + mission-doc STATUS stamp (Gate 4).
+- NO inner-loop skills invoked (design-doc-creator/planner/executor/evaluator): protective
+  bookkeeping, not a feature. Zero Go production-code change.
+
+**Routing evidence**: model=controller(opus) task-class=verify+bookkeeping. No plan/execute/evaluate
+roles used. No routing-policy change (null case; 1 evidence row, not the ≥3 required).
+
+**Ruled out**:
+- "The iteration-13 bounded-wait fix is committed / landed somewhere" — REFUTED: absent from ALL
+  of git history (`git log --all -S`) and from origin/dev; exists only as uncommitted working-tree
+  state, live solely because launchd reads on-disk files.
+- "The 5 non-log dirty files are a sibling agent's active in-progress work" (iteration 18's stated
+  assumption) — REFUTED: no sibling mission-control process; 2 are the mission's own iter-13 fix,
+  3 are auto-gen doc drift; nothing is being actively edited.
+- "Local dev == origin/dev" (what the stale local ref implied at face value) — REFUTED by
+  origin-sync: local is 2 commits behind.
+
+**Gate 3b**: PR #360 — bounded 30-min CI poll; merged only on OBSERVED green required checks
+(result recorded in the mission-doc STATUS + this entry updated at merge; see the iteration report).
+
+**Retro lane**: **none** (no skill/process/backlog edit). The SKILL.md commit **versions an
+EXISTING iteration-13 edit** — it is NOT a new Gate-5 skill improvement (the content was already
+the running skill's text), so the "one skill edit per iteration" budget is untouched. No guardrail
+change is warranted because the recurring blind spot (iters 13–18 kept re-seeing and mislabeling
+these edits) is *closed by the act of committing them*, not by a new rule. Frictions cited in the
+commit (≥2, same gap): (1) iteration-13's 4h wedge that burned a 6h slot; (2) the fix sitting
+unversioned/at-risk for 6 iterations.
+
+**Next**: Iteration 20 — clause-3 continues with a **full inner-loop NEW-DOC sprint**:
+**m-arity-style-diagnostic** (R4c, cheapest, 1–2d) or **m-dx-match-hof** (R4a, 2–3d) via
+design-doc-creator (Conflict Surface mandatory + error-code/mechanism verification gates) → planner
+→ executor in worktree → evaluator. **Carry forward (new this iteration)**: the 3 uncommitted
+auto-generated docs in the main tree remain unversioned drift — commit them or confirm the docs
+build regenerates them. PARKED for human/coordinator (cumulative, unchanged): M-DX-JSON-BOOL Phase-1
+firestore-package fix in `ailang-packages`; tier-assignment ratification (release gate);
+feedback-gate production ops; haiku causal re-run; scope-params release-gate re-score;
+frontier-failure validation of the 8 + 4 sketches; issue #341 triage; rig A/B for
+m-syntax-ai-forgiving (GPU). Carry forward: %-row + m-record-update-local-resolution doc-status
+re-check; the two dev-health flakies (`PipedStdoutFlushesPerLine`; 5 effect-row example failures).

--- a/design_docs/v1-mission.md
+++ b/design_docs/v1-mission.md
@@ -49,6 +49,25 @@ routing table: while on Opus, evaluation is model-homogeneous (Opus judges Opus)
 available (distinct-model skeptic evaluator) but left off. To go back to Fable EARLY (more quota
 sooner): `rm ~/.ailang/state/mission-model`. To extend Opus: bump the epoch in that file.
 
+## STATUS 2026-07-13 — ITERATION 19: versioned the never-committed iteration-13 bounded-wait safety fix (SKILL.md Gate-3b/rule-6 + mission-control.sh stall watchdog — unversioned 6 iters); clause-3 queue untouched, R4c next
+
+The Gate-1/Gate-2 reality-check surfaced a **P0 infrastructure liability that outranks the feature
+queue** (analogous to "red dev outranks queue"): the mission's OWN iteration-13 anti-wedge
+remediation — SKILL.md Gate 3b bounded-poll + Standing rule 6, and the `mission-control.sh`
+`_mc_stalled` stall watchdog — was **never committed to git anywhere in history** (`git log --all
+-S` empty; absent from `origin/dev`). Live for 6 iterations only because launchd reads the on-disk
+working tree; one `git checkout`/`reset`/`clean` from permanent loss of the anti-wedge mechanism.
+Iteration 18's own log had mislabeled these as "a sibling's 5 uncommitted edits" and left them — a
+recurring blind spot across iters 13–18, now closed. Versioned the exact live on-disk content
+(SKILL.md +39, mission-control.sh +74; `bash -n` clean; **no behavioral change**) via a worktree off
+origin/dev → **PR #360**. Gate-1 also caught local dev STALE 2 commits behind origin/dev (iters
+17/18 landed via #358/#359; iteration-12 stale-local class) → read all state from origin. 3
+auto-generated docs (design-docs index, `prompts/current` v0.16.2, roadmap index) remain uncommitted
+build-drift — left untouched to keep the safety-fix commit focused (carried to next iteration). NO
+inner-loop skills invoked (protective bookkeeping, zero Go change). Next: clause-3 R4c
+`m-arity-style-diagnostic` (cheapest) or R4a `m-dx-match-hof` — full inner-loop NEW-DOC sprints.
+Detail: log entry 20.
+
 ## STATUS 2026-07-13 — ITERATION 18: m-dx-record-cons-pattern + m-dx-tapp-trecord-unification BOTH GHOSTS — verified-closed + CI-regression-guarded (clause 3, VERIFY-then-route)
 
 The clause-3 **VERIFY-then-route** pair. Ran each doc's repro LIVE at HEAD (`v0.29.2`): both bugs are

--- a/tools/launchd/mission-control.sh
+++ b/tools/launchd/mission-control.sh
@@ -31,6 +31,48 @@ unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
 LOG=/tmp/ailang-mission-control.log
 log() { echo "[$(date '+%F %H:%M:%S')] $*" | tee -a "$LOG"; }
 
+# --- stall detection (see the stall watchdog below) -------------------------
+# _mc_descendants PID → echoes PID and every descendant PID (one per line).
+_mc_descendants() {
+  local pid="$1"; echo "$pid"
+  local kids k; kids=$(pgrep -P "$pid" 2>/dev/null)
+  for k in $kids; do _mc_descendants "$k"; done
+}
+# _mc_etime_secs "[[DD-]HH:]MM:SS" → seconds (macOS ps has no `etimes`).
+_mc_etime_secs() {
+  local t="${1// /}" dd=0 hh=0 mm=0 ss=0 rest nf
+  [ -n "$t" ] || { echo 0; return; }
+  case "$t" in *-*) dd=${t%%-*}; rest=${t#*-} ;; *) rest="$t" ;; esac
+  nf=$(( $(printf '%s' "$rest" | tr -cd ':' | wc -c) + 1 ))
+  if [ "$nf" -ge 3 ]; then hh=${rest%%:*}; rest=${rest#*:}; fi
+  mm=${rest%%:*}; ss=${rest##*:}
+  echo $(( 10#${dd:-0}*86400 + 10#${hh:-0}*3600 + 10#${mm:-0}*60 + 10#${ss:-0} ))
+}
+# _mc_stalled PID → true when the tree is IDLE (<2% CPU across the tree) AND has
+# a descendant that has itself been alive ≥ STALL_CHILD_AGE. That pair is the
+# fingerprint of a wedged tool call (iteration 13: a `until …; do sleep 30; done`
+# whose zsh child sat alive 4h+ at 0% CPU). We key on the LONG-LIVED CHILD, not a
+# live `sleep` — after hours of polling `gh` is rate-limited/slow, so a `sleep`
+# descendant is only intermittently present and a naive sleep-catcher misses it.
+# Errs safe: macOS `ps %cpu` is a lifetime-decaying average, so a session doing
+# real work reads non-idle and is NOT flagged (we miss late stalls, never kill
+# live work); and STALL_CHILD_AGE is set past the skill's 30-min bounded-wait cap
+# so a COMPLIANT wait can never trip it.
+_mc_stalled() {
+  local root="$1" pids p secs cpu long=0
+  pids=$(_mc_descendants "$root")
+  for p in $pids; do
+    [ "$p" = "$root" ] && continue
+    secs=$(_mc_etime_secs "$(ps -o etime= -p "$p" 2>/dev/null)")
+    [ "${secs:-0}" -ge "${STALL_CHILD_AGE:-2400}" ] && { long=1; break; }
+  done
+  [ "$long" -eq 1 ] || return 1
+  cpu=$(ps -o %cpu= -p "$(echo $pids | tr ' ' ',')" 2>/dev/null | awk '{s+=$1} END{printf "%d", s+0}')
+  [ "${cpu:-0}" -lt 2 ] || return 1
+  return 0
+}
+# ----------------------------------------------------------------------------
+
 # Controller model. Steady state is Fable. A time-boxed override file lets us
 # borrow a different model (e.g. Opus during a Fable-quota window) and REVERT
 # AUTOMATICALLY when it expires — no session or human needed. Format of
@@ -52,6 +94,17 @@ if [ -z "${MISSION_MODEL:-}" ] && [ -f "$OVERRIDE_FILE" ]; then
   fi
 fi
 HARD_TIMEOUT="${MISSION_TIMEOUT:-21600}"   # 6h wall-clock kill per iteration
+# Stall watchdog (2026-07-12): a wedged unbounded poll loop (iteration 13's
+# `until COND; do sleep 30; done`) otherwise burns the whole 6h slot before
+# HARD_TIMEOUT. Kill early once the session is IDLE (<2% CPU) with a descendant
+# that has itself been alive ≥ STALL_CHILD_AGE — a wedged tool call. Both the
+# grace and the child-age gate sit past the skill's 30-min bounded-wait cap so a
+# COMPLIANT wait can never trip it. All env-overridable.
+STALL_GRACE="${MISSION_STALL_GRACE:-2400}"       # 40m before the first check
+STALL_CHILD_AGE="${MISSION_STALL_CHILD_AGE:-2400}" # a descendant alive ≥40m = wedged
+STALL_INTERVAL="${MISSION_STALL_INTERVAL:-120}"  # 2m between samples
+STALL_SAMPLES="${MISSION_STALL_SAMPLES:-3}"      # consecutive idle+long-child hits → kill
+export STALL_CHILD_AGE
 KILL_SWITCH="$HOME/.ailang/state/mission-control.disabled"
 
 # 1. Kill switch — the intended "off" state, exit silently.
@@ -122,8 +175,27 @@ CLAUDE_PID=$!
 ) &
 WATCHDOG_PID=$!
 
+# Stall watchdog: after the grace window, sample for the wedged-tool fingerprint
+# (idle tree + a descendant alive ≥ STALL_CHILD_AGE). STALL_SAMPLES consecutive
+# hits → kill early so the slot recycles instead of idling to HARD_TIMEOUT. hits
+# resets on any non-idle/no-long-child sample, so live work is never killed.
+(
+  sleep "$STALL_GRACE"
+  hits=0
+  while kill -0 "$CLAUDE_PID" 2>/dev/null; do
+    if _mc_stalled "$CLAUDE_PID"; then hits=$((hits + 1)); else hits=0; fi
+    if [ "$hits" -ge "$STALL_SAMPLES" ]; then
+      echo "[$(date '+%F %H:%M:%S')] STALL: claude $CLAUDE_PID idle with a descendant alive ≥${STALL_CHILD_AGE}s across $STALL_SAMPLES samples (unbounded poll loop?) — killing early" >>"$LOG"
+      kill -TERM "$CLAUDE_PID" 2>/dev/null; sleep 30; kill -KILL "$CLAUDE_PID" 2>/dev/null
+      break
+    fi
+    sleep "$STALL_INTERVAL"
+  done
+) &
+STALL_PID=$!
+
 wait "$CLAUDE_PID"; RC=$?
-kill "$WATCHDOG_PID" 2>/dev/null
+kill "$WATCHDOG_PID" "$STALL_PID" 2>/dev/null
 
 if [ "$RC" -ne 0 ]; then
   log "iteration exited rc=$RC"


### PR DESCRIPTION
## Summary

The iteration-13 remediation for the 4h loop-wide wedge was **never committed to git anywhere in history** — it lived only as uncommitted working-tree state in the main checkout, active for 6 iterations solely because launchd reads on-disk files. One `git checkout`/`reset`/`clean` would have permanently destroyed the mission's own anti-wedge mechanism.

This versions the exact live on-disk content (no behavioral change):

- **`.claude/skills/mission-control/SKILL.md`** — Gate 3b bounded-poll rewrite + Standing rule 6 ("Every wait is bounded").
- **`tools/launchd/mission-control.sh`** — the `_mc_stalled` stall watchdog (idle-tree + long-lived-child fingerprint → early kill before HARD_TIMEOUT).

Verified `bash -n` clean; SKILL.md text is identical to what the running skill loads. Iteration 18's log had mislabeled these as "a sibling's uncommitted edits" and left them — a recurring blind spot across iters 13–18 that this commit closes.

A second commit records the iteration-19 mission log entry + queue/status stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)