### PR TITLE
feat(types): parameterized type aliases substitute their arguments (M-XMOD-ALIAS-POLY)

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,41 @@
 
 ## [Unreleased]
 
+### Added — parameterized type aliases substitute their arguments (M-XMOD-ALIAS-POLY)
+
+A type alias may now take type parameters and be **used at a concrete
+instantiation**: `type Box[a] = { items: [a] }` used as `Box[int]` type-checks
+as `{ items: [int] }`. Previously the applied form reached unification as an
+un-expanded `TApp{TCon("Box"), [int]}` and failed with
+`cannot unify old record type with *types.TApp`. Now working, single-module and
+cross-module, for every alias body shape:
+
+- **record** — `type Box[a] = { items: [a] }` → `Box[int]`
+- **bare param** — `type Ident[a] = a` → `Ident[int]`
+- **tuple** — `type Pair[a, b] = (a, b)` → `Pair[int, string]`
+- **function** — `type Fn[a, b] = (a) -> b` → `Fn[int, int]`
+- **nested** — `Box[Box[int]]`
+
+**How:** aliases now carry their parameter names (`AliasParams`) alongside the
+body at every layer (elaborator, `iface.Iface`, type-checker, unifier), threaded
+cross-module through the interface (JSON cache round-trip) and the import
+resolver. `expandAlias` gained a `*TApp` branch that instantiates an applied
+alias by substituting `param→arg` through the body (via the existing
+`Type.Substitute` method, which recurses through record/tuple/function bodies)
+and continues the fixpoint loop, so alias chains still resolve.
+
+**Non-regression (critical):** expansion is keyed **strictly on alias-env
+membership**, so genuine parameterized ADTs (`Option[a]`, `Result[a, b]`, a user
+`type Tree[a] = …`) — whose head constructor is registered as a constructor, not
+an alias — are **never** instantiated and stay nominal. Locked by tests.
+
+**Arity mismatch** (`Box[int, string]` on a 1-param alias, or a nullary alias
+applied with args) now fails with a coded, directional diagnostic
+`TC_ALIAS_ARITY_001` (styled on `TC_ARITY_001`) instead of a generic unification
+error. Adding a parameterized alias is **digest-neutral** (no dependent-package
+cascade), locked by the digest test. `cacheKeyVersion` bumped `v2 → v3`
+(on-disk `Iface` gained `AliasParams`). Example: `examples/type_alias_poly.ail`.
+
 ### Verified — two "footgun" claims closed as ghosts, with regression guards (M-DX-MATCH-HOF, M-POLY-ARITH-LAMBDA)
 
 Mission iteration 25 live-probed two long-queued footgun rows at HEAD; both were already fixed:

--- a/design_docs/implemented/v0_30_0/m-xmod-alias-poly-sprint-plan.md
+++ b/design_docs/implemented/v0_30_0/m-xmod-alias-poly-sprint-plan.md
@@ -1,6 +1,13 @@
 # Sprint Plan: M-XMOD-ALIAS-POLY — Parameterized Type-Alias Substitution
 
-**Design doc**: [m-xmod-alias-poly.md](../v0_29_0/m-xmod-alias-poly.md)
+**Status**: ✅ COMPLETED (mission iteration 26). All milestones landed; M4
+(cross-module) folded into M3 as planned. Acceptance criteria all met — see the
+per-milestone "Acceptance criteria" lists below, each verified by the tests
+named in the design doc's Implementation notes. Full suite green,
+`verify-examples` green (top-level gate; the 5 pre-existing `runnable/` failures
+are unrelated effect-row/Option bugs, identical on the base commit).
+
+**Design doc**: [m-xmod-alias-poly.md](m-xmod-alias-poly.md)
 **Sprint ID**: M-XMOD-ALIAS-POLY
 **Target version**: v0.30.0
 **Duration**: 1.5–2 days

--- a/design_docs/implemented/v0_30_0/m-xmod-alias-poly.md
+++ b/design_docs/implemented/v0_30_0/m-xmod-alias-poly.md
@@ -1,7 +1,7 @@
 ## M-XMOD-ALIAS-POLY: parameterized type aliases substitute their arguments (`type Box[a] = { items: [a] }`)
 
-**Status**: PLANNED
-**Target**: tbd (a real feature, not a quick fix — needs substitution machinery)
+**Status**: IMPLEMENTED (v0.30.0, mission iteration 26 — M-XMOD-ALIAS-POLY sprint)
+**Target**: v0.30.0 (a real feature, not a quick fix — needs substitution machinery)
 **Priority**: P3 (Medium-low — a genuine expressiveness gap, but with a clean workaround: inline the parameterized shape, or use a single-constructor ADT `type Box[a] = Box([a])`. Unblocks nothing outright.)
 **Estimated**: ~1–2 days (alias env must store `(params, body)`; substitute on applied-alias expansion; wire through the interface export; tests).
 **Dependencies**: None, but builds directly on [M-XMOD-ALIAS](implemented/v0_28_1/m-cross-module-type-alias.md) and [M-XMOD-ALIAS-CHAIN](implemented/v0_28_1/m-xmod-alias-chain.md).
@@ -97,3 +97,39 @@ Teach the alias machinery to carry and apply parameters:
 ## Out of scope
 
 - Higher-kinded / partially-applied aliases (`type F = Box` used as `F[int]`) — punt unless a real case appears.
+
+## Implementation notes (as landed, v0.30.0)
+
+Delivered as sprint M-XMOD-ALIAS-POLY across three milestones (see the sprint plan
+alongside this doc). Summary of what landed vs the proposal:
+
+- **Representation:** rather than replacing `TypeAliases map[string]Type` with a
+  `(params, body)` struct, a **sibling** `AliasParams map[string][]string` was
+  added at every layer (elaborator, `iface.Iface`, `CoreTypeChecker`, `Unifier`).
+  A missing entry means "nullary alias". This kept the existing nullary/record-
+  `TypeName` paths byte-identical (the M-XMOD-ALIAS pack is untouched).
+- **Substitution helper:** the right primitive was the `Type.Substitute(map[string]Type)`
+  method (every variant implements it; `TVar2.Substitute` keys by name), NOT
+  `ApplySubstitution` (which walks a unifier `Substitution` of fresh inference
+  vars). No new traversal code.
+- **expandAlias:** a `*TApp` branch was added at the top of the fixpoint loop —
+  decompose, require the head `TCon` be in `aliasEnv` (strict membership = the
+  ADT-nominality guarantee), arity-check, `body.Substitute(param→arg)`, continue
+  the loop. The `seen` cycle guard was extended to the `TApp` head name.
+- **Arity diagnostic:** `TC_ALIAS_ARITY_001` (errors.go), coded + directional,
+  styled on `TC_ARITY_001`. `expandAlias` returns `Type` (4 call sites) so the
+  error is latched on the unifier and surfaced by `Unify` right after expansion.
+- **cacheKey:** bumped `v2 → v3` defensively (on-disk `Iface` gained
+  `AliasParams`; the blob is JSON so tolerant, but a same-version dev build could
+  otherwise treat a parameterized alias as nullary). Digest stays neutral
+  (`computeDigest` excludes both `TypeAliases` and `AliasParams`) — no cascade.
+- **PR #380 ordering:** expansion runs at `Unify` entry, before the type-switch
+  dispatches to `unifyRecord`, so open-record patterns over a parameterized-alias
+  body already see the expanded record. Locked by a test.
+- **Extra shape covered for free:** function-body aliases (`type Fn[a,b] = (a)->b`)
+  work via `TFunc2.Substitute` — not in the original test plan, added as a test.
+
+Tests: `internal/types/alias_poly_test.go` (unit: expansion, ADT nominality,
+arity), `internal/pipeline/alias_poly_test.go` (E2E single- + cross-module, PR
+#380 lock), extended `internal/iface/xmod_alias_digest_test.go` and
+`internal/pipeline/cache_store_test.go`. Example: `examples/type_alias_poly.ail`.

--- a/design_docs/planned/v0_30_0/m-xmod-alias-poly-sprint-plan.md
+++ b/design_docs/planned/v0_30_0/m-xmod-alias-poly-sprint-plan.md
@@ -1,0 +1,248 @@
+# Sprint Plan: M-XMOD-ALIAS-POLY — Parameterized Type-Alias Substitution
+
+**Design doc**: [m-xmod-alias-poly.md](../v0_29_0/m-xmod-alias-poly.md)
+**Sprint ID**: M-XMOD-ALIAS-POLY
+**Target version**: v0.30.0
+**Duration**: 1.5–2 days
+**Risk level**: Medium (touches the hot unification path + iface serialization; strong non-regression guardrails required)
+**Verified against**: worktree binary built at `fedbee699` (origin/dev), behaviourally probed (NOT via `--version`, which lies for worktree builds).
+
+---
+
+## Goal
+
+Make parameterized type aliases substitute their concrete arguments at use sites, so
+`type Box[a] = { items: [a] }` + `func mk(xs: [int]) -> Box[int] = { items: xs }` type-checks
+(and the same imported cross-module), while genuine parameterized ADTs (`Option[a]`,
+`Result[a,b]`, user `type Tree[a] = …`) stay strictly nominal.
+
+---
+
+## Verified Root-Cause Summary
+
+I built the worktree binary and reproduced every failure the doc predicts, then read the
+current code to confirm each of the three root-cause claims. **All three claims CONFIRMED**
+(line refs updated to current tree). Two useful CORRECTIONS/additions below.
+
+### Failure surface (behaviourally reproduced with worktree `bin/ailang check`)
+
+| Probe (single-module) | Result | Error text |
+|---|---|---|
+| `type Box[a] = { items: [a] }` used as `Box[int]` | FAILS | `cannot unify old record type with *types.TApp` |
+| `type Ident[a] = a` used as `Ident[int]` | FAILS | `cannot unify Ident[int] with int` |
+| `type Pair[a,b] = (a,b)` used as `Pair[int,string]` | FAILS | `cannot unify tuple type (int, string) with Pair[int, string]` |
+| `type Box[a] = {items:[a]}` nested `Box[Box[int]]` | FAILS | `cannot unify old record type with *types.TApp` |
+| `type Fn[a,b] = (a) -> b` used as `Fn[int,int]` | FAILS (extra shape) | `cannot unify type application Fn[int, int] with int -> α1 ! {...}` |
+| **Non-regression** `type Tree[a] = Leaf(a) \| Node(...)` + `match` | **PASSES** ✓ | baseline nominal ADT works |
+| **Non-regression** `import std/option` → `Some(5): Option[int]` | **PASSES** ✓ | baseline imported ADT works |
+
+So the failure surface is: **records, bare-param, tuple, function, and nested** alias bodies all fail
+identically (un-expanded applied alias reaches unification as `TApp{TCon(alias), args}`). ADTs are
+untouched. The function-body form (`Fn[a,b] = (a)->b`) is an extra shape not enumerated in the doc's
+test plan — the substitution approach covers it for free (TFunc2 has a `Substitute` method), so we
+add it as a test.
+
+### Root-cause claim verification
+
+1. **`RegisterTypeAlias` stores body without params — CONFIRMED.**
+   `internal/elaborate/core.go:173` — `RegisterTypeAlias(name string, target types.Type)` stores into
+   `e.typeAliases map[string]types.Type`. No param list. The three call sites at
+   `internal/elaborate/file_funcs.go:201,216,225` all have `decl.TypeParams []string` in scope (e.g.
+   `["a"]`) but discard it. Alias param type-vars are converted to `*types.TVar2{Name:"a"}`
+   (`file_funcs.go:333`), so they survive in the body as named vars — but with nothing to bind them to.
+
+2. **`expandAlias` matches bare `*TCon` only — CONFIRMED.**
+   `internal/types/unification_core.go:88-127`. The fixpoint loop does `con, ok := t.(*TCon)` (line 99)
+   and returns `t` unchanged for any non-`TCon` (line 100-102). An applied alias is a `*TApp` whose
+   *constructor* is the alias `TCon`, so it never enters the loop. Called from `Unify` at
+   `unification_core.go:174-175`, **before** the `SafeEquals` check and the type-switch — so expansion
+   correctly happens before record/tuple/func unification (relevant to the PR #380 note below).
+
+3. **iface builder has no param binding — CONFIRMED.**
+   `internal/iface/iface.go:106` — `AddTypeAlias(name string, target types.Type)` stores into
+   `TypeAliases map[string]types.Type`. Builder call sites `internal/iface/builder.go:386,400,443` pass
+   only `(name, internalType)`; `typeDecl.TypeParams` is in scope but dropped.
+
+### CORRECTIONS / additions to the doc
+
+- **CORRECTION (substitution helper):** the doc says "reuse the existing substitution helper in
+  `internal/types`". The right primitive is the **`Substitute(subs map[string]Type) Type` method on the
+  `Type` interface** (every variant implements it: `types.go`, `types_v2.go`, `label_helpers.go`).
+  `*TVar2.Substitute` (types_v2.go:33) keys by `.Name`, so `body.Substitute({"a": int})` binds param `a`.
+  This is NOT `ApplySubstitution` (that walks a unifier `Substitution` keyed by fresh inference vars).
+  Plan uses the `.Substitute(map)` method — no new traversal code needed.
+
+- **ADDITION (PR #380 / open-record ordering):** M-LAMBDA-OPEN-RECORD-PATTERN changed `unifyRecord`
+  (`internal/types/unification_records.go`). Because `expandAlias` runs at `Unify` entry (line 174-175),
+  **before** the type-switch dispatches to `unifyRecord`, the open-record logic already sees the expanded
+  `{items:[int]}` — no reordering needed. We add a regression test proving an *open-record pattern over a
+  parameterized alias body* still works, to lock this ordering.
+
+### cacheKey / digest decision
+
+- **Digest: NEUTRAL, no change.** `computeDigest` (`iface/builder.go:607`) serializes only
+  Module/Schema/Exports/Constructors — **not** `TypeAliases` (locked by
+  `iface/xmod_alias_digest_test.go`). Adding params to the alias representation does **not** change any
+  module's digest → **no dependent-package cascade**. Preserve this; extend the digest test to assert a
+  *parameterized* alias is still digest-neutral.
+
+- **cacheKey: DEFENSIVE bump `v2 → v3` REQUIRED-IF-STRUCT-CHANGES.**
+  `internal/pipeline/cache_key.go:18` — `cacheKeyVersion = "v2"`. Two facts:
+  (a) `compilerVersion` (build commit) already invalidates the module cache on every rebuild, so a
+  released binary is safe either way.
+  (b) `CachedModule.Iface` is **JSON-encoded** on disk (`cache_store.go:131,136`), and JSON tolerates
+  new/missing fields (missing → zero value), so a schema change there is not a hard round-trip hazard
+  the way the v1→v2 **gob** `RecordPattern.Rest` change was.
+  **Decision:** if we change the on-disk shape of `TypeAliases` (i.e. store a struct with `Params`
+  instead of a bare `types.Type`), bump `cacheKeyVersion` to `v3` as a cheap correctness guard against
+  same-version dev/worktree builds colliding keys and decoding an old bare-alias blob into the new
+  struct. **If** we instead keep `TypeAliases map[string]types.Type` unchanged and store params in a
+  **separate** map/field (see M1 design choice), the on-disk Iface shape still gains a field → still
+  bump to `v3`. Net: **bump to v3** in this sprint (one-line, in M3).
+
+---
+
+## Technical Approach
+
+Introduce an alias record carrying `(Params []string, Body Type)` and teach `expandAlias` to
+instantiate an applied alias by `Body.Substitute(param→arg)`, keyed **strictly on alias-env
+membership** so real ADTs are never touched.
+
+**Representation choice (decided):** add a sibling map alongside the existing `TypeAliases`:
+`AliasParams map[string][]string` (name → param names), in `iface.Iface`, in the elaborator, and in the
+`CoreTypeChecker`/`Unifier` alias env. This is minimally invasive (existing `TypeAliases map[string]Type`
+untouched → existing nullary-alias code and the record-`TypeName` path keep working verbatim), and a
+missing entry naturally means "nullary alias" (arity 0). The `Unifier` gains an `aliasParams
+map[string][]string` field next to `aliasEnv`.
+
+Expansion rule in `expandAlias`, added as a new branch that runs when `t` is `*TApp`:
+1. `head, args := decomposeApp(t)`; require `head` is `*TCon` and `head.Name ∈ aliasEnv`.
+2. Look up `params := aliasParams[head.Name]`. If `len(args) != len(params)` → **arity diagnostic**
+   (coded error, see M2). If the name is in `aliasEnv` but has **0** params (nullary) and got args, that
+   is also an arity mismatch.
+3. Build `subs := {params[i]: args[i]}`, compute `expanded := aliasEnv[head.Name].Substitute(subs)`,
+   then **continue the existing fixpoint loop** on `expanded` (so `type A[x] = B[x]` chains resolve, and
+   the record-`TypeName` terminal path still fires).
+4. Non-membership (`head.Name ∉ aliasEnv`) → return `t` unchanged (ADTs stay nominal — the critical
+   non-regression).
+
+---
+
+## Milestones
+
+### M1 — Carry `(params, body)` through elaborate + iface + type-checker alias env (~120 LOC + ~40 test)
+
+**Files:** `internal/elaborate/core.go`, `internal/elaborate/file_funcs.go`,
+`internal/iface/iface.go`, `internal/iface/builder.go`, `internal/types/typechecker_core.go`,
+`internal/types/unification_core.go`.
+
+**Work:**
+- Add `aliasParams map[string][]string` field + `RegisterTypeAliasParams` / getter in the elaborator;
+  populate at the three `file_funcs.go` call sites (201, 216, 225) from `decl.TypeParams`.
+- Add `AliasParams map[string][]string` to `iface.Iface` (+ init in `NewIface`, + `AddTypeAliasParams`);
+  populate at the three `builder.go` call sites (386, 400, 443) from `typeDecl.TypeParams`.
+- Thread params from iface/elaborator into `CoreTypeChecker.aliasParams` and into the `Unifier`
+  (`NewUnifierWithAliases` gains a params arg or a companion `NewUnifierWithAliasesAndParams`; the
+  construction site is `typechecker_core.go:418`).
+
+**Acceptance criteria:**
+- Elaborator stores `["a"]` for `type Box[a] = {items:[a]}` and `[]`/absent for `type Row = Json`.
+- iface round-trips `AliasParams` (imported module's parameterized alias arrives with its params).
+- `make build` green; no behavioural change yet (M1 is plumbing — applied aliases still error).
+
+---
+
+### M2 — Expand applied aliases in `expandAlias` + arity diagnostic (~90 LOC + ~60 test)
+
+**Files:** `internal/types/unification_core.go`, `internal/types/errors.go`.
+
+**Work:**
+- Add the `*TApp` branch to `expandAlias` per the Expansion rule above, keyed strictly on
+  `aliasEnv` membership; substitute via `Body.Substitute(subs)`; continue the fixpoint loop.
+- Add a coded arity diagnostic `TC_ALIAS_ARITY_001`, styled on `TC_ARITY_001`
+  (`errors.go:344-375`): coded prefix + inline `Suggestion:`, directional (`Box[a]` expects 1, got 2 →
+  "supply 1 type argument"; nullary-alias-applied → "`Row` takes no type arguments").
+
+**Acceptance criteria:**
+- `Box[int]`, `Ident[int]`, `Pair[int,string]`, `Fn[int,int]`, and nested `Box[Box[int]]` all
+  type-check (single-module).
+- `Box[int,string]` (arity 2 on a 1-param alias) fails with `TC_ALIAS_ARITY_001` and a directional hint.
+- Golden test asserts the error is coded and directional (mirrors `arity_diagnostic_test.go`).
+
+---
+
+### M3 — Non-regression lock + cacheKey bump + examples + docs (~40 LOC + ~80 test)
+
+**Files:** `internal/types/*_test.go`, `internal/iface/xmod_alias_digest_test.go`,
+`internal/pipeline/cache_key.go`, `examples/type_alias_poly.ail`, `CHANGELOG.md`,
+move design doc `v0_29_0 → implemented/v0_30_0`.
+
+**Work:**
+- Non-regression tests: `Option[int]`, `Result[int,string]`, and a user `type Tree[a]` ADT with
+  `match` stay nominal (assert expansion does NOT fire — key on alias-env membership).
+- Open-record-over-alias test (PR #380 ordering lock): field access / open-record pattern against a
+  parameterized-alias record body still unifies.
+- Extend `xmod_alias_digest_test.go` to assert a **parameterized** alias is digest-neutral.
+- Bump `cacheKeyVersion` `"v2" → "v3"` with a comment citing this milestone (on-disk Iface gained
+  `AliasParams`).
+- Example file `examples/type_alias_poly.ail` (record + bare-param + tuple aliases used with concrete
+  args, runnable `main`). Register it in `make verify-examples` expectations.
+- CHANGELOG entry; move design doc to `design_docs/implemented/v0_30_0/`.
+
+**Acceptance criteria:**
+- All non-regression tests green; `Option`/`Result`/`Tree` behaviour byte-identical to baseline.
+- `examples/type_alias_poly.ail` runs and `make verify-examples` green.
+- `make test` green; digest test proves parameterized alias is digest-neutral.
+
+---
+
+### M4 (optional, fold into M3 if time) — Cross-module end-to-end (~0 new LOC, ~40 test)
+
+**Files:** `internal/link` or `internal/pipeline` module-test fixtures, `examples/`.
+
+**Work:** two-module fixture: module `shapes` exports `type Box[a] = {items:[a]}`; module `main`
+imports and uses `Box[int]`. Proves M1's iface `AliasParams` threading composes with M-XMOD-ALIAS.
+
+**Acceptance criteria:** cross-module `Box[int]` type-checks; arity mismatch across modules still coded.
+
+---
+
+## Test Plan (consolidated)
+
+- **Single-module (M2):** `Box[int]` (record), `Ident[int]` (bare param), `Pair[int,string]` (tuple),
+  `Fn[int,int]` (function body), nested `Box[Box[int]]`, 2-param alias.
+- **Cross-module (M4):** the same, imported and used.
+- **Non-regression (M3):** `Option[int]`, `Result[int,string]`, user `type Tree[a]` ADT + `match` —
+  all still nominal; open-record-over-alias still unifies (PR #380 lock).
+- **Arity-mismatch diagnostic (M2):** `Box[int,string]` and nullary-applied → `TC_ALIAS_ARITY_001`,
+  directional hint; golden test.
+- **Digest neutrality (M3):** parameterized alias does not change module digest.
+- **Gate:** `make test` + `make verify-examples` green.
+
+## Example file to create
+
+`examples/type_alias_poly.ail` — a single module declaring `Box[a]` (record body), `Ident[a]`
+(bare param), and `Pair[a,b]` (tuple body), each used at a concrete instantiation inside a runnable
+`main`, printing a small result. Per CLAUDE.md every language feature needs an example; wire into
+`make verify-examples`.
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| **Accidentally instantiating a real ADT** (`Option[a]`) if keying is loose | Medium | Key STRICTLY on `aliasEnv` membership; ADT constructors are registered as constructors, never aliases. Non-regression tests M3 assert `Option`/`Result`/`Tree` unchanged. |
+| Substitution captures/collides a free var in the body | Low | Alias bodies are closed over `params`; `.Substitute(map)` replaces named `TVar2` leaves only. Add nested `Box[Box[int]]` test to exercise recursion. |
+| Fixpoint loop + new TApp branch introduces non-termination (`type A[x] = A[x]`) | Low | Reuse the existing `seen` cycle guard; extend it to key on the `TApp` head name too. |
+| cacheKey/gob round-trip of a stale bare-alias blob into new struct | Low | Bump `cacheKeyVersion` to `v3` (M3); Iface is JSON (tolerant) but bump anyway. |
+| PR #380 open-record path sees an un-expanded alias | Low | Expansion already runs at `Unify` entry (line 174-175) before the type-switch; add explicit lock test (M3). |
+
+## Out of scope
+
+- Higher-kinded / partially-applied aliases (`type F = Box` used as `F[int]`) — punt unless a real
+  case appears (per design doc).
+
+---
+
+**Velocity note:** ~380 LOC total (≈230 impl + ≈150 test) across 3–4 milestones over 1.5–2 days,
+consistent with the doc's ~1–2 day estimate and recent iteration velocity (M-LAMBDA-OPEN-RECORD-PATTERN
+#380 was a comparable single-day unification-path change).

--- a/examples/type_alias_poly.ail
+++ b/examples/type_alias_poly.ail
@@ -1,0 +1,67 @@
+-- examples/type_alias_poly.ail
+-- Parameterized type aliases (M-XMOD-ALIAS-POLY, v0.30.0).
+--
+-- A type alias may take type parameters and be used at a concrete
+-- instantiation. The alias body is SUBSTITUTED with the applied arguments at
+-- the use site, so `Box[int]` type-checks as `{ items: [int] }`.
+--
+-- Three shapes are shown:
+--   * record body   — `type Box[a]  = { items: [a] }`  used as `Box[int]`
+--   * bare param     — `type Ident[a] = a`               used as `Ident[int]`
+--   * tuple body     — `type Pair[a,b] = (a, b)`          used as `Pair[int, string]`
+--
+-- Genuine parameterized ADTs (Option[a], Result[a,b], a user `type Tree[a]`)
+-- are NOT aliases and stay strictly nominal — only alias heads are instantiated.
+--
+-- Run:
+--   ailang run --caps IO --entry main examples/type_alias_poly.ail
+
+module examples/type_alias_poly
+
+import std/io (println)
+
+-- Record-body alias: Box[a] = { items: [a] }
+type Box[a] = { items: [a] }
+
+-- Bare-parameter alias: Ident[a] = a
+type Ident[a] = a
+
+-- Tuple-body alias: Pair[a, b] = (a, b)
+type Pair[a, b] = (a, b)
+
+-- mkBox builds a Box[int] from a concrete [int]. The return annotation Box[int]
+-- expands to { items: [int] } during unification.
+export func mkBox(xs: [int]) -> Box[int] {
+  { items: xs }
+}
+
+-- idInt uses the bare-param alias Ident[int], which expands to int.
+export func idInt(x: int) -> Ident[int] {
+  x
+}
+
+-- mkPair builds a Pair[int, string], expanding to (int, string).
+export func mkPair(n: int, s: string) -> Pair[int, string] {
+  (n, s)
+}
+
+-- firstItem reads a field off the parameterized-alias record body.
+export func firstItem(b: Box[int]) -> int {
+  match b.items {
+    [] => 0,
+    [x, ..._] => x
+  }
+}
+
+export func main() -> () ! {IO} {
+  let b = mkBox([10, 20, 30]);
+  println("firstItem(Box[int]): ${show(firstItem(b))}");
+
+  let y = idInt(42);
+  println("idInt(Ident[int]): ${show(y)}");
+
+  let p = mkPair(7, "seven");
+  match p {
+    (n, s) => println("mkPair(Pair[int,string]): ${show(n)} = ${s}")
+  }
+}

--- a/internal/elaborate/core.go
+++ b/internal/elaborate/core.go
@@ -26,6 +26,12 @@ type Elaborator struct {
 	// typeAliases stores type aliases for expansion during type checking
 	// M-BUGFIX: Maps alias names to their underlying types (e.g., "Coord" -> {x: int, y: int})
 	typeAliases map[string]types.Type
+	// aliasParams stores the type-parameter names for PARAMETERIZED aliases
+	// (M-XMOD-ALIAS-POLY). Maps alias name -> ordered param names
+	// (e.g. "Box" -> ["a"] for `type Box[a] = {items: [a]}`). A missing entry
+	// means the alias is nullary (arity 0). Kept as a sibling map so the
+	// existing typeAliases[name] -> body path is unchanged.
+	aliasParams map[string][]string
 	// M-FIX-FLOAT-OP: Parameter type annotations from function declarations
 	// Maps Lambda NodeID -> parameter types (preserves float annotations through elaboration)
 	paramTypeAnnots map[uint64][]types.Type
@@ -187,6 +193,25 @@ func (e *Elaborator) RegisterTypeAlias(name string, target types.Type) {
 // M-BUGFIX: Used to pass aliases to the type checker for expansion during unification
 func (e *Elaborator) GetTypeAliases() map[string]types.Type {
 	return e.typeAliases
+}
+
+// RegisterTypeAliasParams records the ordered type-parameter names for a
+// parameterized alias (M-XMOD-ALIAS-POLY). A nil/empty list is not stored
+// (a missing entry naturally means "nullary alias").
+func (e *Elaborator) RegisterTypeAliasParams(name string, params []string) {
+	if len(params) == 0 {
+		return
+	}
+	if e.aliasParams == nil {
+		e.aliasParams = make(map[string][]string)
+	}
+	e.aliasParams[name] = params
+}
+
+// GetTypeAliasParams returns the parameter names for all parameterized aliases
+// registered during elaboration (M-XMOD-ALIAS-POLY).
+func (e *Elaborator) GetTypeAliasParams() map[string][]string {
+	return e.aliasParams
 }
 
 // GetEffectAnnotation returns the effect annotation for a Core node ID

--- a/internal/elaborate/file_funcs.go
+++ b/internal/elaborate/file_funcs.go
@@ -214,6 +214,9 @@ func (e *Elaborator) elaborateTypeDecl(decl *ast.TypeDecl) (core.CoreExpr, error
 		recordType := e.astTypeToInternalType(def)
 		if recordType != nil {
 			e.RegisterTypeAlias(typeName, recordType)
+			// M-XMOD-ALIAS-POLY: record the alias's type params (e.g. Box[a])
+			// so applied uses (`Box[int]`) instantiate the body.
+			e.RegisterTypeAliasParams(typeName, decl.TypeParams)
 		}
 		return nil, nil
 
@@ -223,6 +226,9 @@ func (e *Elaborator) elaborateTypeDecl(decl *ast.TypeDecl) (core.CoreExpr, error
 		targetType := e.astTypeToInternalType(def.Target)
 		if targetType != nil {
 			e.RegisterTypeAlias(typeName, targetType)
+			// M-XMOD-ALIAS-POLY: record the alias's type params (e.g. Ident[a],
+			// Pair[a,b]) so applied uses instantiate the body.
+			e.RegisterTypeAliasParams(typeName, decl.TypeParams)
 		}
 		return nil, nil
 

--- a/internal/iface/builder.go
+++ b/internal/iface/builder.go
@@ -384,6 +384,9 @@ func (b *Builder) Build(prog *core.Program, constructors map[string]*Constructor
 						if recordType, ok := typeDecl.Definition.(*ast.RecordType); ok {
 							internalType := astTypeToInternalType(recordType)
 							iface.AddTypeAlias(typeDecl.Name, internalType)
+							// M-XMOD-ALIAS-POLY: carry param names cross-module so
+							// importers can instantiate `Box[int]`.
+							iface.AddTypeAliasParams(typeDecl.Name, typeDecl.TypeParams)
 							// DEBUG: fmt.Printf("DEBUG: Added type alias %s -> %s\n", typeDecl.Name, internalType)
 						}
 
@@ -398,6 +401,9 @@ func (b *Builder) Build(prog *core.Program, constructors map[string]*Constructor
 						if aliasType, ok := typeDecl.Definition.(*ast.TypeAlias); ok {
 							if internalType := astTypeToInternalType(aliasType.Target); internalType != nil {
 								iface.AddTypeAlias(typeDecl.Name, internalType)
+								// M-XMOD-ALIAS-POLY: carry param names cross-module
+								// (e.g. `Ident[a]`, `Pair[a,b]`).
+								iface.AddTypeAliasParams(typeDecl.Name, typeDecl.TypeParams)
 							}
 						}
 

--- a/internal/iface/iface.go
+++ b/internal/iface/iface.go
@@ -12,6 +12,7 @@ type Iface struct {
 	Constructors map[string]*ConstructorScheme // Exported ADT constructors
 	Types        map[string]*TypeExport        // Exported type names
 	TypeAliases  map[string]types.Type         // M-FIX-RECORD-UPDATE: Type alias expansions for record types
+	AliasParams  map[string][]string           // M-XMOD-ALIAS-POLY: param names for parameterized aliases (name -> ["a"]); missing = nullary
 	Schema       string                        // Schema version, e.g., "ailang.iface/v1"
 	Digest       string                        // Deterministic digest of interface
 }
@@ -47,6 +48,7 @@ func NewIface(module string) *Iface {
 		Constructors: make(map[string]*ConstructorScheme),
 		Types:        make(map[string]*TypeExport),
 		TypeAliases:  make(map[string]types.Type),
+		AliasParams:  make(map[string][]string),
 		Schema:       "ailang.iface/v1",
 	}
 }
@@ -111,4 +113,23 @@ func (i *Iface) AddTypeAlias(name string, target types.Type) {
 func (i *Iface) GetTypeAlias(name string) (types.Type, bool) {
 	typ, ok := i.TypeAliases[name]
 	return typ, ok
+}
+
+// AddTypeAliasParams records the param names of a parameterized alias
+// (M-XMOD-ALIAS-POLY). Empty/nil params are not stored (missing = nullary).
+func (i *Iface) AddTypeAliasParams(name string, params []string) {
+	if len(params) == 0 {
+		return
+	}
+	if i.AliasParams == nil {
+		i.AliasParams = make(map[string][]string)
+	}
+	i.AliasParams[name] = params
+}
+
+// GetTypeAliasParams retrieves the param names of a parameterized alias
+// (M-XMOD-ALIAS-POLY). ok is false for nullary aliases.
+func (i *Iface) GetTypeAliasParams(name string) ([]string, bool) {
+	params, ok := i.AliasParams[name]
+	return params, ok
 }

--- a/internal/iface/xmod_alias_digest_test.go
+++ b/internal/iface/xmod_alias_digest_test.go
@@ -37,3 +37,40 @@ func TestXModAlias_DigestIgnoresTypeAliases(t *testing.T) {
 			"M-XMOD-ALIAS would trigger cascade rebuilds; digest must ignore TypeAliases", d1, d2)
 	}
 }
+
+// TestXModAliasPoly_DigestIgnoresParameterizedAlias extends the digest-neutral
+// lock to M-XMOD-ALIAS-POLY: adding a PARAMETERIZED alias (body + AliasParams)
+// must ALSO leave the interface digest unchanged. computeDigest excludes both
+// TypeAliases and AliasParams, so a module gaining `type Box[a] = { items: [a] }`
+// triggers no dependent-package cascade. If AliasParams ever enters the digest,
+// this fails and the no-cascade claim must be revisited.
+func TestXModAliasPoly_DigestIgnoresParameterizedAlias(t *testing.T) {
+	b := NewBuilder("test/mod", types.NewTypeEnv())
+
+	base := NewIface("test/mod")
+	base.Schema = "ailang.iface/v1"
+
+	withPoly := NewIface("test/mod")
+	withPoly.Schema = "ailang.iface/v1"
+	// `type Box[a] = { items: [a] }` — record body + one param.
+	withPoly.AddTypeAlias("Box", &types.TRecord{
+		Fields: map[string]types.Type{
+			"items": &types.TList{Element: &types.TVar2{Name: "a", Kind: types.Star}},
+		},
+	})
+	withPoly.AddTypeAliasParams("Box", []string{"a"})
+
+	d1, err := b.computeDigest(base)
+	if err != nil {
+		t.Fatalf("computeDigest(base): %v", err)
+	}
+	d2, err := b.computeDigest(withPoly)
+	if err != nil {
+		t.Fatalf("computeDigest(withPoly): %v", err)
+	}
+
+	if d1 != d2 {
+		t.Fatalf("interface digest changed when a PARAMETERIZED alias was added (%q vs %q) — "+
+			"M-XMOD-ALIAS-POLY would trigger cascade rebuilds; digest must ignore AliasParams", d1, d2)
+	}
+}

--- a/internal/pipeline/alias_poly_test.go
+++ b/internal/pipeline/alias_poly_test.go
@@ -1,0 +1,259 @@
+package pipeline
+
+import (
+	"strings"
+	"testing"
+)
+
+// M-XMOD-ALIAS-POLY end-to-end regression pack.
+//
+// Parameterized type aliases (`type Box[a] = { items: [a] }`) must substitute
+// their concrete arguments at use sites (`Box[int]`), single-module AND
+// cross-module, while genuine parameterized ADTs (Option[a], Result[a,b], user
+// `type Tree[a]`) stay strictly nominal. Uses the checkModules harness from
+// cross_module_nonrecord_alias_test.go.
+
+// --- Single-module positives ------------------------------------------------
+
+func TestAliasPolyE2E_RecordSingleModule(t *testing.T) {
+	files := map[string]string{
+		"main.ail": `module main
+
+type Box[a] = { items: [a] }
+
+export func mk(xs: [int]) -> Box[int] { { items: xs } }
+
+export func main() -> int { let b = mk([1, 2, 3]); 0 }
+`,
+	}
+	if err := checkModules(t, files); err != nil {
+		t.Fatalf("Box[int] single-module failed to type-check: %v", err)
+	}
+}
+
+func TestAliasPolyE2E_BareParamSingleModule(t *testing.T) {
+	files := map[string]string{
+		"main.ail": `module main
+
+type Ident[a] = a
+
+export func use(x: int) -> Ident[int] { x }
+
+export func main() -> int { use(5) }
+`,
+	}
+	if err := checkModules(t, files); err != nil {
+		t.Fatalf("Ident[int] single-module failed to type-check: %v", err)
+	}
+}
+
+func TestAliasPolyE2E_TupleSingleModule(t *testing.T) {
+	files := map[string]string{
+		"main.ail": `module main
+
+type Pair[a, b] = (a, b)
+
+export func mk(x: int, y: string) -> Pair[int, string] { (x, y) }
+
+export func main() -> int { let p = mk(1, "a"); 0 }
+`,
+	}
+	if err := checkModules(t, files); err != nil {
+		t.Fatalf("Pair[int, string] single-module failed to type-check: %v", err)
+	}
+}
+
+func TestAliasPolyE2E_FunctionSingleModule(t *testing.T) {
+	files := map[string]string{
+		"main.ail": `module main
+
+type Fn[a, b] = (a) -> b
+
+export func mk(f: (int) -> int) -> Fn[int, int] { f }
+
+export func main() -> int { 0 }
+`,
+	}
+	if err := checkModules(t, files); err != nil {
+		t.Fatalf("Fn[int, int] single-module failed to type-check: %v", err)
+	}
+}
+
+func TestAliasPolyE2E_NestedSingleModule(t *testing.T) {
+	files := map[string]string{
+		"main.ail": `module main
+
+type Box[a] = { items: [a] }
+
+export func wrap(x: Box[int]) -> Box[Box[int]] { { items: [x] } }
+
+export func main() -> int { 0 }
+`,
+	}
+	if err := checkModules(t, files); err != nil {
+		t.Fatalf("Box[Box[int]] nested single-module failed to type-check: %v", err)
+	}
+}
+
+// --- Arity mismatch ---------------------------------------------------------
+
+func TestAliasPolyE2E_ArityMismatch(t *testing.T) {
+	files := map[string]string{
+		"main.ail": `module main
+
+type Box[a] = { items: [a] }
+
+export func mk(xs: [int]) -> Box[int, string] { { items: xs } }
+
+export func main() -> int { 0 }
+`,
+	}
+	err := checkModules(t, files)
+	if err == nil {
+		t.Fatal("Box[int, string] (arity 2 on 1-param alias) must fail")
+	}
+	if !strings.Contains(err.Error(), "TC_ALIAS_ARITY_001") {
+		t.Errorf("expected coded TC_ALIAS_ARITY_001, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "but 2 provided") {
+		t.Errorf("expected directional 'but 2 provided', got: %v", err)
+	}
+}
+
+// --- Critical non-regression: real ADTs stay nominal ------------------------
+
+// TestAliasPolyE2E_OptionStaysNominal: importing and using Option[int] must
+// still work nominally (it is an ADT, absent from aliasEnv — expansion must not
+// fire). This is the baseline that would break if keying were loose.
+func TestAliasPolyE2E_OptionStaysNominal(t *testing.T) {
+	files := map[string]string{
+		"main.ail": `module main
+
+import std/option (Option, Some, None)
+
+export func wrap(x: int) -> Option[int] { Some(x) }
+
+export func main() -> int { let o = wrap(5); 0 }
+`,
+	}
+	if err := checkModules(t, files); err != nil {
+		t.Fatalf("Option[int] must stay nominal and type-check, got: %v", err)
+	}
+}
+
+// TestAliasPolyE2E_UserTreeADTStaysNominal: a user parameterized ADT with match.
+// Expansion must NOT fire (Tree is registered as constructors, not an alias).
+func TestAliasPolyE2E_UserTreeADTStaysNominal(t *testing.T) {
+	files := map[string]string{
+		"main.ail": `module main
+
+type Tree[a] = Leaf(a) | Node(Tree[a], Tree[a])
+
+export func size(t: Tree[int]) -> int {
+    match t {
+        Leaf(_) => 1,
+        Node(_, _) => 2
+    }
+}
+
+export func main() -> int { size(Leaf(5)) }
+`,
+	}
+	if err := checkModules(t, files); err != nil {
+		t.Fatalf("user Tree[a] ADT must stay nominal and type-check, got: %v", err)
+	}
+}
+
+// TestAliasPolyE2E_TreeNotStructural: a bare int must NOT unify with Tree[int]
+// — proves the ADT was not accidentally instantiated to its (nonexistent) body.
+func TestAliasPolyE2E_TreeNotStructural(t *testing.T) {
+	files := map[string]string{
+		"main.ail": `module main
+
+type Tree[a] = Leaf(a) | Node(Tree[a], Tree[a])
+
+export func bad(x: int) -> Tree[int] { x }
+
+export func main() -> int { 0 }
+`,
+	}
+	if err := checkModules(t, files); err == nil {
+		t.Fatal("REGRESSION: int unified with Tree[int] — ADT was wrongly instantiated")
+	}
+}
+
+// --- PR #380 ordering lock: open-record over a parameterized alias body -----
+
+// TestAliasPolyE2E_OpenRecordOverAliasBody: field access (which produces an open
+// record / TRecordOpen) against a value whose type is a parameterized-alias
+// record body must still unify. Expansion runs at Unify entry, BEFORE the type-
+// switch dispatches to unifyRecord (M-LAMBDA-OPEN-RECORD-PATTERN, PR #380), so
+// the open-record logic already sees the expanded { items: [int] }.
+func TestAliasPolyE2E_OpenRecordOverAliasBody(t *testing.T) {
+	files := map[string]string{
+		"main.ail": `module main
+
+type Box[a] = { items: [a], count: int }
+
+export func mk(xs: [int]) -> Box[int] { { items: xs, count: 0 } }
+
+export func getCount(b: Box[int]) -> int { b.count }
+
+export func main() -> int { getCount(mk([1, 2, 3])) }
+`,
+	}
+	if err := checkModules(t, files); err != nil {
+		t.Fatalf("field access over parameterized-alias record body failed: %v", err)
+	}
+}
+
+// --- M4: cross-module ------------------------------------------------------
+
+// TestAliasPolyE2E_CrossModuleRecord: module shapes exports `type Box[a]`; main
+// imports and uses Box[int]. Proves iface AliasParams threading composes with
+// the M-XMOD-ALIAS cross-module path.
+func TestAliasPolyE2E_CrossModuleRecord(t *testing.T) {
+	files := map[string]string{
+		"shapes/box.ail": `module shapes/box
+
+export type Box[a] = { items: [a] }
+`,
+		"main.ail": `module main
+
+import shapes/box (Box)
+
+export func mk(xs: [int]) -> Box[int] { { items: xs } }
+
+export func main() -> int { let b = mk([1, 2, 3]); 0 }
+`,
+	}
+	if err := checkModules(t, files); err != nil {
+		t.Fatalf("cross-module Box[int] failed to type-check: %v", err)
+	}
+}
+
+// TestAliasPolyE2E_CrossModuleArityMismatch: an arity mismatch on an imported
+// parameterized alias still emits the coded diagnostic.
+func TestAliasPolyE2E_CrossModuleArityMismatch(t *testing.T) {
+	files := map[string]string{
+		"shapes/box.ail": `module shapes/box
+
+export type Box[a] = { items: [a] }
+`,
+		"main.ail": `module main
+
+import shapes/box (Box)
+
+export func mk(xs: [int]) -> Box[int, string] { { items: xs } }
+
+export func main() -> int { 0 }
+`,
+	}
+	err := checkModules(t, files)
+	if err == nil {
+		t.Fatal("cross-module Box[int, string] must fail with arity error")
+	}
+	if !strings.Contains(err.Error(), "TC_ALIAS_ARITY_001") {
+		t.Errorf("expected coded TC_ALIAS_ARITY_001 cross-module, got: %v", err)
+	}
+}

--- a/internal/pipeline/cache_key.go
+++ b/internal/pipeline/cache_key.go
@@ -15,7 +15,13 @@ import (
 // Rest bool. Same-version dev/worktree builds could otherwise collide cache keys and
 // round-trip pre-Rest blobs into the new decoder. Bumping guarantees old blobs never
 // decode into the new Core struct.
-const cacheKeyVersion = "v2"
+//
+// v2 -> v3 (M-XMOD-ALIAS-POLY): the on-disk Iface gained an AliasParams
+// map[string][]string (params for parameterized aliases). The blob is JSON
+// (tolerant of new/missing fields), so this is a defensive guard against a
+// same-version dev/worktree build decoding a pre-AliasParams blob and treating a
+// parameterized alias as nullary.
+const cacheKeyVersion = "v3"
 
 // ModuleCacheKey computes a deterministic cache key for a module.
 // The key incorporates:

--- a/internal/pipeline/cache_store.go
+++ b/internal/pipeline/cache_store.go
@@ -260,6 +260,7 @@ type ifaceFullJSON struct {
 	Constructors map[string]*ctorSchemeJSON   `json:"constructors"`
 	Types        map[string]*iface.TypeExport `json:"types"`
 	TypeAliases  map[string]json.RawMessage   `json:"type_aliases,omitempty"`
+	AliasParams  map[string][]string          `json:"alias_params,omitempty"` // M-XMOD-ALIAS-POLY
 }
 
 type ifaceItemJSON struct {
@@ -338,6 +339,14 @@ func marshalIfaceFull(ifc *iface.Iface) ([]byte, error) {
 		}
 	}
 
+	// AliasParams (M-XMOD-ALIAS-POLY): params for parameterized aliases.
+	if len(ifc.AliasParams) > 0 {
+		result.AliasParams = make(map[string][]string, len(ifc.AliasParams))
+		for name, params := range ifc.AliasParams {
+			result.AliasParams[name] = params
+		}
+	}
+
 	return json.Marshal(result)
 }
 
@@ -355,6 +364,7 @@ func unmarshalIfaceFull(data []byte) (*iface.Iface, error) {
 		Constructors: make(map[string]*iface.ConstructorScheme),
 		Types:        d.Types,
 		TypeAliases:  make(map[string]types.Type),
+		AliasParams:  make(map[string][]string),
 	}
 
 	// Exports
@@ -401,6 +411,11 @@ func unmarshalIfaceFull(data []byte) (*iface.Iface, error) {
 			return nil, fmt.Errorf("unmarshal type alias %s: %w", name, err)
 		}
 		ifc.TypeAliases[name] = t
+	}
+
+	// AliasParams (M-XMOD-ALIAS-POLY)
+	for name, params := range d.AliasParams {
+		ifc.AliasParams[name] = params
 	}
 
 	return ifc, nil

--- a/internal/pipeline/cache_store_test.go
+++ b/internal/pipeline/cache_store_test.go
@@ -204,7 +204,13 @@ func TestCacheStore_ArtifactRoundTrip(t *testing.T) {
 					Fields:   map[string]types.Type{"x": &types.TCon{Name: "float"}, "y": &types.TCon{Name: "float"}},
 					TypeName: "Point",
 				},
+				// M-XMOD-ALIAS-POLY: a parameterized alias body.
+				"Box": &types.TRecord{
+					Fields: map[string]types.Type{"items": &types.TList{Element: &types.TVar2{Name: "a", Kind: types.Star}}},
+				},
 			},
+			// M-XMOD-ALIAS-POLY: params for the parameterized alias must round-trip.
+			AliasParams: map[string][]string{"Box": {"a"}},
 		},
 		Constructors: map[string]*ConstructorInfo{
 			"Some": {
@@ -278,6 +284,12 @@ func TestCacheStore_ArtifactRoundTrip(t *testing.T) {
 		t.Errorf("TypeAlias Point: got %T, want *types.TRecord", pt)
 	} else if rec.TypeName != "Point" {
 		t.Errorf("TypeAlias Point.TypeName: got %q", rec.TypeName)
+	}
+	// M-XMOD-ALIAS-POLY: AliasParams must round-trip through the JSON cache.
+	if params, ok := got.Iface.AliasParams["Box"]; !ok {
+		t.Error("Iface.AliasParams missing 'Box'")
+	} else if len(params) != 1 || params[0] != "a" {
+		t.Errorf("AliasParams[Box]: got %v, want [a]", params)
 	}
 
 	// Verify Constructors

--- a/internal/pipeline/pipeline_module_compile.go
+++ b/internal/pipeline/pipeline_module_compile.go
@@ -123,11 +123,20 @@ func typeCheckAndLowerModule(
 	for name, target := range elabAliases {
 		typeChecker.RegisterTypeAlias(name, target)
 	}
+	// M-XMOD-ALIAS-POLY: register local parameterized-alias params so applied
+	// uses (`Box[int]`) instantiate their body during unification.
+	for name, params := range elaborator.GetTypeAliasParams() {
+		typeChecker.RegisterTypeAliasParams(name, params)
+	}
 
 	// M-FIX-RECORD-UPDATE: Also register type aliases from imported modules
 	// This enables cross-module record update (e.g., { npc | pos: ... } where NPC is imported)
 	for name, target := range imports.ImportedTypeAliases {
 		typeChecker.RegisterTypeAlias(name, target)
+	}
+	// M-XMOD-ALIAS-POLY: register imported parameterized-alias params (cross-module).
+	for name, params := range imports.ImportedAliasParams {
+		typeChecker.RegisterTypeAliasParams(name, params)
 	}
 
 	// M-FIX-FLOAT-OP: Pass parameter type annotations to type checker

--- a/internal/pipeline/pipeline_module_imports.go
+++ b/internal/pipeline/pipeline_module_imports.go
@@ -24,6 +24,7 @@ type moduleImports struct {
 	ExternalTypes         map[string]*types.Scheme
 	GlobalRefs            map[string]core.GlobalRef
 	ImportedTypeAliases   map[string]types.Type
+	ImportedAliasParams   map[string][]string // M-XMOD-ALIAS-POLY: params for imported parameterized aliases
 	ImportedCtorTypes     map[string]string
 	ImportedADTTypeParams map[string]int
 	ImportedCtorInfos     map[string]*importedCtorInfo
@@ -47,6 +48,7 @@ func resolveModuleImports(
 		ExternalTypes:         make(map[string]*types.Scheme),
 		GlobalRefs:            make(map[string]core.GlobalRef),
 		ImportedTypeAliases:   make(map[string]types.Type),
+		ImportedAliasParams:   make(map[string][]string),
 		ImportedCtorTypes:     make(map[string]string),
 		ImportedADTTypeParams: make(map[string]int),
 		ImportedCtorInfos:     make(map[string]*importedCtorInfo),
@@ -135,6 +137,10 @@ func resolveModuleImports(
 		for aliasName, aliasTarget := range modIface.TypeAliases {
 			if _, exists := imports.ImportedTypeAliases[aliasName]; !exists {
 				imports.ImportedTypeAliases[aliasName] = aliasTarget
+				// M-XMOD-ALIAS-POLY: carry params alongside the alias body.
+				if params, ok := modIface.GetTypeAliasParams(aliasName); ok {
+					imports.ImportedAliasParams[aliasName] = params
+				}
 				if cfg.TraceDefaulting {
 					fmt.Printf("  Transitive type alias %s -> %s (from %s)\n", aliasName, aliasTarget, modPath)
 				}
@@ -183,6 +189,10 @@ func resolveSelectiveImports(
 			// This enables cross-module record update syntax
 			if alias, hasAlias := depIface.GetTypeAlias(sym); hasAlias {
 				imports.ImportedTypeAliases[sym] = alias
+				// M-XMOD-ALIAS-POLY: carry params for parameterized aliases.
+				if params, ok := depIface.GetTypeAliasParams(sym); ok {
+					imports.ImportedAliasParams[sym] = params
+				}
 				if cfg.TraceDefaulting {
 					fmt.Printf("  Import type alias %s -> %s\n", sym, alias)
 				}
@@ -214,6 +224,10 @@ func resolveSelectiveImports(
 	for aliasName, aliasTarget := range depIface.TypeAliases {
 		if _, exists := imports.ImportedTypeAliases[aliasName]; !exists {
 			imports.ImportedTypeAliases[aliasName] = aliasTarget
+			// M-XMOD-ALIAS-POLY: carry params for parameterized aliases.
+			if params, ok := depIface.GetTypeAliasParams(aliasName); ok {
+				imports.ImportedAliasParams[aliasName] = params
+			}
 			if cfg.TraceDefaulting {
 				fmt.Printf("  Import type alias %s -> %s from %s\n", aliasName, aliasTarget, imp.Path)
 			}

--- a/internal/pipeline/pipeline_single.go
+++ b/internal/pipeline/pipeline_single.go
@@ -261,6 +261,11 @@ func runSingleWithContext(ctx context.Context, cfg Config, src Source) (Result, 
 	for name, target := range elabAliases {
 		typeChecker.RegisterTypeAlias(name, target)
 	}
+	// M-XMOD-ALIAS-POLY: register parameterized-alias params so applied uses
+	// (`Box[int]`) instantiate their body during unification.
+	for name, params := range elaborator.GetTypeAliasParams() {
+		typeChecker.RegisterTypeAliasParams(name, params)
+	}
 
 	// M-FIX-FLOAT-OP: Pass parameter type annotations to type checker
 	// This preserves float annotations from function declarations through elaboration

--- a/internal/types/alias_poly_test.go
+++ b/internal/types/alias_poly_test.go
@@ -1,0 +1,247 @@
+package types
+
+import (
+	"strings"
+	"testing"
+)
+
+// M-XMOD-ALIAS-POLY: unit tests over the parameterized-alias expansion added to
+// expandAlias/Unify. These exercise the unifier directly with a hand-built
+// alias env + params env, mirroring how the pipeline wires them
+// (NewUnifierWithAliasesAndParams). Two layers:
+//   1. Positive: an APPLIED alias (`Box[int]`) instantiates its body and unifies
+//      structurally with the expanded concrete type.
+//   2. Non-regression: a real parameterized ADT head (NOT in aliasEnv) stays
+//      nominal — expansion must NOT fire. This is the critical guardrail.
+//   3. Arity: wrong argument count → coded TC_ALIAS_ARITY_001, directional.
+
+// polyUnifier builds a unifier with the given alias bodies + param lists.
+func polyUnifier(aliases map[string]Type, params map[string][]string) *Unifier {
+	return NewUnifierWithAliasesAndParams(aliases, params)
+}
+
+// boxAliasEnv: `type Box[a] = { items: [a] }`.
+func boxAliasEnv() (map[string]Type, map[string][]string) {
+	body := &TRecord{
+		Fields: map[string]Type{
+			"items": &TList{Element: &TVar2{Name: "a", Kind: Star}},
+		},
+	}
+	return map[string]Type{"Box": body}, map[string][]string{"Box": {"a"}}
+}
+
+// TestAliasPoly_Record_Expands: Box[int] unifies with { items: [int] }.
+func TestAliasPoly_Record_Expands(t *testing.T) {
+	aliases, params := boxAliasEnv()
+	u := polyUnifier(aliases, params)
+
+	applied := &TApp{Constructor: &TCon{Name: "Box"}, Args: []Type{TInt}}
+	concrete := &TRecord{
+		Fields: map[string]Type{"items": &TList{Element: TInt}},
+	}
+
+	if _, err := u.Unify(applied, concrete, Substitution{}); err != nil {
+		t.Fatalf("Box[int] must unify with { items: [int] }, got: %v", err)
+	}
+}
+
+// TestAliasPoly_BareParam_Expands: `type Ident[a] = a`, Ident[int] unifies int.
+func TestAliasPoly_BareParam_Expands(t *testing.T) {
+	aliases := map[string]Type{"Ident": &TVar2{Name: "a", Kind: Star}}
+	params := map[string][]string{"Ident": {"a"}}
+	u := polyUnifier(aliases, params)
+
+	applied := &TApp{Constructor: &TCon{Name: "Ident"}, Args: []Type{TInt}}
+	if _, err := u.Unify(applied, TInt, Substitution{}); err != nil {
+		t.Fatalf("Ident[int] must unify with int, got: %v", err)
+	}
+}
+
+// TestAliasPoly_Tuple_Expands: `type Pair[a,b] = (a,b)`, Pair[int,string].
+func TestAliasPoly_Tuple_Expands(t *testing.T) {
+	aliases := map[string]Type{
+		"Pair": &TTuple{Elements: []Type{
+			&TVar2{Name: "a", Kind: Star},
+			&TVar2{Name: "b", Kind: Star},
+		}},
+	}
+	params := map[string][]string{"Pair": {"a", "b"}}
+	u := polyUnifier(aliases, params)
+
+	applied := &TApp{Constructor: &TCon{Name: "Pair"}, Args: []Type{TInt, TString}}
+	concrete := &TTuple{Elements: []Type{TInt, TString}}
+	if _, err := u.Unify(applied, concrete, Substitution{}); err != nil {
+		t.Fatalf("Pair[int,string] must unify with (int, string), got: %v", err)
+	}
+}
+
+// TestAliasPoly_Function_Expands: `type Fn[a,b] = (a) -> b`, Fn[int,int].
+func TestAliasPoly_Function_Expands(t *testing.T) {
+	aliases := map[string]Type{
+		"Fn": &TFunc2{
+			Params: []Type{&TVar2{Name: "a", Kind: Star}},
+			Return: &TVar2{Name: "b", Kind: Star},
+		},
+	}
+	params := map[string][]string{"Fn": {"a", "b"}}
+	u := polyUnifier(aliases, params)
+
+	applied := &TApp{Constructor: &TCon{Name: "Fn"}, Args: []Type{TInt, TInt}}
+	concrete := &TFunc2{Params: []Type{TInt}, Return: TInt}
+	if _, err := u.Unify(applied, concrete, Substitution{}); err != nil {
+		t.Fatalf("Fn[int,int] must unify with (int) -> int, got: %v", err)
+	}
+}
+
+// TestAliasPoly_Nested_Expands: Box[Box[int]] instantiates recursively.
+func TestAliasPoly_Nested_Expands(t *testing.T) {
+	aliases, params := boxAliasEnv()
+	u := polyUnifier(aliases, params)
+
+	inner := &TApp{Constructor: &TCon{Name: "Box"}, Args: []Type{TInt}}
+	applied := &TApp{Constructor: &TCon{Name: "Box"}, Args: []Type{inner}}
+	// Box[Box[int]] == { items: [ { items: [int] } ] }
+	concrete := &TRecord{
+		Fields: map[string]Type{
+			"items": &TList{Element: &TRecord{
+				Fields: map[string]Type{"items": &TList{Element: TInt}},
+			}},
+		},
+	}
+	if _, err := u.Unify(applied, concrete, Substitution{}); err != nil {
+		t.Fatalf("Box[Box[int]] must unify with nested record, got: %v", err)
+	}
+}
+
+// --- CRITICAL NON-REGRESSION: real ADTs stay nominal -----------------------
+
+// TestAliasPoly_ADT_StaysNominal_Option: Option[a] head is NOT in aliasEnv, so
+// expandAlias must return it unchanged (no instantiation). Two different
+// instantiations must NOT unify to a record — Option[int] vs { items: [int] }
+// must FAIL, proving expansion did not fire on the ADT.
+func TestAliasPoly_ADT_StaysNominal_Option(t *testing.T) {
+	// Only Box is an alias. Option is a genuine ADT (absent from aliasEnv).
+	aliases, params := boxAliasEnv()
+	u := polyUnifier(aliases, params)
+
+	optionInt := &TApp{Constructor: &TCon{Name: "Option"}, Args: []Type{TInt}}
+
+	// Option[int] must NOT expand into anything: unifying it with a record fails.
+	rec := &TRecord{Fields: map[string]Type{"items": &TList{Element: TInt}}}
+	if _, err := u.Unify(optionInt, rec, Substitution{}); err == nil {
+		t.Fatal("Option[int] must NOT expand/unify with a record — ADT must stay nominal")
+	}
+
+	// Option[int] unifies with itself (nominal identity preserved).
+	if _, err := u.Unify(optionInt,
+		&TApp{Constructor: &TCon{Name: "Option"}, Args: []Type{TInt}},
+		Substitution{}); err != nil {
+		t.Fatalf("Option[int] must unify with Option[int] (nominal), got: %v", err)
+	}
+}
+
+// TestAliasPoly_ADT_StaysNominal_Result: Result[a,b] must stay nominal.
+func TestAliasPoly_ADT_StaysNominal_Result(t *testing.T) {
+	aliases, params := boxAliasEnv()
+	u := polyUnifier(aliases, params)
+
+	resultIS := &TApp{Constructor: &TCon{Name: "Result"}, Args: []Type{TInt, TString}}
+	// Result[int,string] vs Result[string,int] must NOT unify (args differ),
+	// which is only meaningful because Result is treated nominally (not expanded).
+	other := &TApp{Constructor: &TCon{Name: "Result"}, Args: []Type{TString, TInt}}
+	if _, err := u.Unify(resultIS, other, Substitution{}); err == nil {
+		t.Fatal("Result[int,string] must NOT unify with Result[string,int]")
+	}
+}
+
+// TestAliasPoly_UserTree_StaysNominal: a user parameterized ADT `type Tree[a]`
+// whose head TCon is not in aliasEnv is untouched.
+func TestAliasPoly_UserTree_StaysNominal(t *testing.T) {
+	aliases, params := boxAliasEnv()
+	u := polyUnifier(aliases, params)
+
+	treeInt := &TApp{Constructor: &TCon{Name: "Tree"}, Args: []Type{TInt}}
+	if _, err := u.Unify(treeInt, TInt, Substitution{}); err == nil {
+		t.Fatal("Tree[int] must NOT expand/unify with int — user ADT must stay nominal")
+	}
+}
+
+// --- Arity diagnostics ------------------------------------------------------
+
+// TestAliasArity_TooMany: Box[int, string] on a 1-param alias → coded, directional.
+func TestAliasArity_TooMany(t *testing.T) {
+	aliases, params := boxAliasEnv()
+	u := polyUnifier(aliases, params)
+
+	applied := &TApp{Constructor: &TCon{Name: "Box"}, Args: []Type{TInt, TString}}
+	_, err := u.Unify(applied,
+		&TRecord{Fields: map[string]Type{"items": &TList{Element: TInt}}},
+		Substitution{})
+	if err == nil {
+		t.Fatal("Box[int, string] (arity 2 on 1-param alias) must fail")
+	}
+	for _, want := range []string{
+		"TC_ALIAS_ARITY_001",
+		"expects 1 type argument(s)",
+		"but 2 provided",
+		"Suggestion:",
+		"remove the extra 1",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("arity-too-many error missing %q\ngot: %v", want, err)
+		}
+	}
+}
+
+// TestAliasArity_NullaryApplied: a nullary alias applied with args → coded.
+func TestAliasArity_NullaryApplied(t *testing.T) {
+	aliases := map[string]Type{"Row": &TRecord{Fields: map[string]Type{"x": TInt}}}
+	// No params entry for Row => nullary.
+	u := polyUnifier(aliases, map[string][]string{})
+
+	applied := &TApp{Constructor: &TCon{Name: "Row"}, Args: []Type{TInt}}
+	_, err := u.Unify(applied, TInt, Substitution{})
+	if err == nil {
+		t.Fatal("Row[int] on a nullary alias must fail")
+	}
+	for _, want := range []string{
+		"TC_ALIAS_ARITY_001",
+		"expects 0 type argument(s)",
+		"but 1 provided",
+		"takes no type arguments",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("nullary-applied error missing %q\ngot: %v", want, err)
+		}
+	}
+}
+
+// TestAliasArityMismatchMsg_Directional: unit test on the rendered text.
+func TestAliasArityMismatchMsg_Directional(t *testing.T) {
+	// too many
+	msg := aliasArityMismatchMsg("Box", 1, 2)
+	if !strings.Contains(msg, "TC_ALIAS_ARITY_001") || !strings.Contains(msg, "remove the extra 1") {
+		t.Errorf("too-many msg wrong:\n%s", msg)
+	}
+	// too few
+	msg = aliasArityMismatchMsg("Pair", 2, 1)
+	if !strings.Contains(msg, "supply the missing 1") {
+		t.Errorf("too-few msg wrong:\n%s", msg)
+	}
+	// nullary applied
+	msg = aliasArityMismatchMsg("Row", 0, 1)
+	if !strings.Contains(msg, "takes no type arguments") {
+		t.Errorf("nullary msg wrong:\n%s", msg)
+	}
+}
+
+// TestAliasPoly_NullaryAliasUnchanged: a plain nullary alias (TCon head, no
+// args) still expands via the existing TCon path — M-XMOD-ALIAS pack regression.
+func TestAliasPoly_NullaryAliasUnchanged(t *testing.T) {
+	aliases := map[string]Type{"MyInt": TInt}
+	u := polyUnifier(aliases, map[string][]string{})
+
+	if _, err := u.Unify(&TCon{Name: "MyInt"}, TInt, Substitution{}); err != nil {
+		t.Fatalf("nullary alias MyInt must still expand to int, got: %v", err)
+	}
+}

--- a/internal/types/errors.go
+++ b/internal/types/errors.go
@@ -374,6 +374,37 @@ func arityMismatchMsg(expected, actual int) string {
 		TC_ARITY_001, expected, actual, hint)
 }
 
+// TC_ALIAS_ARITY_001 codes a parameterized type-alias arity mismatch
+// (M-XMOD-ALIAS-POLY): an alias applied with the wrong number of type
+// arguments, e.g. `type Box[a] = {items:[a]}` used as `Box[int, string]`, or a
+// nullary alias `type Row = Json` used as `Row[int]`. See aliasArityMismatchMsg
+// for the rendered, directional text. Styled on TC_ARITY_001.
+const TC_ALIAS_ARITY_001 = "TC_ALIAS_ARITY_001"
+
+// aliasArityMismatchMsg builds the coded, directional diagnostic for an applied
+// type alias whose argument count doesn't match its declared parameter count.
+//
+// Like TC_ARITY_001, the code + Suggestion are embedded INLINE in the returned
+// string (the error is wrapped by a plain %w and nothing recovers
+// *TypeCheckError via errors.As), so a struct Suggestion would never render.
+//
+// name is the alias name, expected its declared param count, actual the number
+// of type arguments supplied at the use site.
+func aliasArityMismatchMsg(name string, expected, actual int) string {
+	var hint string
+	switch {
+	case expected == 0:
+		// Nullary alias applied with type arguments.
+		hint = fmt.Sprintf("`%s` takes no type arguments — write `%s` without `[...]`.", name, name)
+	case actual < expected:
+		hint = fmt.Sprintf("`%s` expects %d type argument(s); supply the missing %d.", name, expected, expected-actual)
+	default: // actual > expected
+		hint = fmt.Sprintf("`%s` expects %d type argument(s); remove the extra %d.", name, expected, actual-expected)
+	}
+	return fmt.Sprintf("%s: type alias %s expects %d type argument(s), but %d provided\n  Suggestion: %s",
+		TC_ALIAS_ARITY_001, name, expected, actual, hint)
+}
+
 // NewUnsolvedConstraintError creates an unsolved type class constraint error
 func NewUnsolvedConstraintError(className string, typ Type, path []string) *TypeCheckError {
 	suggestion := ""

--- a/internal/types/typechecker_core.go
+++ b/internal/types/typechecker_core.go
@@ -81,6 +81,10 @@ type CoreTypeChecker struct {
 	// aliasEnv maps type alias names to their underlying types
 	// M-BUGFIX: Used for alias expansion during unification
 	aliasEnv map[string]Type
+	// aliasParams maps parameterized-alias names to their ordered param names
+	// (M-XMOD-ALIAS-POLY). Missing entry = nullary alias (arity 0). Passed to
+	// the Unifier so applied aliases (`Box[int]`) instantiate their body.
+	aliasParams map[string][]string
 	// M-FIX-FLOAT-OP: Parameter type annotations from function declarations
 	// Maps Lambda NodeID -> parameter types to preserve float annotations through elaboration
 	paramTypeAnnots map[uint64][]Type
@@ -211,11 +215,12 @@ func NewCoreTypeChecker() *CoreTypeChecker {
 		returnTypeAnnots:    make(map[uint64]Type),
 		CoreTI:              NewCoreTypeInfo(),
 		constructorTypes:    make(map[string]string),
-		adtTypeParams:       make(map[string]int),    // M-TAPP-FIX: Initialize ADT type params
-		aliasEnv:            make(map[string]Type),   // M-BUGFIX: Initialize alias environment
-		paramTypeAnnots:     make(map[uint64][]Type), // M-FIX-FLOAT-OP: Initialize param annotations
-		letTypeAnnots:       make(map[uint64]Type),   // M-TYPE-LIST-ELEMENT-SOUNDNESS: let annotations
-		DebugSink:           NoOpDebugSink{},         // M-DX11: Default to no-op (zero overhead)
+		adtTypeParams:       make(map[string]int),      // M-TAPP-FIX: Initialize ADT type params
+		aliasEnv:            make(map[string]Type),     // M-BUGFIX: Initialize alias environment
+		aliasParams:         make(map[string][]string), // M-XMOD-ALIAS-POLY: Initialize alias params
+		paramTypeAnnots:     make(map[uint64][]Type),   // M-FIX-FLOAT-OP: Initialize param annotations
+		letTypeAnnots:       make(map[uint64]Type),     // M-TYPE-LIST-ELEMENT-SOUNDNESS: let annotations
+		DebugSink:           NoOpDebugSink{},           // M-DX11: Default to no-op (zero overhead)
 	}
 }
 
@@ -237,11 +242,12 @@ func NewCoreTypeCheckerWithInstances(instances *InstanceEnv) *CoreTypeChecker {
 		returnTypeAnnots:    make(map[uint64]Type),
 		CoreTI:              NewCoreTypeInfo(),
 		constructorTypes:    make(map[string]string),
-		adtTypeParams:       make(map[string]int),    // M-TAPP-FIX: Initialize ADT type params
-		aliasEnv:            make(map[string]Type),   // M-BUGFIX: Initialize alias environment
-		paramTypeAnnots:     make(map[uint64][]Type), // M-FIX-FLOAT-OP: Initialize param annotations
-		letTypeAnnots:       make(map[uint64]Type),   // M-TYPE-LIST-ELEMENT-SOUNDNESS: let annotations
-		DebugSink:           NoOpDebugSink{},         // M-DX11: Default to no-op (zero overhead)
+		adtTypeParams:       make(map[string]int),      // M-TAPP-FIX: Initialize ADT type params
+		aliasEnv:            make(map[string]Type),     // M-BUGFIX: Initialize alias environment
+		aliasParams:         make(map[string][]string), // M-XMOD-ALIAS-POLY: Initialize alias params
+		paramTypeAnnots:     make(map[uint64][]Type),   // M-FIX-FLOAT-OP: Initialize param annotations
+		letTypeAnnots:       make(map[uint64]Type),     // M-TYPE-LIST-ELEMENT-SOUNDNESS: let annotations
+		DebugSink:           NoOpDebugSink{},           // M-DX11: Default to no-op (zero overhead)
 	}
 }
 
@@ -268,6 +274,24 @@ func (tc *CoreTypeChecker) RegisterTypeAlias(name string, target Type) {
 // M-BUGFIX: Used to create UnifierWithAliases
 func (tc *CoreTypeChecker) GetAliasEnv() map[string]Type {
 	return tc.aliasEnv
+}
+
+// RegisterTypeAliasParams records the type-parameter names for a parameterized
+// alias (M-XMOD-ALIAS-POLY), so the unifier can instantiate applied uses
+// (`Box[int]`). Empty params are ignored (a missing entry means nullary).
+func (tc *CoreTypeChecker) RegisterTypeAliasParams(name string, params []string) {
+	if len(params) == 0 {
+		return
+	}
+	if tc.aliasParams == nil {
+		tc.aliasParams = make(map[string][]string)
+	}
+	tc.aliasParams[name] = params
+}
+
+// GetAliasParams returns the parameterized-alias param env (M-XMOD-ALIAS-POLY).
+func (tc *CoreTypeChecker) GetAliasParams() map[string][]string {
+	return tc.aliasParams
 }
 
 // SetGlobalTypes sets the global types for import resolution
@@ -415,7 +439,9 @@ func (tc *CoreTypeChecker) InferWithConstraints(expr core.CoreExpr, env *TypeEnv
 	// M-BUGFIX: Create unifier with alias environment for type alias expansion
 	var unifier *Unifier
 	if len(tc.aliasEnv) > 0 {
-		unifier = NewUnifierWithAliases(tc.aliasEnv)
+		// M-XMOD-ALIAS-POLY: thread the parameterized-alias param env so applied
+		// aliases (`Box[int]`) instantiate their body during unification.
+		unifier = NewUnifierWithAliasesAndParams(tc.aliasEnv, tc.aliasParams)
 	} else {
 		unifier = NewUnifier()
 	}

--- a/internal/types/unification_core.go
+++ b/internal/types/unification_core.go
@@ -20,6 +20,11 @@ type Unifier struct {
 	// instantiate an APPLIED alias (`Box[int]`) via Body.Substitute(param->arg),
 	// keyed STRICTLY on aliasEnv membership so real ADTs stay nominal.
 	aliasParams map[string][]string
+	// aliasArityErr latches a coded TC_ALIAS_ARITY_001 diagnostic raised by
+	// expandAlias when an applied alias has the wrong number of type arguments
+	// (M-XMOD-ALIAS-POLY). expandAlias returns Type (4 call sites) and cannot
+	// itself return an error, so Unify checks this immediately after expanding.
+	aliasArityErr error
 	// M-DX11-PHASE2: Debug sink for emitting OnSubstitute events during unification
 	debugSink TypeDebugSink
 	// M-TYPECHECK-NO-AUTO-UNWRAP-RESULT (v0.20.0): constructor → ADT-name
@@ -111,6 +116,51 @@ func (u *Unifier) expandAlias(t Type) Type {
 	// the last TCon, letting unification report a normal mismatch.
 	var seen map[string]bool
 	for {
+		// M-XMOD-ALIAS-POLY: an APPLIED alias reaches unification as a *TApp
+		// whose head constructor is the alias TCon (e.g. Box[int] =
+		// TApp{TCon("Box"), [int]}). Instantiate it by substituting the alias's
+		// declared params with the applied args, keyed STRICTLY on aliasEnv
+		// membership — so genuine parameterized ADTs (Option[a], Result[a,b],
+		// user `type Tree[a]`), whose head TCon is NOT in aliasEnv, are returned
+		// unchanged and stay nominal. This is the critical non-regression.
+		if app, ok := t.(*TApp); ok {
+			head, args := decomposeApp(app)
+			headCon, isCon := head.(*TCon)
+			if !isCon {
+				return t
+			}
+			body, isAlias := u.aliasEnv[headCon.Name]
+			if !isAlias {
+				return t // not an alias head → real ADT / type application, stay nominal
+			}
+			params := u.aliasParams[headCon.Name] // nil for a nullary alias
+			if len(args) != len(params) {
+				// Arity mismatch: applied a k-arg alias with the wrong count
+				// (includes applying a nullary alias with any args). Latch a
+				// coded, directional diagnostic for Unify to surface.
+				u.aliasArityErr = fmt.Errorf("%s", aliasArityMismatchMsg(headCon.Name, len(params), len(args)))
+				return t
+			}
+			if seen[headCon.Name] {
+				return t // cycle detected (e.g. `type A[x] = A[x]`) — stop expanding
+			}
+			if seen == nil {
+				seen = make(map[string]bool)
+			}
+			seen[headCon.Name] = true
+			// Substitute params[i] -> args[i] throughout the body via the
+			// Type.Substitute(map) method (TVar2.Substitute keys by name), which
+			// recurses through record/tuple/function bodies. Continue the fixpoint
+			// loop on the result so alias chains and the record-TypeName terminal
+			// path below still fire.
+			subs := make(map[string]Type, len(params))
+			for i, p := range params {
+				subs[p] = args[i]
+			}
+			t = body.Substitute(subs)
+			continue
+		}
+
 		con, ok := t.(*TCon)
 		if !ok {
 			return t
@@ -188,6 +238,15 @@ func (u *Unifier) Unify(t1, t2 Type, sub Substitution) (Substitution, error) {
 	// This allows `type Coord = {x: int, y: int}` to unify with {x: int, y: int}
 	t1 = u.expandAlias(t1)
 	t2 = u.expandAlias(t2)
+
+	// M-XMOD-ALIAS-POLY: surface a latched arity diagnostic from expandAlias
+	// (an applied alias with the wrong number of type arguments). Clear it so a
+	// later successful unification isn't poisoned by a stale error.
+	if u.aliasArityErr != nil {
+		err := u.aliasArityErr
+		u.aliasArityErr = nil
+		return nil, err
+	}
 
 	// Check if already equal with cycle detection
 	if SafeEquals(t1, t2) {

--- a/internal/types/unification_core.go
+++ b/internal/types/unification_core.go
@@ -15,6 +15,11 @@ type Unifier struct {
 	// aliasEnv maps type alias names to their underlying types
 	// M-BUGFIX: Used to expand aliases during unification (e.g., Coord -> {x: int, y: int})
 	aliasEnv map[string]Type
+	// aliasParams maps parameterized-alias names to their ordered param names
+	// (M-XMOD-ALIAS-POLY). Missing entry = nullary alias. Used by expandAlias to
+	// instantiate an APPLIED alias (`Box[int]`) via Body.Substitute(param->arg),
+	// keyed STRICTLY on aliasEnv membership so real ADTs stay nominal.
+	aliasParams map[string][]string
 	// M-DX11-PHASE2: Debug sink for emitting OnSubstitute events during unification
 	debugSink TypeDebugSink
 	// M-TYPECHECK-NO-AUTO-UNWRAP-RESULT (v0.20.0): constructor → ADT-name
@@ -61,11 +66,21 @@ func NewUnifier() *Unifier {
 // NewUnifierWithAliases creates a unifier with type alias expansion support
 // M-BUGFIX: This allows ADT variants with alias parameters to work correctly
 func NewUnifierWithAliases(aliases map[string]Type) *Unifier {
+	return NewUnifierWithAliasesAndParams(aliases, nil)
+}
+
+// NewUnifierWithAliasesAndParams creates a unifier with type alias expansion
+// support that ALSO instantiates parameterized aliases (M-XMOD-ALIAS-POLY).
+// aliasParams maps a parameterized alias name to its ordered param names; a
+// missing entry means the alias is nullary. Passing nil params degrades to the
+// nullary-only behaviour of NewUnifierWithAliases.
+func NewUnifierWithAliasesAndParams(aliases map[string]Type, aliasParams map[string][]string) *Unifier {
 	u := &Unifier{
-		rowUnifier: NewRowUnifier(),
-		depth:      0,
-		aliasEnv:   aliases,
-		debugSink:  NoOpDebugSink{}, // M-DX11-PHASE2: Default to no-op (zero overhead)
+		rowUnifier:  NewRowUnifier(),
+		depth:       0,
+		aliasEnv:    aliases,
+		aliasParams: aliasParams,
+		debugSink:   NoOpDebugSink{}, // M-DX11-PHASE2: Default to no-op (zero overhead)
 	}
 	// M-FIX-NESTED-RECORD-LIST: Set parent reference for row unification
 	u.rowUnifier.SetParentUnifier(u)


### PR DESCRIPTION
## Summary
- `type Box[a] = { items: [a] }` now instantiates at use sites: `Box[int]` → `{ items: [int] }` — single-module and cross-module. Previously any applied parameterized alias failed with `cannot unify old record type with *types.TApp`.
- Alias machinery carries `(params, body)`: sibling `AliasParams` map through elaborate → iface → type-checker → Unifier; JSON cache round-trip; digest-neutral (locked by test).
- `expandAlias` gains a `*TApp` branch: instantiates via simultaneous `Type.Substitute`, keyed **strictly on alias-env membership** so genuine parameterized ADTs (`Option[a]`, `Result[a,b]`, user ADTs) stay nominal — proven by negative tests.
- New coded diagnostic `TC_ALIAS_ARITY_001` for arity mismatch (`Box[int, string]` on a 1-param alias), styled on TC_ARITY_001.
- cacheKeyVersion v2→v3 (iface gains AliasParams on disk).
- Example `examples/type_alias_poly.ail` (covered by the CI toplevel gate), CHANGELOG entry, design doc + sprint plan → `implemented/v0_30_0/`.

## Verification (independent evaluator, PASS 93/100 round 1)
- Non-vacuity both directions: both design-doc reproducers fail at base `fedbee699`, pass on branch (fresh-built binaries, evaluator-authored probes).
- 12 adversarial shapes green: dup-param tuple, alias-in-alias body, function-type arg, nullary-alias arg, `Pair[a,b]` swap (simultaneous substitution), nested `Box[Box[int]]`, cross-module import+use, recursive alias terminates (no hang), ADT-nominality negative (record ≠ `Option[int]`), runtime execution correct.
- 25 new tests (13 unit + 12 E2E) + digest/cache round-trip locks; 0 test deletions; full suite green (one known pre-existing flaky `TestRunCommand_PipedStdoutFlushesPerLine`, passes 3/3 isolated, diff doesn't touch `cmd/`).
- `verify-examples` runnable failures byte-identical to base (5 pre-existing, unrelated); toplevel gate 39 type-checked / 36 ran (+1 = new example).
- Error-quality side effect: wrong-body programs now get precise field-level errors (`string vs int`) instead of the opaque TApp message.

Mission-control iteration 26 · design doc `implemented/v0_30_0/m-xmod-alias-poly.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)