### PR TITLE
feat(mission): fleet Phase A hardening + Phase B design-doc quorum (M-MISSION-FLEET-AB)

### DIFF
--- a/.ailang/state/sprints/sprint_M-MISSION-FLEET-AB.json
+++ b/.ailang/state/sprints/sprint_M-MISSION-FLEET-AB.json
@@ -1,6 +1,6 @@
 {
   "sprint_id": "M-MISSION-FLEET-AB",
-  "status": "planned",
+  "status": "in_progress",
   "created": "2026-07-14",
   "branch": "mission/iter28-fleet-ab",
   "worktree": "/Users/voightkampff/dev/sunholo-data/ailang-wt-iter28",
@@ -27,10 +27,10 @@
         "Six safety invariants confirmed unchanged: kill switch, overlap guard, stall watchdog, ANTHROPIC_API_KEY strip, subscription-billing probe (claude -p not API), override/env pins",
         "Deployment confirmed: main-checkout on-disk script contains _mc_probe (no deployment action needed)"
       ],
-      "passes": null,
-      "started": null,
-      "completed": null,
-      "notes": "Phase A landed ~3h before planning. Third-vocabulary rule already honored (header cites AIRoutingPolicy.Order with the bash-precedes-Go justification). Read-only + one time-boxed live-ish test that is killed before the iteration begins."
+      "passes": true,
+      "started": "2026-07-14",
+      "completed": "2026-07-14",
+      "notes": "VERIFIED (no build). bash -n clean (exit 0). MISSION_DRY_RUN=1 exits 0, prints 'DRY RUN ok ... prefs=claude-fable-5,claude-opus-4-8', fires NO probes (dry-run step 3 precedes select_model step 4). Fall-through smoke: extracted the REAL probe+select block (sed -n '88,134p') with a stubbed claude — bogus-model-xyz -> 'quota-limited, falling through' -> selects claude-opus-4-8 ('probe ok'), bounded 120s, zero real spend, no iteration launched. Six invariants present+unchanged: kill switch (:149), overlap guard pgrep 'claude -p Run one mission' (:159), stall watchdog _mc_stalled (:73), ANTHROPIC_API_KEY strip (:41), subscription-billing probe uses claude -p never API (:97/:102), override+env pins (:90/:110/:112). Deployment confirmed: main-checkout tools/launchd/mission-control.sh has _mc_probe (3 matches). NO driver edit made -> NO deployment action needed."
     },
     {
       "id": "B1_REVIEWER_CALLER_REJECT_BY_DEFAULT",

--- a/.ailang/state/sprints/sprint_M-MISSION-FLEET-AB.json
+++ b/.ailang/state/sprints/sprint_M-MISSION-FLEET-AB.json
@@ -1,6 +1,6 @@
 {
   "sprint_id": "M-MISSION-FLEET-AB",
-  "status": "in_progress",
+  "status": "completed",
   "created": "2026-07-14",
   "branch": "mission/iter28-fleet-ab",
   "worktree": "/Users/voightkampff/dev/sunholo-data/ailang-wt-iter28",
@@ -44,10 +44,10 @@
         "--max-cost-usd (default 0.10) breach -> structured error, zero spend, no silent fallback",
         "Unit tests: schema conformance (stubbed handler), budget-cap refusal, ADC-vs-apikey provider resolution; superseded tests removed"
       ],
-      "passes": null,
-      "started": null,
-      "completed": null,
-      "notes": "CRITICAL: Gemini MUST route via models.yml/ai_handlers ADC path, NOT exec.go --api-only (which reads the rig-absent GEMINI_API_KEY). This is the design doc's flagged risk, mitigated."
+      "passes": true,
+      "started": "2026-07-14",
+      "completed": "2026-07-14",
+      "notes": "DONE + LIVE-VERIFIED. New package internal/mission/quorum (reviewer.go schema+reject-by-default prompt+validation; call.go models.yml resolver→openai/OPENAI_API_KEY + google/Vertex-ADC, refuses GEMINI_API_KEY dependence; run.go budget-capped RunReviewer with named absence reasons). CLI: cmd/ailang/design_review.go (ailang design-review). Live smokes (bounded): gpt5-6-sol→reject $0.0055; gemini-3-1-pro via Vertex ADC WITHOUT GEMINI_API_KEY (env -u GEMINI_API_KEY)→reject $0.0019 (flagged risk MITIGATED). Budget cap: pre-flight refusal, zero spend (unit test asserts caller NOT invoked). Missing field→hard error (ValidateReviewResult), never a pass. Unit tests: schema conformance, code-fence strip, empty-objection hard-error, unreachable/invalid/budget absences, ADC-vs-apikey resolution (call_test), hoistFlags (cmd). Estimate improved: pre-flight scales to ACTUAL doc size (chars/4), not a fixed 16k (declared deviation — original fixed-estimate over-refused a tiny doc)."
     },
     {
       "id": "B2_QUORUM_ORCHESTRATION_VERDICT_ARTIFACT",
@@ -62,10 +62,10 @@
         "Cost per full quorum recorded and <= budget cap x N (cents/doc)",
         "controller_in_session review recorded in the artifact as a distinct entry (not an API call)"
       ],
-      "passes": null,
-      "started": null,
-      "completed": null,
-      "notes": "This is the genuinely-new engineering per the binding redundancy audit (all quorum logic). Sharp edges: parallel reviewers + the N-1 degrade path. Artifact seeds Phase E."
+      "passes": true,
+      "started": "2026-07-14",
+      "completed": "2026-07-14",
+      "notes": "DONE + LIVE-VERIFIED. quorum.go RunQuorum runs reviewers IN PARALLEL (goroutines+WaitGroup), synthesize(): any present reviewer OR controller reject→blocked, unanimous present pass→proceed, ALL-absent→blocked (refuses zero-signal). Controller review is a distinct in-session entry (NOT an API call). artifact.go writes .ailang/state/mission-quorum/<slug>-<iso>.json + appends mission-log markdown block. Catch-rate hook = per-reviewer landed:null field. CLI cmd/ailang/design_quorum.go (exit 0 proceed / 3 blocked). Live smokes (bounded ≤5min): full quorum on real doc→both reject→BLOCKED, controller pass recorded distinctly, artifact+log both well-formed, total $0.0074 (≤ cap×N). N-1 degrade: env -u OPENAI_API_KEY→gpt5-6-sol absent(reason=auth) NAMED in absent_reviewers, gemini present, proceeds with N-1 (never silent). Unit tests: unanimous-pass proceeds, any-reject blocks, controller-reject blocks, N-1 names absentee, all-absent blocks, artifact JSON round-trip + markdown content, log append preserves+adds. Hook: design-doc-creator SKILL.md documents optional quorum (paragraph only, NO contract change)."
     }
   ],
   "non_goals": [

--- a/.ailang/state/sprints/sprint_M-MISSION-FLEET-AB.json
+++ b/.ailang/state/sprints/sprint_M-MISSION-FLEET-AB.json
@@ -1,0 +1,88 @@
+{
+  "sprint_id": "M-MISSION-FLEET-AB",
+  "status": "planned",
+  "created": "2026-07-14",
+  "branch": "mission/iter28-fleet-ab",
+  "worktree": "/Users/voightkampff/dev/sunholo-data/ailang-wt-iter28",
+  "design_doc": "design_docs/planned/v0_30_0/m-mission-adaptive-multiprovider-routing.md",
+  "sprint_plan": "design_docs/planned/v0_30_0/m-mission-fleet-ab-sprint-plan.md",
+  "github_issues": [329],
+  "scope_note": "Phases A+B ONLY. C/D/E explicitly OUT. Phase A already LANDED (3bee6b6df) + deployed to main checkout -> Milestone A is verification/hardening, not construction. Phase B = quorum (genuinely-new per redundancy audit).",
+  "risk_level": "medium",
+  "velocity": {
+    "target_loc_per_day": 250,
+    "estimated_total_loc": 620,
+    "estimated_days": 2
+  },
+  "features": [
+    {
+      "id": "A_VERIFY_LANDED_PHASE_A_DRIVER",
+      "description": "Verify + harden the already-landed Phase A probe loop in tools/launchd/mission-control.sh (commit 3bee6b6df, deployed to main checkout). NOT a build: bash -n, dry-run, bounded fall-through smoke, safety-invariant + deployment confirmation.",
+      "estimated_loc": 20,
+      "dependencies": [],
+      "acceptance_criteria": [
+        "bash -n tools/launchd/mission-control.sh is clean",
+        "MISSION_DRY_RUN=1 run exits 0, prints 'DRY RUN ok ... prefs=', fires no probes",
+        "Fall-through smoke (MISSION_MODEL_PREFS='bogus-model-xyz,claude-opus-4-8') selects opus within a <=2-min bounded window and logs the fall-through, then is killed before the real iteration runs",
+        "Six safety invariants confirmed unchanged: kill switch, overlap guard, stall watchdog, ANTHROPIC_API_KEY strip, subscription-billing probe (claude -p not API), override/env pins",
+        "Deployment confirmed: main-checkout on-disk script contains _mc_probe (no deployment action needed)"
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": "Phase A landed ~3h before planning. Third-vocabulary rule already honored (header cites AIRoutingPolicy.Order with the bash-precedes-Go justification). Read-only + one time-boxed live-ish test that is killed before the iteration begins."
+    },
+    {
+      "id": "B1_REVIEWER_CALLER_REJECT_BY_DEFAULT",
+      "description": "Thin Go subcommand (ailang design-review) that runs ONE off-Anthropic reviewer via the models.yml resolver + internal/ai handler.CallJson. gpt5-6-sol via OPENAI_API_KEY; gemini-3-pro via Vertex ADC (NOT GEMINI_API_KEY, which is absent on the rig). Reject-by-default prompt with a required strongest_objection field + per-call budget cap. Reuses shipped auth wiring; does NOT rebuild the stalled ailang exec unification.",
+      "estimated_loc": 300,
+      "dependencies": ["A_VERIFY_LANDED_PHASE_A_DRIVER"],
+      "acceptance_criteria": [
+        "ailang design-review <doc> --reviewer gpt5-6-sol --json returns valid JSON: {verdict in {pass,reject}, strongest_objection (non-empty), catch}",
+        "Same works for --reviewer gemini-3-pro WITHOUT GEMINI_API_KEY set (Vertex ADC path proven; ADC token verified working on rig)",
+        "Empty strongest_objection or any missing field -> hard error, not a pass (Principle 2)",
+        "--max-cost-usd (default 0.10) breach -> structured error, zero spend, no silent fallback",
+        "Unit tests: schema conformance (stubbed handler), budget-cap refusal, ADC-vs-apikey provider resolution; superseded tests removed"
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": "CRITICAL: Gemini MUST route via models.yml/ai_handlers ADC path, NOT exec.go --api-only (which reads the rig-absent GEMINI_API_KEY). This is the design doc's flagged risk, mitigated."
+    },
+    {
+      "id": "B2_QUORUM_ORCHESTRATION_VERDICT_ARTIFACT",
+      "description": "Compose gpt5-6-sol + gemini-3-pro reviewers (parallel) plus the Claude controller's IN-SESSION review (NOT an API call) into one quorum verdict. any-reject -> back to author; unanimous-pass -> proceed. Graceful N-1 degrade that NAMES the absent reviewer (never a silent pass). Recordable artifact (JSON under .ailang/state/mission-quorum/ + mission-log markdown row). Catch-rate tracking field. Invoked via a documented HOOK at the design-doc-creator gate / mission-control Gate 3 (no inner-loop skill CONTRACT change).",
+      "estimated_loc": 300,
+      "dependencies": ["B1_REVIEWER_CALLER_REJECT_BY_DEFAULT"],
+      "acceptance_criteria": [
+        "Orchestrator on a real design doc writes .ailang/state/mission-quorum/<slug>-<iso8601>.json AND appends a mission-log routing-evidence markdown block",
+        "Killing one provider (unset OPENAI_API_KEY or block ADC) records the absentee with reason (unreachable/budget/auth), proceeds with N-1, still emits both artifacts (bounded <=5-min test)",
+        "any-reject -> blocked and unanimous-pass -> proceed both exercised",
+        "design-doc-creator SKILL.md documents the optional quorum hook (one paragraph; NO contract change)",
+        "Cost per full quorum recorded and <= budget cap x N (cents/doc)",
+        "controller_in_session review recorded in the artifact as a distinct entry (not an API call)"
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": "This is the genuinely-new engineering per the binding redundancy audit (all quorum logic). Sharp edges: parallel reviewers + the N-1 degrade path. Artifact seeds Phase E."
+    }
+  ],
+  "non_goals": [
+    "Phases C/D/E (cross-provider executors, local-GPU lane, assignment table)",
+    "Rebuilding the ailang exec unification (stalled ledger path m-unified-ai-control-plane)",
+    "Changing inner-loop skill contracts (only a documented optional hook is added)",
+    "Any GPU work or rig.lock touch",
+    "Reading subscription quota gauges directly (probe is the deliberate substitute)"
+  ],
+  "parked_for_human": [
+    "Phase A landed ~3h before planning (3bee6b6df) -> this sprint verifies rather than builds it; flag in case a duplicate build was expected.",
+    "'gemini (latest pro)': rig has gemini-3-pro AND gemini-3-1-pro (both Vertex-ADC). Executor picks the newer ADC-reachable pro.",
+    "Quorum-on-sprint-plans deferred; this sprint scopes the hook to design docs only unless the controller wants sprint-plan quorum now."
+  ],
+  "deployment": {
+    "phase_a": "NONE - already committed AND on-disk in the main checkout (launchd reads it directly).",
+    "phase_b": "No driver deployment - Phase B is an on-demand tool + skill-doc hook invoked inside an iteration; does not modify mission-control.sh.",
+    "guard": "Main tree currently dirty (sprint_M-CODEGEN-IR.json, BenchmarkGallery.jsx). Automated git pull FORBIDDEN (Principle 0). Not triggered this sprint since no driver change ships."
+  }
+}

--- a/.claude/skills/design-doc-creator/SKILL.md
+++ b/.claude/skills/design-doc-creator/SKILL.md
@@ -311,6 +311,32 @@ The design doc MUST include a **Conflict Surface** section (see [resources/desig
 
 **Axiom Compliance:** Every feature must score against all 12 axioms. Hard violations on A1/A3/A4/A7 = automatic rejection, net score must be ≥ +2. See `resources/design_doc_structure.md` for full scoring matrix and examples.
 
+**Quorum review (OPTIONAL, off-Anthropic — M-MISSION-FLEET-AB Phase B):** Before a
+design doc proceeds to planning, you MAY run an independent N-reviewer quorum that scores it
+against these same hard gates (premise verification, Conflict Surface, axiom compliance) using
+non-Anthropic frontier models — a cheap (cents/doc), off-quota second opinion that catches bad
+premises before an Opus sprint is spent on them. This is an **optional documented step, not a
+contract change**: the design-doc-creator flow is unchanged if you skip it.
+
+```bash
+# One reviewer (reject-by-default; exits non-zero if it can't produce a verdict):
+ailang design-review design_docs/planned/vX_Y/my-doc.md --reviewer gpt5-6-sol --json
+
+# Full quorum (parallel reviewers + your own IN-SESSION verdict as the controller):
+ailang design-quorum design_docs/planned/vX_Y/my-doc.md \
+  --reviewers gpt5-6-sol,gemini-3-1-pro \
+  --controller-verdict pass --controller-note "<your in-session judgement>" \
+  --mission-log design_docs/v1-mission-log.md
+```
+
+Reviewers are **reject-by-default** (each must state a `strongest_objection`). Synthesis: any
+present reviewer or the controller rejects → **blocked** (exit 3); the objection goes back to you,
+the author, before planning. A reviewer that is unreachable / over-budget / mis-authed is recorded
+by NAME with its reason and the quorum degrades to N−1 — never a silent pass. Each run writes a
+machine artifact under `.ailang/state/mission-quorum/` (seeds the Phase E assignment table) and,
+with `--mission-log`, a human markdown block. Gemini reviewers use **Vertex ADC** (not
+`GEMINI_API_KEY`). See `ailang design-quorum --help`.
+
 **2. Choose Document Name**
 
 **Naming conventions:**

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,38 @@
 
 ## [Unreleased]
 
+### Added — Design-doc quorum review: off-Anthropic N-reviewer gate (M-MISSION-FLEET-AB, fleet Phase B)
+
+Two new CLI subcommands let a design doc get an independent, off-quota second
+opinion from non-Anthropic frontier models before an Opus sprint is spent on it:
+
+- `ailang design-review <doc> --reviewer <model> [--json] [--max-cost-usd 0.10]` —
+  one **reject-by-default** reviewer verdict (`verdict` ∈ {pass, reject} +
+  required non-empty `strongest_objection` + `catch`). Exits non-zero if the
+  reviewer can't produce a verdict — never a silent pass.
+- `ailang design-quorum <doc> [--reviewers gpt5-6-sol,gemini-3-1-pro]
+  [--controller-verdict pass|reject --controller-note ...] [--mission-log <path>]` —
+  composes N reviewers **in parallel** plus the Claude controller's IN-SESSION
+  review (not an API call) into one verdict. Synthesis: any present reviewer or
+  the controller rejects → **blocked** (exit 3), the objection returns to the
+  author; all present pass → **proceed** (exit 0). Writes a machine artifact
+  under `.ailang/state/mission-quorum/<slug>-<iso>.json` (seeds Phase E's
+  assignment table) and, with `--mission-log`, a human markdown block.
+
+**Graceful N−1 degrade (no silent fallbacks):** an unreachable / over-budget /
+mis-authed reviewer is recorded by NAME with its reason (`unreachable`/`budget`/
+`auth`/`invalid`) and the quorum proceeds with the remaining reviewers; a missing
+reviewer is never treated as a pass, and all-absent = blocked (refuses to proceed
+on zero signal). Per-reviewer **budget cap** (`--max-cost-usd`, default $0.10)
+refuses before any spend when the estimate (scaled to the actual doc size)
+exceeds the cap.
+
+Rides the shipped `internal/ai/{openai,gemini}` handlers + the `models.yml`
+resolver (no `ailang exec` unification rebuild — the binding redundancy audit).
+Gemini reviewers route via **Vertex ADC** (not `GEMINI_API_KEY`). Invoked via a
+documented optional hook in the design-doc-creator skill — **no inner-loop
+skill-contract change**. New package `internal/mission/quorum`.
+
 ### Added — Option/Result are prelude in entry modules, no import needed (M-PRELUDE-OPTION-RESULT)
 
 `Option`/`Some`/`None` and `Result`/`Ok`/`Err` — the types AND their data

--- a/cmd/ailang/design_quorum.go
+++ b/cmd/ailang/design_quorum.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/sunholo-data/ailang/internal/mission/quorum"
+)
+
+// runDesignQuorum implements `ailang design-quorum` (M-MISSION-FLEET-AB Phase B2):
+// it composes N off-Anthropic reviewers (default gpt5-6-sol + gemini-3-1-pro)
+// in parallel into one quorum verdict, records a machine JSON artifact + an
+// optional mission-log markdown block, and degrades gracefully to N-1 (naming
+// any absent reviewer). The Claude controller's own review is IN-SESSION (not
+// an API call) and can be folded in via flags.
+func runDesignQuorum() {
+	fs := flag.NewFlagSet("design-quorum", flag.ExitOnError)
+	reviewers := fs.String("reviewers", "gpt5-6-sol,gemini-3-1-pro", "comma-separated reviewer model ids from models.yml")
+	maxCost := fs.Float64("max-cost-usd", quorum.DefaultMaxCostUSD, "per-reviewer budget cap in USD")
+	artifactDir := fs.String("artifact-dir", quorum.ArtifactDir, "directory for the machine JSON artifact")
+	logPath := fs.String("mission-log", "", "optional mission log path to append the markdown block")
+	ctrlVerdict := fs.String("controller-verdict", "", "the Claude controller's IN-SESSION verdict (pass|reject); NOT an API call")
+	ctrlNote := fs.String("controller-note", "", "the controller's in-session note (required if --controller-verdict set)")
+	asJSON := fs.Bool("json", false, "print the full quorum result JSON to stdout")
+	fs.Usage = func() { fmt.Fprint(os.Stderr, designQuorumHelp) }
+	_ = fs.Parse(hoistFlags(os.Args[2:]))
+
+	docPath, docBody, err := readDoc(fs.Args())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "design-quorum: %v\n", err)
+		os.Exit(1)
+	}
+
+	var controller *quorum.ControllerReview
+	if *ctrlVerdict != "" {
+		v := quorum.Verdict(strings.ToLower(*ctrlVerdict))
+		if v != quorum.VerdictPass && v != quorum.VerdictReject {
+			fmt.Fprintf(os.Stderr, "design-quorum: --controller-verdict must be pass or reject\n")
+			os.Exit(2)
+		}
+		if strings.TrimSpace(*ctrlNote) == "" {
+			fmt.Fprintf(os.Stderr, "design-quorum: --controller-note is required when --controller-verdict is set (no silent controller pass)\n")
+			os.Exit(2)
+		}
+		controller = &quorum.ControllerReview{Verdict: v, Note: *ctrlNote}
+	}
+
+	models := splitCSV(*reviewers)
+	if len(models) == 0 {
+		fmt.Fprintln(os.Stderr, "design-quorum: no reviewers specified")
+		os.Exit(2)
+	}
+
+	isoTS := time.Now().UTC().Format(time.RFC3339)
+	result := quorum.RunQuorum(docPath, docBody, isoTS, models, *maxCost, controller, quorum.RunReviewer)
+
+	// Always write the machine artifact (seeds Phase E).
+	artPath, aerr := quorum.WriteJSONArtifact(*artifactDir, result)
+	if aerr != nil {
+		fmt.Fprintf(os.Stderr, "design-quorum: %v\n", aerr)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stderr, "quorum artifact: %s\n", artPath)
+
+	// Optionally append the human markdown block to the mission log.
+	if *logPath != "" {
+		if _, lerr := quorum.AppendMarkdownToLog(*logPath, result); lerr != nil {
+			fmt.Fprintf(os.Stderr, "design-quorum: %v\n", lerr)
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stderr, "mission-log block appended: %s\n", *logPath)
+	}
+
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(result)
+	} else {
+		fmt.Print(quorum.MarkdownBlock(result))
+	}
+
+	// Exit code encodes the synthesis: proceed = 0, blocked = 3 (distinct from
+	// usage/IO errors) so a caller can gate on it.
+	if result.Synthesis.Verdict == quorum.SynthBlocked {
+		os.Exit(3)
+	}
+}
+
+const designQuorumHelp = `ailang design-quorum — N-reviewer quorum verdict on a design doc (fleet Phase B)
+
+USAGE:
+  ailang design-quorum <doc.md> [flags]
+  ailang design-quorum --reviewers gpt5-6-sol,gemini-3-1-pro < doc.md
+
+FLAGS:
+  --reviewers <csv>          reviewer model ids (default gpt5-6-sol,gemini-3-1-pro)
+  --max-cost-usd <n>         per-reviewer budget cap in USD (default 0.10)
+  --artifact-dir <dir>       machine JSON artifact dir (default .ailang/state/mission-quorum)
+  --mission-log <path>       append the human markdown block to this mission log
+  --controller-verdict <v>   the Claude controller's IN-SESSION verdict (pass|reject) — NOT an API call
+  --controller-note <text>   the controller's in-session note (required with --controller-verdict)
+  --json                     print the full quorum result JSON to stdout
+
+BEHAVIOR:
+  Runs the reviewers IN PARALLEL (reject-by-default). Synthesis: any present
+  reviewer (or the controller) rejects → BLOCKED (objection returns to author);
+  all present pass → PROCEED. An unreachable/over-budget/mis-auth reviewer is
+  recorded by NAME with its reason and the quorum degrades to N-1 — never a
+  silent pass. Always writes a machine JSON artifact; optionally appends a
+  mission-log markdown block.
+
+EXIT CODES:
+  0 = proceed   3 = blocked   1/2 = IO or usage error
+
+SEE ALSO:
+  ailang design-review — a single reviewer verdict.
+`

--- a/cmd/ailang/design_review.go
+++ b/cmd/ailang/design_review.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/sunholo-data/ailang/internal/mission/quorum"
+)
+
+// runDesignReview implements `ailang design-review` (M-MISSION-FLEET-AB Phase B1):
+// a single off-Anthropic reviewer verdict on a design doc, via the shipped
+// internal/ai handlers + the models.yml resolver. It does NOT rebuild the
+// stalled `ailang exec` unification — it is a thin caller over the quorum
+// package's reviewer primitive.
+//
+// Usage:
+//
+//	ailang design-review <doc.md> --reviewer gpt5-6-sol [--json] [--max-cost-usd 0.10]
+//	ailang design-review --reviewer gemini-3-1-pro < doc.md   (reads stdin)
+func runDesignReview() {
+	fs := flag.NewFlagSet("design-review", flag.ExitOnError)
+	reviewer := fs.String("reviewer", "", "reviewer model id from models.yml (e.g. gpt5-6-sol, gemini-3-1-pro)")
+	asJSON := fs.Bool("json", false, "emit the reviewer's structured JSON verdict")
+	maxCost := fs.Float64("max-cost-usd", quorum.DefaultMaxCostUSD, "per-reviewer budget cap in USD")
+	fs.Usage = func() {
+		fmt.Fprint(os.Stderr, designReviewHelp)
+	}
+	_ = fs.Parse(hoistFlags(os.Args[2:]))
+
+	if *reviewer == "" {
+		fmt.Fprintln(os.Stderr, "design-review: --reviewer <model> is required")
+		fs.Usage()
+		os.Exit(2)
+	}
+
+	docPath, docBody, err := readDoc(fs.Args())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "design-review: %v\n", err)
+		os.Exit(1)
+	}
+
+	outcome := quorum.RunReviewer(*reviewer, docPath, docBody, *maxCost)
+
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(outcome)
+	} else {
+		printOutcome(outcome)
+	}
+
+	// Exit non-zero when the reviewer could not produce a verdict — a missing
+	// reviewer is never a silent pass (Principle 2). Present pass/reject both
+	// exit 0; the caller reads the verdict field.
+	if !outcome.Present {
+		os.Exit(1)
+	}
+}
+
+// hoistFlags reorders args so leading positional operands (e.g. a doc path)
+// come AFTER the flags, letting Go's flag package parse `<doc> --reviewer X`
+// the same as `--reviewer X <doc>`. Flags that take a value (--reviewer X,
+// --max-cost-usd 0.1) keep their value adjacent; `--flag=value` and boolean
+// flags are single tokens. Everything after a bare `--` is treated as
+// positional verbatim.
+func hoistFlags(args []string) []string {
+	valueFlags := map[string]bool{
+		"--reviewer": true, "-reviewer": true,
+		"--reviewers": true, "-reviewers": true,
+		"--max-cost-usd": true, "-max-cost-usd": true,
+		"--artifact-dir": true, "-artifact-dir": true,
+		"--mission-log": true, "-mission-log": true,
+		"--controller-verdict": true, "-controller-verdict": true,
+		"--controller-note": true, "-controller-note": true,
+	}
+	var flags, positional []string
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--" {
+			positional = append(positional, args[i+1:]...)
+			break
+		}
+		if strings.HasPrefix(a, "-") && a != "-" {
+			flags = append(flags, a)
+			// Consume a following value token for space-separated value flags.
+			if valueFlags[a] && !strings.Contains(a, "=") && i+1 < len(args) {
+				flags = append(flags, args[i+1])
+				i++
+			}
+			continue
+		}
+		positional = append(positional, a)
+	}
+	return append(flags, positional...)
+}
+
+// readDoc resolves the doc body from a positional path or, if none given,
+// stdin.
+func readDoc(args []string) (path, body string, err error) {
+	if len(args) > 0 && args[0] != "" && args[0] != "-" {
+		path = args[0]
+		b, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return "", "", fmt.Errorf("read %s: %w", path, rerr)
+		}
+		return path, string(b), nil
+	}
+	b, rerr := io.ReadAll(os.Stdin)
+	if rerr != nil {
+		return "", "", fmt.Errorf("read stdin: %w", rerr)
+	}
+	if len(b) == 0 {
+		return "", "", fmt.Errorf("no design doc: pass a path or pipe the doc on stdin")
+	}
+	return "(stdin)", string(b), nil
+}
+
+func printOutcome(o *quorum.ReviewerOutcome) {
+	if !o.Present {
+		fmt.Printf("reviewer %s ABSENT (%s): %s\n", o.Model, o.AbsentReason, o.Err)
+		return
+	}
+	fmt.Printf("reviewer %s → %s ($%.4f)\n", o.Model, o.Result.Verdict, o.CostUSD)
+	fmt.Printf("  strongest_objection: %s\n", o.Result.StrongestObjection)
+	fmt.Printf("  catch: %s\n", o.Result.Catch)
+}
+
+const designReviewHelp = `ailang design-review — single off-Anthropic reviewer verdict on a design doc (fleet Phase B)
+
+USAGE:
+  ailang design-review <doc.md> --reviewer <model> [flags]
+  ailang design-review --reviewer <model> < doc.md
+
+FLAGS:
+  --reviewer <model>     reviewer model id from models.yml (gpt5-6-sol, gemini-3-1-pro, ...)  [required]
+  --json                 emit the reviewer's structured JSON verdict
+  --max-cost-usd <n>     per-reviewer budget cap in USD (default 0.10)
+
+BEHAVIOR:
+  Runs ONE reject-by-default reviewer via the shipped internal/ai handlers +
+  the models.yml resolver. OpenAI reviewers use OPENAI_API_KEY; Google/Gemini
+  reviewers use Vertex ADC (NOT GEMINI_API_KEY). A missing verdict (auth,
+  unreachable, budget, or malformed response) exits non-zero and is NEVER a
+  silent pass.
+
+SEE ALSO:
+  ailang design-quorum — compose N reviewers into one quorum verdict.
+`

--- a/cmd/ailang/design_review_test.go
+++ b/cmd/ailang/design_review_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestHoistFlags(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "positional before value flag",
+			in:   []string{"doc.md", "--reviewer", "gpt5-6-sol", "--json"},
+			want: []string{"--reviewer", "gpt5-6-sol", "--json", "doc.md"},
+		},
+		{
+			name: "already flags first",
+			in:   []string{"--reviewer", "x", "doc.md"},
+			want: []string{"--reviewer", "x", "doc.md"},
+		},
+		{
+			name: "equals form keeps single token",
+			in:   []string{"doc.md", "--max-cost-usd=0.05"},
+			want: []string{"--max-cost-usd=0.05", "doc.md"},
+		},
+		{
+			name: "double dash terminates flag parsing",
+			in:   []string{"--json", "--", "-weird-file.md"},
+			want: []string{"--json", "-weird-file.md"},
+		},
+		{
+			name: "bare dash is positional (stdin)",
+			in:   []string{"-", "--reviewer", "x"},
+			want: []string{"--reviewer", "x", "-"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := hoistFlags(c.in)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("hoistFlags(%v) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/cmd/ailang/main.go
+++ b/cmd/ailang/main.go
@@ -369,6 +369,12 @@ func main() {
 	case "exec":
 		runExec()
 
+	case "design-review":
+		runDesignReview()
+
+	case "design-quorum":
+		runDesignQuorum()
+
 	case "verify":
 		verifyCommand()
 

--- a/design_docs/planned/v0_30_0/m-mission-fleet-ab-sprint-plan.md
+++ b/design_docs/planned/v0_30_0/m-mission-fleet-ab-sprint-plan.md
@@ -3,7 +3,7 @@
 **Sprint ID**: M-MISSION-FLEET-AB
 **Design doc**: [m-mission-adaptive-multiprovider-routing.md](./m-mission-adaptive-multiprovider-routing.md)
 **Branch / worktree**: `mission/iter28-fleet-ab` @ `/Users/voightkampff/dev/sunholo-data/ailang-wt-iter28`
-**Status**: planned
+**Status**: completed (all milestones ✅, 2026-07-14; awaiting independent evaluator)
 **Risk**: MEDIUM (touches the live mission driver + spends OpenAI/Vertex credits per design doc)
 **Estimate**: ~1.5–2.0 dev-days total (Phase A **already landed** → verification-only ~0.25d; Phase B ~1.25–1.75d)
 **GH bookkeeping**: #329
@@ -134,13 +134,12 @@ Build the off-Anthropic reviewer invocation as a thin Go subcommand reusing ship
 4. Per-call **budget cap**: `--max-cost-usd` (default $0.10/reviewer); refuse + record if the
    model's models.yml pricing × expected tokens would exceed it. No silent fallback (Principle 2).
 
-**Acceptance**
-- `ailang design-review <doc> --reviewer gpt5-6-sol --json` returns valid JSON with all four fields.
-- Same for `--reviewer gemini-3-pro` **without** `GEMINI_API_KEY` set (ADC path proven).
-- Empty `strongest_objection` on a `reject` (or any missing field) → the call is a hard error, not a
-  pass. Budget-cap breach → structured error, zero spend.
-- Unit tests: schema-conformance (stubbed handler), budget-cap refusal, ADC-vs-apikey provider
-  resolution. (Delete any superseded tests per coding-standards.)
+**Acceptance** — ✅ ALL MET (verified 2026-07-14, exec; live smokes bounded)
+- [x] `ailang design-review <doc> --reviewer gpt5-6-sol --json` returns valid JSON (verdict/strongest_objection/catch). Live: reject, $0.0055.
+- [x] Same for `--reviewer gemini-3-1-pro` **without** `GEMINI_API_KEY` set (ADC path proven; ran under `env -u GEMINI_API_KEY` → reject, $0.0019). *(picked `gemini-3-1-pro`, the newer ADC pro, per the parked question.)*
+- [x] Empty `strongest_objection`/missing field → hard error, not a pass (`ValidateReviewResult`). Budget-cap breach → structured error, zero spend (unit test asserts caller not invoked).
+- [x] Unit tests: schema-conformance (stubbed handler), budget-cap refusal, ADC-vs-apikey resolution. No superseded tests existed to remove (new package).
+- **Deviation (declared):** pre-flight budget estimate now scales to the ACTUAL doc size (chars/4), not a fixed 16k — the fixed estimate over-refused a small doc at gpt5-6-sol pricing. POST-check still uses real provider token counts.
 
 **Risk**: MEDIUM. Real credit spend (OpenAI + Vertex). Mitigated by budget cap + cents/doc scale.
 
@@ -173,14 +172,12 @@ Compose N reviewers into one quorum verdict with graceful degrade and a recordab
    step* — the design-doc-creator SKILL.md gets a one-paragraph "Quorum review (optional)" note
    pointing at `ailang design-review` + the orchestrator; **no inner-loop skill CONTRACT changes.**
 
-**Acceptance**
-- Orchestrator on a real design doc writes a well-formed JSON artifact + a mission-log markdown block.
-- Kill one provider (unset OPENAI_API_KEY OR block ADC) → verdict records the absentee with reason,
-  proceeds with N−1, still emits both artifacts. Verified by a bounded test (≤5-min cap).
-- `any-reject → blocked` and `unanimous-pass → proceed` both exercised (one real doc each, or a
-  fixture pair).
-- The design-doc-creator SKILL.md documents the hook (paragraph only; no contract change).
-- Cost per full quorum recorded and ≤ the budget cap × N.
+**Acceptance** — ✅ ALL MET (verified 2026-07-14, exec; live smokes bounded ≤5 min)
+- [x] Orchestrator on a real design doc writes a well-formed JSON artifact (`.ailang/state/mission-quorum/<slug>-<iso>.json`) + a mission-log markdown block (both inspected).
+- [x] Kill one provider (`env -u OPENAI_API_KEY`) → gpt5-6-sol recorded absent (reason `auth`), NAMED in `absent_reviewers`, proceeds with N−1 (gemini present), still emits artifact. Never a silent pass.
+- [x] `any-reject → blocked` (both reviewers rejected the fixture → exit 3) and `unanimous-pass → proceed` (covered by unit test `TestRunQuorum_UnanimousPassProceeds`) both exercised. All-absent → blocked (refuses zero signal).
+- [x] design-doc-creator SKILL.md documents the optional quorum hook (one paragraph; no contract change).
+- [x] Full-quorum cost recorded ($0.0074 for 2 reviewers) and ≤ budget cap × N. `controller_in_session` recorded as a distinct non-API entry.
 
 **Risk**: MEDIUM. Orchestration is the genuinely-new engineering. Concurrency + degrade paths are the
 sharp edges — covered by the N−1 degrade test.

--- a/design_docs/planned/v0_30_0/m-mission-fleet-ab-sprint-plan.md
+++ b/design_docs/planned/v0_30_0/m-mission-fleet-ab-sprint-plan.md
@@ -1,0 +1,232 @@
+# Sprint Plan — M-MISSION-FLEET-AB (Phases A+B of m-mission-adaptive-multiprovider-routing)
+
+**Sprint ID**: M-MISSION-FLEET-AB
+**Design doc**: [m-mission-adaptive-multiprovider-routing.md](./m-mission-adaptive-multiprovider-routing.md)
+**Branch / worktree**: `mission/iter28-fleet-ab` @ `/Users/voightkampff/dev/sunholo-data/ailang-wt-iter28`
+**Status**: planned
+**Risk**: MEDIUM (touches the live mission driver + spends OpenAI/Vertex credits per design doc)
+**Estimate**: ~1.5–2.0 dev-days total (Phase A **already landed** → verification-only ~0.25d; Phase B ~1.25–1.75d)
+**GH bookkeeping**: #329
+
+---
+
+## HEADLINE FINDING (re-scopes this sprint)
+
+**Phase A is already implemented AND deployed.** Commit `3bee6b6df`
+("feat(mission): fleet Phase A — quota-aware model preference probing in the driver",
+2026-07-14 07:32) is on `origin/dev`, is an ancestor of the main-checkout HEAD, and the
+main-checkout on-disk `tools/launchd/mission-control.sh` (what launchd reads) contains the Phase A
+probe loop (`MISSION_MODEL_PREFS` + `_mc_probe` + `QUOTA_SIG` matching, 5 matches). The transient
+`mission-control.sh.new` staging file has been cleaned up.
+
+The landed Phase A already delivers **exactly** the redundancy-audit's "genuinely new" surface for
+Phase A — the multi-candidate loop + quota-error-signature matching — and nothing more. It:
+- walks `MISSION_MODEL_PREFS` (default `claude-fable-5,claude-opus-4-8`) with a 1-token probe;
+- classifies quota (fall through) vs transient (retry once) vs auth-dead (fall through);
+- auto-recovers to a higher-preference model when its probe succeeds again (no dates);
+- **subsumes** the old standalone auth probe (probe doubles as the subscription-auth check);
+- preserves the kill switch, overlap guard, stall watchdog, override-file pin, `MISSION_MODEL` pin,
+  `MISSION_DRY_RUN` path, and the `ANTHROPIC_API_KEY` strip (subscription billing);
+- honors the **third-vocabulary rule**: its header comment cites `internal/ai/routing.go`
+  `AIRoutingPolicy.Order` as the semantics it reuses, with the one-paragraph justification the doc
+  requires (selection must happen in bash *before* any Go/claude process exists — the AIRoutingPolicy
+  struct is program-runtime and cannot be consulted at driver-launch time; it is reused as the
+  *ordering contract*, not the *implementation*).
+
+**Consequence:** Milestone A is **not a build** — it is a verification/hardening pass on already-live
+code (bash-n, dry-run, fall-through smoke, deployment confirmation). This matches the audit's
+"only … loop + signature matching" scope and the ~0.5d estimate (now mostly spent).
+
+---
+
+## Verification log (design-doc claims checked against HEAD, 2026-07-14)
+
+| Doc claim | Reality at HEAD | Verdict |
+|---|---|---|
+| Phase A = replace time-box override with probe loop, ~0.5d | **Already landed** `3bee6b6df` + deployed to main checkout | ✅ DONE (re-scoped to verify) |
+| Auth probe at `mission-control.sh:128`; override at `:76–95` | Both existed at those lines pre-Phase-A; Phase A **replaced** them (auth probe folded into `select_model`) | ✅ (now historical) |
+| `AIRoutingPolicy{Order,AllowFallback,Require,Prefer}` in `internal/ai/routing.go` | Confirmed verbatim (struct at routing.go:49) | ✅ |
+| `gpt-5.6-sol` registered in models.yml 2026-07-12 | Confirmed: `gpt5-6-sol`, `api_name: gpt-5.6-sol`, `provider: openai`, `env_var: OPENAI_API_KEY`, `agent_cli: codex` | ✅ |
+| Gemini provider reads `GEMINI_API_KEY` (rig: ABSENT) | **PARTIAL — the doc's worry is real but avoidable.** `ailang exec gemini --api-only` (exec.go:369) reads `GEMINI_API_KEY` → would FAIL on rig. BUT the eval-harness path (`ai_handlers.go` → `gemini.NewVertexAIClient`) uses **Vertex ADC**, and `models.yml gemini-3-pro` is configured `env_var: ""`, `gcp_project: ailang-dev` (ADC). **ADC token verified working on rig** (`gcloud auth application-default print-access-token` → OK). → **Phase B routes Gemini via the models.yml/Vertex-ADC path, NOT via `exec --api-only`.** | ✅ mitigated |
+| OpenAI reachable on rig | `OPENAI_API_KEY` present; `gpt5-6-sol` uses it | ✅ |
+| `internal/ai/{openai,gemini}` `handler.Call/CallJson` surface | Confirmed: `handler.go` `Call(input)`, `CallJson(input, schema)`, `CallWithContext`, `GenerateWithDetails` | ✅ |
+| Prior-attempt ledger `m-unified-ai-control-plane.md` | Read fully. It is the STALLED heavy path: route ALL AI through `ailang exec` + schema migrations + eval-suite rewrite; its "Future Work" literally lists "Multi-provider fallback: try claude, fallback to gemini." **Phase B must NOT rebuild `ailang exec` unification** — it makes direct in-session provider calls. | ✅ avoided |
+| Routing-evidence rows land in the mission log | Confirmed: `v1-mission.md` Gate 4 records "routing evidence row" per iteration in `v1-mission-log.md` | ✅ |
+
+---
+
+## Existing machinery Phase B rides on (do NOT rebuild — redundancy audit BINDING)
+
+- **Text providers**: `internal/ai/openai` (`gpt-5.6-sol` via `OPENAI_API_KEY`) and
+  `internal/ai/gemini` (`gemini-3-pro` via Vertex ADC). Both expose `handler.Call/CallJson`.
+- **Model registry**: `internal/eval_harness/models.yml` — resolves `gpt5-6-sol` and `gemini-3-pro`
+  to api_name + provider + auth; `ailang run --ai <model>` already constructs the right client
+  (`ai_handlers.go` — ADC-first for Gemini, then `GOOGLE_API_KEY`).
+- **The Claude controller's own review is IN-SESSION** — it is the running mission-control skill's
+  own judgement, **NOT an API call** (per doc gate 6). No third provider call.
+
+**Genuinely new (per audit) = ALL of Phase B's quorum logic**: N-reviewer orchestration,
+reject-by-default scoring with a required "strongest objection" field, verdict synthesis,
+catch-rate tracking hooks, and the artifact format.
+
+## Existing CLI surface for one-shot text calls (Critical Principle 1)
+
+Checked `ailang --help` subcommands, `cmd/ailang/exec.go`, `ai_handlers.go`, `chains_chat.go`.
+Findings:
+- `ailang run --ai <model> --caps AI` runs an `.ail` program that calls `AI.call` — heavyweight,
+  needs an AILANG wrapper program. **Not ideal for a shell hook.**
+- `ailang exec <provider> --api-only "<prompt>"` is a one-shot API text call — **but its Gemini
+  branch reads `GEMINI_API_KEY` (absent on rig)**, so it works for OpenAI but not Gemini here.
+- **DECISION**: Phase B's reviewer caller is a small Go helper (`ailang eval-review` OR a
+  reused/extended internal entry) that constructs `openai` + `gemini` handlers **through the
+  models.yml resolver** (so Gemini gets Vertex ADC), and returns structured JSON via `CallJson`.
+  We do **not** invent a new top-level binary; we add one thin subcommand that reuses
+  `eval_harness.GlobalModelsConfig` + `internal/ai` — the same primitives `ai_handlers.go` uses.
+  This keeps us off the stalled `ailang exec` unification path while reusing shipped auth wiring.
+
+---
+
+## Milestones
+
+### Milestone A — Verify + harden the already-landed Phase A driver (~0.25d)
+
+**This is verification, not construction.** Phase A code is live. Confirm it is correct and safe.
+
+**Tasks**
+1. `bash -n tools/launchd/mission-control.sh` → syntax clean (already confirmed in planning).
+2. `MISSION_DRY_RUN=1 tools/launchd/mission-control.sh` → prints `DRY RUN ok … prefs=…`, fires **no**
+   probes, exits 0. (Bounded: single invocation, no wait.)
+3. Fall-through smoke: `MISSION_MODEL_PREFS="bogus-model-xyz,claude-opus-4-8" MISSION_DRY_RUN=0`
+   with a **≤2-min bounded** run that asserts the log shows `bogus-model-xyz … falling through` then
+   selects opus. (Kill after model selection line; do NOT let the full 6h iteration run.)
+4. Confirm invariants **unchanged** vs pre-Phase-A: kill switch (`grep KILL_SWITCH`), overlap guard
+   (`pgrep -f "claude -p Run one mission"`), stall watchdog (`_mc_stalled`), `ANTHROPIC_API_KEY` strip,
+   subscription-billing (probe uses `claude -p`, never the API).
+5. Confirm deployment: main-checkout on-disk script contains `_mc_probe` (5 matches — confirmed).
+   **No deployment action needed** (already deployed).
+
+**Acceptance**
+- `bash -n` clean; dry-run exits 0 with no probes; fall-through selects the next candidate within
+  the ≤2-min bounded window; all six safety invariants present and unchanged; deployment confirmed.
+
+**Risk**: LOW. Read-only verification of live code. The one live-ish test (task 3) is time-boxed and
+killed before the real iteration starts, so it cannot wedge the loop.
+
+---
+
+### Milestone B1 — Reviewer caller + reject-by-default prompt (~0.5d)
+
+Build the off-Anthropic reviewer invocation as a thin Go subcommand reusing shipped primitives.
+
+**Tasks**
+1. Add subcommand `ailang design-review` (name TBD; reuses `eval_harness.GlobalModelsConfig` +
+   `internal/ai` handlers — **no new provider code, no `ailang exec` unification**). Inputs: a
+   design-doc path (or stdin), a reviewer model id (`gpt5-6-sol` | `gemini-3-pro`). Output: one
+   reviewer's structured JSON verdict via `handler.CallJson(prompt, schema)`.
+2. Gemini path MUST resolve through the models.yml/ADC route (`gemini-3-pro`, `env_var: ""`,
+   Vertex ADC) — assert it does NOT require `GEMINI_API_KEY` (the rig-absent var).
+3. Reviewer prompt = **reject-by-default**: score against the design-doc-creator hard gates
+   (premise verification, Conflict Surface, axiom compliance) + a **required non-empty
+   `strongest_objection` field** + a `verdict` ∈ {`pass`,`reject`} + `catch` free-text.
+4. Per-call **budget cap**: `--max-cost-usd` (default $0.10/reviewer); refuse + record if the
+   model's models.yml pricing × expected tokens would exceed it. No silent fallback (Principle 2).
+
+**Acceptance**
+- `ailang design-review <doc> --reviewer gpt5-6-sol --json` returns valid JSON with all four fields.
+- Same for `--reviewer gemini-3-pro` **without** `GEMINI_API_KEY` set (ADC path proven).
+- Empty `strongest_objection` on a `reject` (or any missing field) → the call is a hard error, not a
+  pass. Budget-cap breach → structured error, zero spend.
+- Unit tests: schema-conformance (stubbed handler), budget-cap refusal, ADC-vs-apikey provider
+  resolution. (Delete any superseded tests per coding-standards.)
+
+**Risk**: MEDIUM. Real credit spend (OpenAI + Vertex). Mitigated by budget cap + cents/doc scale.
+
+---
+
+### Milestone B2 — Quorum orchestration + verdict synthesis + artifact (~0.5–0.75d)
+
+Compose N reviewers into one quorum verdict with graceful degrade and a recordable artifact.
+
+**Tasks**
+1. Orchestrator: run `gpt5-6-sol` + `gemini-3-pro` reviewers (B1) **in parallel**; the Claude
+   controller's own review is **in-session** (the mission-control skill's judgement — NOT an API
+   call). Synthesis rule (from doc): **any `reject` → the objection goes back to the doc author
+   before planning; unanimous `pass` → proceed.**
+2. **Graceful degrade (Principle 2 for verdicts)**: a provider unreachable/over-budget → quorum
+   proceeds with N−1 and the verdict record **explicitly names the absent reviewer** with the
+   reason (`unreachable` / `budget` / `auth`). A missing reviewer is NEVER a silent pass.
+3. **Artifact format** (seeds Phase E):
+   - Machine: `.ailang/state/mission-quorum/<doc-slug>-<iso8601>.json` —
+     `{doc, iso_ts, reviewers:[{model, verdict, strongest_objection, catch, cost_usd, present:bool,
+     absent_reason?}], synthesis:{verdict, blocking_objections:[]}, controller_in_session:{verdict,
+     note}}`.
+   - Human: a short markdown block appended to the mission log's routing-evidence row (Gate 4),
+     one line per reviewer + the synthesis verdict.
+4. **Catch-rate tracking hook**: each reviewer record carries whether its objection was
+   subsequently actioned (a `landed: null` field the doc author/evaluator flips) — the seed for the
+   audit's "drop a reviewer whose objections never land". No dashboard, just the recorded field.
+5. **Invocation point (documented HOOK, not a rewired skill — Non-Goal respected)**: the quorum is
+   invoked at the **design-doc-creator gate / mission-control Gate 3** as an *optional documented
+   step* — the design-doc-creator SKILL.md gets a one-paragraph "Quorum review (optional)" note
+   pointing at `ailang design-review` + the orchestrator; **no inner-loop skill CONTRACT changes.**
+
+**Acceptance**
+- Orchestrator on a real design doc writes a well-formed JSON artifact + a mission-log markdown block.
+- Kill one provider (unset OPENAI_API_KEY OR block ADC) → verdict records the absentee with reason,
+  proceeds with N−1, still emits both artifacts. Verified by a bounded test (≤5-min cap).
+- `any-reject → blocked` and `unanimous-pass → proceed` both exercised (one real doc each, or a
+  fixture pair).
+- The design-doc-creator SKILL.md documents the hook (paragraph only; no contract change).
+- Cost per full quorum recorded and ≤ the budget cap × N.
+
+**Risk**: MEDIUM. Orchestration is the genuinely-new engineering. Concurrency + degrade paths are the
+sharp edges — covered by the N−1 degrade test.
+
+---
+
+## Day-by-day
+
+| Day | Work |
+|---|---|
+| **Day 1 AM** | Milestone A (verify/harden landed Phase A — bash-n, dry-run, bounded fall-through smoke, invariant + deployment confirmation). Then B1 start: scaffold `ailang design-review`, wire models.yml resolver + `CallJson`, ADC-path assertion. |
+| **Day 1 PM** | B1 finish: reject-by-default prompt + schema, budget cap, unit tests (schema, budget, ADC-vs-key). |
+| **Day 2 AM** | B2: orchestrator (parallel reviewers), synthesis rule, artifact writer (JSON + mission-log markdown), N−1 degrade path. |
+| **Day 2 PM** | B2 finish: catch-rate field, design-doc-creator SKILL.md hook paragraph, bounded integration tests (degrade, any-reject, unanimous-pass), cost check. CHANGELOG + example. Commit + PR. |
+
+## Success metrics
+- Phase A: all six safety invariants proven unchanged; dry-run + fall-through smoke green.
+- Phase B: quorum runs a real design doc for **cents**, emits both artifacts, degrades to N−1
+  **visibly**, and is reachable via a documented hook — **zero inner-loop skill-contract changes**.
+- Gemini reviewer works on the rig **without `GEMINI_API_KEY`** (Vertex ADC), proving the doc's
+  flagged risk is mitigated, not blocking.
+- Tests added; superseded tests removed (coding-standards). `make test` + `bash -n` green.
+
+## Bounded-wait discipline (mission gate 8)
+Every live-ish test is time-boxed: dry-run is a single invocation; the fall-through smoke is killed
+at the model-selection log line (≤2 min); the degrade integration test caps at ≤5 min. **No unbounded
+polls anywhere** — this is the iteration-13 wedge lesson.
+
+## Deployment / activation
+- **Phase A: NONE required** — already committed AND on-disk in the main checkout (launchd reads it).
+- **Phase B: no driver deployment** — Phase B is an on-demand tool + a skill-doc hook, invoked inside
+  a mission iteration; it does not modify `mission-control.sh`, so no launchd/on-disk sync is needed.
+- If any future Phase-B change DID touch `mission-control.sh`: the main tree is currently **dirty**
+  (`sprint_M-CODEGEN-IR.json`, `BenchmarkGallery.jsx` — sibling work) → an automated `git pull` is
+  **forbidden** (Principle 0). Controller may `git pull --ff-only` **only** after verifying the dirty
+  paths don't include `tools/launchd/`; otherwise **park for human**. (Not triggered this sprint.)
+
+## Non-Goals (this sprint)
+- Phases C, D, E (cross-provider executors, local-GPU lane, assignment table) — explicitly OUT.
+- Rebuilding the `ailang exec` unification (the stalled ledger path) — avoided by design.
+- Changing inner-loop skill **contracts** — only a documented optional hook is added.
+- Any GPU work / `rig.lock` touch — none.
+- Reading subscription quota gauges directly — the probe is the deliberate substitute (unchanged).
+
+## Parked for human
+- **Was Phase A meant to be built THIS sprint?** It landed ~3h before planning (`3bee6b6df`), so this
+  sprint verifies rather than builds it. Flag to controller in case a duplicate build was expected.
+- **`gemini-3-pro` = "latest pro"?** Doc says "gemini (latest pro)"; rig has `gemini-3-pro` +
+  `gemini-3-1-pro` in models.yml. Executor should pick `gemini-3-1-pro` if it's the newer pro and
+  ADC-reachable; else `gemini-3-pro`. (Both are Vertex-ADC; either works — human/executor pick.)
+- **Quorum-on-sprint-plans?** Doc says design docs "and optionally sprint plans". This sprint scopes
+  the hook to **design docs only**; sprint-plan quorum deferred unless the controller wants it now.

--- a/design_docs/planned/v0_30_0/m-mission-fleet-ab-sprint-plan.md
+++ b/design_docs/planned/v0_30_0/m-mission-fleet-ab-sprint-plan.md
@@ -105,9 +105,12 @@ Findings:
 5. Confirm deployment: main-checkout on-disk script contains `_mc_probe` (5 matches — confirmed).
    **No deployment action needed** (already deployed).
 
-**Acceptance**
-- `bash -n` clean; dry-run exits 0 with no probes; fall-through selects the next candidate within
-  the ≤2-min bounded window; all six safety invariants present and unchanged; deployment confirmed.
+**Acceptance** — ✅ ALL MET (verified 2026-07-14, exec)
+- [x] `bash -n` clean (exit 0).
+- [x] dry-run exits 0 with no probes (`DRY RUN ok … prefs=claude-fable-5,claude-opus-4-8`; step-3 dry-run precedes step-4 `select_model`).
+- [x] fall-through selects the next candidate within the bounded window: real `select_model` block (sed `88,134p`) + stubbed `claude` → `bogus-model-xyz … falling through` → selects `claude-opus-4-8` (`probe ok`), bounded 120s, zero real spend, no iteration launched.
+- [x] all six safety invariants present and unchanged: kill switch (:149), overlap guard (:159), stall watchdog (:73), `ANTHROPIC_API_KEY` strip (:41), subscription-billing probe uses `claude -p` never API (:97/:102), override+env pins (:90/:110/:112).
+- [x] deployment confirmed: main-checkout script has `_mc_probe` (3 matches). No driver edit made → no deployment action needed.
 
 **Risk**: LOW. Read-only verification of live code. The one live-ish test (task 3) is time-boxed and
 killed before the real iteration starts, so it cannot wedge the loop.

--- a/internal/mission/quorum/artifact.go
+++ b/internal/mission/quorum/artifact.go
@@ -1,0 +1,98 @@
+package quorum
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// ArtifactDir is where machine-readable quorum verdicts land. It seeds Phase E
+// (the assignment-table evidence). One JSON per doc per run.
+const ArtifactDir = ".ailang/state/mission-quorum"
+
+var slugRe = regexp.MustCompile(`[^a-z0-9]+`)
+
+// Slug turns a doc path into a filesystem-safe slug for the artifact name.
+func Slug(docPath string) string {
+	base := filepath.Base(docPath)
+	base = strings.TrimSuffix(base, filepath.Ext(base))
+	base = strings.ToLower(base)
+	base = slugRe.ReplaceAllString(base, "-")
+	base = strings.Trim(base, "-")
+	if base == "" {
+		base = "doc"
+	}
+	return base
+}
+
+// WriteJSONArtifact writes the machine-readable quorum verdict to
+// <dir>/<slug>-<iso8601>.json and returns the path. The iso timestamp in the
+// filename is sanitized (colons → dashes) for filesystem safety.
+func WriteJSONArtifact(dir string, q *QuorumResult) (string, error) {
+	if dir == "" {
+		dir = ArtifactDir
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("create artifact dir: %w", err)
+	}
+	tsSafe := strings.NewReplacer(":", "-", "/", "-").Replace(q.ISOTimestamp)
+	path := filepath.Join(dir, fmt.Sprintf("%s-%s.json", Slug(q.Doc), tsSafe))
+	b, err := json.MarshalIndent(q, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal quorum: %w", err)
+	}
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		return "", fmt.Errorf("write artifact: %w", err)
+	}
+	return path, nil
+}
+
+// MarkdownBlock renders the human-readable routing-evidence block appended to
+// the mission log (Gate 4). One line per reviewer + the synthesis verdict +
+// any named absentees. Deterministic (no map iteration).
+func MarkdownBlock(q *QuorumResult) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "#### Design-quorum review — `%s` (%s)\n\n", q.Doc, q.ISOTimestamp)
+	fmt.Fprintf(&b, "- **Synthesis: %s** (total $%.4f)\n", strings.ToUpper(string(q.Synthesis.Verdict)), q.Synthesis.TotalCostUSD)
+	for _, o := range q.Reviewers {
+		if o.Present {
+			fmt.Fprintf(&b, "- `%s` → **%s** ($%.4f) — %s\n", o.Model, o.Result.Verdict, o.CostUSD, o.Result.StrongestObjection)
+		} else {
+			fmt.Fprintf(&b, "- `%s` → **ABSENT** (%s) — degraded to N-1, not a silent pass\n", o.Model, o.AbsentReason)
+		}
+	}
+	if q.ControllerInSession != nil {
+		fmt.Fprintf(&b, "- controller (in-session, not an API call) → **%s** — %s\n", q.ControllerInSession.Verdict, q.ControllerInSession.Note)
+	}
+	if len(q.Synthesis.BlockingObjections) > 0 {
+		b.WriteString("- Blocking objections (return to author before planning):\n")
+		for _, obj := range q.Synthesis.BlockingObjections {
+			fmt.Fprintf(&b, "  - %s\n", obj)
+		}
+	}
+	return b.String()
+}
+
+// AppendMarkdownToLog appends the markdown block to the mission log file. If
+// logPath is empty, it is a no-op returning ("", nil) — the caller may prefer
+// to print the block for the controller to paste. Creating the file is allowed
+// (the log may not exist in a test fixture) but NOT the parent dirs beyond one
+// level, to avoid surprising writes.
+func AppendMarkdownToLog(logPath string, q *QuorumResult) (string, error) {
+	if logPath == "" {
+		return "", nil
+	}
+	block := "\n" + MarkdownBlock(q)
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return "", fmt.Errorf("open mission log %s: %w", logPath, err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(block); err != nil {
+		return "", fmt.Errorf("append to mission log: %w", err)
+	}
+	return logPath, nil
+}

--- a/internal/mission/quorum/artifact.go
+++ b/internal/mission/quorum/artifact.go
@@ -31,6 +31,12 @@ func Slug(docPath string) string {
 // WriteJSONArtifact writes the machine-readable quorum verdict to
 // <dir>/<slug>-<iso8601>.json and returns the path. The iso timestamp in the
 // filename is sanitized (colons → dashes) for filesystem safety.
+//
+// The write is collision-proof: two runs on the same doc within the same
+// second (or the same injected timestamp in tests) would otherwise share a
+// name and clobber, so we open with O_CREATE|O_EXCL and, on collision, retry
+// with a numeric suffix. Every run yields its own file (Principle 2 — evidence
+// is never silently overwritten).
 func WriteJSONArtifact(dir string, q *QuorumResult) (string, error) {
 	if dir == "" {
 		dir = ArtifactDir
@@ -38,16 +44,36 @@ func WriteJSONArtifact(dir string, q *QuorumResult) (string, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", fmt.Errorf("create artifact dir: %w", err)
 	}
-	tsSafe := strings.NewReplacer(":", "-", "/", "-").Replace(q.ISOTimestamp)
-	path := filepath.Join(dir, fmt.Sprintf("%s-%s.json", Slug(q.Doc), tsSafe))
 	b, err := json.MarshalIndent(q, "", "  ")
 	if err != nil {
 		return "", fmt.Errorf("marshal quorum: %w", err)
 	}
-	if err := os.WriteFile(path, b, 0o644); err != nil {
-		return "", fmt.Errorf("write artifact: %w", err)
+	tsSafe := strings.NewReplacer(":", "-", "/", "-").Replace(q.ISOTimestamp)
+	base := filepath.Join(dir, fmt.Sprintf("%s-%s", Slug(q.Doc), tsSafe))
+	// Try <base>.json first, then <base>-1.json, <base>-2.json, ... until an
+	// O_EXCL create succeeds — no existing artifact is ever clobbered.
+	for i := 0; ; i++ {
+		path := base + ".json"
+		if i > 0 {
+			path = fmt.Sprintf("%s-%d.json", base, i)
+		}
+		f, oerr := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+		if os.IsExist(oerr) {
+			continue
+		}
+		if oerr != nil {
+			return "", fmt.Errorf("create artifact: %w", oerr)
+		}
+		_, werr := f.Write(b)
+		cerr := f.Close()
+		if werr != nil {
+			return "", fmt.Errorf("write artifact: %w", werr)
+		}
+		if cerr != nil {
+			return "", fmt.Errorf("close artifact: %w", cerr)
+		}
+		return path, nil
 	}
-	return path, nil
 }
 
 // MarkdownBlock renders the human-readable routing-evidence block appended to

--- a/internal/mission/quorum/call.go
+++ b/internal/mission/quorum/call.go
@@ -1,0 +1,103 @@
+package quorum
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sunholo-data/ailang/internal/ai"
+	"github.com/sunholo-data/ailang/internal/ai/gemini"
+	"github.com/sunholo-data/ailang/internal/ai/openai"
+	"github.com/sunholo-data/ailang/internal/eval_harness"
+)
+
+// JSONCaller is the minimal provider surface the reviewer needs: a single
+// structured-JSON call plus token/cost details for budget accounting. Both
+// *ai.Handler (production) and the test stub satisfy it. Keeping the surface
+// this small is what lets us reuse the shipped handler without dragging in the
+// full effects.AIHandler machinery.
+type JSONCaller interface {
+	// CallJSON sends the prompt configured for JSON structured output and
+	// returns the raw JSON text plus the resolved response (for token/cost).
+	CallJSON(systemPrompt, userPrompt, schema string) (string, *ai.Response, error)
+}
+
+// handlerCaller adapts an *ai.Handler to JSONCaller. It uses
+// GenerateWithDetails so we recover token counts + provider-reported CostUSD
+// for the budget ledger.
+type handlerCaller struct {
+	handler *ai.Handler
+}
+
+func (c *handlerCaller) CallJSON(sysPrompt, userPrompt, schema string) (string, *ai.Response, error) {
+	// We drive the provider directly (not Handler.CallJson) so we can attach
+	// the reviewer system prompt per-call AND recover the full *ai.Response
+	// for cost accounting in one round-trip.
+	resp, err := c.handler.Provider().Generate(context.Background(), &ai.Request{
+		Model:          c.handler.Model(),
+		SystemPrompt:   sysPrompt,
+		UserPrompt:     userPrompt,
+		MaxTokens:      reviewMaxTokens,
+		ResponseFormat: "json",
+		ResponseSchema: schema,
+	})
+	if err != nil {
+		return "", nil, err
+	}
+	return strings.TrimSpace(resp.Text), resp, nil
+}
+
+// reviewMaxTokens caps reviewer output. Reviews are short structured JSON;
+// this both bounds cost and leaves reasoning headroom for the frontier models.
+const reviewMaxTokens = 4096
+
+// ResolveCaller builds a JSONCaller for a models.yml model id, wiring the
+// correct provider + auth from the shipped registry:
+//   - openai  → OPENAI_API_KEY (the rig has it)
+//   - google  → Vertex ADC (env_var is "" in models.yml; GEMINI_API_KEY is NOT
+//     consulted — that is the rig-absent var the design doc flagged), with the
+//     model's gcp_project exported so ADC resolves the right project.
+//
+// It refuses (hard error, Principle 2) when the required auth is unavailable
+// rather than silently falling back to a different provider/model.
+func ResolveCaller(modelID string) (JSONCaller, *eval_harness.ModelConfig, error) {
+	if err := eval_harness.InitModelsConfig(); err != nil {
+		return nil, nil, fmt.Errorf("load models.yml: %w", err)
+	}
+	mc, err := eval_harness.GlobalModelsConfig.GetModel(modelID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("model %q not in models.yml: %w", modelID, err)
+	}
+
+	var provider ai.Provider
+	switch ai.ProviderFromString(mc.Provider) {
+	case ai.ProviderOpenAI:
+		apiKey := os.Getenv("OPENAI_API_KEY")
+		if apiKey == "" {
+			return nil, nil, fmt.Errorf("reviewer %q needs OPENAI_API_KEY (openai provider) — not set", modelID)
+		}
+		provider = openai.NewClient(apiKey)
+
+	case ai.ProviderGoogle:
+		// Vertex ADC path — the design doc's flagged-but-mitigated route.
+		// Export the model's gcp_project so NewVertexAIClient/ADC resolves the
+		// right project on a rig where GOOGLE_CLOUD_PROJECT is unset. We do
+		// NOT read GEMINI_API_KEY (absent on the rig) — that is the whole point.
+		if mc.GCPProject != "" && os.Getenv("GOOGLE_CLOUD_PROJECT") == "" {
+			// Set for this process so the ADC client picks up the project.
+			_ = os.Setenv("GOOGLE_CLOUD_PROJECT", mc.GCPProject)
+		}
+		client, gerr := gemini.NewVertexAIClient(mc.GCPProject)
+		if gerr != nil {
+			return nil, nil, fmt.Errorf("reviewer %q needs Vertex ADC (gemini provider, gcp_project=%q) — %w", modelID, mc.GCPProject, gerr)
+		}
+		provider = client
+
+	default:
+		return nil, nil, fmt.Errorf("reviewer %q provider %q unsupported for quorum (want openai or google)", modelID, mc.Provider)
+	}
+
+	handler := ai.NewHandler(provider, mc.APIName, ai.WithMaxTokens(reviewMaxTokens))
+	return &handlerCaller{handler: handler}, mc, nil
+}

--- a/internal/mission/quorum/call.go
+++ b/internal/mission/quorum/call.go
@@ -2,15 +2,30 @@ package quorum
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/sunholo-data/ailang/internal/ai"
 	"github.com/sunholo-data/ailang/internal/ai/gemini"
 	"github.com/sunholo-data/ailang/internal/ai/openai"
 	"github.com/sunholo-data/ailang/internal/eval_harness"
 )
+
+// ErrUnknownModel is returned by ResolveCaller when the model id is not present
+// in models.yml. Callers use errors.Is to report a semantically correct
+// absence reason ("unknown-model") rather than lumping it under "auth".
+var ErrUnknownModel = errors.New("model not in models.yml")
+
+// googleEnvMu serializes the process-global os.Setenv of GOOGLE_CLOUD_PROJECT
+// below. RunQuorum resolves reviewers in PARALLEL, so two Google reviewers with
+// different gcp_project values could otherwise race on this shared env var (a
+// latent data race + a wrong-project mutation). The mutation is process-global
+// because the Vertex ADC client reads GOOGLE_CLOUD_PROJECT from the environment;
+// we serialize rather than restructure that contract.
+var googleEnvMu sync.Mutex
 
 // JSONCaller is the minimal provider surface the reviewer needs: a single
 // structured-JSON call plus token/cost details for budget accounting. Both
@@ -67,7 +82,7 @@ func ResolveCaller(modelID string) (JSONCaller, *eval_harness.ModelConfig, error
 	}
 	mc, err := eval_harness.GlobalModelsConfig.GetModel(modelID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("model %q not in models.yml: %w", modelID, err)
+		return nil, nil, fmt.Errorf("model %q not in models.yml: %w", modelID, ErrUnknownModel)
 	}
 
 	var provider ai.Provider
@@ -84,9 +99,16 @@ func ResolveCaller(modelID string) (JSONCaller, *eval_harness.ModelConfig, error
 		// Export the model's gcp_project so NewVertexAIClient/ADC resolves the
 		// right project on a rig where GOOGLE_CLOUD_PROJECT is unset. We do
 		// NOT read GEMINI_API_KEY (absent on the rig) — that is the whole point.
-		if mc.GCPProject != "" && os.Getenv("GOOGLE_CLOUD_PROJECT") == "" {
+		if mc.GCPProject != "" {
 			// Set for this process so the ADC client picks up the project.
-			_ = os.Setenv("GOOGLE_CLOUD_PROJECT", mc.GCPProject)
+			// Serialized: RunQuorum fans out reviewers in parallel and this env
+			// var is process-global (see googleEnvMu). Re-check inside the lock
+			// so we only mutate when still unset.
+			googleEnvMu.Lock()
+			if os.Getenv("GOOGLE_CLOUD_PROJECT") == "" {
+				_ = os.Setenv("GOOGLE_CLOUD_PROJECT", mc.GCPProject)
+			}
+			googleEnvMu.Unlock()
 		}
 		client, gerr := gemini.NewVertexAIClient(mc.GCPProject)
 		if gerr != nil {

--- a/internal/mission/quorum/call_test.go
+++ b/internal/mission/quorum/call_test.go
@@ -1,0 +1,88 @@
+package quorum
+
+import (
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/eval_harness"
+)
+
+// TestResolveCaller_OpenAIRequiresKey proves the openai reviewer path refuses
+// (hard error, no silent fallback) when OPENAI_API_KEY is absent — and does
+// NOT fall back to another provider.
+func TestResolveCaller_OpenAIRequiresKey(t *testing.T) {
+	if err := eval_harness.InitModelsConfig(); err != nil {
+		t.Skipf("models.yml unavailable: %v", err)
+	}
+	if _, err := eval_harness.GlobalModelsConfig.GetModel("gpt5-6-sol"); err != nil {
+		t.Skipf("gpt5-6-sol not in models.yml: %v", err)
+	}
+	t.Setenv("OPENAI_API_KEY", "")
+
+	_, _, err := ResolveCaller("gpt5-6-sol")
+	if err == nil {
+		t.Fatal("expected hard error when OPENAI_API_KEY is empty, got nil")
+	}
+	if !containsAll(err.Error(), "OPENAI_API_KEY") {
+		t.Errorf("error should name the missing key, got: %v", err)
+	}
+}
+
+// TestResolveCaller_GeminiDoesNotReadGeminiKey proves the google reviewer path
+// resolves via the models.yml provider=google (Vertex ADC) route and does NOT
+// depend on GEMINI_API_KEY (the rig-absent var the design doc flagged). We set
+// GEMINI_API_KEY to empty and assert resolution does not error FOR THAT REASON
+// — it only fails if ADC itself is unavailable (a different, named error).
+func TestResolveCaller_GeminiDoesNotReadGeminiKey(t *testing.T) {
+	if err := eval_harness.InitModelsConfig(); err != nil {
+		t.Skipf("models.yml unavailable: %v", err)
+	}
+	mc, err := eval_harness.GlobalModelsConfig.GetModel("gemini-3-1-pro")
+	if err != nil {
+		t.Skipf("gemini-3-1-pro not in models.yml: %v", err)
+	}
+	// Assert the config itself proves the ADC route: env_var empty, provider
+	// google, gcp_project set. This is the static guarantee that GEMINI_API_KEY
+	// is never consulted — independent of whether ADC is live in CI.
+	if mc.Provider != "google" {
+		t.Errorf("gemini-3-1-pro provider = %q, want google", mc.Provider)
+	}
+	if mc.EnvVar != "" {
+		t.Errorf("gemini-3-1-pro env_var = %q, want empty (ADC path, not GEMINI_API_KEY)", mc.EnvVar)
+	}
+	if mc.GCPProject == "" {
+		t.Errorf("gemini-3-1-pro gcp_project empty; ADC needs a project")
+	}
+
+	t.Setenv("GEMINI_API_KEY", "")
+	_, _, rerr := ResolveCaller("gemini-3-1-pro")
+	if rerr != nil {
+		// Only acceptable failure is ADC being unavailable in CI — and the
+		// error must be about ADC/Vertex, NEVER about GEMINI_API_KEY.
+		if containsAll(rerr.Error(), "GEMINI_API_KEY") {
+			t.Fatalf("gemini resolution referenced GEMINI_API_KEY — the ADC route regressed: %v", rerr)
+		}
+		t.Logf("gemini resolve failed on ADC (expected in CI without ADC): %v", rerr)
+	}
+}
+
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if !contains(s, sub) {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/mission/quorum/quorum.go
+++ b/internal/mission/quorum/quorum.go
@@ -92,7 +92,10 @@ func RunQuorum(docPath, docBody, isoTS string, reviewerModels []string, maxCostU
 // Absent reviewers are recorded but do not vote; they can never turn a real
 // reject into a proceed, and their absence is always visible (Principle 2).
 func synthesize(outcomes []*ReviewerOutcome, controller *ControllerReview) Synthesis {
-	s := Synthesis{Verdict: SynthProceed}
+	// AbsentReviewers is initialized to a non-nil empty slice so it marshals as
+	// [] (not null) when every reviewer was present — a consistent JSON shape
+	// for Phase E consumers.
+	s := Synthesis{Verdict: SynthProceed, AbsentReviewers: []AbsentNote{}}
 	presentCount := 0
 
 	for _, o := range outcomes {

--- a/internal/mission/quorum/quorum.go
+++ b/internal/mission/quorum/quorum.go
@@ -1,0 +1,131 @@
+package quorum
+
+import (
+	"fmt"
+	"sync"
+)
+
+// SynthesisVerdict is the quorum's composed decision.
+type SynthesisVerdict string
+
+const (
+	// SynthProceed: unanimous pass among PRESENT reviewers → the doc proceeds.
+	SynthProceed SynthesisVerdict = "proceed"
+	// SynthBlocked: at least one present reviewer rejected → the objection
+	// goes back to the doc author before planning.
+	SynthBlocked SynthesisVerdict = "blocked"
+)
+
+// ControllerReview is the Claude controller's IN-SESSION judgement. It is NOT
+// an API call (design doc gate 6) — the running mission-control skill fills it
+// in from its own reasoning. Recorded as a distinct entry so the artifact
+// shows the controller participated without pretending it was a provider call.
+type ControllerReview struct {
+	Verdict Verdict `json:"verdict"`
+	Note    string  `json:"note"`
+}
+
+// QuorumResult is the full composed verdict + the per-reviewer records + the
+// controller's in-session review. It is the artifact that seeds Phase E.
+type QuorumResult struct {
+	Doc                 string             `json:"doc"`
+	ISOTimestamp        string             `json:"iso_ts"`
+	Reviewers           []*ReviewerOutcome `json:"reviewers"`
+	ControllerInSession *ControllerReview  `json:"controller_in_session,omitempty"`
+	Synthesis           Synthesis          `json:"synthesis"`
+}
+
+// Synthesis is the composed decision plus the specific blocking objections and
+// an explicit list of absent reviewers (never a silent pass).
+type Synthesis struct {
+	Verdict            SynthesisVerdict `json:"verdict"`
+	BlockingObjections []string         `json:"blocking_objections"`
+	// AbsentReviewers names every reviewer that did not produce a verdict,
+	// with its reason. Empty when all reviewers were present.
+	AbsentReviewers []AbsentNote `json:"absent_reviewers"`
+	TotalCostUSD    float64      `json:"total_cost_usd"`
+}
+
+// AbsentNote records one missing reviewer for the synthesis.
+type AbsentNote struct {
+	Model  string `json:"model"`
+	Reason string `json:"reason"`
+}
+
+// RunQuorum runs the given reviewer models in PARALLEL and composes their
+// verdicts. The controller's in-session review (if provided) is folded into
+// the synthesis as a distinct participant. Degradation is graceful: an absent
+// reviewer is recorded (named, with reason) and the quorum proceeds with the
+// remaining present reviewers — a missing reviewer is NEVER a silent pass.
+//
+// runner is the per-reviewer function (RunReviewer in production; a stub in
+// tests). isoTS is injected so the artifact timestamp is deterministic in
+// tests.
+func RunQuorum(docPath, docBody, isoTS string, reviewerModels []string, maxCostUSD float64, controller *ControllerReview, runner func(model, docPath, docBody string, maxCostUSD float64) *ReviewerOutcome) *QuorumResult {
+	outcomes := make([]*ReviewerOutcome, len(reviewerModels))
+	var wg sync.WaitGroup
+	for i, model := range reviewerModels {
+		wg.Add(1)
+		go func(i int, model string) {
+			defer wg.Done()
+			outcomes[i] = runner(model, docPath, docBody, maxCostUSD)
+		}(i, model)
+	}
+	wg.Wait()
+
+	return &QuorumResult{
+		Doc:                 docPath,
+		ISOTimestamp:        isoTS,
+		Reviewers:           outcomes,
+		ControllerInSession: controller,
+		Synthesis:           synthesize(outcomes, controller),
+	}
+}
+
+// synthesize composes present reviewers + the controller into a verdict.
+//
+// Rule (from the design doc):
+//   - any present reviewer (or the controller) REJECTS → blocked; the objection
+//     goes back to the author.
+//   - all present participants PASS → proceed.
+//
+// Absent reviewers are recorded but do not vote; they can never turn a real
+// reject into a proceed, and their absence is always visible (Principle 2).
+func synthesize(outcomes []*ReviewerOutcome, controller *ControllerReview) Synthesis {
+	s := Synthesis{Verdict: SynthProceed}
+	presentCount := 0
+
+	for _, o := range outcomes {
+		s.TotalCostUSD += o.CostUSD
+		if !o.Present {
+			s.AbsentReviewers = append(s.AbsentReviewers, AbsentNote{Model: o.Model, Reason: o.AbsentReason})
+			continue
+		}
+		presentCount++
+		if o.Result.Verdict == VerdictReject {
+			s.Verdict = SynthBlocked
+			s.BlockingObjections = append(s.BlockingObjections,
+				fmt.Sprintf("%s: %s", o.Model, o.Result.StrongestObjection))
+		}
+	}
+
+	if controller != nil {
+		presentCount++
+		if controller.Verdict == VerdictReject {
+			s.Verdict = SynthBlocked
+			s.BlockingObjections = append(s.BlockingObjections,
+				fmt.Sprintf("controller (in-session): %s", controller.Note))
+		}
+	}
+
+	// Guard: if NO participant was present at all, that is not a pass — it is a
+	// blocked verdict with a synthetic objection so the loop never proceeds on
+	// zero signal (Principle 2 at the quorum level).
+	if presentCount == 0 {
+		s.Verdict = SynthBlocked
+		s.BlockingObjections = append(s.BlockingObjections,
+			"no reviewer produced a verdict (all absent) — refusing to proceed on zero signal")
+	}
+
+	return s
+}

--- a/internal/mission/quorum/quorum_test.go
+++ b/internal/mission/quorum/quorum_test.go
@@ -1,0 +1,158 @@
+package quorum
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeRunner builds a deterministic per-model runner from a table so quorum
+// tests never touch a real provider.
+func fakeRunner(table map[string]*ReviewerOutcome) func(model, docPath, docBody string, maxCostUSD float64) *ReviewerOutcome {
+	return func(model, _, _ string, _ float64) *ReviewerOutcome {
+		if o, ok := table[model]; ok {
+			return o
+		}
+		return &ReviewerOutcome{Model: model, AbsentReason: ReasonUnreachable, Err: "not in table"}
+	}
+}
+
+func present(model string, v Verdict, obj string) *ReviewerOutcome {
+	return &ReviewerOutcome{
+		Model:   model,
+		Present: true,
+		CostUSD: 0.01,
+		Result:  &ReviewResult{Verdict: v, StrongestObjection: obj, Catch: "c"},
+	}
+}
+
+func TestRunQuorum_UnanimousPassProceeds(t *testing.T) {
+	table := map[string]*ReviewerOutcome{
+		"m1": present("m1", VerdictPass, "minor"),
+		"m2": present("m2", VerdictPass, "minor"),
+	}
+	q := RunQuorum("doc.md", "body", "2026-07-14T00:00:00Z", []string{"m1", "m2"}, 0.10, nil, fakeRunner(table))
+	if q.Synthesis.Verdict != SynthProceed {
+		t.Fatalf("verdict = %q, want proceed", q.Synthesis.Verdict)
+	}
+	if len(q.Synthesis.BlockingObjections) != 0 {
+		t.Errorf("unexpected blocking objections: %v", q.Synthesis.BlockingObjections)
+	}
+	if q.Synthesis.TotalCostUSD < 0.019 || q.Synthesis.TotalCostUSD > 0.021 {
+		t.Errorf("total cost = %f, want ~0.02", q.Synthesis.TotalCostUSD)
+	}
+}
+
+func TestRunQuorum_AnyRejectBlocks(t *testing.T) {
+	table := map[string]*ReviewerOutcome{
+		"m1": present("m1", VerdictPass, "minor"),
+		"m2": present("m2", VerdictReject, "premise X unverified"),
+	}
+	q := RunQuorum("doc.md", "body", "t", []string{"m1", "m2"}, 0.10, nil, fakeRunner(table))
+	if q.Synthesis.Verdict != SynthBlocked {
+		t.Fatalf("verdict = %q, want blocked", q.Synthesis.Verdict)
+	}
+	if len(q.Synthesis.BlockingObjections) != 1 || !strings.Contains(q.Synthesis.BlockingObjections[0], "premise X unverified") {
+		t.Errorf("blocking objections = %v, want the m2 objection", q.Synthesis.BlockingObjections)
+	}
+}
+
+func TestRunQuorum_ControllerRejectBlocks(t *testing.T) {
+	table := map[string]*ReviewerOutcome{
+		"m1": present("m1", VerdictPass, "minor"),
+	}
+	ctrl := &ControllerReview{Verdict: VerdictReject, Note: "controller sees an axiom conflict"}
+	q := RunQuorum("doc.md", "body", "t", []string{"m1"}, 0.10, ctrl, fakeRunner(table))
+	if q.Synthesis.Verdict != SynthBlocked {
+		t.Fatalf("verdict = %q, want blocked (controller rejected)", q.Synthesis.Verdict)
+	}
+	if q.ControllerInSession == nil || q.ControllerInSession.Verdict != VerdictReject {
+		t.Errorf("controller review not recorded as a distinct entry")
+	}
+}
+
+func TestRunQuorum_NMinus1DegradeNamesAbsentee(t *testing.T) {
+	table := map[string]*ReviewerOutcome{
+		"m1": present("m1", VerdictPass, "minor"),
+		"m2": {Model: "m2", Present: false, AbsentReason: ReasonUnreachable, Err: "provider down"},
+	}
+	q := RunQuorum("doc.md", "body", "t", []string{"m1", "m2"}, 0.10, nil, fakeRunner(table))
+
+	// Proceeds with N-1 (only m1 present, and it passed) ...
+	if q.Synthesis.Verdict != SynthProceed {
+		t.Fatalf("verdict = %q, want proceed on N-1", q.Synthesis.Verdict)
+	}
+	// ... but the absence is NAMED, never silent.
+	if len(q.Synthesis.AbsentReviewers) != 1 {
+		t.Fatalf("absent reviewers = %v, want 1", q.Synthesis.AbsentReviewers)
+	}
+	if q.Synthesis.AbsentReviewers[0].Model != "m2" || q.Synthesis.AbsentReviewers[0].Reason != ReasonUnreachable {
+		t.Errorf("absentee not named correctly: %+v", q.Synthesis.AbsentReviewers[0])
+	}
+}
+
+func TestRunQuorum_AllAbsentRefusesToProceed(t *testing.T) {
+	table := map[string]*ReviewerOutcome{
+		"m1": {Model: "m1", Present: false, AbsentReason: ReasonAuth},
+		"m2": {Model: "m2", Present: false, AbsentReason: ReasonBudget},
+	}
+	q := RunQuorum("doc.md", "body", "t", []string{"m1", "m2"}, 0.10, nil, fakeRunner(table))
+	// Zero signal must NOT be a silent proceed.
+	if q.Synthesis.Verdict != SynthBlocked {
+		t.Fatalf("verdict = %q, want blocked (all absent = zero signal)", q.Synthesis.Verdict)
+	}
+	if len(q.Synthesis.AbsentReviewers) != 2 {
+		t.Errorf("want 2 named absentees, got %d", len(q.Synthesis.AbsentReviewers))
+	}
+}
+
+func TestWriteJSONArtifactAndMarkdown(t *testing.T) {
+	table := map[string]*ReviewerOutcome{
+		"m1": present("m1", VerdictReject, "objection Y"),
+		"m2": {Model: "m2", Present: false, AbsentReason: ReasonBudget},
+	}
+	q := RunQuorum("design_docs/foo-bar.md", "body", "2026-07-14T12:00:00Z", []string{"m1", "m2"}, 0.10, nil, fakeRunner(table))
+
+	dir := t.TempDir()
+	path, err := WriteJSONArtifact(dir, q)
+	if err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+	if !strings.HasPrefix(filepath.Base(path), "foo-bar-") || !strings.HasSuffix(path, ".json") {
+		t.Errorf("artifact name unexpected: %s", path)
+	}
+	// Round-trips to valid JSON with the expected shape.
+	b, _ := os.ReadFile(path)
+	var back QuorumResult
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("artifact not valid JSON: %v", err)
+	}
+	if back.Synthesis.Verdict != SynthBlocked {
+		t.Errorf("round-tripped verdict = %q, want blocked", back.Synthesis.Verdict)
+	}
+
+	md := MarkdownBlock(q)
+	for _, want := range []string{"BLOCKED", "m1", "reject", "objection Y", "ABSENT", "budget"} {
+		if !strings.Contains(md, want) {
+			t.Errorf("markdown block missing %q:\n%s", want, md)
+		}
+	}
+}
+
+func TestAppendMarkdownToLog(t *testing.T) {
+	q := RunQuorum("doc.md", "body", "t", []string{"m1"}, 0.10, nil,
+		fakeRunner(map[string]*ReviewerOutcome{"m1": present("m1", VerdictPass, "minor")}))
+	logFile := filepath.Join(t.TempDir(), "mission-log.md")
+	if err := os.WriteFile(logFile, []byte("# existing\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := AppendMarkdownToLog(logFile, q); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	b, _ := os.ReadFile(logFile)
+	if !strings.Contains(string(b), "# existing") || !strings.Contains(string(b), "Design-quorum review") {
+		t.Errorf("append did not preserve+add content:\n%s", b)
+	}
+}

--- a/internal/mission/quorum/quorum_test.go
+++ b/internal/mission/quorum/quorum_test.go
@@ -141,6 +141,56 @@ func TestWriteJSONArtifactAndMarkdown(t *testing.T) {
 	}
 }
 
+// TestWriteJSONArtifact_NoClobberOnSameSecond proves two immediate successive
+// writes for the SAME doc + SAME timestamp yield two distinct files rather than
+// clobbering — the O_CREATE|O_EXCL + suffix-retry guard.
+func TestWriteJSONArtifact_NoClobberOnSameSecond(t *testing.T) {
+	q := RunQuorum("design_docs/foo-bar.md", "body", "2026-07-14T12:00:00Z", []string{"m1"}, 0.10, nil,
+		fakeRunner(map[string]*ReviewerOutcome{"m1": present("m1", VerdictPass, "minor")}))
+
+	dir := t.TempDir()
+	p1, err := WriteJSONArtifact(dir, q)
+	if err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	p2, err := WriteJSONArtifact(dir, q)
+	if err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	if p1 == p2 {
+		t.Fatalf("same-second writes clobbered: both wrote %s", p1)
+	}
+	// Both files must exist on disk (neither overwritten).
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("want 2 artifact files, got %d: %v", len(entries), names)
+	}
+}
+
+// TestSynthesis_AbsentReviewersMarshalsAsEmptySlice proves the absent_reviewers
+// field marshals as [] (not null) when all reviewers were present.
+func TestSynthesis_AbsentReviewersMarshalsAsEmptySlice(t *testing.T) {
+	q := RunQuorum("doc.md", "body", "t", []string{"m1"}, 0.10, nil,
+		fakeRunner(map[string]*ReviewerOutcome{"m1": present("m1", VerdictPass, "minor")}))
+	if q.Synthesis.AbsentReviewers == nil {
+		t.Fatal("AbsentReviewers is nil; want non-nil empty slice")
+	}
+	b, err := json.Marshal(q.Synthesis)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), `"absent_reviewers":[]`) {
+		t.Errorf("absent_reviewers did not marshal as []:\n%s", b)
+	}
+}
+
 func TestAppendMarkdownToLog(t *testing.T) {
 	q := RunQuorum("doc.md", "body", "t", []string{"m1"}, 0.10, nil,
 		fakeRunner(map[string]*ReviewerOutcome{"m1": present("m1", VerdictPass, "minor")}))

--- a/internal/mission/quorum/reviewer.go
+++ b/internal/mission/quorum/reviewer.go
@@ -1,0 +1,148 @@
+// Package quorum implements the mission fleet's design-doc quorum review
+// (M-MISSION-FLEET-AB, Phase B). It composes N independent off-Anthropic
+// frontier reviewers (via the shipped internal/ai handlers + the models.yml
+// resolver) into a single reject-by-default verdict, with graceful N-1
+// degradation that always NAMES an absent reviewer (never a silent pass).
+//
+// It deliberately rides the already-shipped primitives (Critical Principle 1,
+// and the design doc's BINDING redundancy audit): text providers in
+// internal/ai/{openai,gemini}, the eval_harness models.yml registry, and the
+// Handler.CallJson surface. It does NOT rebuild the stalled `ailang exec`
+// unification path.
+package quorum
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Verdict is a reviewer's binary judgement. Reject-by-default: a reviewer
+// that cannot articulate a strong objection still must return an explicit
+// pass; there is no implicit/empty state.
+type Verdict string
+
+const (
+	// VerdictPass means the reviewer found no blocking objection.
+	VerdictPass Verdict = "pass"
+	// VerdictReject means the reviewer found a blocking objection; the
+	// strongest one MUST be populated in ReviewResult.StrongestObjection.
+	VerdictReject Verdict = "reject"
+)
+
+// ReviewResult is one reviewer's structured verdict on a design doc.
+//
+// The schema is enforced two ways: the provider is asked for JSON conforming
+// to reviewSchema, AND ValidateReviewResult re-checks the parsed result so a
+// malformed or gate-violating response is a hard error, never a silent pass
+// (Critical Principle 2 — no silent fallbacks).
+type ReviewResult struct {
+	// Verdict is "pass" or "reject". Any other value is a hard error.
+	Verdict Verdict `json:"verdict"`
+	// StrongestObjection is the single most important reason to reject or,
+	// on a pass, the closest thing to a concern the reviewer could find.
+	// REQUIRED and non-empty on a reject; the reject-by-default lever.
+	StrongestObjection string `json:"strongest_objection"`
+	// Catch is free-text: the specific thing the reviewer would flag to the
+	// doc author (a premise gap, a Conflict-Surface omission, an axiom
+	// violation, etc.). Required non-empty.
+	Catch string `json:"catch"`
+}
+
+// reviewSchema is the JSON schema handed to CallJson so schema-supporting
+// providers enforce structure server-side. ValidateReviewResult re-checks it
+// regardless (providers vary in enforcement strength).
+const reviewSchema = `{
+  "type": "object",
+  "properties": {
+    "verdict": {"type": "string", "enum": ["pass", "reject"]},
+    "strongest_objection": {"type": "string"},
+    "catch": {"type": "string"}
+  },
+  "required": ["verdict", "strongest_objection", "catch"]
+}`
+
+// systemPrompt is the reject-by-default reviewer instruction. It scores
+// against the design-doc-creator hard gates (premise verification, Conflict
+// Surface, axiom compliance) and forces a strongest-objection field so
+// reviewers cannot rubber-stamp (the LGTM-bias risk in the design doc's risk
+// table).
+const systemPrompt = `You are an adversarial design-doc reviewer for the AILANG mission. Your job is to REJECT by default.
+
+Score the document against these hard gates:
+1. PREMISE VERIFICATION — is every factual claim about the codebase (files, APIs, behavior) verified, or asserted? Unverified premises are grounds to reject.
+2. CONFLICT SURFACE — does the doc identify what existing machinery it overlaps/conflicts with, and justify not reusing it? A missing conflict-surface analysis is grounds to reject.
+3. AXIOM COMPLIANCE — does it respect the mission axioms: minimal frozen core, route-to-extension bias, no silent fallbacks, bounded waits, deterministic behavior?
+
+You MUST return a single JSON object with exactly these fields:
+- "verdict": "pass" or "reject"
+- "strongest_objection": the SINGLE most important reason this doc should not proceed as written. On a reject this MUST be a concrete, specific objection (never empty, never "looks fine"). On a pass, state the closest concern you could find.
+- "catch": the specific thing you would flag to the author to fix or verify.
+
+Do not praise. Do not summarize the doc. Output ONLY the JSON object, no prose, no code fences.`
+
+// BuildPrompt returns the user prompt for reviewing a design doc.
+func BuildPrompt(docPath, docBody string) string {
+	var b strings.Builder
+	b.WriteString("Review this AILANG mission design doc")
+	if docPath != "" {
+		b.WriteString(" (" + docPath + ")")
+	}
+	b.WriteString(". Apply the reject-by-default rubric.\n\n---\n")
+	b.WriteString(docBody)
+	b.WriteString("\n---\n")
+	return b.String()
+}
+
+// ParseReviewResult parses a provider's JSON response into a ReviewResult and
+// validates it. A malformed or gate-violating response is a hard error.
+func ParseReviewResult(raw string) (*ReviewResult, error) {
+	trimmed := stripCodeFences(strings.TrimSpace(raw))
+	var r ReviewResult
+	if err := json.Unmarshal([]byte(trimmed), &r); err != nil {
+		return nil, fmt.Errorf("reviewer returned non-JSON or malformed response: %w (raw: %.200q)", err, trimmed)
+	}
+	if err := ValidateReviewResult(&r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+// ValidateReviewResult enforces the reject-by-default contract:
+//   - verdict must be exactly "pass" or "reject";
+//   - strongest_objection must be non-empty (ALWAYS — a reject with no
+//     objection is the LGTM-bias failure we are guarding against, and a pass
+//     must still name its closest concern);
+//   - catch must be non-empty.
+//
+// Any violation is an error, never a coerced pass (Critical Principle 2).
+func ValidateReviewResult(r *ReviewResult) error {
+	switch r.Verdict {
+	case VerdictPass, VerdictReject:
+	default:
+		return fmt.Errorf("reviewer verdict %q is not one of {pass, reject}", r.Verdict)
+	}
+	if strings.TrimSpace(r.StrongestObjection) == "" {
+		return fmt.Errorf("reviewer verdict %q has empty strongest_objection (reject-by-default requires a stated objection; a missing one is not a pass)", r.Verdict)
+	}
+	if strings.TrimSpace(r.Catch) == "" {
+		return fmt.Errorf("reviewer verdict %q has empty catch field", r.Verdict)
+	}
+	return nil
+}
+
+// stripCodeFences removes a leading ```json / ``` fence and trailing ``` if a
+// provider wrapped the JSON despite the instruction not to.
+func stripCodeFences(s string) string {
+	if !strings.HasPrefix(s, "```") {
+		return s
+	}
+	// Drop first line (```json or ```)
+	if nl := strings.IndexByte(s, '\n'); nl >= 0 {
+		s = s[nl+1:]
+	}
+	if idx := strings.LastIndex(s, "```"); idx >= 0 {
+		s = s[:idx]
+	}
+	return strings.TrimSpace(s)
+}

--- a/internal/mission/quorum/reviewer_test.go
+++ b/internal/mission/quorum/reviewer_test.go
@@ -80,6 +80,25 @@ func TestValidateReviewResult_EmptyObjectionIsHardError(t *testing.T) {
 	}
 }
 
+// TestRunReviewer_UnknownModelIsNamedAbsence proves an unknown model id is
+// reported with the semantically correct reason "unknown-model" (not "auth"),
+// while staying loud: Present=false with a named reason.
+func TestRunReviewer_UnknownModelIsNamedAbsence(t *testing.T) {
+	if err := eval_harness.InitModelsConfig(); err != nil {
+		t.Skipf("models.yml unavailable: %v", err)
+	}
+	got := RunReviewer("definitely-not-a-real-model-id", "doc.md", "body", DefaultMaxCostUSD)
+	if got.Present {
+		t.Fatalf("expected absent for unknown model id")
+	}
+	if got.AbsentReason != ReasonUnknownModel {
+		t.Errorf("absent reason = %q, want %q", got.AbsentReason, ReasonUnknownModel)
+	}
+	if got.Err == "" {
+		t.Errorf("unknown-model absence must still carry an error (named, not silent)")
+	}
+}
+
 func TestRunReviewerWith_ValidVerdict(t *testing.T) {
 	stub := &stubCaller{
 		raw:  `{"verdict":"pass","strongest_objection":"none material","catch":"double-check the cost cap"}`,

--- a/internal/mission/quorum/reviewer_test.go
+++ b/internal/mission/quorum/reviewer_test.go
@@ -1,0 +1,166 @@
+package quorum
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/ai"
+	"github.com/sunholo-data/ailang/internal/eval_harness"
+)
+
+// stubCaller is a JSONCaller test double: it returns a canned raw JSON string
+// and response, or a canned error, without touching any real provider.
+type stubCaller struct {
+	raw  string
+	resp *ai.Response
+	err  error
+	// captured inputs for assertion
+	gotSystem string
+	gotSchema string
+}
+
+func (s *stubCaller) CallJSON(sysPrompt, userPrompt, schema string) (string, *ai.Response, error) {
+	s.gotSystem = sysPrompt
+	s.gotSchema = schema
+	if s.err != nil {
+		return "", nil, s.err
+	}
+	return s.raw, s.resp, nil
+}
+
+// cheapModel is a synthetic pricing config keeping estimateCost well under any
+// realistic cap so budget tests are deterministic.
+func cheapModel() *eval_harness.ModelConfig {
+	return &eval_harness.ModelConfig{
+		APIName:  "test-model",
+		Provider: "openai",
+		Pricing:  eval_harness.Pricing{InputPer1K: 0.001, OutputPer1K: 0.002},
+	}
+}
+
+func TestParseReviewResult_SchemaConformance(t *testing.T) {
+	raw := `{"verdict":"reject","strongest_objection":"premise unverified: claims file X exists","catch":"verify internal/foo.go before planning"}`
+	r, err := ParseReviewResult(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Verdict != VerdictReject {
+		t.Errorf("verdict = %q, want reject", r.Verdict)
+	}
+	if r.StrongestObjection == "" || r.Catch == "" {
+		t.Errorf("required fields empty: %+v", r)
+	}
+}
+
+func TestParseReviewResult_StripsCodeFences(t *testing.T) {
+	raw := "```json\n{\"verdict\":\"pass\",\"strongest_objection\":\"minor: naming\",\"catch\":\"consider renaming\"}\n```"
+	r, err := ParseReviewResult(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Verdict != VerdictPass {
+		t.Errorf("verdict = %q, want pass", r.Verdict)
+	}
+}
+
+func TestValidateReviewResult_EmptyObjectionIsHardError(t *testing.T) {
+	// A reject with an empty strongest_objection is the LGTM-bias failure we
+	// guard against — MUST be an error, never a coerced pass.
+	cases := []*ReviewResult{
+		{Verdict: VerdictReject, StrongestObjection: "", Catch: "x"},
+		{Verdict: VerdictPass, StrongestObjection: "  ", Catch: "x"},
+		{Verdict: VerdictPass, StrongestObjection: "y", Catch: ""},
+		{Verdict: Verdict("maybe"), StrongestObjection: "y", Catch: "z"},
+	}
+	for i, c := range cases {
+		if err := ValidateReviewResult(c); err == nil {
+			t.Errorf("case %d: expected hard error for %+v, got nil", i, c)
+		}
+	}
+}
+
+func TestRunReviewerWith_ValidVerdict(t *testing.T) {
+	stub := &stubCaller{
+		raw:  `{"verdict":"pass","strongest_objection":"none material","catch":"double-check the cost cap"}`,
+		resp: &ai.Response{InputTokens: 1000, OutputTokens: 200},
+	}
+	out := &ReviewerOutcome{Model: "test-model"}
+	got := runReviewerWith(stub, cheapModel(), out, "doc.md", "some body", DefaultMaxCostUSD)
+
+	if !got.Present {
+		t.Fatalf("expected Present, got absent: %s", got.Err)
+	}
+	if got.Result.Verdict != VerdictPass {
+		t.Errorf("verdict = %q, want pass", got.Result.Verdict)
+	}
+	// cost = 1000/1000*0.001 + 200/1000*0.002 = 0.001 + 0.0004 = 0.0014
+	if got.CostUSD < 0.0013 || got.CostUSD > 0.0015 {
+		t.Errorf("cost = %f, want ~0.0014", got.CostUSD)
+	}
+	// system prompt + schema must have been passed through
+	if !strings.Contains(stub.gotSystem, "REJECT by default") {
+		t.Errorf("reviewer system prompt not passed to caller")
+	}
+	if !strings.Contains(stub.gotSchema, "strongest_objection") {
+		t.Errorf("schema not passed to caller")
+	}
+}
+
+func TestRunReviewerWith_MalformedResponseIsInvalidAbsence(t *testing.T) {
+	stub := &stubCaller{
+		raw:  `{"verdict":"reject","strongest_objection":"","catch":""}`, // gate violation
+		resp: &ai.Response{InputTokens: 100, OutputTokens: 10},
+	}
+	out := &ReviewerOutcome{Model: "test-model"}
+	got := runReviewerWith(stub, cheapModel(), out, "doc.md", "body", DefaultMaxCostUSD)
+
+	if got.Present {
+		t.Fatalf("expected absent for gate-violating response")
+	}
+	if got.AbsentReason != ReasonInvalid {
+		t.Errorf("absent reason = %q, want %q", got.AbsentReason, ReasonInvalid)
+	}
+}
+
+func TestRunReviewerWith_UnreachableProvider(t *testing.T) {
+	stub := &stubCaller{err: errors.New("connection refused")}
+	out := &ReviewerOutcome{Model: "test-model"}
+	got := runReviewerWith(stub, cheapModel(), out, "doc.md", "body", DefaultMaxCostUSD)
+
+	if got.Present {
+		t.Fatalf("expected absent for unreachable provider")
+	}
+	if got.AbsentReason != ReasonUnreachable {
+		t.Errorf("absent reason = %q, want %q", got.AbsentReason, ReasonUnreachable)
+	}
+}
+
+func TestRunReviewerWith_BudgetCapRefusalZeroSpend(t *testing.T) {
+	// A model priced so the pre-flight estimate blows the cap. The stub would
+	// error if called — proving zero spend on refusal.
+	pricey := &eval_harness.ModelConfig{
+		APIName:  "pricey",
+		Provider: "openai",
+		Pricing:  eval_harness.Pricing{InputPer1K: 1.0, OutputPer1K: 1.0}, // est >> cap
+	}
+	stub := &stubCaller{err: errors.New("MUST NOT BE CALLED")}
+	out := &ReviewerOutcome{Model: "pricey"}
+	// A body large enough that even the floor-scaled estimate blows the cap at
+	// $1/1K pricing.
+	bigBody := strings.Repeat("x", 8000)
+	got := runReviewerWith(stub, pricey, out, "doc.md", bigBody, DefaultMaxCostUSD)
+
+	if got.Present {
+		t.Fatalf("expected budget refusal")
+	}
+	if got.AbsentReason != ReasonBudget {
+		t.Errorf("absent reason = %q, want %q", got.AbsentReason, ReasonBudget)
+	}
+	if got.CostUSD != 0 {
+		t.Errorf("budget refusal must be zero spend, got $%f", got.CostUSD)
+	}
+	if stub.gotSchema != "" {
+		t.Errorf("caller was invoked despite budget refusal (non-zero spend risk)")
+	}
+}

--- a/internal/mission/quorum/run.go
+++ b/internal/mission/quorum/run.go
@@ -1,0 +1,140 @@
+package quorum
+
+import (
+	"fmt"
+
+	"github.com/sunholo-data/ailang/internal/eval_harness"
+)
+
+// DefaultMaxCostUSD is the per-reviewer budget cap. A design-doc review is a
+// few thousand tokens each way; even the priciest reviewer lands in single-
+// digit cents. The cap is a guardrail against a runaway (e.g. a reviewer that
+// echoes the whole doc back), not an expected-cost estimate.
+const DefaultMaxCostUSD = 0.10
+
+// expectedOutputTokens is the pre-flight output estimate for the budget-cap
+// PRE-check. The review output is a small structured JSON object; this is a
+// generous headroom for reasoning models. Input tokens are estimated from the
+// ACTUAL prompt size (see estimateInputTokens) so the cap scales with the doc
+// rather than assuming a fixed worst case.
+const expectedOutputTokens = 1024
+
+// charsPerToken is a coarse tokens≈chars/4 heuristic for the pre-flight
+// estimate only. The POST-check uses the provider's real token counts.
+const charsPerToken = 4
+
+// estimateInputTokens estimates prompt tokens from the built prompt + the
+// reviewer system prompt, using the chars/4 heuristic with a small floor so a
+// trivially short doc still reserves some budget.
+func estimateInputTokens(prompt string) int {
+	chars := len(prompt) + len(systemPrompt)
+	tokens := chars / charsPerToken
+	if tokens < 256 {
+		tokens = 256
+	}
+	return tokens
+}
+
+// ReviewerOutcome is the full record of one reviewer invocation, including the
+// verdict (when present), the cost, and — when the reviewer could not run —
+// an explicit absence reason. A missing reviewer is NEVER a silent pass
+// (Critical Principle 2): Present=false with a non-empty AbsentReason.
+type ReviewerOutcome struct {
+	Model   string  `json:"model"`
+	CostUSD float64 `json:"cost_usd"`
+
+	// Present is true iff the reviewer ran and returned a valid verdict.
+	Present bool `json:"present"`
+	// AbsentReason is populated iff Present is false: one of "unreachable",
+	// "budget", "auth", "invalid" (malformed/gate-violating response).
+	AbsentReason string `json:"absent_reason,omitempty"`
+	// Err carries the underlying error text for an absent reviewer (audit).
+	Err string `json:"error,omitempty"`
+
+	// Result is the parsed verdict when Present is true; nil otherwise.
+	Result *ReviewResult `json:"result,omitempty"`
+
+	// Landed seeds the catch-rate hook (design doc's "drop a reviewer whose
+	// objections never land"): the doc author/evaluator later flips this to
+	// true/false once they act (or don't) on the objection. null = not yet
+	// adjudicated.
+	Landed *bool `json:"landed"`
+}
+
+// AbsentReason values.
+const (
+	ReasonUnreachable = "unreachable"
+	ReasonBudget      = "budget"
+	ReasonAuth        = "auth"
+	ReasonInvalid     = "invalid"
+)
+
+// RunReviewer runs one reviewer end-to-end with a budget cap. It NEVER returns
+// a nil outcome: on any failure it returns an outcome with Present=false and a
+// named AbsentReason, so the caller (the orchestrator) can degrade gracefully
+// and record the absence. The error return is non-nil only for programmer
+// errors (e.g. empty model id), not for provider/auth/budget failures — those
+// are data on the outcome.
+func RunReviewer(modelID, docPath, docBody string, maxCostUSD float64) *ReviewerOutcome {
+	out := &ReviewerOutcome{Model: modelID}
+	if maxCostUSD <= 0 {
+		maxCostUSD = DefaultMaxCostUSD
+	}
+
+	// Resolve provider + auth. A resolve failure (no key / no ADC / unknown
+	// model) is an auth/unreachable absence, not a pass.
+	caller, mc, err := ResolveCaller(modelID)
+	if err != nil {
+		out.AbsentReason = ReasonAuth
+		out.Err = err.Error()
+		return out
+	}
+	return runReviewerWith(caller, mc, out, docPath, docBody, maxCostUSD)
+}
+
+// runReviewerWith is the resolver-independent core of RunReviewer: given an
+// already-built caller + model config, it runs the budget-capped review. Split
+// out so unit tests can inject a stub caller + a synthetic ModelConfig without
+// touching real providers or auth.
+func runReviewerWith(caller JSONCaller, mc *eval_harness.ModelConfig, out *ReviewerOutcome, docPath, docBody string, maxCostUSD float64) *ReviewerOutcome {
+	prompt := BuildPrompt(docPath, docBody)
+
+	// PRE-flight budget cap: refuse before spending if the estimate (scaled to
+	// the ACTUAL doc size) already exceeds the cap. No silent fallback — a
+	// structured refusal, zero spend.
+	estCost := estimateCost(mc, estimateInputTokens(prompt), expectedOutputTokens)
+	if estCost > maxCostUSD {
+		out.AbsentReason = ReasonBudget
+		out.Err = fmt.Sprintf("estimated cost $%.4f (doc ~%d input tok) exceeds cap $%.4f (pre-flight refusal, zero spend)", estCost, estimateInputTokens(prompt), maxCostUSD)
+		return out
+	}
+
+	raw, resp, cerr := caller.CallJSON(systemPrompt, prompt, reviewSchema)
+	if cerr != nil {
+		out.AbsentReason = ReasonUnreachable
+		out.Err = cerr.Error()
+		return out
+	}
+
+	// POST-flight actual cost from token counts × models.yml pricing.
+	out.CostUSD = estimateCost(mc, resp.InputTokens, resp.OutputTokens)
+
+	result, perr := ParseReviewResult(raw)
+	if perr != nil {
+		out.AbsentReason = ReasonInvalid
+		out.Err = perr.Error()
+		return out
+	}
+
+	out.Present = true
+	out.Result = result
+	return out
+}
+
+// estimateCost computes USD cost from token counts and the model's
+// models.yml pricing. Used both for the pre-flight cap and post-flight
+// accounting so the two use identical arithmetic.
+func estimateCost(mc *eval_harness.ModelConfig, inputTokens, outputTokens int) float64 {
+	return float64(inputTokens)/1000.0*mc.Pricing.InputPer1K +
+		float64(outputTokens)/1000.0*mc.Pricing.OutputPer1K
+}

--- a/internal/mission/quorum/run.go
+++ b/internal/mission/quorum/run.go
@@ -1,6 +1,7 @@
 package quorum
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/sunholo-data/ailang/internal/eval_harness"
@@ -46,7 +47,8 @@ type ReviewerOutcome struct {
 	// Present is true iff the reviewer ran and returned a valid verdict.
 	Present bool `json:"present"`
 	// AbsentReason is populated iff Present is false: one of "unreachable",
-	// "budget", "auth", "invalid" (malformed/gate-violating response).
+	// "budget", "auth", "unknown-model", "invalid" (malformed/gate-violating
+	// response).
 	AbsentReason string `json:"absent_reason,omitempty"`
 	// Err carries the underlying error text for an absent reviewer (audit).
 	Err string `json:"error,omitempty"`
@@ -63,10 +65,11 @@ type ReviewerOutcome struct {
 
 // AbsentReason values.
 const (
-	ReasonUnreachable = "unreachable"
-	ReasonBudget      = "budget"
-	ReasonAuth        = "auth"
-	ReasonInvalid     = "invalid"
+	ReasonUnreachable  = "unreachable"
+	ReasonBudget       = "budget"
+	ReasonAuth         = "auth"
+	ReasonUnknownModel = "unknown-model"
+	ReasonInvalid      = "invalid"
 )
 
 // RunReviewer runs one reviewer end-to-end with a budget cap. It NEVER returns
@@ -81,11 +84,16 @@ func RunReviewer(modelID, docPath, docBody string, maxCostUSD float64) *Reviewer
 		maxCostUSD = DefaultMaxCostUSD
 	}
 
-	// Resolve provider + auth. A resolve failure (no key / no ADC / unknown
-	// model) is an auth/unreachable absence, not a pass.
+	// Resolve provider + auth. A resolve failure is a named absence, not a
+	// pass. An unknown model id gets its own semantically correct reason
+	// ("unknown-model") rather than being mislabeled as "auth".
 	caller, mc, err := ResolveCaller(modelID)
 	if err != nil {
-		out.AbsentReason = ReasonAuth
+		if errors.Is(err, ErrUnknownModel) {
+			out.AbsentReason = ReasonUnknownModel
+		} else {
+			out.AbsentReason = ReasonAuth
+		}
 		out.Err = err.Error()
 		return out
 	}


### PR DESCRIPTION
## Summary

Fleet expansion iteration 28 — **Phase A hardening** (verify the already-landed quota-aware model-preference probe in the mission driver) + **Phase B** (the genuinely-new work per the design doc's binding redundancy audit: an off-Anthropic, off-quota **design-doc quorum** that catches bad premises before an Opus sprint is spent on them).

Design doc: `design_docs/planned/v0_30_0/m-mission-adaptive-multiprovider-routing.md`
Sprint plan: `design_docs/planned/v0_30_0/m-mission-fleet-ab-sprint-plan.md`
Mission bookkeeping: #329

## Milestones

- **A — Verify + harden the landed Phase A driver** (`267460c12`). Verification only, no driver edit → no deployment needed. `bash -n` clean; `MISSION_DRY_RUN=1` exits 0 with no probes; fall-through smoke on the **real** `select_model` block (stubbed `claude`, bounded 120s) selects `claude-opus-4-8` after a bogus model falls through; six safety invariants confirmed unchanged; main-checkout deployment confirmed.
- **B1 + B2 — Reviewer + N-reviewer quorum orchestration** (`8e46fdaf9`). New package `internal/mission/quorum` + `ailang design-review` / `ailang design-quorum`. Reject-by-default reviewers (required `strongest_objection`), models.yml resolver (OpenAI via `OPENAI_API_KEY`, Gemini via **Vertex ADC — not `GEMINI_API_KEY`**), per-reviewer budget cap, parallel synthesis (any-reject → blocked / unanimous-pass → proceed), graceful **N−1 degrade that names the absent reviewer** (never a silent pass), JSON + mission-log artifacts, catch-rate `landed` hook. Invoked via a documented **optional** hook in the design-doc-creator skill — no inner-loop skill-contract change.

## Test evidence

Live smokes (bounded, tiny doc, real spend in cents):
- `design-review --reviewer gpt5-6-sol` → `reject`, $0.0055.
- `design-review --reviewer gemini-3-1-pro` under `env -u GEMINI_API_KEY` → `reject`, $0.0019 (**ADC path proven; the design doc's flagged risk mitigated**).
- Full `design-quorum` (both reviewers parallel + controller in-session `pass`) → **BLOCKED** (both reviewers rejected the fixture), total $0.0074, artifact + mission-log block well-formed.
- N−1 degrade: `env -u OPENAI_API_KEY` → `gpt5-6-sol` recorded absent (reason `auth`), NAMED in `absent_reviewers`, quorum proceeds with gemini — never a silent pass.

Unit tests (all green): schema conformance + code-fence strip, empty-objection/missing-field hard-error, budget-cap refusal (asserts caller **not** invoked → zero spend), ADC-vs-apikey resolution, unanimous-pass/any-reject/controller-reject/N−1/all-absent synthesis, artifact JSON round-trip + markdown, log append, `hoistFlags`.

Gates: `make fmt`, `golangci-lint` (0 issues on new packages), `make check-file-sizes` (all <800; new files 88–166 lines) — green in the worktree; clean non-dirty build `v0.29.2-171-g8e46fdaf9`. Full `make test` green **except** one pre-existing flaky timing test (`TestRunCommand_PipedStdoutFlushesPerLine`) that passes on isolated re-run — unrelated to this change.

## Deviations from plan (declared)

1. **Pre-flight budget estimate scales to the actual doc size** (chars/4) instead of a fixed 16k-token worst case. The fixed estimate over-refused a small doc at `gpt5-6-sol` pricing ($0.11 > $0.10 cap). POST-check still uses the provider's real token counts. (Improvement, but declared.)
2. **Reviewer model = `gemini-3-1-pro`** (the newer ADC pro) per the plan's parked question — both `gemini-3-pro` and `gemini-3-1-pro` are Vertex-ADC; picked the newer.
3. **B1+B2 shipped in one commit** (tightly coupled — the quorum builds directly on the reviewer primitive) rather than two.
4. Milestone A is **verification, not construction** — Phase A landed (`3bee6b6df`) ~3h before planning. Flagged in the plan's "parked for human" in case a duplicate build was expected.

## Parked for human

- Quorum-on-sprint-plans deferred; this sprint scopes the hook to design docs only.
- Phases C/D/E (cross-provider executors, local-GPU lane, assignment table) explicitly OUT.

## Deployment

None required. Milestone A made no driver edit (verification only); Phase B is an on-demand tool + a skill-doc hook — it does not touch `mission-control.sh`, so no launchd/main-checkout sync is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
