### PR TITLE
feat(types): TC_ARITY_001 coded directional arity diagnostic (M-ARITY-STYLE, clause-3 R4c)

### DIFF
--- a/.ailang/state/sprints/sprint_m_arity_style_diagnostic.json
+++ b/.ailang/state/sprints/sprint_m_arity_style_diagnostic.json
@@ -1,0 +1,120 @@
+{
+  "sprint_id": "M-ARITY-STYLE-DIAGNOSTIC",
+  "design_doc": "design_docs/planned/v1_0_0/m-arity-style-diagnostic.md",
+  "mission": "V1 clause-3 R4c (footgun burn-down)",
+  "target_version": "v1.0.0",
+  "created": "2026-07-13",
+  "planner_model": "claude-opus-4-8",
+  "github_issues": [],
+  "risk_level": "low",
+  "velocity": {
+    "target_loc_per_day": 100,
+    "estimated_total_loc": 100,
+    "estimated_days": 2
+  },
+  "scope_note": "Diagnostic-quality ONLY. No arity semantics change: strict arity + no-partial-application preserved. Confined to the post-curry-flatten else branch at internal/types/unification_types.go:39 and the arity error text in internal/types/errors.go. No grammar/AST change.",
+  "direction_investigation": {
+    "question": "Which of fp1/fp2 at unification_types.go:39 is the callee's declared arity (expected) vs the call-site arg count (actual)?",
+    "resolved_by_planner": true,
+    "answer": "For the App footgun path, fp1 (t1) = EXPECTED (declared arity), fp2 (t2) = ACTUAL (provided args).",
+    "chain": [
+      "typechecker_functions.go:471 inferApp builds TypeEq{Left: getType(funcNode) [callee's actual declared func type], Right: expectedFuncType [TFunc2 with Params: argTypes = the N supplied args]}.",
+      "inference_helpers.go:181-187 solves TypeEq via Unify(ApplySubst(Left), ApplySubst(Right)) => t1=Left=declared callee, t2=Right=call-site.",
+      "unification_core.go:275 dispatches u.unifyFunctions(t1, t2). unification_types.go:33-39: fp1=flatten(t1)=declared/EXPECTED, fp2=flatten(t2Func)=provided/ACTUAL.",
+      "Matches live orientation: partial/too-few '2 vs 1' (expected 2, got 1), too-many '2 vs 3' (expected 2, got 3)."
+    ],
+    "stability_caveat": "Direction is stable ONLY for the concrete App path (both sides concrete *TFunc2, no TVar swap-and-retry fires before unifyFunctions). In raw unit tests (e.g. curry_unify_test.go) either side may be t1 (TestCurriedMismatchStillFails passes Unify(curried, threeParam) => fp1=2, fp2=3 with NO callee semantics). Therefore the wording must degrade gracefully and stay coded/correct even when 'expected/actual' labels are semantically arbitrary. Message with 'expects N argument(s), but M provided' is neutral-safe: it always describes the two function types being unified, which is true regardless of which is the source of truth.",
+    "executor_action": "Wire fp1 -> expected, fp2 -> actual at line 39. Pin with the three golden App tests (too-many MUST render 'but 3 provided', too-few 'but 1 provided'). Do NOT add a swap heuristic; the App path is the only user-facing one and it is direction-stable."
+  },
+  "features": [
+    {
+      "id": "M1_CODED_DIRECTIONAL_MESSAGE",
+      "description": "Allocate TC_ARITY_001 and replace the bare fmt.Errorf at unification_types.go:39 with a coded, directional, style-aware inline message. Code+hint MUST be inline in the string (not a *TypeCheckError.Suggestion field) because the wrap at inference_helpers.go:187 is plain %w and nothing recovers *TypeCheckError via errors.As, so a struct Suggestion would never render. Mirror the TC_REC_00X convention (errors.go:409).",
+      "estimated_loc": 20,
+      "dependencies": [],
+      "files": [
+        "internal/types/errors.go (add TC_ARITY_001 const next to TC_REC_00X block ~line 393; add arityMismatchMsg(expected, actual int) string helper next to NewArityMismatchError ~line 336)",
+        "internal/types/unification_types.go (replace bare fmt.Errorf at line 39 with fmt.Errorf(\"%s\", arityMismatchMsg(len(fp1), len(fp2))); fp1=expected, fp2=actual)"
+      ],
+      "message_spec": {
+        "line1": "TC_ARITY_001: function expects <expected> argument(s), but <actual> provided",
+        "suggestion_line": "\\n  Suggestion: <direction-specific hint>  (mirror TypeCheckError.Error() render at errors.go:88-89)",
+        "hint_actual_lt_expected": "AILANG has no partial application — call with all <expected> arguments, or wrap in a lambda `\\a b. f(a, b)`.",
+        "hint_actual_gt_expected": "Remove the extra <actual-expected> argument(s); this function takes <expected>."
+      },
+      "acceptance_criteria": [
+        "TC_ARITY_001 constant added and greppable; grep TC_ARITY finds it in non-test code",
+        "arityMismatchMsg(expected, actual) produces line containing 'TC_ARITY_001', 'expects <expected>', 'but <actual> provided', and a Suggestion line",
+        "actual<expected (too-few/partial) hint explicitly names AILANG's no-partial-application rule",
+        "actual>expected (too-many) hint says to remove the extra argument(s)",
+        "Direction wired correctly: fp1=expected, fp2=actual at unification_types.go:39"
+      ],
+      "passes": true,
+      "started": "2026-07-13T06:24:22Z",
+      "completed": "2026-07-13T06:24:22Z",
+      "notes": "TC_ARITY_001 const + arityMismatchMsg(expected,actual) helper added in errors.go; bare fmt.Errorf at unification_types.go:39 replaced with inline coded/directional/style-aware message. Direction verified from inferApp: fp1=expected, fp2=actual. Repros in tmp_arity/ emit correct directional wording + Suggestion. Commit f1b506e53."
+    },
+    {
+      "id": "M2_GOLDEN_TESTS_REGRESSION_LOCK",
+      "description": "New golden tests for the three footgun cases + regression lock over the Conflict-Surface programs. Prefer table-driven unit tests over arityMismatchMsg and/or a full type-check of the three .ail repros. Use make verify-examples + curry_unify_test.go for the regression surface.",
+      "estimated_loc": 80,
+      "dependencies": [
+        "M1_CODED_DIRECTIONAL_MESSAGE"
+      ],
+      "files": [
+        "internal/types/arity_diagnostic_test.go (new): golden tests for partial/too-many/too-few + regression asserts",
+        "internal/types/curry_unify_test.go (VERIFY only — see discrepancy: no text change actually needed; see notes)"
+      ],
+      "test_list": {
+        "new_golden_tests": [
+          "TestArityDiagnostic_TooFew_Partial: message contains TC_ARITY_001, 'expects 2', 'but 1 provided', and the no-partial-application hint",
+          "TestArityDiagnostic_TooMany: message contains TC_ARITY_001, 'expects 2', 'but 3 provided', 'Remove the extra' / 'remove ... argument'",
+          "TestArityDiagnostic_TooFew: same family as partial (add(1) where add is arity-2)"
+        ],
+        "regression_asserts": [
+          "All 7 curry_unify_test.go tests stay GREEN (TestCurriedLambdaUnifiesWithMultiParam, TestCurriedLambdaUnifiesWithConcreteTypes, TestTripleCurriedUnifies, TestMultiParamStillWorks, TestSymmetricCurriedUnification, TestPartialCurriedUnification, TestCurriedMismatchStillFails)",
+          "TestCurriedMismatchStillFails still FAILS to unify (asserts err != nil only — does NOT assert text; no edit required, see discrepancy)"
+        ],
+        "regression_fixtures": [
+          "make verify-examples green (covers all 36 examples; the doc-named examples/lambdas_higher_order.ail and examples/no_loops_fold.ail DO NOT EXIST — use verify-examples as the regression surface instead)",
+          "benchmarks/higher_order_functions.yml unaffected",
+          "benchmarks/fold_reduce.yml unaffected",
+          "positive controls in /tmp/mc20/ok.ail and /tmp/mc20/curry.ail still emit '✓ No errors' (re-create if /tmp cleared: ok.ail = 2-arg call of arity-2 add; curry.ail = curried↔tupled unification)"
+        ]
+      },
+      "acceptance_criteria": [
+        "arity_diagnostic_test.go covers all three footgun cases with code+direction+hint asserts",
+        "All 7 curry_unify_test.go tests green",
+        "make verify-examples green",
+        "make test green",
+        "higher_order_functions and fold_reduce benchmarks unaffected (spot-check type-check)",
+        "One-paragraph note added to the DX/error-quality reference (mirror m-match-xcheck-error-quality)"
+      ],
+      "passes": true,
+      "started": "2026-07-13T06:24:22Z",
+      "completed": "2026-07-13T06:24:22Z",
+      "notes": "arity_diagnostic_test.go: 6 golden tests (too-few/partial, too-many, too-few, equal-defensive, curried-flatten-reconciles) asserting code+direction+hint via both arityMismatchMsg and App-path Unify orientation. All 7 curry_unify_test.go tests green. TestCurriedMismatchStillFails left untouched (no text assert). Errors reference + CHANGELOG updated."
+    }
+  ],
+  "acceptance_criteria_overall": [
+    "SM1: each of the three cases emits a message containing (a) TC_ARITY_001, (b) directional wording ('expects N ... but M provided'), (c) a Suggestion-style hint — verified by golden test",
+    "SM2: the too-few/partial case's hint explicitly names AILANG's no-partial-application rule",
+    "SM3: zero regressions — all 7 curry_unify_test.go positive cases green; /tmp/mc20/ok.ail and /tmp/mc20/curry.ail still '✓ No errors'",
+    "SM4: make test + make verify-examples green; higher_order_functions and fold_reduce benchmarks unaffected"
+  ],
+  "discrepancies_found": [
+    "TestCurriedMismatchStillFails does NOT assert on error text (only err != nil at curry_unify_test.go:137-140). The design doc's claim that this is 'the ONE intentional test-text change' is INCORRECT — no text edit is required there; it keeps passing regardless. Executor should NOT invent a text assertion just to satisfy the doc.",
+    "The two example files named in the Conflict Surface (examples/lambdas_higher_order.ail, examples/no_loops_fold.ail) DO NOT EXIST. Use make verify-examples (all 36 examples) as the regression surface instead.",
+    "unification_types.go:187 (TCon arity, already directional) is explicitly OUT of scope — do not touch.",
+    "Direction is stable only for the concrete App path; unit-test callers can invert t1/t2. Message wording is neutral-safe so this does not break correctness."
+  ],
+  "out_of_scope": [
+    "Any arity SEMANTICS change (partial application / auto-currying)",
+    "Touching TCon arity site unification_types.go:187",
+    "Upgrading inference_helpers.go:187 %w wrap to preserve structured errors via errors.As",
+    "A dedicated 'ailang explain TC_ARITY_001' entry"
+  ],
+  "status": "completed",
+  "completed": "2026-07-13T06:24:22Z",
+  "actual_loc": 130
+}

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,28 @@
 
 ## [Unreleased]
 
+### Added — coded, directional arity diagnostic `TC_ARITY_001` (M-ARITY-STYLE)
+
+- Calling a function with the wrong number of arguments now emits a **coded,
+  directional, style-aware** diagnostic instead of the bare
+  `function arity mismatch: 2 vs 1`. The message carries the greppable code
+  `TC_ARITY_001`, states how many arguments the function expects vs how many were
+  provided, and adds a `Suggestion:` line naming the fix:
+  ```
+  TC_ARITY_001: function expects 2 argument(s), but 1 provided
+    Suggestion: AILANG has no partial application — call with all 2 arguments, or wrap in a lambda `\a b. f(a, b)`.
+  ```
+  - **Under-supply / partial application** (`add(1)` or `let inc = add(1)` on an
+    arity-2 `add`) names AILANG's no-partial-application rule.
+  - **Over-supply** (`add(1, 2, 3)`) tells you to remove the extra argument(s).
+- **Diagnostic-only** — no arity semantics change. Strict arity and
+  no-partial-application are preserved; no program that compiled before stops
+  compiling, and curried↔tupled unification still works. The code + hint are
+  inline in the message (mirroring the `TC_REC_00X` convention) because the
+  unification error is plain-`%w`-wrapped and never recovered via `errors.As`.
+- Documented in [docs/docs/reference/errors/index.md](../docs/docs/reference/errors/index.md).
+  Golden tests: `internal/types/arity_diagnostic_test.go`.
+
 ### Fixed — record patterns in cons & nested-record-list extraction verified + regression-guarded (M-DX-RECORD-CONS, M-DX-TAPP-TRECORD)
 
 - Two long-standing DX bugs from the `docparse-demo` feedback (Feb 2026) were **verified fixed at

--- a/design_docs/implemented/v0_30_0/m-arity-style-diagnostic.md
+++ b/design_docs/implemented/v0_30_0/m-arity-style-diagnostic.md
@@ -1,6 +1,6 @@
 # Arity-Style Diagnostic (m-arity-style-diagnostic)
 
-**Status**: Planned
+**Status**: Implemented (mission iteration 21, 2026-07-13 — PASS 97/100 round 1)
 **Target**: v1.0.0 (clause-3 accessibility — fleet-tier footgun burn-down)
 **Priority**: P1
 **Estimated**: 1–2 days

--- a/docs/docs/reference/errors/index.md
+++ b/docs/docs/reference/errors/index.md
@@ -80,6 +80,17 @@ type ErrorCodesOutput struct {
 }
 ```
 
+## Type-checker error-quality codes
+
+Some type-checker failures carry an inline `TC_*` code plus a `Suggestion:` line so a model (or human) can look up the failure class and get an actionable fix. Examples: `TC_REC_001`–`TC_REC_004` (record errors) and `TC_ARITY_001`.
+
+**`TC_ARITY_001` — function arity mismatch.** Emitted when a function is called with the wrong number of arguments. AILANG has **strict arity and no partial application**, so the diagnostic is directional and style-aware: it states how many arguments the function expects vs how many were provided, and the `Suggestion:` line names the fix. Under-supply (e.g. `add(1)` on an arity-2 `add`, or a partial application `let inc = add(1)`) reminds you that AILANG has no partial application — call with all N arguments, or wrap in a lambda. Over-supply (e.g. `add(1, 2, 3)`) tells you to remove the extra argument(s). This is a diagnostic-only improvement; arity semantics are unchanged.
+
+```
+TC_ARITY_001: function expects 2 argument(s), but 1 provided
+  Suggestion: AILANG has no partial application — call with all 2 arguments, or wrap in a lambda `\a b. f(a, b)`.
+```
+
 ## Individual error code pages
 
 - [MOD013 — Shared module_prefix](mod013.md)

--- a/internal/types/arity_diagnostic_test.go
+++ b/internal/types/arity_diagnostic_test.go
@@ -1,0 +1,146 @@
+package types
+
+import (
+	"strings"
+	"testing"
+)
+
+// M-ARITY-STYLE golden tests for the TC_ARITY_001 coded, directional,
+// style-aware arity diagnostic. See design_docs/planned/v1_0_0/m-arity-style-diagnostic.md.
+//
+// Two layers:
+//   1. Unit tests over arityMismatchMsg (the exact rendered text).
+//   2. Integration tests through Unify using the concrete App-path orientation
+//      (Left = declared callee = EXPECTED arity, Right = call-site func type =
+//      ACTUAL args), matching how inferApp builds the TypeEq constraint at
+//      typechecker_functions.go and how it is solved at inference_helpers.go.
+
+// funcType builds a flat (non-curried) function type with n Star-kinded params.
+func funcType(n int) *TFunc2 {
+	params := make([]Type, n)
+	for i := range params {
+		params[i] = &TVar2{Name: "p", Kind: Star}
+	}
+	return &TFunc2{Params: params, Return: &TVar2{Name: "r", Kind: Star}}
+}
+
+// unifyAppArity mirrors the App path: Left=declared callee (expected arity),
+// Right=call-site func type built from the supplied args (actual arity).
+func unifyAppArity(t *testing.T, expected, actual int) error {
+	t.Helper()
+	u := NewUnifier()
+	_, err := u.Unify(funcType(expected), funcType(actual), Substitution{})
+	return err
+}
+
+func TestArityDiagnostic_TooFew_Partial(t *testing.T) {
+	// add(1) where add is arity-2: expected 2, actual 1 (partial application).
+	msg := arityMismatchMsg(2, 1)
+
+	for _, want := range []string{
+		"TC_ARITY_001",
+		"expects 2 argument(s)",
+		"but 1 provided",
+		"Suggestion:",
+		"no partial application",
+		"call with all 2 arguments",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("too-few/partial message missing %q\ngot:\n%s", want, msg)
+		}
+	}
+
+	// End-to-end through Unify with the App orientation.
+	err := unifyAppArity(t, 2, 1)
+	if err == nil {
+		t.Fatal("arity 2 vs 1 must fail to unify")
+	}
+	if !strings.Contains(err.Error(), "TC_ARITY_001") || !strings.Contains(err.Error(), "but 1 provided") {
+		t.Errorf("Unify App-path error missing code/direction\ngot: %v", err)
+	}
+}
+
+func TestArityDiagnostic_TooMany(t *testing.T) {
+	// add(1, 2, 3) where add is arity-2: expected 2, actual 3 (over-supply).
+	msg := arityMismatchMsg(2, 3)
+
+	for _, want := range []string{
+		"TC_ARITY_001",
+		"expects 2 argument(s)",
+		"but 3 provided",
+		"Suggestion:",
+		"Remove the extra 1 argument(s)",
+		"this function takes 2",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("too-many message missing %q\ngot:\n%s", want, msg)
+		}
+	}
+
+	// The too-many hint must NOT mention partial application.
+	if strings.Contains(msg, "partial application") {
+		t.Errorf("too-many message should not mention partial application\ngot:\n%s", msg)
+	}
+
+	// End-to-end through Unify with the App orientation.
+	err := unifyAppArity(t, 2, 3)
+	if err == nil {
+		t.Fatal("arity 2 vs 3 must fail to unify")
+	}
+	if !strings.Contains(err.Error(), "TC_ARITY_001") || !strings.Contains(err.Error(), "but 3 provided") {
+		t.Errorf("Unify App-path error missing code/direction\ngot: %v", err)
+	}
+}
+
+func TestArityDiagnostic_TooFew(t *testing.T) {
+	// Same family as partial: add(1) where add is arity-2.
+	msg := arityMismatchMsg(2, 1)
+
+	if !strings.Contains(msg, "TC_ARITY_001") {
+		t.Errorf("too-few message missing code\ngot:\n%s", msg)
+	}
+	if !strings.Contains(msg, "but 1 provided") {
+		t.Errorf("too-few message missing direction\ngot:\n%s", msg)
+	}
+	if !strings.Contains(msg, "no partial application") {
+		t.Errorf("too-few (under-supply) hint must name the no-partial-application rule\ngot:\n%s", msg)
+	}
+}
+
+// TestArityDiagnostic_EqualDefensive: the else branch never emits this in
+// practice (it runs only when arities differ), but the helper must stay coded
+// and not emit a nonsense directional hint if ever called with expected==actual.
+func TestArityDiagnostic_EqualDefensive(t *testing.T) {
+	msg := arityMismatchMsg(2, 2)
+	if !strings.Contains(msg, "TC_ARITY_001") {
+		t.Errorf("defensive equal-arity message must still be coded\ngot:\n%s", msg)
+	}
+	if strings.Contains(msg, "partial application") || strings.Contains(msg, "Remove the extra") {
+		t.Errorf("defensive equal-arity message must not emit a directional hint\ngot:\n%s", msg)
+	}
+}
+
+// TestArityDiagnostic_CurriedFlattenStillReconciles is a regression guard: the
+// new message lives ONLY in the post-flatten else branch, so curried↔tupled
+// forms with equal FLATTENED arity must still unify (no diagnostic emitted).
+func TestArityDiagnostic_CurriedFlattenStillReconciles(t *testing.T) {
+	u := NewUnifier()
+
+	// a -> (b -> c) (curried, flattened arity 2)
+	curried := &TFunc2{
+		Params: []Type{&TVar2{Name: "a", Kind: Star}},
+		Return: &TFunc2{
+			Params: []Type{&TVar2{Name: "b", Kind: Star}},
+			Return: &TVar2{Name: "c", Kind: Star},
+		},
+	}
+	// (x, y) -> z (tupled, arity 2)
+	tupled := &TFunc2{
+		Params: []Type{&TVar2{Name: "x", Kind: Star}, &TVar2{Name: "y", Kind: Star}},
+		Return: &TVar2{Name: "z", Kind: Star},
+	}
+
+	if _, err := u.Unify(curried, tupled, Substitution{}); err != nil {
+		t.Fatalf("curried↔tupled (equal flattened arity) must still unify, got: %v", err)
+	}
+}

--- a/internal/types/errors.go
+++ b/internal/types/errors.go
@@ -341,6 +341,39 @@ func NewArityMismatchError(expected, actual int, path []string) *TypeCheckError 
 	}
 }
 
+// TC_ARITY_001 codes an irreconcilable function-arity mismatch (M-ARITY-STYLE).
+// See arityMismatchMsg for the rendered, directional, style-aware text.
+const TC_ARITY_001 = "TC_ARITY_001"
+
+// arityMismatchMsg builds the coded, directional, style-aware arity diagnostic
+// emitted at unification_types.go's post-curry-flatten else branch (M-ARITY-STYLE).
+//
+// The code + Suggestion are embedded INLINE in the returned string (not a
+// *TypeCheckError.Suggestion field): the error is wrapped by a plain `%w` at
+// inference_helpers.go and nothing recovers *TypeCheckError via errors.As, so a
+// struct Suggestion would never render. Mirrors the TC_REC_00X convention.
+//
+// AILANG has strict arity and NO partial application, so the hint targets the
+// two fleet-tier ML habits directly: under-supply (partial application) and
+// over-supply (extra arguments).
+func arityMismatchMsg(expected, actual int) string {
+	var hint string
+	switch {
+	case actual < expected:
+		hint = fmt.Sprintf("AILANG has no partial application — call with all %d arguments, or wrap in a lambda `\\a b. f(a, b)`.", expected)
+	case actual > expected:
+		extra := actual - expected
+		hint = fmt.Sprintf("Remove the extra %d argument(s); this function takes %d.", extra, expected)
+	default:
+		// Unreachable in the emission-site else branch (that branch runs only
+		// when arities differ), but stay coded and neutral rather than emit a
+		// nonsense hint if ever reached.
+		hint = "Check the function's declared arity against the call site."
+	}
+	return fmt.Sprintf("%s: function expects %d argument(s), but %d provided\n  Suggestion: %s",
+		TC_ARITY_001, expected, actual, hint)
+}
+
 // NewUnsolvedConstraintError creates an unsolved type class constraint error
 func NewUnsolvedConstraintError(className string, typ Type, path []string) *TypeCheckError {
 	suggestion := ""

--- a/internal/types/unification_types.go
+++ b/internal/types/unification_types.go
@@ -36,7 +36,12 @@ func (u *Unifier) unifyFunctions(t1 *TFunc2, t2 Type, sub Substitution) (Substit
 				p1, r1 = fp1, fr1
 				p2, r2 = fp2, fr2
 			} else {
-				return nil, fmt.Errorf("function arity mismatch: %d vs %d", len(fp1), len(fp2))
+				// M-ARITY-STYLE: coded, directional, style-aware diagnostic.
+				// For the user-facing App path, t1=Left=declared callee (EXPECTED
+				// arity) and t2=Right=call-site func type (ACTUAL args); so
+				// fp1=expected, fp2=actual. Wording is neutral-safe for raw
+				// unit-test callers where the orientation is arbitrary.
+				return nil, fmt.Errorf("%s", arityMismatchMsg(len(fp1), len(fp2)))
 			}
 		}
 


### PR DESCRIPTION
## Summary

Mission iteration 21 (clause-3 R4c, design doc PR #361). Turns the three arity footguns (partial application / too many / too few args) into a single **coded, directional, style-aware** diagnostic — diagnostic-only, **no arity-semantics change**.

**Before** (all three cases): `function arity mismatch: 2 vs 1`

**After**:
```
TC_ARITY_001: function expects 2 argument(s), but 1 provided
  Suggestion: AILANG has no partial application — call with all 2 arguments, or wrap in a lambda `\a b. f(a, b)`.
```

## Changes
- `internal/types/errors.go` — `TC_ARITY_001` const + `arityMismatchMsg` helper (code + Suggestion inline in the string, per the `TC_REC_00X` convention — the plain `%w` wrap at `inference_helpers.go:187` would flatten a struct Suggestion)
- `internal/types/unification_types.go` — bare `fmt.Errorf` in the post-curry-flatten `else` replaced with the helper; direction pinned from `inferApp`'s constraint construction (`fp1`=declared/expected, `fp2`=call-site/actual), verified independently by planner AND executor
- `internal/types/arity_diagnostic_test.go` (new) — 5 golden/regression tests (message text + through-`Unify` App-path orientation + curried↔tupled flatten still reconciles + equal-arity defensive)
- Docs: `docs/docs/reference/errors/index.md` TC_* error-quality section; CHANGELOG Unreleased entry
- Design doc → `implemented/v0_30_0/` (independent eval **PASS 97/100 round 1**)

## Verification (independent evaluator, worktree-built binary)
- 3 live repros emit code + direction + hint; positive controls (2-arg call, curried↔tupled) still `✓ No errors`
- Non-vacuity: same repros on base `d6b22b75d` emit the old bare message
- `go test ./internal/... -count=1` green; 7/7 `curry_unify_test.go`; gofmt clean; `make check-file-sizes` green
- `make verify-examples`: 185 pass / 5 fail = exactly the pre-existing issue #341 baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)