### PR TITLE
chore(deps): auto-merge safe Dependabot PRs + batch gomod minors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # Go modules — shipped binary. Group patches so PRs don't fragment.
+  # Go modules — shipped binary. Group minor+patch so PRs don't fragment.
   - package-ecosystem: gomod
     directory: /
     schedule:
@@ -15,9 +15,22 @@ updates:
         patterns:
           - "google.golang.org/grpc*"
           - "google.golang.org/protobuf*"
-      patches:
+      # Catch-all so minor + patch bumps batch into one PR instead of
+      # fragmenting one-per-dependency (mirrors the npm blocks below).
+      # Majors still open individually so they get human eyes.
+      all-minor-patch:
+        patterns:
+          - "*"
         update-types:
+          - minor
           - patch
+    ignore:
+      # go.lsp.dev/* v1.0 is a coordinated breaking change across
+      # uri + protocol (+ jsonrpc2) that touches all of internal/lsp.
+      # Dependabot can't bundle it — upgrade the LSP stack deliberately,
+      # not via a piecemeal major bump that never compiles. (#374, #377)
+      - dependency-name: "go.lsp.dev/*"
+        update-types: ["version-update:semver-major"]
 
   # GitHub Actions — keep our workflow actions pinned to current patched majors.
   - package-ecosystem: github-actions

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,38 @@
+name: Dependabot auto-merge
+
+# Auto-merges low-risk Dependabot PRs once required CI (test/lint/build) is
+# green, so the weekly Monday batch clears itself instead of piling up.
+#
+# Scope: patch + minor bumps only (any ecosystem). Grouped PRs whose highest
+# bump is minor/patch qualify too, because fetch-metadata reports the group's
+# max update-type. ANY major — grouped or not — is held for a human, which is
+# exactly the set that needs eyes (e.g. the go.lsp.dev 1.0 breakage).
+#
+# --auto enables GitHub's merge queue: the PR only merges after the branch
+# protection checks pass, and Dependabot auto-rebases conflicting go.sum PRs.
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for patch/minor updates
+        if: >
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

The weekly Monday Dependabot batch was piling up (9 open PRs) because:
1. **Nothing auto-merged** — every green patch/minor bump needed a manual click.
2. **gomod had no catch-all minor group** (only `patch`), so each *minor* gomod dep spawned its own PR (#375 firestore, #376 storage) instead of batching.

## Changes

- **New `.github/workflows/dependabot-automerge.yml`** — enables GitHub auto-merge for patch/minor bumps (any ecosystem) once required CI (`test`/`lint`/`build`) passes. Any **major** — grouped or not — is held for a human, which is exactly the set that needs eyes.
- **`dependabot.yml` gomod** — replace the patch-only group with an `all-minor-patch` catch-all so minor bumps batch (mirrors the npm blocks).
- **`dependabot.yml` gomod** — pin `go.lsp.dev/*` major bumps. v1.0 is a coordinated breaking change across uri+protocol+jsonrpc2 spanning all of `internal/lsp`; the piecemeal major PRs ([#374](https://github.com/sunholo-data/ailang/pull/374), [#377](https://github.com/sunholo-data/ailang/pull/377)) never compile.

## Effect

Weekly load drops from ~9 PRs-to-review to ~1–2 majors-to-decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)