### PR TITLE
fix(docs): pin @mermaid-js/layout-elk to ^0.1.9 (fixes flaky docs build)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -12,7 +12,7 @@
         "@docusaurus/preset-classic": "3.10.2",
         "@docusaurus/theme-mermaid": "3.10.2",
         "@mdx-js/react": "^3.0.0",
-        "@mermaid-js/layout-elk": "^0.2.2",
+        "@mermaid-js/layout-elk": "^0.1.9",
         "clsx": "^2.0.0",
         "lucide-react": "^1.24.0",
         "prism-react-renderer": "^2.3.0",
@@ -4632,9 +4632,9 @@
       }
     },
     "node_modules/@mermaid-js/layout-elk": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/layout-elk/-/layout-elk-0.2.2.tgz",
-      "integrity": "sha512-vnH3gtqfhyBiRVKNpT8iDENTw18q/OF0GF/SfYfHN43KZpu+6eZDEOMHTfNYAkpmUWJNgtRQFIS6BTc7vH/DYQ==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/layout-elk/-/layout-elk-0.1.9.tgz",
+      "integrity": "sha512-HuvaqFZBr6yT9PpWYockvKAZPJVd89yn/UjOYPxhzbZxlybL2v+2BjVCg7MVH6vRs1irUohb/s42HEdec1CCZw==",
       "license": "MIT",
       "dependencies": {
         "d3": "^7.9.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -22,7 +22,7 @@
     "@docusaurus/preset-classic": "3.10.2",
     "@docusaurus/theme-mermaid": "3.10.2",
     "@mdx-js/react": "^3.0.0",
-    "@mermaid-js/layout-elk": "^0.2.2",
+    "@mermaid-js/layout-elk": "^0.1.9",
     "clsx": "^2.0.0",
     "lucide-react": "^1.24.0",
     "prism-react-renderer": "^2.3.0",


### PR DESCRIPTION
## Problem

The `build` CI check has been **flaky** since the docusaurus group bump [#373](https://github.com/sunholo-data/ailang/pull/373). That PR moved `@mermaid-js/layout-elk` to `^0.2.2`, but `@docusaurus/theme-mermaid@3.10.2` declares:

```
peerOptional @mermaid-js/layout-elk: ^0.1.9
```

`make docs-install` runs `npm install` (not `npm ci`), which re-resolves peers on every run, so the conflict surfaces as an intermittent `ERESOLVE` failure. Evidence it's flaky, not hard-broken: #373's own commit has **both a passing and a failing** `build` check-run, and [#390](https://github.com/sunholo-data/ailang/pull/390) failed then passed on retry.

Left unfixed, this randomly reds-out every PR's required `build` check and can stall the new Dependabot auto-merge (it waits for green).

## Fix

`@docusaurus/theme-mermaid` is pinned to the docusaurus 3.10.x line, so it can't adopt a layout-elk 0.2.x peer without a full docusaurus major upgrade. Pin `layout-elk` back to `^0.1.9` — the version dev ran before #373 — so `npm install` resolves deterministically. Lockfile regenerated; `npm install` verified clean (no ERESOLVE), 0 remaining 0.2.2 refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)