### PR TITLE
fix(feedback): external feedback delivery — pkg:* Discord tag + daemon dual-subscribe (M-PUBLIC-FEEDBACK-DELIVERY-AUDIT)

### DIFF
--- a/.ailang/state/sprints/sprint_M-PUBLIC-FEEDBACK-DELIVERY-AUDIT.json
+++ b/.ailang/state/sprints/sprint_M-PUBLIC-FEEDBACK-DELIVERY-AUDIT.json
@@ -1,11 +1,12 @@
 {
   "sprint_id": "M-PUBLIC-FEEDBACK-DELIVERY-AUDIT",
-  "status": "planned",
+  "status": "in_progress",
   "branch": "sprint/m-public-feedback-delivery-audit",
-  "worktree": "/Users/voightkampff/dev/sunholo-data/ailang-worktrees/m-public-feedback-delivery-audit",
+  "worktree": "/Users/voightkampff/dev/sunholo-data/ailang/.claude/worktrees/m-public-feedback-audit",
   "commits": {},
   "gates": {
     "premise_check": "PLANNER-VERIFIED at HEAD: (1) prod sub projects/ailang-multivac/subscriptions/ailang-messages-laptop EXISTS + ACTIVE (topic ailang-messages, ack 30s); (2) daemon ADC identity m@sunholo.com is roles/owner on BOTH ailang-multivac-dev and ailang-multivac -> pubsub.subscriber access already present, NO new IAM/Terraform; (3) EnvProject[prod]={ailang-multivac,ailang}; Client.Subscription prepends prefix so base 'messages-laptop' resolves correctly for both projects. Executor re-confirms in M0.",
+    "m0_premise_reconfirm": "EXECUTOR-RECONFIRMED 2026-07-13 (worktree, read-only): (1) `gcloud pubsub subscriptions describe ailang-messages-laptop --project ailang-multivac` -> projects/ailang-multivac/subscriptions/ailang-messages-laptop | topic projects/ailang-multivac/topics/ailang-messages | ackDeadline 30 (EXISTS+ACTIVE). (2) `gcloud auth list` active=m@sunholo.com; `gcloud projects get-iam-policy ailang-multivac --filter=roles/owner` -> user:m@sunholo.com (OWNER on prod). (3) internal/daemon/config.go:22 EnvProject[prod]={Project:ailang-multivac, Prefix:ailang}. ALL THREE PASS -- no drift since planning; no escalation needed.",
     "make_test": null,
     "make_lint": null,
     "docs_build": null,
@@ -36,10 +37,10 @@
         "internal/daemon/config.go EnvProject[prod] == {Project: ailang-multivac, Prefix: ailang}",
         "If ANY confirmation fails, STOP and escalate to Mark (fix approach would change to a Terraform-managed prod subscription)"
       ],
-      "passes": null,
-      "started": null,
-      "completed": null,
-      "notes": null
+      "passes": true,
+      "started": "2026-07-13T15:30:00Z",
+      "completed": "2026-07-13T15:35:00Z",
+      "notes": "All three premise checks re-confirmed read-only in the worktree (see gates.m0_premise_reconfirm). No drift; no escalation. No code changes in M0."
     },
     {
       "id": "M1_DEFECT_A_EXTERNAL_FEEDBACK_TAGGING",

--- a/.ailang/state/sprints/sprint_M-PUBLIC-FEEDBACK-DELIVERY-AUDIT.json
+++ b/.ailang/state/sprints/sprint_M-PUBLIC-FEEDBACK-DELIVERY-AUDIT.json
@@ -1,15 +1,20 @@
 {
   "sprint_id": "M-PUBLIC-FEEDBACK-DELIVERY-AUDIT",
-  "status": "in_progress",
+  "status": "completed",
   "branch": "sprint/m-public-feedback-delivery-audit",
   "worktree": "/Users/voightkampff/dev/sunholo-data/ailang/.claude/worktrees/m-public-feedback-audit",
-  "commits": {},
+  "commits": {
+    "M0_PREMISE_CONFIRMATION_GATE": "bfde6fe25f7be5db4ee9d9bcc71d1b14229f0716",
+    "M1_DEFECT_A_EXTERNAL_FEEDBACK_TAGGING": "47df615acb2ab9ae3a1ddf9fc2df06f67922ac9a",
+    "M2_DEFECT_B_DAEMON_DUAL_SUBSCRIBE": "4f631e1bf6f143a044b189ea6f0ecd2cf5e6adc4",
+    "M3_RUNBOOK_CONFIG_DOCS_CHANGELOG": "pending-this-commit"
+  },
   "gates": {
     "premise_check": "PLANNER-VERIFIED at HEAD: (1) prod sub projects/ailang-multivac/subscriptions/ailang-messages-laptop EXISTS + ACTIVE (topic ailang-messages, ack 30s); (2) daemon ADC identity m@sunholo.com is roles/owner on BOTH ailang-multivac-dev and ailang-multivac -> pubsub.subscriber access already present, NO new IAM/Terraform; (3) EnvProject[prod]={ailang-multivac,ailang}; Client.Subscription prepends prefix so base 'messages-laptop' resolves correctly for both projects. Executor re-confirms in M0.",
     "m0_premise_reconfirm": "EXECUTOR-RECONFIRMED 2026-07-13 (worktree, read-only): (1) `gcloud pubsub subscriptions describe ailang-messages-laptop --project ailang-multivac` -> projects/ailang-multivac/subscriptions/ailang-messages-laptop | topic projects/ailang-multivac/topics/ailang-messages | ackDeadline 30 (EXISTS+ACTIVE). (2) `gcloud auth list` active=m@sunholo.com; `gcloud projects get-iam-policy ailang-multivac --filter=roles/owner` -> user:m@sunholo.com (OWNER on prod). (3) internal/daemon/config.go:22 EnvProject[prod]={Project:ailang-multivac, Prefix:ailang}. ALL THREE PASS -- no drift since planning; no escalation needed.",
-    "make_test": null,
-    "make_lint": null,
-    "docs_build": null,
+    "make_test": "PASS with ONE pre-existing flake. Touched packages ALL green: go test ./internal/daemon/... ./internal/notify/... ./internal/storage/... ./cmd/ailang/ -> ok (daemon, notify, storage, storage/firestore, cmd/ailang). -race -count=3 ./internal/daemon/... green. Full `make test` reported ONE failure: TestRunCommand_PipedStdoutFlushesPerLine (cmd/ailang) -- a TIMING-flaky test (asserts per-line stdout flush timings) that PASSES in isolation (5/5 reruns) and failed only under full-suite parallel CPU contention. PRE-EXISTING + UNRELATED: not in this branch's diff (main_run_pipe_test.go last touched by 675da8ecf), no connection to daemon/feedback code.",
+    "make_lint": "PASS -- `make lint` -> 0 issues. `make check-file-sizes` -> all files within 800-line limit (largest touched: daemon_test.go 516, cmd/ailang/daemon.go 269, daemon.go 233).",
+    "docs_build": "PRE-EXISTING FAILURE (not caused by this sprint): `npm run build` in docs/ fails at docusaurus sidebars validation -- 'These sidebar document ids do not exist: reference/errors/index, reference/errors/mod007, reference/errors/mod013, reference/errors/typ_effect_row_mismatch'. PROVEN pre-existing: stashing OUT my three guide edits reproduces the IDENTICAL failure. My edits are plain .md guides (agent-messaging, notify-daemon, cloud-messaging-integration) -- no sidebars/reference-errors/doc-file changes. The sync-all-generated design-docs.md/roadmap/index.md churn was reverted to keep the diff focused.",
     "live_prod_verification": null
   },
   "created": "2026-07-13T00:00:00Z",
@@ -97,10 +102,10 @@
         "CHANGELOG.md v0.30.x entry present",
         "Docs build (npm run build in docs/) passes if docs changed"
       ],
-      "passes": null,
-      "started": null,
-      "completed": null,
-      "notes": null
+      "passes": true,
+      "started": "2026-07-13T16:21:00Z",
+      "completed": "2026-07-13T16:45:00Z",
+      "notes": "Runbook: added 'Triaging Public Feedback (READ THIS -- it lives in PROD)' to docs/docs/guides/agent-messaging.md naming AILANG_CLOUD_PROJECT=ailang-multivac (prod) for public-feedback + pkg:* triage, with the never-export-globally caveat. Dual-subscribe opt-in: added a 'Dual-subscribe (dev+prod external feedback)' section to docs/docs/guides/notify-daemon.md (Configuration) with copy-pasteable daemon.yaml (extra_message_envs: [prod]), --also-subscribe prod flag, plist edit, semantics, and the launchctl reload; cross-linked from docs/docs/guides/cloud-messaging-integration.md (+ a 'Public feedback lives in PROD' note). Updated notify-daemon 'What gets notified' table to include pkg:* -> 🌐. CHANGELOG: entry under [Unreleased] in changelogs/v0.18-current.md (the active changelog; CHANGELOG.md is an index) covering Defect A, Defect B, dual-subscribe opt-in, runbook. Added Related Documents runbook links to the design doc. DOCS BUILD: `npm run build` (docusaurus) FAILS at the sidebars stage with a PRE-EXISTING error ('These sidebar document ids do not exist: reference/errors/index, mod007, mod013, typ_effect_row_mismatch') that reproduces identically with my three guide edits stashed OUT -> NOT caused by this sprint (I touched no sidebars, no reference/errors pages, added/removed no doc files). My edits are plain .md (not .mdx). Reverted the sync-all auto-generated churn in docs/docs/design-docs.md + roadmap/index.md to keep the PR diff focused (regenerated by CI/sync)."
     }
   ],
   "parked_for_human": {

--- a/.ailang/state/sprints/sprint_M-PUBLIC-FEEDBACK-DELIVERY-AUDIT.json
+++ b/.ailang/state/sprints/sprint_M-PUBLIC-FEEDBACK-DELIVERY-AUDIT.json
@@ -57,10 +57,10 @@
         "New table test TestMessageNotification_PkgInboxIsExternalFeedback follows handlers_test.go idiom",
         "go test ./internal/daemon/... ./internal/notify/... green"
       ],
-      "passes": null,
-      "started": null,
-      "completed": null,
-      "notes": null
+      "passes": true,
+      "started": "2026-07-13T15:36:00Z",
+      "completed": "2026-07-13T15:45:00Z",
+      "notes": "Added isExternalFeedbackInbox(inbox) helper (public-feedback OR pkg: prefix) + const pkgInboxPrefix in handlers.go; messageNotification now gates the 🌐 External-feedback shape + EventType public-feedback on that helper, with the inbox name already in the body ([%s] %s). DefaultDiscordEventTypes untouched. Tests: TestMessageNotification_PkgInboxIsExternalFeedback (table: public-feedback/pkg:*/internal) + TestIsExternalFeedbackInbox. Existing TestMessageNotification_PublicFeedback, TestDaemon_PublicFeedbackEventFiresDedicatedNotification, TestDiscordDefaultEventTypes (Accepts public-feedback==true, message==false) unchanged and green. go test ./internal/daemon/... ./internal/notify/... green; gofmt clean."
     },
     {
       "id": "M2_DEFECT_B_DAEMON_DUAL_SUBSCRIBE",

--- a/.ailang/state/sprints/sprint_M-PUBLIC-FEEDBACK-DELIVERY-AUDIT.json
+++ b/.ailang/state/sprints/sprint_M-PUBLIC-FEEDBACK-DELIVERY-AUDIT.json
@@ -7,7 +7,7 @@
     "M0_PREMISE_CONFIRMATION_GATE": "bfde6fe25f7be5db4ee9d9bcc71d1b14229f0716",
     "M1_DEFECT_A_EXTERNAL_FEEDBACK_TAGGING": "47df615acb2ab9ae3a1ddf9fc2df06f67922ac9a",
     "M2_DEFECT_B_DAEMON_DUAL_SUBSCRIBE": "4f631e1bf6f143a044b189ea6f0ecd2cf5e6adc4",
-    "M3_RUNBOOK_CONFIG_DOCS_CHANGELOG": "pending-this-commit"
+    "M3_RUNBOOK_CONFIG_DOCS_CHANGELOG": "baf4d3e8f1053a3a14766dd4e59f587bfaa04325"
   },
   "gates": {
     "premise_check": "PLANNER-VERIFIED at HEAD: (1) prod sub projects/ailang-multivac/subscriptions/ailang-messages-laptop EXISTS + ACTIVE (topic ailang-messages, ack 30s); (2) daemon ADC identity m@sunholo.com is roles/owner on BOTH ailang-multivac-dev and ailang-multivac -> pubsub.subscriber access already present, NO new IAM/Terraform; (3) EnvProject[prod]={ailang-multivac,ailang}; Client.Subscription prepends prefix so base 'messages-laptop' resolves correctly for both projects. Executor re-confirms in M0.",

--- a/.ailang/state/sprints/sprint_M-PUBLIC-FEEDBACK-DELIVERY-AUDIT.json
+++ b/.ailang/state/sprints/sprint_M-PUBLIC-FEEDBACK-DELIVERY-AUDIT.json
@@ -78,10 +78,10 @@
         "go test ./internal/daemon/... and go build ./... green; make lint green",
         "PR records: refactor-vs-two-instance choice AND how prod Firestore fetcher is scoped without env mutation"
       ],
-      "passes": null,
-      "started": null,
-      "completed": null,
-      "notes": null
+      "passes": true,
+      "started": "2026-07-13T15:46:00Z",
+      "completed": "2026-07-13T16:20:00Z",
+      "notes": "CHOSEN APPROACH: Daemon source-list REFACTOR (primary approach, not two-instance). Rationale: keeps ONE dedup window (message IDs are globally unique fb_*/msg_*, so shared dedup is correct + simpler), ONE Daemon/notifier/webhook, and cleanly separates 'task events = primary(dev) only' from 'N message sources'; two-instance would either double the task sub or need awkward suppression. Daemon now holds msgSources []MessageSource{Sub,Fetcher,SubName,Label}; New() seeds the primary source; AddMessageSource() appends extras; Run() fans out one goroutine per message source (+1 for primary task events). handleMessageEvent -> messageHandlerFor(src) using src.Fetcher. PROD FETCHER SCOPING (highest risk, resolved): storage.NewGCPBackends + firestore.NewClient read AILANG_CLOUD_PROJECT PROCESS-GLOBALLY -> mutating env would collide dev/prod. Added firestore.NewClientForProject(ctx, projectID) (explicit project, no env); CLI builds the prod messaging store via NewMessagingStore(NewClientForProject(ctx,'ailang-multivac')) WITHOUT touching AILANG_CLOUD_PROJECT. Config: FileConfig.ExtraMessageEnvs (yaml extra_message_envs) + repeatable --also-subscribe flag; ResolveExtraMessageSources resolves via EnvProject, dedups against primary+self, fails loudly on unknown env. Default OFF -> single-project byte-identical. Tests: TestDaemon_DualProjectMessageFiresOnce, TestDaemon_ProdFetcherScopedToProdStore (prod id nacks on dev source, fires on prod source = scoping proof), TestDaemon_SingleProjectUnchanged, TestResolveExtraMessageSources. All existing daemon_test.go tests pass unchanged. go test ./internal/daemon/... ./internal/notify/... ./internal/storage/... green; -race -count=3 green; go build ./internal/... ./cmd/ailang/ green; gofmt clean. No prod resource created/modified (daemon only READS the existing ailang-messages-laptop sub confirmed in M0)."
     },
     {
       "id": "M3_RUNBOOK_CONFIG_DOCS_CHANGELOG",
@@ -116,7 +116,7 @@
     ]
   },
   "open_premises_for_executor": [
-    "storage.NewBackends project selection (M2, highest risk): confirm it accepts an explicit project vs reading AILANG_CLOUD_PROJECT globally; the prod messaging store must be built WITHOUT mutating shared env or the dev/prod fetchers collide",
-    "M2 approach: pick Daemon source-list refactor vs two Daemon instances; both satisfy acceptance — record the choice"
+    "RESOLVED — storage.NewBackends project selection (M2, highest risk): NewGCPBackends reads AILANG_CLOUD_PROJECT globally, and firestore.NewClient(ctx) also reads it globally. So mutating the env WOULD collide the dev/prod fetchers. Resolution: added firestore.NewClientForProject(ctx, projectID) (explicit project, ignores env); the CLI builds the prod messaging store via NewMessagingStore(NewClientForProject(ctx,'ailang-multivac')) with NO env mutation.",
+    "RESOLVED — M2 approach: chose the Daemon source-list REFACTOR (not two instances). One dedup window (globally-unique message IDs), one Daemon/notifier/webhook, task events primary-only. See M2 feature notes for full rationale."
   ]
 }

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,44 @@
 
 ## [Unreleased]
 
+### Fixed — external user feedback silently lost (M-PUBLIC-FEEDBACK-DELIVERY-AUDIT)
+
+Two independent defects caused external users' public feedback to never reach
+Discord (or any watched inbox). Both are fixed; the live prod round-trip is a
+one-time human daemon reload (see the daemon docs).
+
+- **Defect A — package feedback was Discord-invisible by construction.** The
+  notify daemon tagged `EventType: "public-feedback"` (the only inbox class the
+  Discord allow-list accepts) **only** for the literal `public-feedback` inbox,
+  but the feedback publisher routes package feedback to `pkg:*` inboxes, which
+  got `EventType: "message"` and were dropped. `messageNotification`
+  (`internal/daemon/handlers.go`) now treats an inbox as external-feedback-worthy
+  when it is `public-feedback` **or** any `pkg:*` inbox (new named, unit-tested
+  `isExternalFeedbackInbox` helper), giving both the 🌐 shape and the
+  `public-feedback` EventType with the inbox name in the body. Internal inboxes
+  (`user`/`controlplane`/agents) keep `EventType: "message"` and stay
+  Discord-dropped — `DefaultDiscordEventTypes` is deliberately **not** widened
+  (that would leak internal chatter to Discord).
+- **Defect B — daemon watched dev only; the public MCP writes prod.** The public
+  MCP (`mcp.ailang.sunholo.com`) writes to **prod** Firestore/PubSub
+  (`ailang-multivac`), but the rig notify daemon subscribed to **dev**
+  (`ailang-multivac-dev`) only, so nothing listened to prod. The daemon can now
+  **dual-subscribe**: it holds N inbox-message sources (dev + prod) fanning out
+  to the same notifier/webhook, with a shared dedup window (message IDs are
+  globally unique) and task events kept dev-only. Opt-in and **off by default**
+  (existing single-project behavior is byte-identical) via
+  `extra_message_envs: [prod]` in `daemon.yaml` or `--also-subscribe prod` on
+  `ailang daemon run`. Each extra source's Firestore fetcher is scoped to its own
+  project via the new `firestore.NewClientForProject(ctx, projectID)` — **without**
+  mutating the shared `AILANG_CLOUD_PROJECT` env (which would collide the dev/prod
+  fetchers). No prod resource is created or modified; the daemon only reads the
+  already-existing `ailang-messages-laptop` subscription.
+- **Runbook:** triaging public feedback requires
+  `AILANG_CLOUD_PROJECT=ailang-multivac` (**prod**) — every dev-only check has
+  been blind to real users. Documented in
+  [agent-messaging](docs/docs/guides/agent-messaging.md) and
+  [cloud-messaging-integration](docs/docs/guides/cloud-messaging-integration.md).
+
 ### Fixed / Changed — module-level `let`/`letrec` resolves module funcs (M-MODULE-LET-FUNC-RESOLUTION, #366)
 
 A module-level `let`/`letrec` value now resolves module-scope names **exactly as a

--- a/cmd/ailang/daemon.go
+++ b/cmd/ailang/daemon.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sunholo-data/ailang/internal/notify"
 	"github.com/sunholo-data/ailang/internal/pubsub"
 	"github.com/sunholo-data/ailang/internal/storage"
+	firestore "github.com/sunholo-data/ailang/internal/storage/firestore"
 )
 
 // daemonCommand is the entry point for `ailang daemon ...`. Subcommands:
@@ -73,6 +74,8 @@ func daemonRun(args []string) error {
 	fs := flag.NewFlagSet("daemon run", flag.ExitOnError)
 	envFlag := fs.String("env", "", "Cloud environment to subscribe to (dev|test|prod). Default: from daemon.yaml or 'prod'.")
 	dryRun := fs.Bool("dry-run", false, "Log notifications instead of firing them. Useful for tests.")
+	var alsoSubscribe multiFlag
+	fs.Var(&alsoSubscribe, "also-subscribe", "ADDITIONAL cloud env whose inbox messages to also watch (dev|test|prod). Repeatable. Appends to daemon.yaml extra_message_envs. Example: --env dev --also-subscribe prod.")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -84,11 +87,14 @@ func daemonRun(args []string) error {
 	if *dryRun {
 		fc.DryRun = true
 	}
+	// CLI --also-subscribe appends to the yaml extra_message_envs.
+	fc.ExtraMessageEnvs = append(fc.ExtraMessageEnvs, alsoSubscribe...)
 
 	cfg, project, prefix, err := daemon.ConfigForEnv(*envFlag, fc)
 	if err != nil {
 		return err
 	}
+	primaryEnv := envOrDefault(*envFlag, fc.Env, "prod")
 
 	ctx, cancel := signalContext()
 	defer cancel()
@@ -127,11 +133,62 @@ func daemonRun(args []string) error {
 		reg.FanOut(log.Default()),
 	)
 
-	fmt.Printf("ailang daemon: env=%s project=%s events=%s messages=%s dry_run=%t channels=%v\n",
-		envOrDefault(*envFlag, fc.Env, "prod"), project, cfg.EventsSub, cfg.MessagesSub, cfg.DryRun,
+	// Additional inbox-message sources (e.g. prod), each scoped to its OWN
+	// project's Firestore WITHOUT mutating the shared AILANG_CLOUD_PROJECT env
+	// (env mutation would make the dev/prod fetchers collide). We build a
+	// project-explicit Firestore messaging store per extra source.
+	extras, err := daemon.ResolveExtraMessageSources(primaryEnv, fc.ExtraMessageEnvs)
+	if err != nil {
+		return err
+	}
+	var extraClosers []func()
+	defer func() {
+		for _, c := range extraClosers {
+			c()
+		}
+	}()
+	for _, ex := range extras {
+		exPS, err := pubsub.NewClient(ctx, ex.Project, ex.Prefix)
+		if err != nil {
+			return fmt.Errorf("pubsub client (%s): %w", ex.Env, err)
+		}
+		extraClosers = append(extraClosers, func() { _ = exPS.Close() })
+
+		fsClient, err := firestore.NewClientForProject(ctx, ex.Project)
+		if err != nil {
+			return fmt.Errorf("firestore client (%s): %w", ex.Env, err)
+		}
+		exStore := firestore.NewMessagingStore(fsClient)
+		extraClosers = append(extraClosers, func() { _ = exStore.Close() })
+
+		d.AddMessageSource(daemon.MessageSource{
+			Sub:     pubsubAdapter{sub: pubsub.NewSubscriber(exPS)},
+			Fetcher: storeFetcher{store: exStore},
+			SubName: ex.MessagesSub,
+			Label:   ex.Env,
+		})
+	}
+
+	extraLabels := make([]string, 0, len(extras))
+	for _, ex := range extras {
+		extraLabels = append(extraLabels, ex.Env+"("+ex.Project+")")
+	}
+	fmt.Printf("ailang daemon: env=%s project=%s events=%s messages=%s extra_message_sources=%v dry_run=%t channels=%v\n",
+		primaryEnv, project, cfg.EventsSub, cfg.MessagesSub, extraLabels, cfg.DryRun,
 		reg.Names())
 
 	return d.Run(ctx)
+}
+
+// multiFlag collects a repeatable string flag (e.g. --also-subscribe prod
+// --also-subscribe test).
+type multiFlag []string
+
+func (m *multiFlag) String() string { return strings.Join(*m, ",") }
+
+func (m *multiFlag) Set(v string) error {
+	*m = append(*m, v)
+	return nil
 }
 
 func daemonInstall(args []string) error {

--- a/design_docs/planned/v0_30_0/m-public-feedback-delivery-audit.md
+++ b/design_docs/planned/v0_30_0/m-public-feedback-delivery-audit.md
@@ -99,6 +99,7 @@ eval→public-feedback→Discord path; weaken the edge rate-limit's abuse protec
 
 - [m-feedback-triage-gate](../../implemented/v0_29_0/) + [m-feedback-gate-cloud-adapter] — the gate that sits on this path (off by default)
 - [project_ailang_notify_daemon] (agent memory) — Pub/Sub → daemon → Registry fan-out architecture
+- **Runbook (added by this sprint):** [Agent Messaging → Triaging Public Feedback](../../../docs/docs/guides/agent-messaging.md) names the PROD project (`ailang-multivac`) as the home of external feedback; [macOS Notification Daemon → Dual-subscribe](../../../docs/docs/guides/notify-daemon.md) documents the `extra_message_envs` / `--also-subscribe` opt-in.
 
 ---
 

--- a/docs/docs/guides/agent-messaging.md
+++ b/docs/docs/guides/agent-messaging.md
@@ -46,6 +46,30 @@ All messages are stored in a SQLite database:
 - **Accessible via**: CLI (`ailang messages`) and Collaboration Hub dashboard
 - **Message statuses**: `unread`, `read`, `archived`, `deleted`
 
+## Triaging Public Feedback (READ THIS — it lives in PROD)
+
+**External user feedback is written to the PROD project (`ailang-multivac`), not
+dev.** The public MCP (`mcp.ailang.sunholo.com`) writes to prod Firestore; every
+agent session that checks dev-only has been **blind to real users**. To read or
+triage public/package feedback you MUST scope the query to prod:
+
+```bash
+# List public feedback from real users (PROD):
+AILANG_STORAGE=gcp AILANG_CLOUD_PROJECT=ailang-multivac \
+  ailang messages list --inbox public-feedback
+
+# Package-scoped feedback lands in pkg:<vendor>/<name> inboxes (also PROD):
+AILANG_STORAGE=gcp AILANG_CLOUD_PROJECT=ailang-multivac \
+  ailang messages list --inbox "pkg:sunholo/ailang"
+```
+
+> **Only prefix these env vars on the *feedback* command** — never export them
+> globally, or your local SQLite reads (agent inboxes, sprint state) break.
+
+For real-time notification (Discord/macOS) of prod feedback, the notify daemon
+must **dual-subscribe** dev + prod — see
+[Cloud Messaging Integration → Dual-subscribe](./cloud-messaging-integration.md#dual-subscribe-devprod-external-feedback).
+
 ## Message Format
 
 Messages in the system contain:

--- a/docs/docs/guides/cloud-messaging-integration.md
+++ b/docs/docs/guides/cloud-messaging-integration.md
@@ -1080,6 +1080,28 @@ Messages are routed to agents by `inbox` name. The coordinator matches inbox to 
 
 Custom agents can be added in `~/.ailang/config.yaml` — each agent watches its own inbox.
 
+### Public feedback lives in PROD
+
+External user feedback (via the public MCP `mcp.ailang.sunholo.com`) is written
+to the **PROD** project (`ailang-multivac`), landing in the `public-feedback`
+inbox for general feedback and `pkg:<vendor>/<name>` inboxes for package-scoped
+feedback. Agent sessions that query dev-only are blind to real users. To read
+it, scope the CLI to prod (only on that command — never export globally):
+
+```bash
+AILANG_STORAGE=gcp AILANG_CLOUD_PROJECT=ailang-multivac \
+  ailang messages list --inbox public-feedback
+```
+
+### Dual-subscribe (dev/prod external feedback)
+
+For real-time Discord/macOS notification of prod feedback, the notify daemon
+must watch **both** dev and prod inbox-message subscriptions in one process.
+This is an **opt-in** (`extra_message_envs: [prod]` in `daemon.yaml`, or
+`--also-subscribe prod`), off by default. Full setup, semantics, and the
+one-time `launchctl` reload are documented in
+[macOS Notification Daemon → Dual-subscribe](./notify-daemon.md#dual-subscribe-devprod-external-feedback).
+
 ### Skip-Approval Agents (Direct Push)
 
 Some agents are configured with `skip_approval: true` to bypass the human approval step. These agents push their changes directly to a target branch (e.g., `main`) instead of creating a `coordinator/{taskID}` branch.

--- a/docs/docs/guides/notify-daemon.md
+++ b/docs/docs/guides/notify-daemon.md
@@ -50,8 +50,15 @@ The default subcommand is `run`, so `ailang daemon` alone starts the foreground 
 | Task pending approval | `TaskStreamEvent.status = "pending_approval"` | ⏳ Approval needed |
 | Task completed | `TaskStreamEvent.status = "completed"` | ✅ Task done |
 | Task failed | `TaskStreamEvent.status = "failed"` | ❌ Task failed |
-| Public feedback | InboxMessage with `to_inbox = "public-feedback"` | 🌐 External feedback |
+| Public feedback | InboxMessage with `to_inbox = "public-feedback"` **or any `pkg:*` inbox** | 🌐 External feedback |
 | Other inbox message | Any other InboxMessage notification | ✉️ Message from `<from_agent>` |
+
+External feedback (the `public-feedback` inbox **and** package-scoped `pkg:*`
+inboxes, which the feedback publisher routes package feedback to) is tagged
+`EventType: "public-feedback"` so it passes the Discord allow-list. Internal
+inbox traffic (`user`, `controlplane`, agent inboxes) stays `EventType:
+"message"` — surfaced on macOS but intentionally dropped by Discord to avoid
+phone noise.
 
 Other Pub/Sub events (intermediate task states like `running` or `queued`) are silently dropped.
 
@@ -80,9 +87,64 @@ task_window_sec: 60        # task event dedup window
 msg_window_sec: 300        # message event dedup window (5 min)
 dry_run: false             # skip notifier; log instead
 excludes_path: ""          # override path to notify_excludes.conf
+extra_message_envs: []     # ADDITIONAL envs to also watch for inbox messages (see below)
 ```
 
 `~/.ailang/config/notify_excludes.conf` (optional): one substring per line; matched against title and body. Lines starting with `#` are comments. Useful for muting noisy event categories without editing code.
+
+### Dual-subscribe (dev+prod external feedback)
+
+By default the daemon watches ONE project's inbox-message subscription (the
+`env` above). But **the public MCP (`mcp.ailang.sunholo.com`) writes external
+user feedback to the PROD project (`ailang-multivac`)**, while the rig daemon
+typically runs on `env: dev`. Without dual-subscribe, prod feedback never pings
+Discord/macOS — it is silently lost.
+
+Enable a second (or third) inbox-message source with `extra_message_envs`:
+
+```yaml
+env: dev                   # primary: task events + dev messages
+extra_message_envs: [prod] # ALSO watch prod inbox messages (external feedback)
+```
+
+Or opt in at the command line (appends to the yaml list, repeatable):
+
+```bash
+ailang daemon run --env dev --also-subscribe prod
+```
+
+Equivalently, in `~/Library/LaunchAgents/com.sunholo.ailang.daemon.plist`
+`ProgramArguments`, add `--also-subscribe` and `prod` as two entries after
+`--env`/`dev`.
+
+Semantics:
+
+- **Off by default** — with no `extra_message_envs`, behavior is byte-identical
+  to single-project.
+- **Task events stay primary-env only** (the rig emits eval pings to dev; prod
+  task events are not double-fanned).
+- **Each source reads its OWN project's Firestore.** The prod source is scoped
+  to `ailang-multivac` explicitly, without mutating the process
+  `AILANG_CLOUD_PROJECT`, so dev and prod fetchers never collide.
+- **Shared dedup** — message IDs are globally unique (`fb_*`/`msg_*`), so a
+  message fires exactly once even in the (non-occurring) case of cross-project id
+  overlap.
+- **No prod resource is created.** The daemon only READS the already-existing
+  `ailang-messages-laptop` subscription in `ailang-multivac`. The active ADC
+  identity needs read access to prod (the rig's `m@sunholo.com` is Owner on both
+  projects).
+
+After editing `daemon.yaml` or the plist, reload the daemon:
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.sunholo.ailang.daemon.plist
+launchctl load   ~/Library/LaunchAgents/com.sunholo.ailang.daemon.plist
+tail -f /tmp/ailang-daemon.log   # startup line lists extra_message_sources=[prod(ailang-multivac)]
+```
+
+> To TRIAGE (read) prod feedback from the CLI without the daemon, scope the
+> command to prod — see
+> [Agent Messaging → Triaging Public Feedback](./agent-messaging.md#triaging-public-feedback--read-this--it-lives-in-prod).
 
 ## Logs and troubleshooting
 

--- a/internal/daemon/config.go
+++ b/internal/daemon/config.go
@@ -31,6 +31,55 @@ type FileConfig struct {
 	MsgWindowSec  int    `yaml:"msg_window_sec"`  // dedup window for messages   (default: 300)
 	DryRun        bool   `yaml:"dry_run"`         // skip notifier (default: false)
 	ExcludesPath  string `yaml:"excludes_path"`   // override path to notify_excludes.conf
+
+	// ExtraMessageEnvs lists ADDITIONAL cloud environments whose inbox-message
+	// subscriptions this daemon should ALSO watch, beyond the primary Env.
+	// Each entry is resolved through EnvProject to a (project, prefix) and the
+	// daemon subscribes to that project's MessagesSub. Default empty =
+	// single-project (backward-compatible). Example: env=dev +
+	// extra_message_envs=[prod] makes one process watch BOTH dev and prod
+	// inbox messages (fixing silent loss of external prod feedback). Task
+	// events remain primary-env only. The `--also-subscribe` CLI flag appends
+	// to this list.
+	ExtraMessageEnvs []string `yaml:"extra_message_envs"`
+}
+
+// ExtraMessageSource is a resolved additional inbox-message source: the env
+// label plus its (project, prefix, base sub name). The CLI uses these to build
+// a project-scoped fetcher + subscriber per extra env.
+type ExtraMessageSource struct {
+	Env         string
+	Project     string
+	Prefix      string
+	MessagesSub string
+}
+
+// ResolveExtraMessageSources maps each extra env label to its (project, prefix)
+// via EnvProject, de-duplicating against the primary env (so `env: prod` +
+// `extra_message_envs: [prod]` does not double-subscribe the same project) and
+// against itself. Returns an error for an unknown env label — a typo must fail
+// loudly rather than silently drop a feedback source.
+func ResolveExtraMessageSources(primaryEnv string, extras []string) ([]ExtraMessageSource, error) {
+	seen := map[string]bool{primaryEnv: true}
+	var out []ExtraMessageSource
+	for _, env := range extras {
+		env = strings.TrimSpace(env)
+		if env == "" || seen[env] {
+			continue
+		}
+		mapping, ok := EnvProject[env]
+		if !ok {
+			return nil, fmt.Errorf("unknown extra_message_env %q (want dev|test|prod)", env)
+		}
+		seen[env] = true
+		out = append(out, ExtraMessageSource{
+			Env:         env,
+			Project:     mapping.Project,
+			Prefix:      mapping.Prefix,
+			MessagesSub: "messages-laptop",
+		})
+	}
+	return out, nil
 }
 
 // LoadFileConfig reads ~/.ailang/config/daemon.yaml if present. Returns a

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -48,42 +48,78 @@ type Config struct {
 	Logger      *log.Logger   // optional; defaults to log.Default()
 }
 
-// Daemon is the running pull loop.
-type Daemon struct {
-	cfg       Config
-	sub       EventSubscriber
-	fetcher   MessageFetcher
-	notify    func(notify.Notification) error
-	taskDedup *dedup
-	msgDedup  *dedup
-	log       *log.Logger
+// MessageSource is one project's inbox-message feed: a Pub/Sub subscriber, the
+// Firestore fetcher scoped to THAT project, the base subscription name, and a
+// human label for logs. A daemon fans out over N of these so a single process
+// can watch both dev and prod (see cmd/ailang/daemon.go). Every source shares
+// the daemon's notifier and dedup window — message IDs are globally unique
+// (fb_*/msg_*), so a shared dedup is both correct and simpler than per-source.
+type MessageSource struct {
+	Sub     EventSubscriber
+	Fetcher MessageFetcher
+	SubName string // base sub name; the Pub/Sub client prepends the project prefix
+	Label   string // e.g. "dev", "prod" — for startup/delivery logs only
 }
 
-// New constructs a Daemon. Pass interface implementations for sub/fetcher so
-// tests can substitute fakes.
+// Daemon is the running pull loop.
+type Daemon struct {
+	cfg        Config
+	sub        EventSubscriber // primary source's subscriber; task events use this
+	msgSources []MessageSource // all inbox-message sources (includes the primary)
+	notify     func(notify.Notification) error
+	taskDedup  *dedup
+	msgDedup   *dedup
+	log        *log.Logger
+}
+
+// New constructs a single-source Daemon (dev-only, backward-compatible). Task
+// events and inbox messages both flow through sub/fetcher. Pass interface
+// implementations so tests can substitute fakes. To watch additional projects,
+// build with New then AddMessageSource, or use NewMulti.
 func New(cfg Config, sub EventSubscriber, fetcher MessageFetcher, notifyFn func(notify.Notification) error) *Daemon {
 	logger := cfg.Logger
 	if logger == nil {
 		logger = log.Default()
 	}
-	return &Daemon{
+	d := &Daemon{
 		cfg:       cfg,
 		sub:       sub,
-		fetcher:   fetcher,
 		notify:    notifyFn,
 		taskDedup: newDedup(cfg.TaskWindow),
 		msgDedup:  newDedup(cfg.MsgWindow),
 		log:       logger,
 	}
+	// The primary (task+message) source is also the first message source, using
+	// the configured MessagesSub. Task events are pulled ONLY from this source
+	// (the rig emits eval pings to dev; we never double-fan prod task events).
+	d.msgSources = []MessageSource{{
+		Sub:     sub,
+		Fetcher: fetcher,
+		SubName: cfg.MessagesSub,
+		Label:   "primary",
+	}}
+	return d
 }
 
-// Run blocks until ctx is cancelled, pulling from both subscriptions in
-// parallel and firing notifications for relevant events. Returns nil on a
-// clean shutdown; returns the first error from a subscription if one fails.
+// AddMessageSource registers an ADDITIONAL inbox-message source (e.g. prod)
+// beyond the primary. Task events are NOT pulled from added sources — only
+// messages. Each source's Fetcher MUST resolve against that source's project's
+// Firestore (see cmd/ailang/daemon.go, where the prod fetcher is scoped to
+// ailang-multivac without mutating the shared process env).
+func (d *Daemon) AddMessageSource(src MessageSource) {
+	d.msgSources = append(d.msgSources, src)
+}
+
+// Run blocks until ctx is cancelled, pulling task events from the primary
+// source and inbox messages from EVERY registered message source in parallel.
+// Returns nil on a clean shutdown; returns the first error from a subscription
+// if one fails.
 func (d *Daemon) Run(ctx context.Context) error {
 	var wg sync.WaitGroup
-	errCh := make(chan error, 2)
+	// One goroutine per message source, plus one for the primary task events.
+	errCh := make(chan error, len(d.msgSources)+1)
 
+	// Task events: primary source only.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -93,14 +129,18 @@ func (d *Daemon) Run(ctx context.Context) error {
 		}
 	}()
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		err := d.sub.Subscribe(ctx, d.cfg.MessagesSub, d.handleMessageEvent)
-		if err != nil && !errors.Is(err, context.Canceled) {
-			errCh <- fmt.Errorf("messages subscription: %w", err)
-		}
-	}()
+	// Inbox messages: every registered source.
+	for _, src := range d.msgSources {
+		src := src // capture per-iteration
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := src.Sub.Subscribe(ctx, src.SubName, d.messageHandlerFor(src))
+			if err != nil && !errors.Is(err, context.Canceled) {
+				errCh <- fmt.Errorf("messages subscription (%s): %w", src.Label, err)
+			}
+		}()
+	}
 
 	wg.Wait()
 	close(errCh)
@@ -137,39 +177,44 @@ func (d *Daemon) handleTaskEvent(_ context.Context, data []byte, _ map[string]st
 	return nil
 }
 
-func (d *Daemon) handleMessageEvent(ctx context.Context, data []byte, _ map[string]string) error {
-	var m pubsub.MessageNotification
-	if err := json.Unmarshal(data, &m); err != nil {
-		d.log.Printf("daemon: malformed message event: %v", err)
+// messageHandlerFor returns a MessageHandler bound to src's project-scoped
+// fetcher. Dedup is shared across sources (message IDs are globally unique), so
+// a message that somehow arrives on two sources fires exactly once.
+func (d *Daemon) messageHandlerFor(src MessageSource) MessageHandler {
+	return func(ctx context.Context, data []byte, _ map[string]string) error {
+		var m pubsub.MessageNotification
+		if err := json.Unmarshal(data, &m); err != nil {
+			d.log.Printf("daemon: malformed message event (%s): %v", src.Label, err)
+			return nil
+		}
+		key := messageDedupKey(m.MessageID)
+		if d.msgDedup.seen(key) {
+			return nil
+		}
+		full, err := src.Fetcher.Fetch(ctx, m.MessageID)
+		if err != nil {
+			d.msgDedup.forget(key) // nack: let redelivery retry the fetch
+			return fmt.Errorf("fetch message %s (%s): %w", m.MessageID, src.Label, err)
+		}
+		if full == nil {
+			// Notification arrived before Firestore replication; nack to retry.
+			d.msgDedup.forget(key)
+			return fmt.Errorf("message %s not yet visible (%s)", m.MessageID, src.Label)
+		}
+		n, fire := messageNotification(full)
+		if !fire {
+			return nil
+		}
+		if shouldExclude(n, d.cfg.Excludes) {
+			return nil
+		}
+		if err := d.fire(n); err != nil {
+			d.msgDedup.forget(key) // nack: let redelivery retry delivery
+			return err
+		}
+		d.log.Printf("daemon: delivered message %s [src=%s, from=%s, inbox=%s] -> %q", m.MessageID, src.Label, full.FromAgent, full.ToInbox, n.Title)
 		return nil
 	}
-	key := messageDedupKey(m.MessageID)
-	if d.msgDedup.seen(key) {
-		return nil
-	}
-	full, err := d.fetcher.Fetch(ctx, m.MessageID)
-	if err != nil {
-		d.msgDedup.forget(key) // nack: let redelivery retry the fetch
-		return fmt.Errorf("fetch message %s: %w", m.MessageID, err)
-	}
-	if full == nil {
-		// Notification arrived before Firestore replication; nack to retry.
-		d.msgDedup.forget(key)
-		return fmt.Errorf("message %s not yet visible", m.MessageID)
-	}
-	n, fire := messageNotification(full)
-	if !fire {
-		return nil
-	}
-	if shouldExclude(n, d.cfg.Excludes) {
-		return nil
-	}
-	if err := d.fire(n); err != nil {
-		d.msgDedup.forget(key) // nack: let redelivery retry delivery
-		return err
-	}
-	d.log.Printf("daemon: delivered message %s [from=%s, inbox=%s] -> %q", m.MessageID, full.FromAgent, full.ToInbox, n.Title)
-	return nil
 }
 
 // fire invokes the notifier (or logs in dry-run). Returning an error causes

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -299,6 +299,205 @@ func TestDaemon_ExcludesMatchedNotificationsSkipped(t *testing.T) {
 	}
 }
 
+// prodOnlyFetcher resolves a message ID to a message ONLY if the ID belongs to
+// the prod set — proving in-test that a source's fetcher is scoped to its own
+// project's store (a dev fetcher would return nil for a prod ID and vice versa).
+type prodOnlyFetcher struct {
+	prodMsgs map[string]*messaging.InboxMessage
+}
+
+func (f *prodOnlyFetcher) Fetch(_ context.Context, messageID string) (*messaging.InboxMessage, error) {
+	if f.prodMsgs == nil {
+		return nil, nil
+	}
+	return f.prodMsgs[messageID], nil // nil for any non-prod id
+}
+
+// TestDaemon_DualProjectMessageFiresOnce proves that with a prod message source
+// added, a message delivered on the prod source fires exactly one notification,
+// resolved via the prod-scoped fetcher.
+func TestDaemon_DualProjectMessageFiresOnce(t *testing.T) {
+	// Primary (dev) source.
+	devSub := newFakeSubscriber()
+	devFetch := &fakeFetcher{msgs: map[string]*messaging.InboxMessage{}}
+	rec := &recordingNotifier{}
+	d := New(Config{
+		EventsSub:   "events-laptop",
+		MessagesSub: "messages-laptop",
+		TaskWindow:  60 * time.Second,
+		MsgWindow:   5 * time.Minute,
+	}, devSub, devFetch, rec.notify)
+
+	// Prod source: its OWN subscriber + a prod-scoped fetcher that only knows
+	// prod message IDs.
+	prodSub := newFakeSubscriber()
+	prodFetch := &prodOnlyFetcher{prodMsgs: map[string]*messaging.InboxMessage{
+		"fb_prod_1": {
+			MessageID: "fb_prod_1",
+			ToInbox:   "public-feedback",
+			FromAgent: "mcp-public",
+			Title:     "prod feedback from a real user",
+		},
+	}}
+	d.AddMessageSource(MessageSource{
+		Sub:     prodSub,
+		Fetcher: prodFetch,
+		SubName: "messages-laptop",
+		Label:   "prod",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = d.Run(ctx) }()
+	time.Sleep(30 * time.Millisecond) // let all sources register handlers
+
+	data := msgNotificationJSON(t, pubsub.MessageNotification{MessageID: "fb_prod_1"})
+	if err := prodSub.deliver(t, "messages-laptop", data, map[string]string{"inbox": "public-feedback"}); err != nil {
+		t.Fatalf("prod deliver: %v", err)
+	}
+
+	calls := rec.calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 notification from prod source, got %d", len(calls))
+	}
+	if calls[0].Title != "🌐 External feedback" {
+		t.Errorf("title = %q, want 🌐 External feedback", calls[0].Title)
+	}
+	if calls[0].EventType != "public-feedback" {
+		t.Errorf("EventType = %q, want public-feedback", calls[0].EventType)
+	}
+
+	// Dedup: a duplicate prod delivery is suppressed.
+	if err := prodSub.deliver(t, "messages-laptop", data, nil); err != nil {
+		t.Fatalf("prod redeliver: %v", err)
+	}
+	if got := len(rec.calls()); got != 1 {
+		t.Errorf("expected dedup to suppress duplicate prod message, got %d calls", got)
+	}
+}
+
+// TestDaemon_ProdFetcherScopedToProdStore proves the prod source resolves
+// against its OWN store: a prod message ID resolves via the prod fetcher, but
+// the SAME id delivered on the dev source (whose fetcher does not know it)
+// nacks (not-yet-visible) rather than firing — the fetchers do not collide.
+func TestDaemon_ProdFetcherScopedToProdStore(t *testing.T) {
+	devSub := newFakeSubscriber()
+	devFetch := &fakeFetcher{msgs: map[string]*messaging.InboxMessage{}} // dev knows nothing
+	rec := &recordingNotifier{}
+	d := New(Config{
+		EventsSub: "events-laptop", MessagesSub: "messages-laptop",
+		TaskWindow: 60 * time.Second, MsgWindow: 5 * time.Minute,
+	}, devSub, devFetch, rec.notify)
+
+	prodSub := newFakeSubscriber()
+	prodFetch := &prodOnlyFetcher{prodMsgs: map[string]*messaging.InboxMessage{
+		"fb_prod_2": {MessageID: "fb_prod_2", ToInbox: "public-feedback", FromAgent: "mcp-public", Title: "prod"},
+	}}
+	d.AddMessageSource(MessageSource{Sub: prodSub, Fetcher: prodFetch, SubName: "messages-laptop", Label: "prod"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = d.Run(ctx) }()
+	time.Sleep(30 * time.Millisecond)
+
+	data := msgNotificationJSON(t, pubsub.MessageNotification{MessageID: "fb_prod_2"})
+
+	// Delivered on the DEV source: dev fetcher returns nil -> handler nacks.
+	if err := devSub.deliver(t, "messages-laptop", data, nil); err == nil {
+		t.Fatal("expected dev source to nack a prod-only message id (fetcher scoping)")
+	}
+	if got := len(rec.calls()); got != 0 {
+		t.Fatalf("dev source must not fire for a prod id, got %d", got)
+	}
+
+	// Delivered on the PROD source: prod fetcher resolves it -> fires once.
+	if err := prodSub.deliver(t, "messages-laptop", data, nil); err != nil {
+		t.Fatalf("prod deliver: %v", err)
+	}
+	if got := len(rec.calls()); got != 1 {
+		t.Fatalf("expected prod source to fire once, got %d", got)
+	}
+}
+
+// TestDaemon_SingleProjectUnchanged proves that a daemon built with New (no
+// added sources) behaves exactly as before: the single messages-laptop source
+// fires from the primary subscriber, and task events still flow.
+func TestDaemon_SingleProjectUnchanged(t *testing.T) {
+	d, sub, fetch, rec := newTestDaemon(t)
+	fetch.msgs["msg_single_1"] = &messaging.InboxMessage{
+		MessageID: "msg_single_1",
+		ToInbox:   "public-feedback",
+		FromAgent: "nightly-eval",
+		Title:     "regression fade",
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = d.Run(ctx) }()
+	time.Sleep(20 * time.Millisecond)
+
+	// Message on the single (primary) source fires.
+	data := msgNotificationJSON(t, pubsub.MessageNotification{MessageID: "msg_single_1"})
+	if err := sub.deliver(t, "messages-laptop", data, nil); err != nil {
+		t.Fatalf("deliver: %v", err)
+	}
+	if got := len(rec.calls()); got != 1 {
+		t.Fatalf("expected 1 notification, got %d", got)
+	}
+
+	// Task events still flow on the same primary subscriber.
+	tdata := taskCompletionJSON(t, pubsub.TaskCompletion{TaskID: "t1", AgentID: "x", Status: "pending_approval"})
+	if err := sub.deliver(t, "events-laptop", tdata, nil); err != nil {
+		t.Fatalf("task deliver: %v", err)
+	}
+	if got := len(rec.calls()); got != 2 {
+		t.Fatalf("expected 2 notifications (msg+task), got %d", got)
+	}
+}
+
+func TestResolveExtraMessageSources(t *testing.T) {
+	// Basic: env=dev + extra prod -> one prod source.
+	got, err := ResolveExtraMessageSources("dev", []string{"prod"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].Env != "prod" || got[0].Project != "ailang-multivac" ||
+		got[0].Prefix != "ailang" || got[0].MessagesSub != "messages-laptop" {
+		t.Fatalf("got %+v", got)
+	}
+
+	// Dedup against primary: env=prod + extra prod -> no extra source.
+	got, err = ResolveExtraMessageSources("prod", []string{"prod"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected extra prod to dedup against primary prod, got %+v", got)
+	}
+
+	// Dedup against itself + blank-skip: [prod, , prod] -> one prod.
+	got, err = ResolveExtraMessageSources("dev", []string{"prod", "", "prod"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("expected self-dedup to yield 1 source, got %+v", got)
+	}
+
+	// Unknown env fails loudly.
+	if _, err := ResolveExtraMessageSources("dev", []string{"staging"}); err == nil {
+		t.Error("expected error for unknown env label")
+	}
+
+	// Nil/empty extras -> nil, backward compatible.
+	got, err = ResolveExtraMessageSources("dev", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected no extra sources for nil, got %+v", got)
+	}
+}
+
 func TestDaemon_GracefulShutdown(t *testing.T) {
 	d, _, _, _ := newTestDaemon(t)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/daemon/handlers.go
+++ b/internal/daemon/handlers.go
@@ -63,13 +63,32 @@ func taskNotification(t pubsub.TaskCompletion) (notify.Notification, bool) {
 	}
 }
 
-// messageNotification builds a Notification for an inbox message. Public-feedback
-// messages get a dedicated 🌐 prefix; everything else uses the generic shape.
+// pkgInboxPrefix is the inbox-name prefix the feedback publisher uses to route
+// package-scoped feedback (e.g. "pkg:sunholo/auth"). See
+// internal/feedback/publisher.go.
+const pkgInboxPrefix = "pkg:"
+
+// isExternalFeedbackInbox reports whether an inbox carries externally-sourced
+// user feedback that should reach Discord. Today that is the literal
+// "public-feedback" inbox OR any package-scoped "pkg:*" inbox (which the
+// feedback publisher routes package feedback to). Naming the rule here keeps it
+// unit-testable and gives a single place for a future Source=external flag to
+// extend it — instead of widening the Discord allow-list to all "message"
+// traffic (which would leak internal inbox chatter to Discord).
+func isExternalFeedbackInbox(inbox string) bool {
+	return inbox == "public-feedback" || strings.HasPrefix(inbox, pkgInboxPrefix)
+}
+
+// messageNotification builds a Notification for an inbox message. Externally-
+// sourced feedback (public-feedback + pkg:* inboxes) gets a dedicated 🌐 prefix
+// and the "public-feedback" EventType (which the Discord allow-list accepts);
+// everything else uses the generic shape and stays EventType "message" (macOS
+// only, dropped by Discord).
 func messageNotification(m *messaging.InboxMessage) (notify.Notification, bool) {
 	if m == nil {
 		return notify.Notification{}, false
 	}
-	if m.ToInbox == "public-feedback" {
+	if isExternalFeedbackInbox(m.ToInbox) {
 		return notify.Notification{
 			Title:     "🌐 External feedback",
 			Subtitle:  m.FromAgent,

--- a/internal/daemon/handlers_test.go
+++ b/internal/daemon/handlers_test.go
@@ -95,6 +95,65 @@ func TestMessageNotification_PublicFeedback(t *testing.T) {
 	}
 }
 
+func TestMessageNotification_PkgInboxIsExternalFeedback(t *testing.T) {
+	cases := []struct {
+		name            string
+		inbox           string
+		wantEventType   string
+		wantExternal    bool // 🌐 External feedback shape
+		wantInboxInBody bool
+	}{
+		{"public-feedback", "public-feedback", "public-feedback", true, true},
+		{"pkg scoped", "pkg:sunholo/auth", "public-feedback", true, true},
+		{"pkg ailang", "pkg:sunholo/ailang", "public-feedback", true, true},
+		{"internal user", "user", "message", false, false},
+		{"internal controlplane", "controlplane", "message", false, false},
+		{"internal agent", "sprint-executor", "message", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n, fire := messageNotification(&messaging.InboxMessage{
+				MessageID: "m_" + tc.name,
+				ToInbox:   tc.inbox,
+				FromAgent: "mcp-public",
+				Title:     "Effect row mismatch confused parser",
+			})
+			if !fire {
+				t.Fatal("expected fire=true")
+			}
+			if n.EventType != tc.wantEventType {
+				t.Errorf("EventType = %q, want %q", n.EventType, tc.wantEventType)
+			}
+			gotExternal := strings.Contains(n.Title, "External feedback")
+			if gotExternal != tc.wantExternal {
+				t.Errorf("external-feedback shape = %v, want %v (title=%q)", gotExternal, tc.wantExternal, n.Title)
+			}
+			if tc.wantInboxInBody && !strings.Contains(n.Body, tc.inbox) {
+				t.Errorf("expected inbox %q visible in body, got %q", tc.inbox, n.Body)
+			}
+		})
+	}
+}
+
+func TestIsExternalFeedbackInbox(t *testing.T) {
+	cases := map[string]bool{
+		"public-feedback":    true,
+		"pkg:sunholo/auth":   true,
+		"pkg:sunholo/ailang": true,
+		"pkg:":               true,
+		"user":               false,
+		"controlplane":       false,
+		"sprint-executor":    false,
+		"feedback":           false, // note: not the literal "public-feedback"
+		"":                   false,
+	}
+	for inbox, want := range cases {
+		if got := isExternalFeedbackInbox(inbox); got != want {
+			t.Errorf("isExternalFeedbackInbox(%q) = %v, want %v", inbox, got, want)
+		}
+	}
+}
+
 func TestMessageNotification_GenericInbox(t *testing.T) {
 	n, fire := messageNotification(&messaging.InboxMessage{
 		MessageID: "msg_abc",

--- a/internal/storage/firestore/client.go
+++ b/internal/storage/firestore/client.go
@@ -24,10 +24,22 @@ func NewClient(ctx context.Context) (*Client, error) {
 	if projectID == "" {
 		return nil, fmt.Errorf("AILANG_CLOUD_PROJECT must be set for Firestore backend")
 	}
+	return NewClientForProject(ctx, projectID)
+}
+
+// NewClientForProject creates a Firestore client for an EXPLICIT project,
+// bypassing the AILANG_CLOUD_PROJECT env var. Use this when a single process
+// must talk to more than one project (e.g. the notify daemon watching both dev
+// and prod inbox messages) — mutating the shared env would make the two clients
+// collide. Uses Application Default Credentials.
+func NewClientForProject(ctx context.Context, projectID string) (*Client, error) {
+	if projectID == "" {
+		return nil, fmt.Errorf("projectID must be non-empty for Firestore backend")
+	}
 
 	client, err := firestore.NewClient(ctx, projectID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Firestore client: %w", err)
+		return nil, fmt.Errorf("failed to create Firestore client (project %s): %w", projectID, err)
 	}
 
 	return &Client{


### PR DESCRIPTION
## Summary

Fixes the silent loss of external user feedback (mission-control iteration 24, Mark's NEXT-FIRST P1). Two independent defects were dropping real users' public feedback before it could reach Discord or a watched inbox. Both are fixed here; the one live prod round-trip is a parked human daemon reload (agent `launchctl` is auto-denied on the rig).

## Milestones

### M0 — Premise gate (`bfde6fe25`)
Read-only re-confirmation before touching code (all pass; no escalation):
- prod sub `projects/ailang-multivac/subscriptions/ailang-messages-laptop` EXISTS + ACTIVE (topic `ailang-messages`, ack 30s)
- active ADC identity `m@sunholo.com` is `roles/owner` on `ailang-multivac`
- `EnvProject["prod"] = {ailang-multivac, ailang}` (`config.go:22`)

### M1 — Defect A: `pkg:*` feedback reaches Discord (`47df615ac`)
Package feedback lands in `pkg:*` inboxes but `messageNotification` tagged `EventType: "public-feedback"` (the only class the Discord allow-list accepts) **only** for the literal `public-feedback` inbox — so package feedback got `EventType: "message"` and was dropped by construction. New named, unit-tested `isExternalFeedbackInbox(inbox)` helper (`public-feedback` OR `pkg:` prefix) gates the 🌐 shape + `public-feedback` EventType, with the inbox name in the body. Internal inboxes stay `EventType: "message"` (Discord-dropped). **`DefaultDiscordEventTypes` is deliberately NOT widened** (that would leak internal chatter to Discord).

### M2 — Defect B: daemon dual-subscribes dev + prod (`4f631e1bf`)
The public MCP writes to **prod** (`ailang-multivac`); the rig daemon subscribed to **dev** only — nothing listened to prod. The daemon now holds N message sources and fans out over dev + prod to the same notifier/webhook.
- **Chosen approach: `Daemon` source-list refactor** (not two instances) — one dedup window (message IDs are globally unique `fb_*`/`msg_*`), one notifier/webhook, task events kept primary(dev)-only.
- **Prod-fetcher scoping (highest-risk detail):** `storage.NewGCPBackends` + `firestore.NewClient` read `AILANG_CLOUD_PROJECT` **process-globally**, so mutating env would collide the dev/prod fetchers. Added `firestore.NewClientForProject(ctx, projectID)` (explicit project, ignores env); the CLI builds the prod messaging store with it, **without** touching `AILANG_CLOUD_PROJECT`.
- **Config:** `FileConfig.ExtraMessageEnvs` (`extra_message_envs`) + repeatable `--also-subscribe`, resolved via `EnvProject` (dedups primary+self, fails loudly on unknown env). **Default off → single-project byte-identical.**
- **No prod resource created/modified** — the daemon only READS the existing sub (confirmed M0).

### M3 — Runbook + dual-subscribe docs + CHANGELOG (`baf4d3e8f`)
- `agent-messaging.md`: triaging public/package feedback requires `AILANG_CLOUD_PROJECT=ailang-multivac` (**prod**) — every dev-only check has been blind to real users.
- `notify-daemon.md`: dual-subscribe opt-in with copy-pasteable `daemon.yaml` + plist edit + `launchctl` reload; cross-linked from `cloud-messaging-integration.md`.
- CHANGELOG `[Unreleased]` entry in `changelogs/v0.18-current.md`.

## Test evidence

- `go test ./internal/daemon/... ./internal/notify/... ./internal/storage/... ./cmd/ailang/` → **all green**.
- `go test -race -count=3 ./internal/daemon/...` → green (no races, stable).
- New tests: `TestMessageNotification_PkgInboxIsExternalFeedback`, `TestIsExternalFeedbackInbox`, `TestDaemon_DualProjectMessageFiresOnce`, `TestDaemon_ProdFetcherScopedToProdStore`, `TestDaemon_SingleProjectUnchanged`, `TestResolveExtraMessageSources`. All existing `daemon_test.go` / `notify` tests pass unchanged.
- `make lint` → **0 issues**. `make check-file-sizes` → all within 800.
- `make test` (full): passes **except one pre-existing flake** — `TestRunCommand_PipedStdoutFlushesPerLine` (`cmd/ailang`), a timing-based stdout-flush test that PASSES in isolation (5/5 reruns) and failed only under full-suite parallel CPU contention. Not in this diff; unrelated to daemon/feedback.
- Docs `npm run build`: **pre-existing docusaurus sidebars failure** (`reference/errors/*` doc ids) that reproduces identically with these guide edits stashed out — not caused by this sprint (plain `.md` guide edits, no sidebars/reference changes).

## Parked for Mark (see sprint plan "Parked for human")

Live prod end-to-end verification needs a daemon reload (agent `launchctl` auto-denied). After merge + `make install`: enable `extra_message_envs: [prod]` (or `--also-subscribe prod`), `launchctl unload/load` the daemon plist, then submit a prod public-feedback + a `pkg:*` feedback and confirm the 🌐 Discord pings. Full checklist in `.ailang/state/sprints/sprint_M-PUBLIC-FEEDBACK-DELIVERY-AUDIT.json` (`parked_for_human`) and the sprint plan.

## Conflict-surface guardrails held
- `DefaultDiscordEventTypes` unchanged; internal inboxes stay Discord-dropped.
- No regression to the working public-feedback path; all existing daemon+notify tests pass; dual-subscribe defaults off (byte-identical).
- `internal/apiserver/ratelimit.go` untouched.
- No prod resource creation/mutation (READ-only sub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)