### PR TITLE
test(examples): ghost-close R4a match-hof + R4b poly-arith-lambda with regression guards

### DIFF
--- a/examples/match_hof_lambda.ail
+++ b/examples/match_hof_lambda.ail
@@ -1,0 +1,38 @@
+-- `match` inside block-body lambdas passed to higher-order functions.
+-- Regression guard for M-DX-MATCH-HOF (R4a): the strategy review's footgun row
+-- claimed this fails to parse. Verified GHOST in mission iteration 25
+-- (2026-07-13): the failing pattern used the retired `match … with` syntax;
+-- brace-form match works in every position probed here (design doc archived at
+-- design_docs/archive/v0_13_0_m-dx-match-in-hof-block-lambda.md).
+module examples/match_hof_lambda
+
+import std/io (println)
+import std/list (map, foldl)
+
+type Chunk = Delta(string) | Usage(int)
+
+export func main() -> () ! {IO} {
+  -- Block-body lambda with a let-bound match, passed straight to map.
+  let labels = map(\item. { let s = match item { 0 => "zero", _ => "ok" }; s }, [0, 1, 2]);
+  println(show(labels));
+
+  -- Direct match body (no braces) in a lambda over an ADT.
+  let texts = map(\c. match c { Delta(t) => t, Usage(_) => "usage" }, [Delta("a"), Usage(3)]);
+  println(show(texts));
+
+  -- Match mid-block after another statement.
+  let bumped = map(\x. {
+    let doubled = x * 2;
+    let label = match doubled { 0 => 0, n => n + 1 };
+    label
+  }, [0, 1, 2]);
+  println(show(bumped));
+
+  -- Nested HOFs with match in the inner lambda.
+  let nested = map(\xs. map(\x. match x { 0 => "z", _ => "nz" }, xs), [[0], [1, 0]]);
+  println(show(nested));
+
+  -- Match inside a curried two-argument lambda passed to foldl.
+  let total = foldl(\acc. \x. match x { 0 => acc, n => acc + n }, 0, [0, 1, 2, 3]);
+  println(show(total))
+}

--- a/examples/poly_arith_lambda.ail
+++ b/examples/poly_arith_lambda.ail
@@ -1,0 +1,40 @@
+-- Polymorphic arithmetic in lambdas.
+-- Regression guard for M-POLY-ARITH-LAMBDA (R4b): the strategy review's footgun
+-- row claimed polymorphic *arithmetic* in lambdas panics while polymorphic
+-- comparison works. Verified GHOST in mission iteration 25 (2026-07-13): fixed
+-- in v0.7.0 (design_docs/implemented/v0_7_0/m-poly-arithmetic-fix.md); every
+-- variant probed here — including one binding used at BOTH int and float —
+-- type-checks and runs.
+module examples/poly_arith_lambda
+
+import std/io (println)
+import std/list (map, foldl)
+
+-- Polymorphic top-level helper used at two Num instantiations.
+pure func double[a](x: a) -> a { x + x }
+
+export func main() -> () ! {IO} {
+  -- Curried polymorphic arithmetic lambda, instantiated at float and int.
+  let add = \x. \y. x + y;
+  println(show(add(3.14)(2.71)));
+  println(show(add(3)(4)));
+
+  -- One let-bound lambda used at BOTH int and float (real let-polymorphism).
+  let twice = \x. x + x;
+  println(show(twice(4)));
+  println(show(twice(2.5)));
+
+  -- Polymorphic helper func at both types.
+  println(show(double(21)));
+  println(show(double(1.5)));
+
+  -- Arithmetic lambdas passed to HOFs at each instantiation.
+  println(show(map(\x. x * 2, [1, 2, 3])));
+  println(show(map(\x. x * 2.0, [1.5, 2.5])));
+  println(show(foldl(\acc. \x. acc * x, 1, [2, 3, 4])));
+  println(show(foldl(\acc. \x. acc * x, 1.0, [0.5, 4.0])));
+
+  -- Comparison AND arithmetic mixed in the same lambda.
+  let clamp = \x. if x > 10 then x - 10 else x + 1;
+  println(show(map(clamp, [5, 20])))
+}


### PR DESCRIPTION
## Mission iteration 25 — ghost-close (Gate-2 reality check)

The clause-3 queue listed **R4a `m-dx-match-hof`** (2–3d) and **R4b `m-poly-arith-lambda`** (2–3d) as NEW-DOC footgun fixes. The strategy review that sourced them explicitly noted its footgun rows were *not re-verified individually* — so before designing anything, iteration 25 live-probed both at HEAD (`999bd629f`) with fresh version-verified binaries.

**Both are ghosts:**

- **R4a**: the original failure used the retired `match … with` syntax. Brace-form `match` works in every position probed: block-body lambda in `map`, direct match body over an ADT, match mid-block, nested HOFs, curried `foldl` lambda. The design doc was already archived as *Not Applicable* ([archive/v0_13_0_m-dx-match-in-hof-block-lambda.md](https://github.com/sunholo-data/ailang/blob/dev/design_docs/archive/v0_13_0_m-dx-match-in-hof-block-lambda.md), investigated 2026-05-09). The conflated `\x ->` wrong-arrow issue already has a first-line teaching diagnostic (`lambda body separator is '.' not '->'`).
- **R4b**: fixed in v0.7.0 ([m-poly-arithmetic-fix](https://github.com/sunholo-data/ailang/blob/dev/design_docs/implemented/v0_7_0/m-poly-arithmetic-fix.md)). Verified including a single let-bound lambda used at **both** int and float, a poly func at two instantiations, and arithmetic+comparison mixed in one lambda.

**This PR adds the two regression guards** (same pattern as iteration 18's ghost closes, PR #358): top-level `examples/*.ail` files that run in `verify-examples` (38 type-checked · 35 ran clean locally).

Queue/log bookkeeping follows on dev after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)