### PR TITLE
feat(dx): examples coverage, real CI gate, working --examples flag (M-DX-EXAMPLES-COVERAGE)

### DIFF
--- a/.ailang/state/sprints/sprint_M-DX-EXAMPLES-COVERAGE.json
+++ b/.ailang/state/sprints/sprint_M-DX-EXAMPLES-COVERAGE.json
@@ -1,0 +1,330 @@
+{
+  "sprint_id": "M-DX-EXAMPLES-COVERAGE",
+  "title": "Close the Examples Gap \u2014 Coverage, a Real CI Gate, and a Working --examples Flag",
+  "design_doc": "design_docs/planned/v0_29_0/m-dx-examples-coverage.md",
+  "mission_iteration": 29,
+  "target_version": "v0.30.x",
+  "base_version_at_plan": "v0.29.2",
+  "priority": "P2",
+  "risk_level": "medium",
+  "github_issues": [
+    341
+  ],
+  "created": "2026-07-14",
+  "created_at_head": "b0869604f24f7fced54081a2ebfb0bfd755f7a6e",
+  "origin_dev_at_plan": "4f486f0c2676736c8aa2bb61aadb365d745967bb",
+  "executor_constraints": {
+    "worktree": "Work in an isolated git worktree branched from origin/dev. NEVER the shared main tree. Commit promptly.",
+    "forbidden_paths": [
+      "internal/types/",
+      "internal/effects/"
+    ],
+    "forbidden_rationale": "No type-system/effect changes. If Phase-1 bisect shows a GENUINE regression, the deliverable is quarantine + a filed follow-up issue, NOT a fix.",
+    "no_gpu_ollama": "No GPU/ollama steps anywhere.",
+    "bounded_waits": "Every wait must be bounded (no unbounded `until COND; do sleep; done`).",
+    "sequencing": "Phase 1 before Phase 3. Phases 2 and 3 may land in either order. Phase 4 last. Phase 3 must land in the SAME PR as (or after) Phase 1 \u2014 never before, or CI ships permanently red."
+  },
+  "velocity": {
+    "target_loc_per_day": 250,
+    "estimated_total_loc": 700,
+    "estimated_days": 2,
+    "basis": "Recent mission sprints (M-PRELUDE-OPTION-RESULT #382, M-XMOD-ALIAS-POLY #381, M-LAMBDA-OPEN-RECORD) each landed a single milestone same-day. This sprint is 4 smaller mechanical/DX phases; 2 days is realistic with buffer."
+  },
+  "premise_verification": {
+    "status": "ALL PREMISES VERIFIED at HEAD b0869604f (2026-07-14). No discrepancies found.",
+    "checks": [
+      "CI gate triple-defeated: ci.yml:205 `make verify-examples ... || true`; ci.yml:207 `grep -q \"Failed: 0\"` cannot match actual `**Summary:** N passed...` format; steps.verify.outputs.status consumed nowhere; make/examples.mk:12-13 both wrap go-run in `|| true`. CONFIRMED.",
+      "skippedExamples is a hardcoded map[string]string in scripts/verify_examples.go:87-93 with per-file reasons; does NOT consult manifest for skipping. CONFIRMED.",
+      "findExamplesDir (cmd/ailang/examples.go:669-710): AILANG_EXAMPLES -> exe-relative -> ~/.ailang/examples -> CWD, explicit actionable error at :709. CONFIRMED.",
+      "Valid manifest statuses = working/broken/experimental ONLY (internal/manifest/manifest.go:27-29). CONFIRMED.",
+      "validate_manifest.go exists (scripts/validate_manifest.go, 11KB) with ZERO refs in make/ or .github/workflows/. CONFIRMED unwired.",
+      "examples/manifest.json has 176 entries; keys = path/status/tags/description/expected (NO `modules` field yet). CONFIRMED.",
+      "6 zero-importer modules: embedding, game, gzip, sharedindex, simhash, smoke = 0 importers each. CONFIRMED.",
+      "AST: ast.File.Imports []*ImportDecl (internal/ast/ast.go:140); Parser.ParseFile() (internal/parser/parser_file.go:13). CONFIRMED present.",
+      "docs.go:328 prints only mod.Examples (comment-derived, empty for all modules) -> --examples inert. CONFIRMED.",
+      "Report artifact consumers: tools/build-snapshot, tools/verify_examples.sh, scripts/update_readme.go, scripts/flag_broken_examples.go, scripts/update_docs_examples.go, docusaurus-deploy.yml. CONFIRMED (must preserve generation).",
+      "ci.yml:213-217 subsequent step = `make verify-examples-trace` (Verify example determinism / traces) \u2014 matches doc. Needs `if: always()`. CONFIRMED.",
+      "Item has NOT landed: only design commit b0869604f touches the doc; origin/dev (4f486f0c2) is an ancestor of HEAD. CONFIRMED not-landed."
+    ]
+  },
+  "features": [
+    {
+      "id": "M1_TRIAGE_RED_EXAMPLES",
+      "phase": 1,
+      "description": "Triage the 5 red runnable examples (effectful_list.ail, effectful_list_t7_chain_combinators.ail, mcp_tools.ail, stream_multi_source.ail, stream_process_source.ail). HARD half-day timebox on the bisect of ONE representative (effectful_list.ail). Apply the doc's decision rule.",
+      "estimated_loc": 120,
+      "estimated_hours": 4,
+      "timebox": "HALF DAY HARD. Bisect inconclusive at expiry -> treat as genuine-regression branch.",
+      "dependencies": [],
+      "blocks": [
+        "M3_MAKE_GATE_REAL"
+      ],
+      "implementation": {
+        "bisect": "git bisect run sh -c 'go build -o /tmp/bisect-ailang ./cmd/ailang && /tmp/bisect-ailang check examples/runnable/effectful_list.ail' between v0.13.0 (last-touched 99f76ec7a, green) and HEAD (red). Bounded: half-day hard timebox.",
+        "decision_rule": {
+          "deliberate_semantics_change": "(likely: effect-row strictness landed post-v0.13.0) UPDATE the 5 examples to current semantics (or delete + replace with a modern equivalent showing the same pattern). Record breaking commit SHA in the commit message. Per testing policy: no backward compat.",
+          "genuine_regression_or_timebox_expiry": "Do NOT touch internal/types or internal/effects. Quarantine: (a) add the 5 files to skippedExamples map in scripts/verify_examples.go with reason = the follow-up GitHub issue URL; (b) set their manifest status to `broken` (the valid enum); (c) FILE a follow-up GitHub issue carrying the bisect result, an owner (mission queue), and the 5-file quarantine list as its closing checklist. No unowned indefinite skip."
+        }
+      },
+      "files": [
+        "examples/runnable/effectful_list.ail",
+        "examples/runnable/effectful_list_t7_chain_combinators.ail",
+        "examples/runnable/mcp_tools.ail",
+        "examples/runnable/stream_multi_source.ail",
+        "examples/runnable/stream_process_source.ail",
+        "examples/manifest.json",
+        "scripts/verify_examples.go (skippedExamples map \u2014 quarantine branch only)"
+      ],
+      "acceptance_criteria": [
+        "make verify-examples reports 0 failed at HEAD (5 reds triaged: updated OR quarantined-and-skipped-with-reason)",
+        "Bisect result for effectful_list.ail recorded (breaking commit SHA in commit message, OR explicit timebox-expired note)",
+        "If quarantine branch: follow-up GitHub issue filed with bisect result + owner + the 5 skippedExamples entries as its closing checklist; each skip prints visibly as SKIP (reason) in the summary, never silently",
+        "NO changes under internal/types/ or internal/effects/",
+        "Half-day timebox respected"
+      ],
+      "test_requirements": [
+        "make verify-examples run shows the 5 previously-red files now pass OR appear as SKIP with the issue-URL reason",
+        "git bisect log captured in commit message"
+      ],
+      "passes": true,
+      "started": "2026-07-14",
+      "completed": "2026-07-14",
+      "notes": "Bisect INCONCLUSIVE (stale-binary corruption \u2192 false-positive on docs-only 607b5b5df; parent+bad both pass on clean rebuild). In-file bisection root-caused a genuine effect-row inference regression (show() in effectful-lambda interpolation collapses effect row to closed-empty vs explicit {IO}); mcp_tools is a separate getString\u2192Option[string] regression. Per Conflict Surface (no internal/types|effects), QUARANTINED all 5: skippedExamples entries (reason=issue URL) + manifest status=broken; filed follow-up issue #386 with bisect result + owner (mission queue) + 5-file closing checklist. make verify-examples \u2192 0 failed (5 show as SKIP)."
+    },
+    {
+      "id": "M2_COVERAGE_ZERO_IMPORTER_MODULES",
+      "phase": 2,
+      "description": "Add 6 runnable examples covering the zero-importer std modules, each registered in manifest.json with deterministic expected output.",
+      "estimated_loc": 300,
+      "estimated_hours": 4,
+      "dependencies": [],
+      "blocks": [],
+      "implementation": {
+        "files_to_create": [
+          "examples/runnable/stdlib_embedding.ail (pure or IO-only; vector embeddings headline pattern)",
+          "examples/runnable/stdlib_game.ail (needs Clock capability; frame timing)",
+          "examples/runnable/stdlib_gzip.ail (compress/decompress round-trip)",
+          "examples/runnable/stdlib_sharedindex.ail (needs SharedIndex capability; semantic index)",
+          "examples/runnable/stdlib_simhash.ail (pure or IO-only; LSH)",
+          "examples/runnable/stdlib_smoke.ail (demonstrates the _smoke.ail one-liner package-probe pattern)"
+        ],
+        "constraints": "Each ~30-60 LOC showing the module's HEADLINE pattern (not bare function calls), deterministic output. Capability notes in each file header. Register each in examples/manifest.json with status=working and expected output.",
+        "scope_note": "The 17 one-importer modules are OUT of scope (recorded in the doc for the next pass)."
+      },
+      "files": [
+        "examples/runnable/stdlib_embedding.ail",
+        "examples/runnable/stdlib_game.ail",
+        "examples/runnable/stdlib_gzip.ail",
+        "examples/runnable/stdlib_sharedindex.ail",
+        "examples/runnable/stdlib_simhash.ail",
+        "examples/runnable/stdlib_smoke.ail",
+        "examples/manifest.json"
+      ],
+      "acceptance_criteria": [
+        "All 6 new stdlib_*.ail pass `ailang check`",
+        "All 6 run with deterministic output matching their manifest `expected` field",
+        "All 6 registered in examples/manifest.json (status=working, expected populated)",
+        "Each file header notes required capabilities",
+        "std/embedding, std/game, std/gzip, std/sharedindex, std/simhash, std/smoke each now have >=1 example importer"
+      ],
+      "test_requirements": [
+        "make verify-examples includes and passes all 6 new files",
+        "Each example's expected output is deterministic across two runs"
+      ],
+      "passes": true,
+      "started": "2026-07-14",
+      "completed": "2026-07-14",
+      "notes": "6 examples added (embedding/game/gzip/sharedindex/simhash/smoke), each headline pattern + deterministic (2-run stable) + manifest expected populated + capability header notes. Verifier taught the SharedIndex cap. All 6 pass check + run; all 6 modules now have \u22651 importer."
+    },
+    {
+      "id": "M3_MAKE_GATE_REAL",
+      "phase": 3,
+      "description": "Fix all three defeat layers so verify-examples actually gates dev CI, while preserving report-artifact generation for all 6 consumers. Guard the call-site with a deliberately-broken-fixture self-test.",
+      "estimated_loc": 130,
+      "estimated_hours": 3,
+      "dependencies": [
+        "M1_TRIAGE_RED_EXAMPLES"
+      ],
+      "sequencing_note": "MUST land in the same PR as (or after) M1. Never before M1, or CI ships permanently red.",
+      "blocks": [],
+      "implementation": {
+        "make_examples_mk": "Capture the exit code of `go run ./scripts/verify_examples.go --json`; STILL write both examples_report.json and examples_status.md unconditionally (5+ consumers); print the status markdown; THEN exit non-zero if the verifier failed. Remove the `|| true` swallow on the gating go-run line.",
+        "ci_yml": "In the 'Verify examples' step (ci.yml:202-211): drop `|| true`, delete the dead `grep -q \"Failed: 0\"` block and the unused steps.verify.outputs.status; let the make target's exit code gate the step.",
+        "if_always": "Add `if: always()` to the 'Verify example determinism (traces)' step (ci.yml:213-217) so the trace signal still prints when the gate is red (a non-zero step aborts remaining steps by default).",
+        "wire_validate_manifest": "Wire `go run ./scripts/validate_manifest.go --ci` into the same gating CI step (it currently has ZERO refs). Prepares for M4's drift-lint.",
+        "self_test": "Add a gate self-test: a `make` target OR a Go test that runs the verifier against a deliberately-broken fixture (a throwaway .ail that fails check, NOT committed to examples/runnable/ permanently \u2014 use a temp dir/fixture) and asserts non-zero exit AND that examples_report.json + examples_status.md were still written. Guard the CALL-SITE, not the helper (env-forward lesson).",
+        "skipped_non_fatal": "skipped examples (AI/network + quarantined) stay NON-fatal \u2014 they log a reason and do not fail the gate."
+      },
+      "files": [
+        "make/examples.mk",
+        ".github/workflows/ci.yml",
+        "scripts/verify_examples.go (exit-code propagation if needed)",
+        "scripts/gate_self_test.go OR make/examples.mk self-test target OR a *_test.go",
+        "make/ci.mk (if validate_manifest wiring lands here)"
+      ],
+      "acceptance_criteria": [
+        "A deliberately-broken example makes `make verify-examples` exit non-zero (self-test proves the gate)",
+        "examples_report.json AND examples_status.md are STILL written on both pass and fail",
+        "CI 'Verify examples' step fails on a red example (proven on the PR branch via temporary broken fixture then reverted, or via the self-test)",
+        "`if: always()` present on the trace step so trace signal prints on a red gate",
+        "`validate_manifest --ci` wired into the gating CI step",
+        "skipped examples remain non-fatal (log reason, no gate failure)",
+        "All 6 report-artifact consumers still receive generated artifacts (no regression)"
+      ],
+      "test_requirements": [
+        "Self-test: broken fixture -> non-zero exit AND artifacts written (assert both)",
+        "Manually confirm on PR branch: a temporary broken example turns the CI step red, then revert",
+        "make verify-examples green with M1+M2 landed"
+      ],
+      "passes": true,
+      "started": "2026-07-14",
+      "completed": "2026-07-14",
+      "notes": "make/examples.mk captures verifier exit code, writes BOTH artifacts unconditionally, re-raises non-zero. ci.yml: dropped || true + dead Failed:0 grep + unused status output, added if: always() to trace step. validate_manifest --ci wired into the gate (schema reconciled in internal/manifest so it can load the real manifest: Mode optional, expected optional for working, aspirational status, broken-info optional-but-error-code-required-if-present). Gate self-test (verify-examples-gate-selftest): broken fixture \u2192 non-zero + artifacts written = PROVEN. Parser-backed shared extractor added (scripts/internal/importextract, unit-tested)."
+    },
+    {
+      "id": "M4_WIRE_EXAMPLES_FLAG",
+      "phase": 4,
+      "description": "Make `ailang docs --examples <module>` show real registered examples via a committed `modules` manifest field, a parser-backed backfill script shared with validate_manifest drift enforcement, and an installed-binary integration test.",
+      "estimated_loc": 180,
+      "estimated_hours": 3,
+      "dependencies": [
+        "M2_COVERAGE_ZERO_IMPORTER_MODULES",
+        "M3_MAKE_GATE_REAL"
+      ],
+      "sequencing_note": "Phase 4 is LAST. Depends on M3 for the validate_manifest CI wiring it extends, and on M2 so backfilled examples include the new files.",
+      "blocks": [],
+      "implementation": {
+        "schema": "Add optional `modules []string` field to the canonical schema in internal/manifest/manifest.go AND mirror in cmd/ailang/examples.go ExampleEntry. All parsers are json.Unmarshal-based -> additive, unknown fields ignored. Consumers = exactly cmd/ailang/examples.go, internal/manifest/manifest.go, scripts/validate_manifest.go (pipeline/cache_store.go is a DIFFERENT manifest \u2014 do NOT touch).",
+        "shared_parser_backed_extractor": "ONE canonical shared function: parse each example with the real parser (internal/parser Parser.ParseFile() -> ast.File.Imports []*ImportDecl) and read the std/... module paths from the AST. NO line/regex scanning anywhere. Called by BOTH the one-time backfill script AND the validate_manifest drift assertion.",
+        "backfill": "One-time Go script that populates `modules` for all 176 entries via the shared extractor; run at development time; COMMIT the result to manifest.json (NOT a runtime scan). Files that fail to parse are already red via the M3 gate \u2014 extractor never guesses at malformed input.",
+        "drift_enforcement": "Extend scripts/validate_manifest.go with a modules-vs-actual-imports assertion using the SAME shared extractor; fail on drift with the exact regeneration command in the error. Already wired into the gating CI step in M3 -> a new/stale example turns CI red.",
+        "docs_go": "In cmd/ailang/docs.go, when --examples <module> passed: load manifest via loadExamplesManifest (reuses findExamplesDir resolution), filter entries whose `modules` field contains `std/<module>` (single linear pass over ~176 in-memory entries), print a 'Try it' section with run commands. Keep comment-derived mod.Examples printing (additive). If no match: print 'No registered examples import std/<module> yet' \u2014 NEVER silently byte-identical to flagless output. On resolution failure: print the explicit findExamplesDir error text as a note under the doc (doc still shown), never a silent fallback."
+      },
+      "files": [
+        "internal/manifest/manifest.go",
+        "cmd/ailang/examples.go",
+        "cmd/ailang/docs.go",
+        "scripts/validate_manifest.go",
+        "scripts/backfill_manifest_modules.go (new one-time backfill)",
+        "internal/manifest/import_extract.go OR shared helper file (parser-backed extractor)",
+        "examples/manifest.json (backfilled modules field, committed)"
+      ],
+      "acceptance_criteria": [
+        "`ailang docs --examples gzip` prints a 'Try it' section listing registered examples that import std/gzip, with run commands",
+        "`ailang docs gzip` (no flag) is byte-identical to today",
+        "`ailang docs --examples <module-with-no-examples>` says 'No registered examples...' explicitly (never silently identical output)",
+        "`modules` field backfilled for all 176 manifest entries via the parser-backed script, committed",
+        "Import extraction is parser-backed (Parser.ParseFile -> ast.File.Imports), ONE shared function used by both backfill and validate_manifest \u2014 NO regex/line scanning",
+        "validate_manifest --ci asserts modules-vs-actual-imports; a deliberately-drifted modules entry turns it red (drift-lint proven, same self-test pattern as M3)",
+        "Integration test: built binary + AILANG_EXAMPLES pointed at a temp download-layout dir (manifest.json + runnable/*.ail copied) + CWD outside any source checkout -> Try-it section prints (installed-binary path proven, NO network)",
+        "Schema addition is additive; internal/pipeline/cache_store.go manifest NOT touched"
+      ],
+      "test_requirements": [
+        "Installed-binary integration test (AILANG_EXAMPLES temp layout, CWD outside repo) asserting Try-it prints",
+        "Drift-lint self-test: deliberately-drifted modules entry -> validate_manifest --ci non-zero",
+        "Unit test for the shared parser-backed extractor (aliases, selective imports, duplicates handled by the grammar)",
+        "docs --examples output snapshot for a with-examples module and a no-examples module"
+      ],
+      "passes": true,
+      "started": "2026-07-14",
+      "completed": "2026-07-14",
+      "notes": "modules field added to internal/manifest.Example + ExampleEntry; backfilled 108 entries via shared parser-backed extractor (committed, zero non-modules field loss). validate_manifest drift assertion uses SAME extractor; drift-lint self-test PROVEN (validate-manifest-selftest). docs --examples prints Try-it section from modules field; flagless byte-identical; no-match explicit; installed-binary integration test (AILANG_EXAMPLES temp download-layout + CWD outside repo, no network) PASSES."
+    },
+    {
+      "id": "M5_CHANGELOG_AND_ISSUE",
+      "phase": 4,
+      "description": "Update CHANGELOG.md and post the closeable comment on issue #341 linking the PR.",
+      "estimated_loc": 30,
+      "estimated_hours": 1,
+      "dependencies": [
+        "M1_TRIAGE_RED_EXAMPLES",
+        "M2_COVERAGE_ZERO_IMPORTER_MODULES",
+        "M3_MAKE_GATE_REAL",
+        "M4_WIRE_EXAMPLES_FLAG"
+      ],
+      "blocks": [],
+      "files": [
+        "CHANGELOG.md"
+      ],
+      "acceptance_criteria": [
+        "CHANGELOG.md updated (semantic versioning, grouped by category) covering all 4 phases",
+        "Issue #341 comment posted linking the PR; issue closeable (use `Fixes #341` in the final commit if the reds are resolved, or `refs #341` + explicit note if quarantined)"
+      ],
+      "test_requirements": [
+        "CHANGELOG entry present and accurate"
+      ],
+      "passes": true,
+      "started": "2026-07-14",
+      "completed": "2026-07-14",
+      "notes": "CHANGELOG (changelogs/v0.18-current.md) entry added covering all 4 phases. Issue #341 comment posted linking the PR; quarantine tracked in #386."
+    }
+  ],
+  "phase_sequencing": {
+    "constraint": "1 -> (2, 3 in either order) -> 4 -> 5",
+    "hard_rules": [
+      "M3 (gate) must NOT land before M1 (triage) \u2014 same PR or after, else permanently-red gate",
+      "M1 bisect is HARD half-day timeboxed; expiry -> genuine-regression (quarantine) branch",
+      "M4 depends on both M2 (examples exist to backfill) and M3 (validate_manifest CI wiring)"
+    ]
+  },
+  "success_criteria_rollup": [
+    "make verify-examples -> 0 failed at HEAD (5 reds triaged)",
+    "Bisect result for effectful_list.ail recorded (SHA or timebox note)",
+    "If quarantine: follow-up issue filed with bisect + owner + skippedExamples closing checklist",
+    "6 new stdlib_*.ail pass check + run with expected output, registered in manifest",
+    "Deliberately-broken example -> make verify-examples non-zero (self-test) AND artifacts still written",
+    "CI 'Verify examples' step fails on a red example (observed on PR branch)",
+    "if: always() on the trace step",
+    "ailang docs --examples gzip prints Try-it; ailang docs gzip unchanged; no-examples module says so explicitly",
+    "Installed-binary integration test (AILANG_EXAMPLES temp download-layout, CWD outside repo) -> Try-it prints, no network",
+    "modules field backfilled for all manifest entries (parser-backed, committed)",
+    "validate_manifest --ci wired into gating CI step; drifted modules entry turns it red",
+    "Parser-backed import extraction shared by backfill + validate_manifest drift assertion",
+    "CHANGELOG updated; issue #341 closeable (PR linked)"
+  ],
+  "risks": [
+    {
+      "risk": "Phase-1 bisect is inconclusive within the half-day timebox",
+      "mitigation": "Doc's decision rule: treat as genuine-regression -> quarantine (skip map + broken status + filed issue). No type-system fix. Timebox is HARD.",
+      "severity": "medium"
+    },
+    {
+      "risk": "Bisect reveals a genuine effect-row regression the executor is tempted to 'just fix'",
+      "mitigation": "internal/types + internal/effects are FORBIDDEN. Deliverable is quarantine + filed follow-up issue, per constraints.",
+      "severity": "high"
+    },
+    {
+      "risk": "Landing M3 before M1 ships a permanently-red gate",
+      "mitigation": "Sequencing hard-rule: M3 same-PR-or-after M1. Enforced in phase_sequencing.",
+      "severity": "high"
+    },
+    {
+      "risk": "Breaking report-artifact generation for the 6 consumers when fixing make/examples.mk",
+      "mitigation": "Artifacts MUST be written unconditionally (before the non-zero exit). Self-test asserts artifacts written on failure.",
+      "severity": "medium"
+    },
+    {
+      "risk": "Non-deterministic output in the 6 new examples (esp. game/Clock, sharedindex)",
+      "mitigation": "Deterministic patterns only; expected output must be stable across two runs; A2 axiom requirement.",
+      "severity": "medium"
+    },
+    {
+      "risk": "Installed-binary integration test flakiness / network dependence",
+      "mitigation": "Test uses a temp dir laid out like a download (manifest.json + runnable/*.ail COPIED locally) + AILANG_EXAMPLES + CWD outside repo. NO network.",
+      "severity": "low"
+    },
+    {
+      "risk": "Touching the wrong manifest (pipeline/cache_store.go compile-cache manifest)",
+      "mitigation": "Doc verified: consumers are exactly examples.go, internal/manifest, validate_manifest.go. cache_store.go is a DIFFERENT file \u2014 do not touch.",
+      "severity": "low"
+    }
+  ],
+  "handoff": {
+    "worktree_required": true,
+    "branch_from": "origin/dev",
+    "estimated_duration": "2 days (~15 hours across 5 milestones)",
+    "total_loc_estimate": 760,
+    "risk_level": "medium"
+  },
+  "status": "completed"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,16 +202,16 @@ jobs:
     - name: Verify examples
       id: verify
       run: |
-        make verify-examples > examples_output.txt 2>&1 || true
-        cat examples_output.txt
-        if grep -q "Failed: 0" examples_output.txt; then
-          echo "status=success" >> $GITHUB_OUTPUT
-        else
-          echo "status=failure" >> $GITHUB_OUTPUT
-        fi
-    
+        # Real gate: `make verify-examples` exits non-zero on any red example or
+        # manifest modules drift, while still writing examples_report.json +
+        # examples_status.md. Tee keeps the full log visible AND lets the step's
+        # own exit code fail the job (no `|| true`, no unmatchable grep).
+        make verify-examples 2>&1 | tee examples_output.txt
+        exit "${PIPESTATUS[0]}"
+
     - name: Verify example determinism (traces)
       id: verify-traces
+      if: always()  # still print the trace signal even when the gate above is red
       run: |
         make verify-examples-trace > trace_output.txt 2>&1 || true
         cat trace_output.txt

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,7 +4,61 @@
 
 ## [Unreleased]
 
-### Added — Design-doc quorum review: off-Anthropic N-reviewer gate (M-MISSION-FLEET-AB, fleet Phase B)
+### Added / Fixed — Examples coverage, a REAL CI gate, and a working `ailang docs --examples` (M-DX-EXAMPLES-COVERAGE, mission iter 29)
+
+Closed four verified gaps in the examples surface (issue #341 absorbed as Phase 1).
+
+**Coverage (M2)** — 6 new runnable examples for the previously zero-importer std
+modules, each ~30–60 LOC showing the module's headline pattern with deterministic
+output and a manifest entry: `stdlib_embedding.ail` (cosine-similarity ranking),
+`stdlib_game.ail` (fixed-timestep movement + Clock `frame_count()`),
+`stdlib_gzip.ail` (lossless compress→decompress round-trip), `stdlib_sharedindex.ail`
+(namespaced SimHash index + deterministic query, needs `--caps SharedIndex`),
+`stdlib_simhash.ail` (SimHash + Hamming near-duplicate classify), `stdlib_smoke.ail`
+(package boot-probe pattern). `std/embedding`, `std/game`, `std/gzip`,
+`std/sharedindex`, `std/simhash`, `std/smoke` now each have ≥1 example importer.
+
+**A real CI gate (M3)** — `make verify-examples` now actually gates: it captures
+the verifier's exit code and re-raises it AFTER writing both `examples_report.json`
+and `examples_status.md` unconditionally (preserving all 5+ report consumers).
+Removed all three silent-pass layers (`|| true` in `make/examples.mk`, the
+unmatchable `Failed: 0` grep and the unused `status` output in `ci.yml`) — this is
+the NO-SILENT-FALLBACKS principle applied to CI (A5). Added `if: always()` to the
+following trace step so its signal still prints on a red gate. New
+`make verify-examples-gate-selftest` guards the call-site: a deliberately-broken
+fixture must turn the verifier non-zero AND still write both artifacts.
+
+**Manifest `modules` + drift-lint (M3/M4)** — `examples/manifest.json` entries gain
+an additive `modules` field, backfilled for all resolvable entries by a one-time
+parser-backed script (`make backfill-manifest-modules`) using the real compiler
+parser (`internal/parser` → `ast.File.Imports`), NOT regex. `validate_manifest.go`
+was previously unwired (it couldn't even load the real manifest); it's rewritten to
+do schema + `modules`-vs-actual-imports drift validation via the SAME shared
+extractor, wired into the `verify-examples` gate (`--ci`), with a self-test
+(`make validate-manifest-selftest`) proving a drifted entry turns it red.
+
+**`ailang docs --examples <module>` works (M4)** — the flag was inert (byte-identical
+with/without it, A11 tooling-honesty lie). It now prints a "Try it" section of
+registered runnable examples that import the module, with `ailang run` commands,
+resolved via the existing installed-binary path (`AILANG_EXAMPLES` /
+`~/.ailang/examples`). No matches says so explicitly; resolution failure prints the
+explicit error as a note — never silently identical to flagless output.
+`ailang docs <module>` (no flag) is byte-identical to before.
+
+**Triage of the 5 red examples (M1)** — `effectful_list.ail`,
+`effectful_list_t7_chain_combinators.ail`, `mcp_tools.ail`, `stream_multi_source.ail`,
+`stream_process_source.ail` were red on dev with CI green. Bisect from v0.13.0 was
+inconclusive (corrupted by stale-binary caching → false-positive on a docs-only
+commit); in-file bisection root-caused a **genuine effect-row inference regression**
+(`show()` in an effectful-lambda string interpolation collapses the combinator
+effect row to closed-empty, conflicting with an explicit `{IO}`) plus a separate
+`getString`-returns-`Option[string]` regression in mcp_tools. Per the sprint's
+Conflict Surface (no `internal/types`/`internal/effects` changes), the 5 files are
+**quarantined** (skipped with reason in `verify_examples.go` + `status: broken` in
+the manifest) and owned by follow-up issue **#386** (bisect result + owner + the
+5-file quarantine list as its closing checklist). `make verify-examples` → 0 failed.
+
+
 
 Two new CLI subcommands let a design doc get an independent, off-quota second
 opinion from non-Anthropic frontier models before an Opus sprint is spent on it:

--- a/cmd/ailang/docs.go
+++ b/cmd/ailang/docs.go
@@ -406,13 +406,15 @@ func printTryItSection(moduleName string) {
 
 // exampleRunPath normalizes a manifest entry path to a `examples/...`-rooted
 // path suitable for `ailang run`. Legacy bare-name entries live under runnable/.
+// Always slash-form: this is a display/run-command string, and `ailang run`
+// accepts slash paths on every platform (Windows renders backslashes otherwise).
 func exampleRunPath(entryPath string) string {
 	if strings.HasPrefix(entryPath, "runnable/") ||
 		strings.HasPrefix(entryPath, "experimental/") ||
 		strings.Contains(entryPath, "/") {
-		return filepath.Join("examples", entryPath)
+		return filepath.ToSlash(filepath.Join("examples", entryPath))
 	}
-	return filepath.Join("examples", "runnable", entryPath)
+	return filepath.ToSlash(filepath.Join("examples", "runnable", entryPath))
 }
 
 // formatExportSignature formats an export signature for display

--- a/cmd/ailang/docs.go
+++ b/cmd/ailang/docs.go
@@ -333,6 +333,86 @@ func showModuleDocs(stdlibPath, moduleName string, showExamples bool) {
 			fmt.Printf("  %s\n", ex)
 		}
 	}
+
+	// Print a "Try it" section of registered runnable examples that import this
+	// module (additive; only when --examples is passed).
+	if showExamples {
+		printTryItSection(mod.Name)
+	}
+}
+
+// printTryItSection prints registered runnable examples that import moduleName
+// (e.g. "std/gzip"), read from examples/manifest.json's `modules` field. It
+// reuses loadExamplesManifest -> findExamplesDir resolution, so it works both
+// in-repo and from an installed binary (AILANG_EXAMPLES / ~/.ailang/examples).
+//
+// Behavior is never silently identical to flagless output:
+//   - resolution failure -> prints the explicit findExamplesDir error as a note
+//     under the doc (the doc is still shown above);
+//   - no matches -> says so explicitly.
+func printTryItSection(moduleName string) {
+	fmt.Println()
+	fmt.Println("## Try it")
+	fmt.Println()
+
+	m, err := loadExamplesManifest()
+	if err != nil {
+		// Explicit note, never a silent fallback (see findExamplesDir error text).
+		fmt.Printf("  (could not load registered examples: %v)\n", err)
+		return
+	}
+
+	var matches []ExampleEntry
+	for _, e := range m.Examples {
+		if e.Status != "working" {
+			continue
+		}
+		for _, mod := range e.Modules {
+			if mod == moduleName {
+				matches = append(matches, e)
+				break
+			}
+		}
+	}
+
+	if len(matches) == 0 {
+		fmt.Printf("  No registered examples import %s yet\n", moduleName)
+		return
+	}
+
+	// Deterministic order.
+	sort.Slice(matches, func(i, j int) bool { return matches[i].Path < matches[j].Path })
+
+	shown := 0
+	for _, e := range matches {
+		if shown >= 3 {
+			break
+		}
+		path := exampleRunPath(e.Path)
+		desc := e.Description
+		if desc != "" {
+			fmt.Printf("  %s — %s\n", path, desc)
+		} else {
+			fmt.Printf("  %s\n", path)
+		}
+		fmt.Printf("    ailang run %s\n", path)
+		shown++
+	}
+	if len(matches) > shown {
+		short := strings.TrimPrefix(moduleName, "std/")
+		fmt.Printf("\n  (%d more: ailang examples search %s)\n", len(matches)-shown, short)
+	}
+}
+
+// exampleRunPath normalizes a manifest entry path to a `examples/...`-rooted
+// path suitable for `ailang run`. Legacy bare-name entries live under runnable/.
+func exampleRunPath(entryPath string) string {
+	if strings.HasPrefix(entryPath, "runnable/") ||
+		strings.HasPrefix(entryPath, "experimental/") ||
+		strings.Contains(entryPath, "/") {
+		return filepath.Join("examples", entryPath)
+	}
+	return filepath.Join("examples", "runnable", entryPath)
 }
 
 // formatExportSignature formats an export signature for display
@@ -352,12 +432,13 @@ func printDocsHelp() {
 	fmt.Println()
 	fmt.Println("Options:")
 	fmt.Println("  --list        List all available stdlib modules")
-	fmt.Println("  --examples    Show usage examples (with module name)")
+	fmt.Println("  --examples    Also print a 'Try it' section of registered runnable")
+	fmt.Println("                examples that import the module (with run commands)")
 	fmt.Println("  --help        Show this help message")
 	fmt.Println()
 	fmt.Println("Examples:")
 	fmt.Println("  ailang docs --list              List all modules")
 	fmt.Println("  ailang docs std/io              Show std/io documentation")
 	fmt.Println("  ailang docs io                  Short form (same as std/io)")
-	fmt.Println("  ailang docs --examples array    Show array module with examples")
+	fmt.Println("  ailang docs --examples gzip     Show std/gzip docs + runnable examples")
 }

--- a/cmd/ailang/docs_examples_test.go
+++ b/cmd/ailang/docs_examples_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/testutil"
+)
+
+// TestDocsExamples_InstalledBinaryLayout proves `ailang docs --examples <module>`
+// prints its "Try it" section from a download-style examples layout resolved via
+// AILANG_EXAMPLES, with the process CWD OUTSIDE any source checkout — i.e. the
+// installed-binary path, no network, no repo-relative resolution.
+func TestDocsExamples_InstalledBinaryLayout(t *testing.T) {
+	bin := testutil.FindAilangBinary(t)
+
+	repoRoot := findRepoRootForTest(t)
+
+	// Build a temp dir laid out exactly like `ailang examples download` produces:
+	//   <examplesDir>/manifest.json
+	//   <examplesDir>/runnable/stdlib_gzip.ail
+	examplesDir := t.TempDir()
+	runnable := filepath.Join(examplesDir, "runnable")
+	if err := os.MkdirAll(runnable, 0o755); err != nil {
+		t.Fatalf("mkdir runnable: %v", err)
+	}
+
+	// Copy the real example so its imports match the manifest `modules` entry.
+	srcExample := filepath.Join(repoRoot, "examples", "runnable", "stdlib_gzip.ail")
+	copyFile(t, srcExample, filepath.Join(runnable, "stdlib_gzip.ail"))
+
+	// Minimal manifest carrying the committed `modules` field for the example.
+	manifest := `{
+  "schema": "ailang.manifest/v1",
+  "schema_version": "1.0.0",
+  "examples": [
+    {
+      "path": "runnable/stdlib_gzip.ail",
+      "status": "working",
+      "tags": ["stdlib", "std/gzip"],
+      "description": "gzip round-trip demo",
+      "modules": ["std/bytes", "std/gzip", "std/io", "std/result"]
+    }
+  ],
+  "statistics": {"total": 1, "working": 1, "broken": 0, "experimental": 0, "coverage": 1.0}
+}
+`
+	if err := os.WriteFile(filepath.Join(examplesDir, "manifest.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	// CWD outside any source checkout.
+	outsideCWD := t.TempDir()
+
+	cmd := exec.Command(bin, "docs", "--examples", "gzip")
+	cmd.Dir = outsideCWD
+	cmd.Env = append(os.Environ(),
+		"AILANG_EXAMPLES="+examplesDir,
+		// Installed binaries ship stdlib too; point at the repo's std for the
+		// module-doc header render. The Try-it section under test is driven by
+		// AILANG_EXAMPLES, not this.
+		"AILANG_STDLIB_PATH="+filepath.Join(repoRoot, "std"),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("docs --examples gzip failed: %v\n%s", err, out)
+	}
+
+	got := string(out)
+	if !strings.Contains(got, "## Try it") {
+		t.Fatalf("expected a '## Try it' section, got:\n%s", got)
+	}
+	if !strings.Contains(got, "examples/runnable/stdlib_gzip.ail") {
+		t.Fatalf("expected the gzip example path in Try-it, got:\n%s", got)
+	}
+	if !strings.Contains(got, "ailang run examples/runnable/stdlib_gzip.ail") {
+		t.Fatalf("expected a run command in Try-it, got:\n%s", got)
+	}
+}
+
+// TestDocsExamples_NoMatchesIsExplicit proves a module with no registered
+// examples says so explicitly (never silently identical to flagless output).
+func TestDocsExamples_NoMatchesIsExplicit(t *testing.T) {
+	bin := testutil.FindAilangBinary(t)
+	repoRoot := findRepoRootForTest(t)
+
+	examplesDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(examplesDir, "runnable"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Manifest with one example that imports std/io only — nothing imports std/gzip.
+	manifest := `{
+  "schema": "ailang.manifest/v1",
+  "schema_version": "1.0.0",
+  "examples": [
+    {"path": "runnable/x.ail", "status": "working", "modules": ["std/io"]}
+  ],
+  "statistics": {"total": 1, "working": 1, "broken": 0, "experimental": 0, "coverage": 1.0}
+}
+`
+	if err := os.WriteFile(filepath.Join(examplesDir, "manifest.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	cmd := exec.Command(bin, "docs", "--examples", "gzip")
+	cmd.Dir = t.TempDir()
+	cmd.Env = append(os.Environ(),
+		"AILANG_EXAMPLES="+examplesDir,
+		"AILANG_STDLIB_PATH="+filepath.Join(repoRoot, "std"),
+	)
+	out, _ := cmd.CombinedOutput()
+	got := string(out)
+	if !strings.Contains(got, "No registered examples import std/gzip yet") {
+		t.Fatalf("expected explicit no-examples message, got:\n%s", got)
+	}
+}
+
+func copyFile(t *testing.T, src, dst string) {
+	t.Helper()
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read %s: %v", src, err)
+	}
+	if err := os.WriteFile(dst, data, 0o644); err != nil {
+		t.Fatalf("write %s: %v", dst, err)
+	}
+}
+
+// findRepoRootForTest walks up from the test's working directory to the repo
+// root (the dir containing go.mod). Used only to locate source example/std files
+// to seed the temp download layout — the binary under test never sees this path.
+func findRepoRootForTest(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find repo root (go.mod) from test cwd")
+		}
+		dir = parent
+	}
+}

--- a/cmd/ailang/examples.go
+++ b/cmd/ailang/examples.go
@@ -30,6 +30,9 @@ type ExampleEntry struct {
 	Tags        []string        `json:"tags"`
 	Description string          `json:"description"`
 	Expected    *ExpectedOutput `json:"expected,omitempty"`
+	// Modules is the set of std/* modules this example imports (backfilled and
+	// drift-checked in the manifest). Powers `ailang docs --examples <module>`.
+	Modules []string `json:"modules,omitempty"`
 }
 
 // ExpectedOutput defines the expected output for an example

--- a/examples/manifest.json
+++ b/examples/manifest.json
@@ -1513,7 +1513,7 @@
     },
     {
       "path": "runnable/effectful_list.ail",
-      "status": "working",
+      "status": "broken",
       "tags": [
         "effects",
         "higher-order",
@@ -1525,7 +1525,13 @@
         "forEachE",
         "flatMap"
       ],
-      "description": "Effectful list combinators smoke test: mapE, filterE, foldlE, flatMapE, forEachE, and pure flatMap"
+      "description": "Effectful list combinators smoke test: mapE, filterE, foldlE, flatMapE, forEachE, and pure flatMap",
+      "broken": {
+        "reason": "effect-row inference regression: show() in effectful-lambda interpolation collapses effect row to closed-empty (conflicts with foldlE {IO})",
+        "error_code": "TC_EFFECT_ROW",
+        "requires": [],
+        "tracked_issue": "https://github.com/sunholo-data/ailang/issues/386"
+      }
     },
     {
       "path": "runnable/effectful_list_t1_mapE_basic.ail",
@@ -1606,7 +1612,7 @@
     },
     {
       "path": "runnable/effectful_list_t7_chain_combinators.ail",
-      "status": "working",
+      "status": "broken",
       "tags": [
         "types",
         "type-inference",
@@ -1615,7 +1621,13 @@
         "regression",
         "std/list"
       ],
-      "description": "Type inference regression T7: chaining multiple effectful combinators"
+      "description": "Type inference regression T7: chaining multiple effectful combinators",
+      "broken": {
+        "reason": "effect-row inference regression: chained effectful combinators with show()-interpolation over-constrain the effect row",
+        "error_code": "TC_EFFECT_ROW",
+        "requires": [],
+        "tracked_issue": "https://github.com/sunholo-data/ailang/issues/386"
+      }
     },
     {
       "path": "runnable/effectful_list_t8_string_list.ail",
@@ -1649,7 +1661,7 @@
     },
     {
       "path": "runnable/stream_multi_source.ail",
-      "status": "working",
+      "status": "broken",
       "tags": [
         "stream",
         "async",
@@ -1658,15 +1670,16 @@
         "M-ASYNC-IO"
       ],
       "description": "Multi-source event multiplexing: stdin + selectEvents (M-ASYNC-IO)",
-      "expected": {
-        "stdin": "hello from stdin",
-        "stdout": "stdin: hello from stdin\ndone\n",
-        "exit_code": 0
+      "broken": {
+        "reason": "effect-row inference regression: show()-interpolation in effectful lambda collapses effect row",
+        "error_code": "TC_EFFECT_ROW",
+        "requires": [],
+        "tracked_issue": "https://github.com/sunholo-data/ailang/issues/386"
       }
     },
     {
       "path": "runnable/stream_process_source.ail",
-      "status": "working",
+      "status": "broken",
       "tags": [
         "stream",
         "async",
@@ -1675,9 +1688,11 @@
         "M-ASYNC-IO"
       ],
       "description": "Subprocess stdout as SourceBytes events via asyncExecProcess (M-ASYNC-IO Phase 2)",
-      "expected": {
-        "stdout": "[echo] hello from subprocess\ndone\n",
-        "exit_code": 0
+      "broken": {
+        "reason": "effect-row inference regression: show()-interpolation in effectful lambda collapses effect row",
+        "error_code": "TC_EFFECT_ROW",
+        "requires": [],
+        "tracked_issue": "https://github.com/sunholo-data/ailang/issues/386"
       }
     },
     {
@@ -1958,11 +1973,12 @@
     }
   ],
   "statistics": {
-    "total": 144,
-    "working": 136,
+    "total": 176,
+    "working": 165,
     "aspirational": 4,
-    "broken": 3,
-    "coverage": 0.951
+    "broken": 7,
+    "coverage": 0.9375,
+    "experimental": 0
   },
   "milestones": {
     "completed": [

--- a/examples/manifest.json
+++ b/examples/manifest.json
@@ -1814,6 +1814,27 @@
       ]
     },
     {
+      "path": "runnable/mcp_tools.ail",
+      "status": "broken",
+      "tags": [
+        "mcp",
+        "tools",
+        "effects"
+      ],
+      "description": "MCP tool definitions and dispatch demo (quarantined: getString→Option[string] regression)",
+      "modules": [
+        "std/json",
+        "std/list",
+        "std/string"
+      ],
+      "broken": {
+        "reason": "getString now returns Option[string]; example predates the API change",
+        "error_code": "TC_UNIFY",
+        "requires": [],
+        "tracked_issue": "https://github.com/sunholo-data/ailang/issues/386"
+      }
+    },
+    {
       "path": "runnable/parser_block_trailing_record.ail",
       "status": "working",
       "tags": [
@@ -2513,11 +2534,11 @@
     }
   ],
   "statistics": {
-    "total": 182,
+    "total": 183,
     "working": 171,
     "aspirational": 4,
-    "broken": 7,
-    "coverage": 0.9395604395604396,
+    "broken": 8,
+    "coverage": 0.9344262295081968,
     "experimental": 0
   },
   "milestones": {

--- a/examples/manifest.json
+++ b/examples/manifest.json
@@ -5,87 +5,6 @@
   "generator": "auto-metadata-v0.6.2",
   "examples": [
     {
-      "path": "hello.ail",
-      "status": "working",
-      "tags": [
-        "basic",
-        "io"
-      ],
-      "description": "Basic hello world program",
-      "expected": {
-        "stdout": "Hello, AILANG!\n",
-        "exit_code": 0
-      }
-    },
-    {
-      "path": "exit_code.ail",
-      "status": "working",
-      "tags": [
-        "io",
-        "exit",
-        "cli",
-        "process"
-      ],
-      "description": "Process exit with explicit exit code",
-      "expected": {
-        "stdout": "Exiting with code 42\n",
-        "exit_code": 42
-      }
-    },
-    {
-      "path": "simple.ail",
-      "status": "working",
-      "tags": [
-        "basic",
-        "arithmetic",
-        "let"
-      ],
-      "description": "Let bindings and arithmetic",
-      "expected": {
-        "stdout": "10\n",
-        "exit_code": 0
-      }
-    },
-    {
-      "path": "arithmetic.ail",
-      "status": "working",
-      "tags": [
-        "typeclass",
-        "show",
-        "arithmetic"
-      ],
-      "description": "Show type class usage with multiple types",
-      "expected": {
-        "stdout": "42\n3.14159\ntrue\nHello, AILANG!\n",
-        "exit_code": 0
-      }
-    },
-    {
-      "path": "lambda_expressions.ail",
-      "status": "working",
-      "tags": [
-        "lambda",
-        "functional",
-        "closures",
-        "higher-order"
-      ],
-      "description": "Comprehensive lambda examples: currying, closures, composition"
-    },
-    {
-      "path": "adt_simple.ail",
-      "status": "working",
-      "tags": [
-        "adt",
-        "pattern-matching",
-        "m-p3"
-      ],
-      "description": "ADT declaration and constructor pattern matching",
-      "expected": {
-        "stdout": "42\n",
-        "exit_code": 0
-      }
-    },
-    {
       "path": "adt_option.ail",
       "status": "working",
       "tags": [
@@ -101,117 +20,18 @@
       }
     },
     {
-      "path": "patterns.ail",
+      "path": "adt_simple.ail",
       "status": "working",
       "tags": [
-        "pattern-matching",
-        "tuples",
         "adt",
+        "pattern-matching",
         "m-p3"
       ],
-      "description": "All pattern types: tuples, literals, constructors, nested"
-    },
-    {
-      "path": "typeclasses.ail",
-      "status": "working",
-      "tags": [
-        "typeclass",
-        "num",
-        "eq",
-        "ord",
-        "show"
-      ],
-      "description": "Type class usage: Num, Eq, Ord, Show"
-    },
-    {
-      "path": "records.ail",
-      "status": "working",
-      "tags": [
-        "records",
-        "field-access",
-        "nesting"
-      ],
-      "description": "Record literals, field access, nested records"
-    },
-    {
-      "path": "experimental/factorial.ail",
-      "status": "aspirational",
-      "tags": [
-        "func",
-        "recursion",
-        "tests",
-        "future"
-      ],
-      "description": "\u26a0\ufe0f VISION ONLY: Factorial with inline tests/properties. DO NOT RUN - causes infinite loop",
-      "requires": [
-        "func",
-        "tests",
-        "properties"
-      ],
-      "skip_reason": "tests/properties syntax not implemented. Running causes memory explosion."
-    },
-    {
-      "path": "experimental/quicksort.ail",
-      "status": "working",
-      "tags": [
-        "algorithms",
-        "sorting",
-        "pattern-matching",
-        "stdlib"
-      ],
-      "description": "Functional sorting: custom quicksort and std/list sortBy"
-    },
-    {
-      "path": "experimental/concurrent_pipeline.ail",
-      "status": "aspirational",
-      "tags": [
-        "csp",
-        "channels",
-        "concurrency",
-        "future"
-      ],
-      "description": "\u26a0\ufe0f VISION ONLY: CSP-based concurrent pipeline. DO NOT RUN - causes infinite loop",
-      "requires": [
-        "channels",
-        "spawn",
-        "parallel",
-        "session-types"
-      ],
-      "skip_reason": "CSP not implemented. Running causes memory explosion."
-    },
-    {
-      "path": "experimental/web_api.ail",
-      "status": "aspirational",
-      "tags": [
-        "quasiquotes",
-        "http",
-        "effects",
-        "future"
-      ],
-      "description": "\u26a0\ufe0f VISION ONLY: Web API with SQL quasiquotes. DO NOT RUN - causes infinite loop",
-      "requires": [
-        "quasiquotes",
-        "http-effects",
-        "db-effects"
-      ],
-      "skip_reason": "Quasiquotes not implemented. Running causes memory explosion."
-    },
-    {
-      "path": "experimental/ai_agent_integration.ail",
-      "status": "aspirational",
-      "tags": [
-        "ai",
-        "effects",
-        "introspection",
-        "future"
-      ],
-      "description": "\u26a0\ufe0f VISION ONLY: AI agent integration demo. Uses unsupported syntax.",
-      "requires": [
-        "effects",
-        "introspection",
-        "json-schema"
-      ],
-      "skip_reason": "Uses arrow lambda syntax and spread operators not yet implemented"
+      "description": "ADT declaration and constructor pattern matching",
+      "expected": {
+        "stdout": "42\n",
+        "exit_code": 0
+      }
     },
     {
       "path": "adt_tree.ail",
@@ -241,88 +61,18 @@
       "description": "AI Effect Example"
     },
     {
-      "path": "runnable/structured_ai_basic.ail",
+      "path": "arithmetic.ail",
       "status": "working",
       "tags": [
-        "effects",
-        "ai",
-        "json",
-        "structured-output"
+        "typeclass",
+        "show",
+        "arithmetic"
       ],
-      "description": "Demonstrates callJsonSimple: AI returns valid JSON without schema enforcement"
-    },
-    {
-      "path": "runnable/structured_ai_schema.ail",
-      "status": "working",
-      "tags": [
-        "effects",
-        "ai",
-        "json",
-        "structured-output"
-      ],
-      "description": "Demonstrates callJson: AI returns schema-enforced JSON output"
-    },
-    {
-      "path": "runnable/ai_caching.ail",
-      "status": "working",
-      "tags": [
-        "effects",
-        "ai",
-        "cache",
-        "tool-use"
-      ],
-      "description": "Demonstrates std/ai.stepWithCache \u2014 opt-in prompt caching across providers (M-AI-PROMPT-CACHING v0.18.4)"
-    },
-    {
-      "path": "runnable/ai_call_json_simple_result.ail",
-      "status": "working",
-      "tags": [
-        "effects",
-        "ai",
-        "result",
-        "typed-errors",
-        "json"
-      ],
-      "description": "Demonstrates std/ai.callJsonSimpleResult \u2014 Result-returning no-schema JSON call with retryable typed errors (M-DOCPARSE-RESILIENCE-FIXES v0.23.0)"
-    },
-    {
-      "path": "runnable/ai_stream_openai.ail",
-      "status": "working",
-      "tags": [
-        "effects",
-        "ai",
-        "streaming",
-        "sse",
-        "config-driven"
-      ],
-      "description": "AI token streaming via std/ai/streaming.openaiCompatStream + manual event loop (per-delta control flow)"
-    },
-    {
-      "path": "runnable/ai_call_stream.ail",
-      "status": "working",
-      "tags": [
-        "effects",
-        "ai",
-        "streaming",
-        "sse",
-        "config-driven",
-        "accumulator"
-      ],
-      "description": "AI token streaming via std/ai/streaming.callStream \u2014 synchronous accumulator returning Result[string, AIError]"
-    },
-    {
-      "path": "runnable/ai_streaming.ail",
-      "status": "working",
-      "tags": [
-        "effects",
-        "ai",
-        "streaming",
-        "sse",
-        "tool-use",
-        "cache",
-        "typed"
-      ],
-      "description": "Demonstrates std/ai.stepWithStream \u2014 typed-StepResult streaming with per-chunk callback (M-AI-STEP-STREAMING v0.18.7)"
+      "description": "Show type class usage with multiple types",
+      "expected": {
+        "stdout": "42\n3.14159\ntrue\nHello, AILANG!\n",
+        "exit_code": 0
+      }
     },
     {
       "path": "array_adt.ail",
@@ -379,6 +129,39 @@
       "description": "Bug Demonstration: Float Comparison"
     },
     {
+      "path": "bugs/concat_operator_list_inference.ail",
+      "status": "broken",
+      "tags": [
+        "bug",
+        "list",
+        "type-inference"
+      ],
+      "description": "Bug reproduction: ++ operator list concat inference issue with workaround",
+      "skip_reason": "Demonstrates ++ operator type inference bug with workaround"
+    },
+    {
+      "path": "bugs/list_concat_match.ail",
+      "status": "broken",
+      "tags": [
+        "bug",
+        "list",
+        "type-inference"
+      ],
+      "description": "Bug: ++ operator defaults to string concat in simple expressions. See bugs/concat_operator_list_inference.ail",
+      "skip_reason": "Type inference bug: ++ defaults to string concat instead of list concat"
+    },
+    {
+      "path": "bugs/parser_infinite_loop_on_test_syntax.ail",
+      "status": "broken",
+      "tags": [
+        "bug",
+        "parser",
+        "critical"
+      ],
+      "description": "Bug: Parser infinite loop on test/property syntax causes 67GB memory usage",
+      "skip_reason": "DO NOT UNCOMMENT - documents parser loop bug. See M-PARSER-LOOP design doc."
+    },
+    {
       "path": "claude_haiku_call.ail",
       "status": "working",
       "tags": [
@@ -410,6 +193,17 @@
         "misc"
       ],
       "description": "Example file demonstrating cyclic type patterns"
+    },
+    {
+      "path": "cons_expression.ail",
+      "status": "working",
+      "tags": [
+        "list",
+        "data-structures",
+        "cons",
+        "expression"
+      ],
+      "description": "Cons (::) in expression position \u2014 building lists by prepending"
     },
     {
       "path": "conway_grid.ail",
@@ -447,6 +241,19 @@
       "description": "Demo: Call a public API endpoint"
     },
     {
+      "path": "effect_budget_demo.ail",
+      "status": "working",
+      "tags": [
+        "effects",
+        "budget",
+        "m-dx25"
+      ],
+      "description": "Effect budget demo: @limit for max calls, @min for minimum requirements",
+      "expected": {
+        "exit_code": 0
+      }
+    },
+    {
       "path": "effect_budgets.ail",
       "status": "working",
       "tags": [
@@ -479,33 +286,6 @@
       "description": "Demonstrates effect budget annotations with Rand capability"
     },
     {
-      "path": "effect_budget_demo.ail",
-      "status": "working",
-      "tags": [
-        "effects",
-        "budget",
-        "m-dx25"
-      ],
-      "description": "Effect budget demo: @limit for max calls, @min for minimum requirements",
-      "expected": {
-        "exit_code": 0
-      }
-    },
-    {
-      "path": "reference/budget_minimum.ail",
-      "status": "working",
-      "tags": [
-        "effects",
-        "budget",
-        "reference",
-        "m-dx25"
-      ],
-      "description": "Reference: Minimum budget (@min) verification for audit logging and cache bypass",
-      "expected": {
-        "exit_code": 0
-      }
-    },
-    {
       "path": "effects_basic.ail",
       "status": "working",
       "tags": [
@@ -528,6 +308,156 @@
         "effects"
       ],
       "description": "Pure functional programming: basic list operations"
+    },
+    {
+      "path": "exit_code.ail",
+      "status": "working",
+      "tags": [
+        "io",
+        "exit",
+        "cli",
+        "process"
+      ],
+      "description": "Process exit with explicit exit code",
+      "expected": {
+        "stdout": "Exiting with code 42\n",
+        "exit_code": 42
+      }
+    },
+    {
+      "path": "expected_fail/contracts/hof_verify.ail",
+      "status": "working",
+      "tags": [
+        "contracts",
+        "smt-verification",
+        "ailang-verify",
+        "higher-order",
+        "hof-inlining",
+        "map",
+        "filter",
+        "lambda"
+      ],
+      "description": "Higher-order function verification \u2014 Z3 proves properties about map/filter with known lambdas via monomorphic inlining and bounded unrolling"
+    },
+    {
+      "path": "expected_fail/contracts/list_recursive_verify.ail",
+      "status": "working",
+      "tags": [
+        "contracts",
+        "smt-verification",
+        "ailang-verify",
+        "lists",
+        "list-contains",
+        "list-extract",
+        "z3-sequence-theory"
+      ],
+      "description": "Recursive list operation contracts \u2014 Z3 proves containment and extraction properties using seq.contains and seq.extract"
+    },
+    {
+      "path": "expected_fail/contracts/per_function_depth_verify.ail",
+      "status": "working",
+      "tags": [
+        "contracts",
+        "smt-verification",
+        "ailang-verify",
+        "bounded-recursion",
+        "verify-attribute",
+        "per-function-depth"
+      ],
+      "description": "Per-function recursion depth \u2014 @verify(depth: N) attribute overrides global --verify-recursive-depth for individual functions"
+    },
+    {
+      "path": "expected_fail/contracts/quantifier_verify.ail",
+      "status": "working",
+      "tags": [
+        "contracts",
+        "smt-verification",
+        "ailang-verify",
+        "quantifiers",
+        "forall",
+        "bounded-quantifiers"
+      ],
+      "description": "Bounded quantifier verification \u2014 forall i: lo..hi => P(i) in ensures clauses, encoded to Z3 bounded quantifiers"
+    },
+    {
+      "path": "experimental/ai_agent_integration.ail",
+      "status": "aspirational",
+      "tags": [
+        "ai",
+        "effects",
+        "introspection",
+        "future"
+      ],
+      "description": "\u26a0\ufe0f VISION ONLY: AI agent integration demo. Uses unsupported syntax.",
+      "requires": [
+        "effects",
+        "introspection",
+        "json-schema"
+      ],
+      "skip_reason": "Uses arrow lambda syntax and spread operators not yet implemented"
+    },
+    {
+      "path": "experimental/concurrent_pipeline.ail",
+      "status": "aspirational",
+      "tags": [
+        "csp",
+        "channels",
+        "concurrency",
+        "future"
+      ],
+      "description": "\u26a0\ufe0f VISION ONLY: CSP-based concurrent pipeline. DO NOT RUN - causes infinite loop",
+      "requires": [
+        "channels",
+        "spawn",
+        "parallel",
+        "session-types"
+      ],
+      "skip_reason": "CSP not implemented. Running causes memory explosion."
+    },
+    {
+      "path": "experimental/factorial.ail",
+      "status": "aspirational",
+      "tags": [
+        "func",
+        "recursion",
+        "tests",
+        "future"
+      ],
+      "description": "\u26a0\ufe0f VISION ONLY: Factorial with inline tests/properties. DO NOT RUN - causes infinite loop",
+      "requires": [
+        "func",
+        "tests",
+        "properties"
+      ],
+      "skip_reason": "tests/properties syntax not implemented. Running causes memory explosion."
+    },
+    {
+      "path": "experimental/quicksort.ail",
+      "status": "working",
+      "tags": [
+        "algorithms",
+        "sorting",
+        "pattern-matching",
+        "stdlib"
+      ],
+      "description": "Functional sorting: custom quicksort and std/list sortBy"
+    },
+    {
+      "path": "experimental/web_api.ail",
+      "status": "aspirational",
+      "tags": [
+        "quasiquotes",
+        "http",
+        "effects",
+        "future"
+      ],
+      "description": "\u26a0\ufe0f VISION ONLY: Web API with SQL quasiquotes. DO NOT RUN - causes infinite loop",
+      "requires": [
+        "quasiquotes",
+        "http-effects",
+        "db-effects"
+      ],
+      "skip_reason": "Quasiquotes not implemented. Running causes memory explosion."
     },
     {
       "path": "factorial.ail",
@@ -574,14 +504,31 @@
       "description": "guards_module.ail - Pattern guards with module structure"
     },
     {
-      "path": "http_simple.ail",
+      "path": "hello.ail",
       "status": "working",
       "tags": [
-        "http",
-        "effects",
-        "net"
+        "basic",
+        "io"
       ],
-      "description": "http_simple.ail - Simple HTTP request example"
+      "description": "Basic hello world program",
+      "expected": {
+        "stdout": "Hello, AILANG!\n",
+        "exit_code": 0
+      }
+    },
+    {
+      "path": "hello_world.ail",
+      "status": "working",
+      "tags": [
+        "basic",
+        "io",
+        "classic"
+      ],
+      "description": "Classic Hello, World! program",
+      "expected": {
+        "stdout": "Hello, World!\n",
+        "exit_code": 0
+      }
     },
     {
       "path": "http_put_bytes.ail",
@@ -593,6 +540,16 @@
         "binary"
       ],
       "description": "http_put_bytes.ail - PUT raw bytes (image/binary upload via httpRequestBytes)"
+    },
+    {
+      "path": "http_simple.ail",
+      "status": "working",
+      "tags": [
+        "http",
+        "effects",
+        "net"
+      ],
+      "description": "http_simple.ail - Simple HTTP request example"
     },
     {
       "path": "if_else_chain.ail",
@@ -648,6 +605,17 @@
       "description": "json_parsing.ail - JSON parsing example"
     },
     {
+      "path": "lambda_expressions.ail",
+      "status": "working",
+      "tags": [
+        "lambda",
+        "functional",
+        "closures",
+        "higher-order"
+      ],
+      "description": "Comprehensive lambda examples: currying, closures, composition"
+    },
+    {
       "path": "lambdas.ail",
       "status": "working",
       "tags": [
@@ -700,50 +668,6 @@
         "letrec"
       ],
       "description": "letrec_recursion.ail"
-    },
-    {
-      "path": "bugs/list_concat_match.ail",
-      "status": "broken",
-      "tags": [
-        "bug",
-        "list",
-        "type-inference"
-      ],
-      "description": "Bug: ++ operator defaults to string concat in simple expressions. See bugs/concat_operator_list_inference.ail",
-      "skip_reason": "Type inference bug: ++ defaults to string concat instead of list concat"
-    },
-    {
-      "path": "bugs/concat_operator_list_inference.ail",
-      "status": "broken",
-      "tags": [
-        "bug",
-        "list",
-        "type-inference"
-      ],
-      "description": "Bug reproduction: ++ operator list concat inference issue with workaround",
-      "skip_reason": "Demonstrates ++ operator type inference bug with workaround"
-    },
-    {
-      "path": "bugs/parser_infinite_loop_on_test_syntax.ail",
-      "status": "broken",
-      "tags": [
-        "bug",
-        "parser",
-        "critical"
-      ],
-      "description": "Bug: Parser infinite loop on test/property syntax causes 67GB memory usage",
-      "skip_reason": "DO NOT UNCOMMENT - documents parser loop bug. See M-PARSER-LOOP design doc."
-    },
-    {
-      "path": "cons_expression.ail",
-      "status": "working",
-      "tags": [
-        "list",
-        "data-structures",
-        "cons",
-        "expression"
-      ],
-      "description": "Cons (::) in expression position \u2014 building lists by prepending"
     },
     {
       "path": "list_pattern_cons.ail",
@@ -919,6 +843,17 @@
       "description": "S-CONS Pattern Sugar Example (v0.4.3)"
     },
     {
+      "path": "patterns.ail",
+      "status": "working",
+      "tags": [
+        "pattern-matching",
+        "tuples",
+        "adt",
+        "m-p3"
+      ],
+      "description": "All pattern types: tuples, literals, constructors, nested"
+    },
+    {
       "path": "polymorphic_comparison_simple.ail",
       "status": "working",
       "tags": [
@@ -960,6 +895,16 @@
         "records"
       ],
       "description": "Record Update Examples"
+    },
+    {
+      "path": "records.ail",
+      "status": "working",
+      "tags": [
+        "records",
+        "field-access",
+        "nesting"
+      ],
+      "description": "Record literals, field access, nested records"
     },
     {
       "path": "recursion_factorial.ail",
@@ -1008,66 +953,61 @@
       "description": "recursion_quicksort.ail"
     },
     {
-      "path": "simple_func_match.ail",
+      "path": "reference/budget_minimum.ail",
       "status": "working",
       "tags": [
-        "pattern-matching"
+        "effects",
+        "budget",
+        "reference",
+        "m-dx25"
       ],
-      "description": "Simple Func Match example"
+      "description": "Reference: Minimum budget (@min) verification for audit logging and cache bypass",
+      "expected": {
+        "exit_code": 0
+      }
     },
     {
-      "path": "stdlib_demo.ail",
+      "path": "regex_basics.ail",
       "status": "working",
       "tags": [
-        "demo"
-      ],
-      "description": "Standard library demo: string functions and options"
-    },
-    {
-      "path": "stdlib_demo_simple.ail",
-      "status": "working",
-      "tags": [
-        "demo"
-      ],
-      "description": "Simple stdlib demo - Demonstrates basic IO builtins"
-    },
-    {
-      "path": "string_parsing.ail",
-      "status": "working",
-      "tags": [
-        "parsing",
-        "string"
-      ],
-      "description": "Demonstrates string-to-number parsing with Option types"
-    },
-    {
-      "path": "string_split.ail",
-      "status": "working",
-      "tags": [
-        "parsing",
-        "string"
-      ],
-      "description": "String Split example"
-    },
-    {
-      "path": "runnable/string_contains.ail",
-      "status": "working",
-      "tags": [
+        "regex",
         "string",
-        "stdlib"
+        "stdlib",
+        "re2"
       ],
-      "description": "Demonstrates std/string contains and find functions"
+      "description": "std/regex core ops: isMatch, replaceAll, split (linear-time RE2)",
+      "requires": [
+        "IO"
+      ]
     },
     {
-      "path": "runnable/record_width_subtyping.ail",
+      "path": "regex_capture.ail",
       "status": "working",
       "tags": [
-        "records",
-        "row-polymorphism",
-        "width-subtyping",
-        "types"
+        "regex",
+        "capture-groups",
+        "stdlib",
+        "re2"
       ],
-      "description": "Record width subtyping via open record types ({a: T | r} and {a: T, ...})"
+      "description": "Extract regex capture groups with std/regex findFirst + nth_or",
+      "requires": [
+        "IO"
+      ]
+    },
+    {
+      "path": "regex_log_orchestration.ail",
+      "status": "working",
+      "tags": [
+        "regex",
+        "orchestration",
+        "stdlib",
+        "re2",
+        "routing"
+      ],
+      "description": "Parse + route structured log lines with std/regex (orchestration use case)",
+      "requires": [
+        "IO"
+      ]
     },
     {
       "path": "runnable/adt_list_fields.ail",
@@ -1081,30 +1021,66 @@
       "description": "ADT record types with list fields for Go codegen (Issue #116)"
     },
     {
-      "path": "runnable/poly_adt_result_type.ail",
+      "path": "runnable/ai_caching.ail",
       "status": "working",
       "tags": [
-        "adt",
-        "polymorphism",
-        "type-inference",
-        "m-poly-adt"
+        "effects",
+        "ai",
+        "cache",
+        "tool-use"
       ],
-      "description": "Polymorphic ADT with mixed field types: Result[a] = Ok(a) | Err(string)"
+      "description": "Demonstrates std/ai.stepWithCache \u2014 opt-in prompt caching across providers (M-AI-PROMPT-CACHING v0.18.4)"
     },
     {
-      "path": "runnable/polymorphic_adt.ail",
+      "path": "runnable/ai_call_json_simple_result.ail",
       "status": "working",
       "tags": [
-        "adt",
-        "polymorphism",
-        "type-inference",
-        "m-poly-adt",
-        "option",
+        "effects",
+        "ai",
         "result",
-        "either",
-        "functional"
+        "typed-errors",
+        "json"
       ],
-      "description": "Comprehensive polymorphic ADT examples: Result, Either, mapResult, bindResult, Option integration"
+      "description": "Demonstrates std/ai.callJsonSimpleResult \u2014 Result-returning no-schema JSON call with retryable typed errors (M-DOCPARSE-RESILIENCE-FIXES v0.23.0)"
+    },
+    {
+      "path": "runnable/ai_call_stream.ail",
+      "status": "working",
+      "tags": [
+        "effects",
+        "ai",
+        "streaming",
+        "sse",
+        "config-driven",
+        "accumulator"
+      ],
+      "description": "AI token streaming via std/ai/streaming.callStream \u2014 synchronous accumulator returning Result[string, AIError]"
+    },
+    {
+      "path": "runnable/ai_stream_openai.ail",
+      "status": "working",
+      "tags": [
+        "effects",
+        "ai",
+        "streaming",
+        "sse",
+        "config-driven"
+      ],
+      "description": "AI token streaming via std/ai/streaming.openaiCompatStream + manual event loop (per-delta control flow)"
+    },
+    {
+      "path": "runnable/ai_streaming.ail",
+      "status": "working",
+      "tags": [
+        "effects",
+        "ai",
+        "streaming",
+        "sse",
+        "tool-use",
+        "cache",
+        "typed"
+      ],
+      "description": "Demonstrates std/ai.stepWithStream \u2014 typed-StepResult streaming with per-chunk callback (M-AI-STEP-STREAMING v0.18.7)"
     },
     {
       "path": "runnable/bitwise.ail",
@@ -1120,121 +1096,16 @@
       "description": "Bitwise operators: AND (&), XOR (^), NOT (~), shift left (<<), shift right (>>), XOR encryption pattern, nibble extraction"
     },
     {
-      "path": "runnable/fnv1a.ail",
+      "path": "runnable/contracts/access_control.ail",
       "status": "working",
       "tags": [
-        "hash",
-        "bitwise",
-        "string",
-        "foldChars",
-        "charCode",
-        "benchmark"
+        "contracts",
+        "smt-verification",
+        "ailang-verify",
+        "security",
+        "cross-function-calls"
       ],
-      "description": "FNV-1a hash function using bitwise XOR, charCode, and foldChars \u2014 demonstrates character-level string processing and deterministic hashing"
-    },
-    {
-      "path": "test_cli_io.ail",
-      "status": "working",
-      "tags": [
-        "testing"
-      ],
-      "description": "Simple IO test for CLI tests"
-    },
-    {
-      "path": "test_fizzbuzz.ail",
-      "status": "working",
-      "tags": [
-        "testing"
-      ],
-      "description": "Integration Test: FizzBuzz"
-    },
-    {
-      "path": "test_guard_bool.ail",
-      "status": "working",
-      "tags": [
-        "testing"
-      ],
-      "description": "Test guard with boolean literal"
-    },
-    {
-      "path": "test_import_func.ail",
-      "status": "working",
-      "tags": [
-        "testing"
-      ],
-      "description": "Test Import Func example"
-    },
-    {
-      "path": "test_io_builtins.ail",
-      "status": "working",
-      "tags": [
-        "testing"
-      ],
-      "description": "Test builtin IO functions (M-R1 Phase 5)"
-    },
-    {
-      "path": "test_module_minimal.ail",
-      "status": "working",
-      "tags": [
-        "testing"
-      ],
-      "description": "Test Module Minimal example"
-    },
-    {
-      "path": "type_classes.ail",
-      "status": "working",
-      "tags": [
-        "types"
-      ],
-      "description": "Showcase: Type Classes"
-    },
-    {
-      "path": "type_inference.ail",
-      "status": "working",
-      "tags": [
-        "types"
-      ],
-      "description": "Showcase: Type Inference"
-    },
-    {
-      "path": "type_inference_regression.ail",
-      "status": "working",
-      "tags": [
-        "types"
-      ],
-      "description": "Type Inference Regression Test"
-    },
-    {
-      "path": "values_basic.ail",
-      "status": "working",
-      "tags": [
-        "misc"
-      ],
-      "description": "values_basic.ail - Working with values and string concatenation"
-    },
-    {
-      "path": "web_api_demo/api/math.ail",
-      "status": "working",
-      "tags": [
-        "api",
-        "serve-api",
-        "pure",
-        "demo"
-      ],
-      "description": "Web API demo: pure math functions (add, multiply, factorial, fibonacci) served via ailang serve-api",
-      "run_mode": "serve-api"
-    },
-    {
-      "path": "web_api_demo/api/greet.ail",
-      "status": "working",
-      "tags": [
-        "api",
-        "serve-api",
-        "json",
-        "demo"
-      ],
-      "description": "Web API demo: string and JSON functions (hello, farewell, welcome) served via ailang serve-api",
-      "run_mode": "serve-api"
+      "description": "Role-based access control with cross-function calls and Z3-verified security properties"
     },
     {
       "path": "runnable/contracts/basic.ail",
@@ -1251,18 +1122,38 @@
       ]
     },
     {
-      "path": "runnable/contracts/park.ail",
+      "path": "runnable/contracts/cross_function.ail",
       "status": "working",
       "tags": [
         "contracts",
-        "requires",
-        "ensures",
-        "m-verify-contracts"
+        "smt-verification",
+        "ailang-verify",
+        "cross-function-calls",
+        "transitive"
       ],
-      "description": "Contract verification: theme park admission example with age/height constraints",
-      "run_flags": [
-        "--verify-contracts"
-      ]
+      "description": "Cross-function verification \u2014 Z3 inlines callee definitions to verify 3-level call chains"
+    },
+    {
+      "path": "runnable/contracts/cross_module_functions.ail",
+      "status": "working",
+      "tags": [
+        "contracts",
+        "smt-verification",
+        "cross-module",
+        "m-smt-cross-module-functions"
+      ],
+      "description": "M-SMT-CROSS-MODULE-FUNCTIONS: cross-module function calls verified via inline (define-fun) and contract-as-spec paths (3 verified)"
+    },
+    {
+      "path": "runnable/contracts/cross_module_functions_lib.ail",
+      "status": "working",
+      "tags": [
+        "contracts",
+        "smt-verification",
+        "cross-module",
+        "m-smt-cross-module-functions"
+      ],
+      "description": "M-SMT-CROSS-MODULE-FUNCTIONS: library with double (inlineable) and sumTo (recursive, contract fallback)"
     },
     {
       "path": "runnable/contracts/finance.ail",
@@ -1277,27 +1168,29 @@
       "description": "Financial calculations with cross-function calls, provably correct tax rules, and counterexample demo"
     },
     {
-      "path": "runnable/contracts/access_control.ail",
+      "path": "runnable/contracts/inbox_v2_app.ail",
       "status": "working",
       "tags": [
         "contracts",
-        "smt-verification",
-        "ailang-verify",
-        "security",
-        "cross-function-calls"
+        "ifc",
+        "labels",
+        "m-taint-types",
+        "cross-module",
+        "smt-verification"
       ],
-      "description": "Role-based access control with cross-function calls and Z3-verified security properties"
+      "description": "M-TAINT-TYPES: cross-module inbox-injection demo (5 functions: 3 verified, 2 violations)"
     },
     {
-      "path": "runnable/contracts/temperature.ail",
+      "path": "runnable/contracts/inbox_v2_lib.ail",
       "status": "working",
       "tags": [
         "contracts",
-        "smt-verification",
-        "ailang-verify",
-        "physics"
+        "ifc",
+        "labels",
+        "m-taint-types",
+        "cross-module"
       ],
-      "description": "Temperature conversion with verified physical constraints"
+      "description": "M-TAINT-TYPES: cross-module library exporting Mail record with labelled fields"
     },
     {
       "path": "runnable/contracts/insurance.ail",
@@ -1310,84 +1203,6 @@
         "business-rules"
       ],
       "description": "Complex insurance pricing with 768 code paths \u2014 Z3 catches subtle discount overflow"
-    },
-    {
-      "path": "runnable/contracts/scoring.ail",
-      "status": "working",
-      "tags": [
-        "contracts",
-        "smt-verification",
-        "ailang-verify",
-        "complex",
-        "scoring"
-      ],
-      "description": "Multi-factor scoring system \u2014 Z3 finds score exceeds 100 in specific enum combination"
-    },
-    {
-      "path": "runnable/contracts/cross_function.ail",
-      "status": "working",
-      "tags": [
-        "contracts",
-        "smt-verification",
-        "ailang-verify",
-        "cross-function-calls",
-        "transitive"
-      ],
-      "description": "Cross-function verification \u2014 Z3 inlines callee definitions to verify 3-level call chains"
-    },
-    {
-      "path": "runnable/contracts/record_verify.ail",
-      "status": "working",
-      "tags": [
-        "contracts",
-        "smt-verification",
-        "ailang-verify",
-        "records",
-        "field-access",
-        "cross-function-calls",
-        "record-construction"
-      ],
-      "description": "Record contract verification \u2014 Z3 proves properties about record field access, construction, cross-function calls with records, and counterexample generation"
-    },
-    {
-      "path": "runnable/contracts/string_verify.ail",
-      "status": "working",
-      "tags": [
-        "contracts",
-        "smt-verification",
-        "ailang-verify",
-        "strings",
-        "z3-string-theory"
-      ],
-      "description": "String contract verification \u2014 Z3 proves properties about string concatenation, equality, and prefix operations"
-    },
-    {
-      "path": "runnable/contracts/list_verify.ail",
-      "status": "working",
-      "tags": [
-        "contracts",
-        "smt-verification",
-        "ailang-verify",
-        "lists",
-        "z3-sequence-theory"
-      ],
-      "description": "List contract verification \u2014 Z3 proves properties about list length, head, nth, cons using sequence theory"
-    },
-    {
-      "path": "runnable/contracts/showcase.ail",
-      "status": "working",
-      "tags": [
-        "contracts",
-        "smt-verification",
-        "ailang-verify",
-        "records",
-        "strings",
-        "lists",
-        "enums",
-        "cross-function-calls",
-        "showcase"
-      ],
-      "description": "Comprehensive verification showcase \u2014 combines enums, records, strings, lists, and cross-function calls in one file"
     },
     {
       "path": "runnable/contracts/invoice.ail",
@@ -1407,109 +1222,121 @@
       "description": "Provably correct invoice processing \u2014 Z3 verifies billing invariants across 5 tiers x 5 tax regions x promo codes x line items. Catches volume pricing bug."
     },
     {
-      "path": "hello_world.ail",
+      "path": "runnable/contracts/list_verify.ail",
       "status": "working",
       "tags": [
-        "basic",
-        "io",
-        "classic"
+        "contracts",
+        "smt-verification",
+        "ailang-verify",
+        "lists",
+        "z3-sequence-theory"
       ],
-      "description": "Classic Hello, World! program",
-      "expected": {
-        "stdout": "Hello, World!\n",
-        "exit_code": 0
-      }
+      "description": "List contract verification \u2014 Z3 proves properties about list length, head, nth, cons using sequence theory"
     },
     {
-      "path": "runnable/zip_reader.ail",
+      "path": "runnable/contracts/nested_record_verify.ail",
       "status": "working",
       "tags": [
-        "stdlib",
-        "zip",
-        "fs",
-        "effects",
-        "result",
-        "std/zip"
+        "contracts",
+        "smt-verification",
+        "ailang-verify",
+        "records",
+        "nested-records",
+        "field-access"
       ],
-      "description": "ZIP archive reading with std/zip builtins: list entries, read text/binary content",
+      "description": "Nested record contract verification \u2014 Z3 proves properties about nested record field access (o.pos.x) with dependency-ordered type declarations"
+    },
+    {
+      "path": "runnable/contracts/park.ail",
+      "status": "working",
+      "tags": [
+        "contracts",
+        "requires",
+        "ensures",
+        "m-verify-contracts"
+      ],
+      "description": "Contract verification: theme park admission example with age/height constraints",
       "run_flags": [
-        "--caps",
-        "IO,FS"
+        "--verify-contracts"
       ]
     },
     {
-      "path": "runnable/xml_parser.ail",
+      "path": "runnable/contracts/record_pattern_verify.ail",
       "status": "working",
       "tags": [
-        "stdlib",
-        "xml",
-        "parsing",
-        "adt",
-        "result",
-        "option",
-        "std/xml"
+        "contracts",
+        "smt-verification",
+        "ailang-verify",
+        "records",
+        "pattern-matching",
+        "record-patterns"
       ],
-      "description": "XML parsing with std/xml builtins: parse XML strings, query elements, extract text and attributes"
+      "description": "Record pattern matching in contracts \u2014 Z3 verifies match expressions that destructure records into field bindings"
     },
     {
-      "path": "runnable/html_parser.ail",
+      "path": "runnable/contracts/record_verify.ail",
       "status": "working",
       "tags": [
-        "stdlib",
-        "html",
-        "parsing",
-        "adt",
-        "result",
-        "option",
-        "std/html",
-        "std/xml"
+        "contracts",
+        "smt-verification",
+        "ailang-verify",
+        "records",
+        "field-access",
+        "cross-function-calls",
+        "record-construction"
       ],
-      "description": "HTML5 parsing with std/html: lenient parse of unclosed tags, boolean attributes, mixed-case tags; returns same XmlNode ADT as std/xml",
-      "run_flags": [
-        "--caps",
-        "IO"
-      ]
+      "description": "Record contract verification \u2014 Z3 proves properties about record field access, construction, cross-function calls with records, and counterexample generation"
     },
     {
-      "path": "runnable/xml_fold.ail",
+      "path": "runnable/contracts/scoring.ail",
       "status": "working",
       "tags": [
-        "stdlib",
-        "xml",
-        "fold",
-        "streaming",
-        "performance",
-        "std/xml"
+        "contracts",
+        "smt-verification",
+        "ailang-verify",
+        "complex",
+        "scoring"
       ],
-      "description": "XML fold: process elements one-at-a-time via parseFold without building a result list"
+      "description": "Multi-factor scoring system \u2014 Z3 finds score exceeds 100 in specific enum combination"
     },
     {
-      "path": "runnable/xml_walk_perf.ail",
+      "path": "runnable/contracts/showcase.ail",
       "status": "working",
       "tags": [
-        "stdlib",
-        "xml",
-        "performance",
-        "foldChildren",
-        "getAttrMap",
-        "std/xml"
+        "contracts",
+        "smt-verification",
+        "ailang-verify",
+        "records",
+        "strings",
+        "lists",
+        "enums",
+        "cross-function-calls",
+        "showcase"
       ],
-      "description": "Wallclock comparison of classic getChildren+getAttr walks vs new foldChildren+getAttrMap walks (M-STDLIB-XML-WALK-PERF)"
+      "description": "Comprehensive verification showcase \u2014 combines enums, records, strings, lists, and cross-function calls in one file"
     },
     {
-      "path": "runnable/zip_xml_fold.ail",
+      "path": "runnable/contracts/string_verify.ail",
       "status": "working",
       "tags": [
-        "stdlib",
-        "xml",
-        "zip",
-        "fold",
-        "streaming",
-        "performance",
-        "std/zip",
-        "std/xml"
+        "contracts",
+        "smt-verification",
+        "ailang-verify",
+        "strings",
+        "z3-string-theory"
       ],
-      "description": "Streaming ZIP+XML fold: extract shared strings from XLSX-like ZIP without OOM"
+      "description": "String contract verification \u2014 Z3 proves properties about string concatenation, equality, and prefix operations"
+    },
+    {
+      "path": "runnable/contracts/temperature.ail",
+      "status": "working",
+      "tags": [
+        "contracts",
+        "smt-verification",
+        "ailang-verify",
+        "physics"
+      ],
+      "description": "Temperature conversion with verified physical constraints"
     },
     {
       "path": "runnable/effectful_list.ail",
@@ -1644,6 +1471,94 @@
       "description": "Type inference regression T8: effectful combinators on string lists"
     },
     {
+      "path": "runnable/fnv1a.ail",
+      "status": "working",
+      "tags": [
+        "hash",
+        "bitwise",
+        "string",
+        "foldChars",
+        "charCode",
+        "benchmark"
+      ],
+      "description": "FNV-1a hash function using bitwise XOR, charCode, and foldChars \u2014 demonstrates character-level string processing and deterministic hashing"
+    },
+    {
+      "path": "runnable/html_parser.ail",
+      "status": "working",
+      "tags": [
+        "stdlib",
+        "html",
+        "parsing",
+        "adt",
+        "result",
+        "option",
+        "std/html",
+        "std/xml"
+      ],
+      "description": "HTML5 parsing with std/html: lenient parse of unclosed tags, boolean attributes, mixed-case tags; returns same XmlNode ADT as std/xml",
+      "run_flags": [
+        "--caps",
+        "IO"
+      ]
+    },
+    {
+      "path": "runnable/map_basic.ail",
+      "status": "working",
+      "tags": [
+        "map",
+        "hashmap",
+        "std-map",
+        "data-structures",
+        "option"
+      ],
+      "description": "Hash map operations: fromList, lookup (Option), member, size, keys, insert, remove"
+    },
+    {
+      "path": "runnable/parser_block_trailing_record.ail",
+      "status": "working",
+      "tags": [
+        "parser",
+        "regression",
+        "record",
+        "block",
+        "if-then-else"
+      ],
+      "description": "Demonstrates the M-PARSER-BLOCK-TR fix (inbox c8813647): a block expression with `;`-separated effect statements followed by a trailing record literal now parses cleanly inside if-then-else branches.",
+      "run_flags": [
+        "--caps",
+        "IO",
+        "--entry",
+        "main"
+      ]
+    },
+    {
+      "path": "runnable/poly_adt_result_type.ail",
+      "status": "working",
+      "tags": [
+        "adt",
+        "polymorphism",
+        "type-inference",
+        "m-poly-adt"
+      ],
+      "description": "Polymorphic ADT with mixed field types: Result[a] = Ok(a) | Err(string)"
+    },
+    {
+      "path": "runnable/polymorphic_adt.ail",
+      "status": "working",
+      "tags": [
+        "adt",
+        "polymorphism",
+        "type-inference",
+        "m-poly-adt",
+        "option",
+        "result",
+        "either",
+        "functional"
+      ],
+      "description": "Comprehensive polymorphic ADT examples: Result, Either, mapResult, bindResult, Option integration"
+    },
+    {
       "path": "runnable/process_demo.ail",
       "status": "working",
       "tags": [
@@ -1656,6 +1571,149 @@
       "description": "External command execution with Process effect: exec, error handling, completion semantics",
       "expected": {
         "stdout": "=== Echo test ===\nstdout: hello from AILANG\n\n=== Non-zero exit ===\nexitCode: 1\n=== NotFound test ===\nnot found: nonexistent_cmd_xyz\n=== Stderr test ===\nstderr: stderr_msg\n\nDone!\n",
+        "exit_code": 0
+      }
+    },
+    {
+      "path": "runnable/process_stdin_write.ail",
+      "status": "working",
+      "tags": [
+        "process",
+        "stdin",
+        "pipe",
+        "subprocess",
+        "M-ASYNC-IO"
+      ],
+      "description": "Write data to subprocess stdin via spawnProcess + writeProcessStdin (M-ASYNC-IO Phase 3)",
+      "expected": {
+        "stdout": "hello from AILANG\nstreaming to subprocess\ndone!\nwrote line 1\nwrote line 2\nwrote line 3\n",
+        "exit_code": 0
+      }
+    },
+    {
+      "path": "runnable/record_width_subtyping.ail",
+      "status": "working",
+      "tags": [
+        "records",
+        "row-polymorphism",
+        "width-subtyping",
+        "types"
+      ],
+      "description": "Record width subtyping via open record types ({a: T | r} and {a: T, ...})"
+    },
+    {
+      "path": "runnable/std_deflate_pdf_objstm.ail",
+      "status": "working",
+      "tags": [
+        "stdlib",
+        "deflate",
+        "zlib",
+        "pdf",
+        "result",
+        "io",
+        "std/deflate"
+      ],
+      "description": "Decode a PDF FlateDecode /ObjStm payload via std/deflate.inflateZlib (3 annotation dicts)",
+      "run_flags": [
+        "--caps",
+        "IO",
+        "--entry",
+        "main"
+      ]
+    },
+    {
+      "path": "runnable/stdlib_embedding.ail",
+      "status": "working",
+      "tags": [
+        "stdlib",
+        "std/embedding",
+        "vectors",
+        "similarity",
+        "pure"
+      ],
+      "description": "std/embedding headline: cosine-similarity ranking + pure vector ops (magnitude, normalize)",
+      "expected": {
+        "stdout": "cosine scores: [0.9999999999999998, 0.0, 0.9999999999999998]\nbest match: cat (score 0.9999999999999998)\nmagnitude([3,4]): 5.0\nnormalize([3,4]): [0.6, 0.8]\n",
+        "exit_code": 0
+      }
+    },
+    {
+      "path": "runnable/stdlib_game.ail",
+      "status": "working",
+      "tags": [
+        "stdlib",
+        "std/game",
+        "clock",
+        "frame-timing",
+        "capability"
+      ],
+      "description": "std/game headline: frame-rate-independent movement with a fixed timestep + Clock frame_count()",
+      "expected": {
+        "stdout": "frame_count at start: 0\nposition after 60 frames @ dt=0.016: 95.99999999999991\n",
+        "exit_code": 0
+      }
+    },
+    {
+      "path": "runnable/stdlib_gzip.ail",
+      "status": "working",
+      "tags": [
+        "stdlib",
+        "std/gzip",
+        "compression",
+        "bytes",
+        "base64"
+      ],
+      "description": "std/gzip headline: lossless compress -> decompress round-trip over base64 bytes",
+      "expected": {
+        "stdout": "original bytes: 55\nround-trip lossless: true\n",
+        "exit_code": 0
+      }
+    },
+    {
+      "path": "runnable/stdlib_sharedindex.ail",
+      "status": "working",
+      "tags": [
+        "stdlib",
+        "std/sharedindex",
+        "index",
+        "similarity",
+        "capability"
+      ],
+      "description": "std/sharedindex headline: namespace-partitioned SimHash index + deterministic similarity query",
+      "expected": {
+        "stdout": "namespaces: [docs]\nentry count: 3\nquery hits: 3\n",
+        "exit_code": 0
+      }
+    },
+    {
+      "path": "runnable/stdlib_simhash.ail",
+      "status": "working",
+      "tags": [
+        "stdlib",
+        "std/simhash",
+        "lsh",
+        "near-duplicate",
+        "pure"
+      ],
+      "description": "std/simhash headline: SimHash fingerprints + Hamming-distance near-duplicate classification",
+      "expected": {
+        "stdout": "edit vs base: somewhat similar\nother vs base: different\ndist(base, edit) = 4\ndist(base, other) = 35\n",
+        "exit_code": 0
+      }
+    },
+    {
+      "path": "runnable/stdlib_smoke.ail",
+      "status": "working",
+      "tags": [
+        "stdlib",
+        "std/smoke",
+        "smoke-test",
+        "package",
+        "dispatch"
+      ],
+      "description": "std/smoke headline: dispatchAllTools/dispatchTool/okSuite package boot-probe pattern",
+      "expected": {
+        "stdout": "  -> exercised search\nOK: tool search dispatched without crash\n  -> exercised fetch\nOK: tool fetch dispatched without crash\n  -> exercised summarize\nOK: tool summarize dispatched without crash\n  -> exercised healthcheck\nOK: tool healthcheck dispatched without crash\nOK: demo_package smoke complete\n",
         "exit_code": 0
       }
     },
@@ -1696,113 +1754,35 @@
       }
     },
     {
-      "path": "runnable/process_stdin_write.ail",
+      "path": "runnable/string_contains.ail",
       "status": "working",
       "tags": [
-        "process",
-        "stdin",
-        "pipe",
-        "subprocess",
-        "M-ASYNC-IO"
+        "string",
+        "stdlib"
       ],
-      "description": "Write data to subprocess stdin via spawnProcess + writeProcessStdin (M-ASYNC-IO Phase 3)",
-      "expected": {
-        "stdout": "hello from AILANG\nstreaming to subprocess\ndone!\nwrote line 1\nwrote line 2\nwrote line 3\n",
-        "exit_code": 0
-      }
+      "description": "Demonstrates std/string contains and find functions"
     },
     {
-      "path": "runnable/contracts/nested_record_verify.ail",
+      "path": "runnable/structured_ai_basic.ail",
       "status": "working",
       "tags": [
-        "contracts",
-        "smt-verification",
-        "ailang-verify",
-        "records",
-        "nested-records",
-        "field-access"
+        "effects",
+        "ai",
+        "json",
+        "structured-output"
       ],
-      "description": "Nested record contract verification \u2014 Z3 proves properties about nested record field access (o.pos.x) with dependency-ordered type declarations"
+      "description": "Demonstrates callJsonSimple: AI returns valid JSON without schema enforcement"
     },
     {
-      "path": "runnable/contracts/record_pattern_verify.ail",
+      "path": "runnable/structured_ai_schema.ail",
       "status": "working",
       "tags": [
-        "contracts",
-        "smt-verification",
-        "ailang-verify",
-        "records",
-        "pattern-matching",
-        "record-patterns"
+        "effects",
+        "ai",
+        "json",
+        "structured-output"
       ],
-      "description": "Record pattern matching in contracts \u2014 Z3 verifies match expressions that destructure records into field bindings"
-    },
-    {
-      "path": "expected_fail/contracts/list_recursive_verify.ail",
-      "status": "working",
-      "tags": [
-        "contracts",
-        "smt-verification",
-        "ailang-verify",
-        "lists",
-        "list-contains",
-        "list-extract",
-        "z3-sequence-theory"
-      ],
-      "description": "Recursive list operation contracts \u2014 Z3 proves containment and extraction properties using seq.contains and seq.extract"
-    },
-    {
-      "path": "expected_fail/contracts/per_function_depth_verify.ail",
-      "status": "working",
-      "tags": [
-        "contracts",
-        "smt-verification",
-        "ailang-verify",
-        "bounded-recursion",
-        "verify-attribute",
-        "per-function-depth"
-      ],
-      "description": "Per-function recursion depth \u2014 @verify(depth: N) attribute overrides global --verify-recursive-depth for individual functions"
-    },
-    {
-      "path": "expected_fail/contracts/hof_verify.ail",
-      "status": "working",
-      "tags": [
-        "contracts",
-        "smt-verification",
-        "ailang-verify",
-        "higher-order",
-        "hof-inlining",
-        "map",
-        "filter",
-        "lambda"
-      ],
-      "description": "Higher-order function verification \u2014 Z3 proves properties about map/filter with known lambdas via monomorphic inlining and bounded unrolling"
-    },
-    {
-      "path": "expected_fail/contracts/quantifier_verify.ail",
-      "status": "working",
-      "tags": [
-        "contracts",
-        "smt-verification",
-        "ailang-verify",
-        "quantifiers",
-        "forall",
-        "bounded-quantifiers"
-      ],
-      "description": "Bounded quantifier verification \u2014 forall i: lo..hi => P(i) in ensures clauses, encoded to Z3 bounded quantifiers"
-    },
-    {
-      "path": "runnable/map_basic.ail",
-      "status": "working",
-      "tags": [
-        "map",
-        "hashmap",
-        "std-map",
-        "data-structures",
-        "option"
-      ],
-      "description": "Hash map operations: fromList, lookup (Option), member, size, keys, insert, remove"
+      "description": "Demonstrates callJson: AI returns schema-enforced JSON output"
     },
     {
       "path": "runnable/tar_gzip_reader.ail",
@@ -1821,73 +1801,6 @@
       "run_flags": [
         "--caps",
         "IO,FS"
-      ]
-    },
-    {
-      "path": "runnable/contracts/cross_module_functions_lib.ail",
-      "status": "working",
-      "tags": [
-        "contracts",
-        "smt-verification",
-        "cross-module",
-        "m-smt-cross-module-functions"
-      ],
-      "description": "M-SMT-CROSS-MODULE-FUNCTIONS: library with double (inlineable) and sumTo (recursive, contract fallback)"
-    },
-    {
-      "path": "runnable/contracts/cross_module_functions.ail",
-      "status": "working",
-      "tags": [
-        "contracts",
-        "smt-verification",
-        "cross-module",
-        "m-smt-cross-module-functions"
-      ],
-      "description": "M-SMT-CROSS-MODULE-FUNCTIONS: cross-module function calls verified via inline (define-fun) and contract-as-spec paths (3 verified)"
-    },
-    {
-      "path": "runnable/contracts/inbox_v2_lib.ail",
-      "status": "working",
-      "tags": [
-        "contracts",
-        "ifc",
-        "labels",
-        "m-taint-types",
-        "cross-module"
-      ],
-      "description": "M-TAINT-TYPES: cross-module library exporting Mail record with labelled fields"
-    },
-    {
-      "path": "runnable/contracts/inbox_v2_app.ail",
-      "status": "working",
-      "tags": [
-        "contracts",
-        "ifc",
-        "labels",
-        "m-taint-types",
-        "cross-module",
-        "smt-verification"
-      ],
-      "description": "M-TAINT-TYPES: cross-module inbox-injection demo (5 functions: 3 verified, 2 violations)"
-    },
-    {
-      "path": "runnable/std_deflate_pdf_objstm.ail",
-      "status": "working",
-      "tags": [
-        "stdlib",
-        "deflate",
-        "zlib",
-        "pdf",
-        "result",
-        "io",
-        "std/deflate"
-      ],
-      "description": "Decode a PDF FlateDecode /ObjStm payload via std/deflate.inflateZlib (3 annotation dicts)",
-      "run_flags": [
-        "--caps",
-        "IO",
-        "--entry",
-        "main"
       ]
     },
     {
@@ -1911,73 +1824,256 @@
       ]
     },
     {
-      "path": "runnable/parser_block_trailing_record.ail",
+      "path": "runnable/xml_fold.ail",
       "status": "working",
       "tags": [
-        "parser",
-        "regression",
-        "record",
-        "block",
-        "if-then-else"
+        "stdlib",
+        "xml",
+        "fold",
+        "streaming",
+        "performance",
+        "std/xml"
       ],
-      "description": "Demonstrates the M-PARSER-BLOCK-TR fix (inbox c8813647): a block expression with `;`-separated effect statements followed by a trailing record literal now parses cleanly inside if-then-else branches.",
+      "description": "XML fold: process elements one-at-a-time via parseFold without building a result list"
+    },
+    {
+      "path": "runnable/xml_parser.ail",
+      "status": "working",
+      "tags": [
+        "stdlib",
+        "xml",
+        "parsing",
+        "adt",
+        "result",
+        "option",
+        "std/xml"
+      ],
+      "description": "XML parsing with std/xml builtins: parse XML strings, query elements, extract text and attributes"
+    },
+    {
+      "path": "runnable/xml_walk_perf.ail",
+      "status": "working",
+      "tags": [
+        "stdlib",
+        "xml",
+        "performance",
+        "foldChildren",
+        "getAttrMap",
+        "std/xml"
+      ],
+      "description": "Wallclock comparison of classic getChildren+getAttr walks vs new foldChildren+getAttrMap walks (M-STDLIB-XML-WALK-PERF)"
+    },
+    {
+      "path": "runnable/zip_reader.ail",
+      "status": "working",
+      "tags": [
+        "stdlib",
+        "zip",
+        "fs",
+        "effects",
+        "result",
+        "std/zip"
+      ],
+      "description": "ZIP archive reading with std/zip builtins: list entries, read text/binary content",
       "run_flags": [
         "--caps",
-        "IO",
-        "--entry",
-        "main"
+        "IO,FS"
       ]
     },
     {
-      "path": "regex_basics.ail",
+      "path": "runnable/zip_xml_fold.ail",
       "status": "working",
       "tags": [
-        "regex",
-        "string",
         "stdlib",
-        "re2"
+        "xml",
+        "zip",
+        "fold",
+        "streaming",
+        "performance",
+        "std/zip",
+        "std/xml"
       ],
-      "description": "std/regex core ops: isMatch, replaceAll, split (linear-time RE2)",
-      "requires": [
-        "IO"
-      ]
+      "description": "Streaming ZIP+XML fold: extract shared strings from XLSX-like ZIP without OOM"
     },
     {
-      "path": "regex_capture.ail",
+      "path": "simple.ail",
       "status": "working",
       "tags": [
-        "regex",
-        "capture-groups",
-        "stdlib",
-        "re2"
+        "basic",
+        "arithmetic",
+        "let"
       ],
-      "description": "Extract regex capture groups with std/regex findFirst + nth_or",
-      "requires": [
-        "IO"
-      ]
+      "description": "Let bindings and arithmetic",
+      "expected": {
+        "stdout": "10\n",
+        "exit_code": 0
+      }
     },
     {
-      "path": "regex_log_orchestration.ail",
+      "path": "simple_func_match.ail",
       "status": "working",
       "tags": [
-        "regex",
-        "orchestration",
-        "stdlib",
-        "re2",
-        "routing"
+        "pattern-matching"
       ],
-      "description": "Parse + route structured log lines with std/regex (orchestration use case)",
-      "requires": [
-        "IO"
-      ]
+      "description": "Simple Func Match example"
+    },
+    {
+      "path": "stdlib_demo.ail",
+      "status": "working",
+      "tags": [
+        "demo"
+      ],
+      "description": "Standard library demo: string functions and options"
+    },
+    {
+      "path": "stdlib_demo_simple.ail",
+      "status": "working",
+      "tags": [
+        "demo"
+      ],
+      "description": "Simple stdlib demo - Demonstrates basic IO builtins"
+    },
+    {
+      "path": "string_parsing.ail",
+      "status": "working",
+      "tags": [
+        "parsing",
+        "string"
+      ],
+      "description": "Demonstrates string-to-number parsing with Option types"
+    },
+    {
+      "path": "string_split.ail",
+      "status": "working",
+      "tags": [
+        "parsing",
+        "string"
+      ],
+      "description": "String Split example"
+    },
+    {
+      "path": "test_cli_io.ail",
+      "status": "working",
+      "tags": [
+        "testing"
+      ],
+      "description": "Simple IO test for CLI tests"
+    },
+    {
+      "path": "test_fizzbuzz.ail",
+      "status": "working",
+      "tags": [
+        "testing"
+      ],
+      "description": "Integration Test: FizzBuzz"
+    },
+    {
+      "path": "test_guard_bool.ail",
+      "status": "working",
+      "tags": [
+        "testing"
+      ],
+      "description": "Test guard with boolean literal"
+    },
+    {
+      "path": "test_import_func.ail",
+      "status": "working",
+      "tags": [
+        "testing"
+      ],
+      "description": "Test Import Func example"
+    },
+    {
+      "path": "test_io_builtins.ail",
+      "status": "working",
+      "tags": [
+        "testing"
+      ],
+      "description": "Test builtin IO functions (M-R1 Phase 5)"
+    },
+    {
+      "path": "test_module_minimal.ail",
+      "status": "working",
+      "tags": [
+        "testing"
+      ],
+      "description": "Test Module Minimal example"
+    },
+    {
+      "path": "type_classes.ail",
+      "status": "working",
+      "tags": [
+        "types"
+      ],
+      "description": "Showcase: Type Classes"
+    },
+    {
+      "path": "type_inference.ail",
+      "status": "working",
+      "tags": [
+        "types"
+      ],
+      "description": "Showcase: Type Inference"
+    },
+    {
+      "path": "type_inference_regression.ail",
+      "status": "working",
+      "tags": [
+        "types"
+      ],
+      "description": "Type Inference Regression Test"
+    },
+    {
+      "path": "typeclasses.ail",
+      "status": "working",
+      "tags": [
+        "typeclass",
+        "num",
+        "eq",
+        "ord",
+        "show"
+      ],
+      "description": "Type class usage: Num, Eq, Ord, Show"
+    },
+    {
+      "path": "values_basic.ail",
+      "status": "working",
+      "tags": [
+        "misc"
+      ],
+      "description": "values_basic.ail - Working with values and string concatenation"
+    },
+    {
+      "path": "web_api_demo/api/greet.ail",
+      "status": "working",
+      "tags": [
+        "api",
+        "serve-api",
+        "json",
+        "demo"
+      ],
+      "description": "Web API demo: string and JSON functions (hello, farewell, welcome) served via ailang serve-api",
+      "run_mode": "serve-api"
+    },
+    {
+      "path": "web_api_demo/api/math.ail",
+      "status": "working",
+      "tags": [
+        "api",
+        "serve-api",
+        "pure",
+        "demo"
+      ],
+      "description": "Web API demo: pure math functions (add, multiply, factorial, fibonacci) served via ailang serve-api",
+      "run_mode": "serve-api"
     }
   ],
   "statistics": {
-    "total": 176,
-    "working": 165,
+    "total": 182,
+    "working": 171,
     "aspirational": 4,
     "broken": 7,
-    "coverage": 0.9375,
+    "coverage": 0.9395604395604396,
     "experimental": 0
   },
   "milestones": {

--- a/examples/manifest.json
+++ b/examples/manifest.json
@@ -49,7 +49,12 @@
         "effects",
         "ai"
       ],
-      "description": "AILANG OpenAI API Integration Example"
+      "description": "AILANG OpenAI API Integration Example",
+      "modules": [
+        "std/io",
+        "std/json",
+        "std/net"
+      ]
     },
     {
       "path": "ai_effect.ail",
@@ -58,7 +63,11 @@
         "effects",
         "ai"
       ],
-      "description": "AI Effect Example"
+      "description": "AI Effect Example",
+      "modules": [
+        "std/ai",
+        "std/io"
+      ]
     },
     {
       "path": "arithmetic.ail",
@@ -90,7 +99,12 @@
         "array",
         "data-structures"
       ],
-      "description": "Array Basics Example"
+      "description": "Array Basics Example",
+      "modules": [
+        "std/array",
+        "std/io",
+        "std/option"
+      ]
     },
     {
       "path": "array_grid.ail",
@@ -99,7 +113,11 @@
         "array",
         "data-structures"
       ],
-      "description": "Array Grid Example"
+      "description": "Array Grid Example",
+      "modules": [
+        "std/array",
+        "std/io"
+      ]
     },
     {
       "path": "block_demo.ail",
@@ -118,7 +136,10 @@
         "syntax",
         "blocks"
       ],
-      "description": "Blocks with recursive calls"
+      "description": "Blocks with recursive calls",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "bug_float_comparison.ail",
@@ -148,6 +169,9 @@
         "type-inference"
       ],
       "description": "Bug: ++ operator defaults to string concat in simple expressions. See bugs/concat_operator_list_inference.ail",
+      "modules": [
+        "std/io"
+      ],
       "skip_reason": "Type inference bug: ++ defaults to string concat instead of list concat"
     },
     {
@@ -167,7 +191,12 @@
       "tags": [
         "misc"
       ],
-      "description": "Example: Real Claude Haiku API call using AILANG"
+      "description": "Example: Real Claude Haiku API call using AILANG",
+      "modules": [
+        "std/io",
+        "std/json",
+        "std/net"
+      ]
     },
     {
       "path": "cli_args_demo.ail",
@@ -175,7 +204,12 @@
       "tags": [
         "demo"
       ],
-      "description": "Demonstrates CLI argument access using getArgs()"
+      "description": "Demonstrates CLI argument access using getArgs()",
+      "modules": [
+        "std/env",
+        "std/io",
+        "std/list"
+      ]
     },
     {
       "path": "closures.ail",
@@ -203,7 +237,10 @@
         "cons",
         "expression"
       ],
-      "description": "Cons (::) in expression position \u2014 building lists by prepending"
+      "description": "Cons (::) in expression position — building lists by prepending",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "conway_grid.ail",
@@ -211,7 +248,10 @@
       "tags": [
         "misc"
       ],
-      "description": "Conway's Game of Life on an Array grid"
+      "description": "Conway's Game of Life on an Array grid",
+      "modules": [
+        "std/array"
+      ]
     },
     {
       "path": "debug_effect.ail",
@@ -220,7 +260,10 @@
         "debug",
         "effects"
       ],
-      "description": "Debug Effect Example"
+      "description": "Debug Effect Example",
+      "modules": [
+        "std/debug"
+      ]
     },
     {
       "path": "debug_types_demo.ail",
@@ -238,7 +281,10 @@
       "tags": [
         "demo"
       ],
-      "description": "Demo: Call a public API endpoint"
+      "description": "Demo: Call a public API endpoint",
+      "modules": [
+        "std/net"
+      ]
     },
     {
       "path": "effect_budget_demo.ail",
@@ -249,6 +295,11 @@
         "m-dx25"
       ],
       "description": "Effect budget demo: @limit for max calls, @min for minimum requirements",
+      "modules": [
+        "std/io",
+        "std/list",
+        "std/string"
+      ],
       "expected": {
         "exit_code": 0
       }
@@ -291,7 +342,10 @@
       "tags": [
         "effects"
       ],
-      "description": "Effects Basic example"
+      "description": "Effects Basic example",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "effects_fs_io.ail",
@@ -299,7 +353,11 @@
       "tags": [
         "effects"
       ],
-      "description": "effects_fs_io.ail - Demonstrates multiple effect capabilities"
+      "description": "effects_fs_io.ail - Demonstrates multiple effect capabilities",
+      "modules": [
+        "std/fs",
+        "std/io"
+      ]
     },
     {
       "path": "effects_pure.ail",
@@ -319,6 +377,9 @@
         "process"
       ],
       "description": "Process exit with explicit exit code",
+      "modules": [
+        "std/io"
+      ],
       "expected": {
         "stdout": "Exiting with code 42\n",
         "exit_code": 42
@@ -337,7 +398,7 @@
         "filter",
         "lambda"
       ],
-      "description": "Higher-order function verification \u2014 Z3 proves properties about map/filter with known lambdas via monomorphic inlining and bounded unrolling"
+      "description": "Higher-order function verification — Z3 proves properties about map/filter with known lambdas via monomorphic inlining and bounded unrolling"
     },
     {
       "path": "expected_fail/contracts/list_recursive_verify.ail",
@@ -351,7 +412,7 @@
         "list-extract",
         "z3-sequence-theory"
       ],
-      "description": "Recursive list operation contracts \u2014 Z3 proves containment and extraction properties using seq.contains and seq.extract"
+      "description": "Recursive list operation contracts — Z3 proves containment and extraction properties using seq.contains and seq.extract"
     },
     {
       "path": "expected_fail/contracts/per_function_depth_verify.ail",
@@ -364,7 +425,7 @@
         "verify-attribute",
         "per-function-depth"
       ],
-      "description": "Per-function recursion depth \u2014 @verify(depth: N) attribute overrides global --verify-recursive-depth for individual functions"
+      "description": "Per-function recursion depth — @verify(depth: N) attribute overrides global --verify-recursive-depth for individual functions"
     },
     {
       "path": "expected_fail/contracts/quantifier_verify.ail",
@@ -377,7 +438,7 @@
         "forall",
         "bounded-quantifiers"
       ],
-      "description": "Bounded quantifier verification \u2014 forall i: lo..hi => P(i) in ensures clauses, encoded to Z3 bounded quantifiers"
+      "description": "Bounded quantifier verification — forall i: lo..hi => P(i) in ensures clauses, encoded to Z3 bounded quantifiers"
     },
     {
       "path": "experimental/ai_agent_integration.ail",
@@ -388,7 +449,7 @@
         "introspection",
         "future"
       ],
-      "description": "\u26a0\ufe0f VISION ONLY: AI agent integration demo. Uses unsupported syntax.",
+      "description": "⚠️ VISION ONLY: AI agent integration demo. Uses unsupported syntax.",
       "requires": [
         "effects",
         "introspection",
@@ -405,7 +466,7 @@
         "concurrency",
         "future"
       ],
-      "description": "\u26a0\ufe0f VISION ONLY: CSP-based concurrent pipeline. DO NOT RUN - causes infinite loop",
+      "description": "⚠️ VISION ONLY: CSP-based concurrent pipeline. DO NOT RUN - causes infinite loop",
       "requires": [
         "channels",
         "spawn",
@@ -423,7 +484,7 @@
         "tests",
         "future"
       ],
-      "description": "\u26a0\ufe0f VISION ONLY: Factorial with inline tests/properties. DO NOT RUN - causes infinite loop",
+      "description": "⚠️ VISION ONLY: Factorial with inline tests/properties. DO NOT RUN - causes infinite loop",
       "requires": [
         "func",
         "tests",
@@ -440,7 +501,11 @@
         "pattern-matching",
         "stdlib"
       ],
-      "description": "Functional sorting: custom quicksort and std/list sortBy"
+      "description": "Functional sorting: custom quicksort and std/list sortBy",
+      "modules": [
+        "std/io",
+        "std/list"
+      ]
     },
     {
       "path": "experimental/web_api.ail",
@@ -451,7 +516,7 @@
         "effects",
         "future"
       ],
-      "description": "\u26a0\ufe0f VISION ONLY: Web API with SQL quasiquotes. DO NOT RUN - causes infinite loop",
+      "description": "⚠️ VISION ONLY: Web API with SQL quasiquotes. DO NOT RUN - causes infinite loop",
       "requires": [
         "quasiquotes",
         "http-effects",
@@ -465,7 +530,10 @@
       "tags": [
         "misc"
       ],
-      "description": "Factorial function with inline tests"
+      "description": "Factorial function with inline tests",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "func_expressions.ail",
@@ -474,7 +542,10 @@
         "syntax",
         "functions"
       ],
-      "description": "func_expressions.ail"
+      "description": "func_expressions.ail",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "game_npc_dialogue.ail",
@@ -483,7 +554,11 @@
         "game",
         "demo"
       ],
-      "description": "Game NPC Dialogue Example"
+      "description": "Game NPC Dialogue Example",
+      "modules": [
+        "std/ai",
+        "std/io"
+      ]
     },
     {
       "path": "guards_basic.ail",
@@ -511,6 +586,9 @@
         "io"
       ],
       "description": "Basic hello world program",
+      "modules": [
+        "std/io"
+      ],
       "expected": {
         "stdout": "Hello, AILANG!\n",
         "exit_code": 0
@@ -525,6 +603,9 @@
         "classic"
       ],
       "description": "Classic Hello, World! program",
+      "modules": [
+        "std/io"
+      ],
       "expected": {
         "stdout": "Hello, World!\n",
         "exit_code": 0
@@ -539,7 +620,13 @@
         "net",
         "binary"
       ],
-      "description": "http_put_bytes.ail - PUT raw bytes (image/binary upload via httpRequestBytes)"
+      "description": "http_put_bytes.ail - PUT raw bytes (image/binary upload via httpRequestBytes)",
+      "modules": [
+        "std/bytes",
+        "std/io",
+        "std/net",
+        "std/result"
+      ]
     },
     {
       "path": "http_simple.ail",
@@ -549,7 +636,12 @@
         "effects",
         "net"
       ],
-      "description": "http_simple.ail - Simple HTTP request example"
+      "description": "http_simple.ail - Simple HTTP request example",
+      "modules": [
+        "std/io",
+        "std/net",
+        "std/string"
+      ]
     },
     {
       "path": "if_else_chain.ail",
@@ -575,7 +667,10 @@
         "imports",
         "modules"
       ],
-      "description": "Imports example"
+      "description": "Imports example",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "imports_basic.ail",
@@ -584,7 +679,10 @@
         "imports",
         "modules"
       ],
-      "description": "Basic import test: imports std/io and uses println"
+      "description": "Basic import test: imports std/io and uses println",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "json_basic_decode.ail",
@@ -593,7 +691,11 @@
         "parsing",
         "json"
       ],
-      "description": "Basic JSON decoding with direct pattern matching"
+      "description": "Basic JSON decoding with direct pattern matching",
+      "modules": [
+        "std/json",
+        "std/result"
+      ]
     },
     {
       "path": "json_parsing.ail",
@@ -602,7 +704,13 @@
         "parsing",
         "json"
       ],
-      "description": "json_parsing.ail - JSON parsing example"
+      "description": "json_parsing.ail - JSON parsing example",
+      "modules": [
+        "std/io",
+        "std/json",
+        "std/option",
+        "std/result"
+      ]
     },
     {
       "path": "lambda_expressions.ail",
@@ -667,7 +775,10 @@
         "recursion",
         "letrec"
       ],
-      "description": "letrec_recursion.ail"
+      "description": "letrec_recursion.ail",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "list_pattern_cons.ail",
@@ -676,7 +787,10 @@
         "list",
         "data-structures"
       ],
-      "description": "List pattern matching with :: (cons) constructor"
+      "description": "List pattern matching with :: (cons) constructor",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "list_pattern_records.ail",
@@ -694,7 +808,12 @@
         "list",
         "data-structures"
       ],
-      "description": "List Patterns example"
+      "description": "List Patterns example",
+      "modules": [
+        "std/io",
+        "std/list",
+        "std/option"
+      ]
     },
     {
       "path": "list_sum.ail",
@@ -719,7 +838,10 @@
       "tags": [
         "pattern-matching"
       ],
-      "description": "Match arm with block: println THEN nested match"
+      "description": "Match arm with block: println THEN nested match",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "match_in_block.ail",
@@ -735,7 +857,11 @@
       "tags": [
         "misc"
       ],
-      "description": "Math Trigonometry Example (v0.5.10)"
+      "description": "Math Trigonometry Example (v0.5.10)",
+      "modules": [
+        "std/io",
+        "std/math"
+      ]
     },
     {
       "path": "micro_block_if.ail",
@@ -743,7 +869,10 @@
       "tags": [
         "misc"
       ],
-      "description": "Blocks work in if-then-else branches"
+      "description": "Blocks work in if-then-else branches",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "micro_block_seq.ail",
@@ -751,7 +880,10 @@
       "tags": [
         "misc"
       ],
-      "description": "Block expressions allow sequencing multiple expressions"
+      "description": "Block expressions allow sequencing multiple expressions",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "micro_io_echo.ail",
@@ -759,7 +891,10 @@
       "tags": [
         "misc"
       ],
-      "description": "Micro example: IO effect with println"
+      "description": "Micro example: IO effect with println",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "micro_option_map.ail",
@@ -767,7 +902,10 @@
       "tags": [
         "higher-order"
       ],
-      "description": "Micro example: Option map usage (pure ADT operations)"
+      "description": "Micro example: Option map usage (pure ADT operations)",
+      "modules": [
+        "std/option"
+      ]
     },
     {
       "path": "micro_record_person.ail",
@@ -775,7 +913,10 @@
       "tags": [
         "misc"
       ],
-      "description": "Micro example: Record field access and aliasing"
+      "description": "Micro example: Record field access and aliasing",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "nested_match_minimal.ail",
@@ -795,7 +936,10 @@
         "pattern-matching",
         "records"
       ],
-      "description": "Nested Match Simple example"
+      "description": "Nested Match Simple example",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "no_loops_filter_map.ail",
@@ -805,7 +949,10 @@
         "recursion",
         "functional"
       ],
-      "description": "no_loops_filter_map.ail - Transformation without loops"
+      "description": "no_loops_filter_map.ail - Transformation without loops",
+      "modules": [
+        "std/list"
+      ]
     },
     {
       "path": "no_loops_fold.ail",
@@ -815,7 +962,10 @@
         "recursion",
         "functional"
       ],
-      "description": "no_loops_fold.ail - Aggregation without loops"
+      "description": "no_loops_fold.ail - Aggregation without loops",
+      "modules": [
+        "std/list"
+      ]
     },
     {
       "path": "no_loops_recursion.ail",
@@ -832,7 +982,10 @@
       "tags": [
         "demo"
       ],
-      "description": "Option type demo: Some, None, map, getOrElse"
+      "description": "Option type demo: Some, None, map, getOrElse",
+      "modules": [
+        "std/option"
+      ]
     },
     {
       "path": "pattern_sugar.ail",
@@ -840,7 +993,10 @@
       "tags": [
         "pattern-matching"
       ],
-      "description": "S-CONS Pattern Sugar Example (v0.4.3)"
+      "description": "S-CONS Pattern Sugar Example (v0.4.3)",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "patterns.ail",
@@ -878,7 +1034,10 @@
         "pattern-matching",
         "records"
       ],
-      "description": "Example: Inline Record Literals in Match Arms (M-DX16)"
+      "description": "Example: Inline Record Literals in Match Arms (M-DX16)",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "record_patterns.ail",
@@ -913,7 +1072,10 @@
         "algorithms",
         "recursion"
       ],
-      "description": "recursion_factorial.ail"
+      "description": "recursion_factorial.ail",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "recursion_fibonacci.ail",
@@ -922,7 +1084,10 @@
         "algorithms",
         "recursion"
       ],
-      "description": "recursion_fibonacci.ail"
+      "description": "recursion_fibonacci.ail",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "recursion_match.ail",
@@ -932,7 +1097,10 @@
         "pattern-matching",
         "recursion"
       ],
-      "description": "recursion_match.ail"
+      "description": "recursion_match.ail",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "recursion_mutual.ail",
@@ -941,7 +1109,10 @@
         "algorithms",
         "recursion"
       ],
-      "description": "recursion_mutual.ail"
+      "description": "recursion_mutual.ail",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "recursion_quicksort.ail",
@@ -950,7 +1121,11 @@
         "algorithms",
         "recursion"
       ],
-      "description": "recursion_quicksort.ail"
+      "description": "recursion_quicksort.ail",
+      "modules": [
+        "std/io",
+        "std/list"
+      ]
     },
     {
       "path": "reference/budget_minimum.ail",
@@ -962,6 +1137,9 @@
         "m-dx25"
       ],
       "description": "Reference: Minimum budget (@min) verification for audit logging and cache bypass",
+      "modules": [
+        "std/io"
+      ],
       "expected": {
         "exit_code": 0
       }
@@ -976,6 +1154,11 @@
         "re2"
       ],
       "description": "std/regex core ops: isMatch, replaceAll, split (linear-time RE2)",
+      "modules": [
+        "std/io",
+        "std/regex",
+        "std/result"
+      ],
       "requires": [
         "IO"
       ]
@@ -990,6 +1173,13 @@
         "re2"
       ],
       "description": "Extract regex capture groups with std/regex findFirst + nth_or",
+      "modules": [
+        "std/io",
+        "std/list",
+        "std/option",
+        "std/regex",
+        "std/result"
+      ],
       "requires": [
         "IO"
       ]
@@ -1005,6 +1195,14 @@
         "routing"
       ],
       "description": "Parse + route structured log lines with std/regex (orchestration use case)",
+      "modules": [
+        "std/io",
+        "std/list",
+        "std/option",
+        "std/regex",
+        "std/result",
+        "std/string"
+      ],
       "requires": [
         "IO"
       ]
@@ -1018,7 +1216,11 @@
         "codegen",
         "types"
       ],
-      "description": "ADT record types with list fields for Go codegen (Issue #116)"
+      "description": "ADT record types with list fields for Go codegen (Issue #116)",
+      "modules": [
+        "std/io",
+        "std/list"
+      ]
     },
     {
       "path": "runnable/ai_caching.ail",
@@ -1029,7 +1231,12 @@
         "cache",
         "tool-use"
       ],
-      "description": "Demonstrates std/ai.stepWithCache \u2014 opt-in prompt caching across providers (M-AI-PROMPT-CACHING v0.18.4)"
+      "description": "Demonstrates std/ai.stepWithCache — opt-in prompt caching across providers (M-AI-PROMPT-CACHING v0.18.4)",
+      "modules": [
+        "std/ai",
+        "std/io",
+        "std/result"
+      ]
     },
     {
       "path": "runnable/ai_call_json_simple_result.ail",
@@ -1041,7 +1248,12 @@
         "typed-errors",
         "json"
       ],
-      "description": "Demonstrates std/ai.callJsonSimpleResult \u2014 Result-returning no-schema JSON call with retryable typed errors (M-DOCPARSE-RESILIENCE-FIXES v0.23.0)"
+      "description": "Demonstrates std/ai.callJsonSimpleResult — Result-returning no-schema JSON call with retryable typed errors (M-DOCPARSE-RESILIENCE-FIXES v0.23.0)",
+      "modules": [
+        "std/ai",
+        "std/io",
+        "std/result"
+      ]
     },
     {
       "path": "runnable/ai_call_stream.ail",
@@ -1054,7 +1266,12 @@
         "config-driven",
         "accumulator"
       ],
-      "description": "AI token streaming via std/ai/streaming.callStream \u2014 synchronous accumulator returning Result[string, AIError]"
+      "description": "AI token streaming via std/ai/streaming.callStream — synchronous accumulator returning Result[string, AIError]",
+      "modules": [
+        "std/ai/streaming",
+        "std/io",
+        "std/result"
+      ]
     },
     {
       "path": "runnable/ai_stream_openai.ail",
@@ -1066,7 +1283,13 @@
         "sse",
         "config-driven"
       ],
-      "description": "AI token streaming via std/ai/streaming.openaiCompatStream + manual event loop (per-delta control flow)"
+      "description": "AI token streaming via std/ai/streaming.openaiCompatStream + manual event loop (per-delta control flow)",
+      "modules": [
+        "std/ai/streaming",
+        "std/io",
+        "std/result",
+        "std/stream"
+      ]
     },
     {
       "path": "runnable/ai_streaming.ail",
@@ -1080,7 +1303,12 @@
         "cache",
         "typed"
       ],
-      "description": "Demonstrates std/ai.stepWithStream \u2014 typed-StepResult streaming with per-chunk callback (M-AI-STEP-STREAMING v0.18.7)"
+      "description": "Demonstrates std/ai.stepWithStream — typed-StepResult streaming with per-chunk callback (M-AI-STEP-STREAMING v0.18.7)",
+      "modules": [
+        "std/ai",
+        "std/io",
+        "std/result"
+      ]
     },
     {
       "path": "runnable/bitwise.ail",
@@ -1131,7 +1359,7 @@
         "cross-function-calls",
         "transitive"
       ],
-      "description": "Cross-function verification \u2014 Z3 inlines callee definitions to verify 3-level call chains"
+      "description": "Cross-function verification — Z3 inlines callee definitions to verify 3-level call chains"
     },
     {
       "path": "runnable/contracts/cross_module_functions.ail",
@@ -1178,7 +1406,10 @@
         "cross-module",
         "smt-verification"
       ],
-      "description": "M-TAINT-TYPES: cross-module inbox-injection demo (5 functions: 3 verified, 2 violations)"
+      "description": "M-TAINT-TYPES: cross-module inbox-injection demo (5 functions: 3 verified, 2 violations)",
+      "modules": [
+        "std/string"
+      ]
     },
     {
       "path": "runnable/contracts/inbox_v2_lib.ail",
@@ -1202,7 +1433,7 @@
         "complex",
         "business-rules"
       ],
-      "description": "Complex insurance pricing with 768 code paths \u2014 Z3 catches subtle discount overflow"
+      "description": "Complex insurance pricing with 768 code paths — Z3 catches subtle discount overflow"
     },
     {
       "path": "runnable/contracts/invoice.ail",
@@ -1219,7 +1450,11 @@
         "business-logic",
         "billing"
       ],
-      "description": "Provably correct invoice processing \u2014 Z3 verifies billing invariants across 5 tiers x 5 tax regions x promo codes x line items. Catches volume pricing bug."
+      "description": "Provably correct invoice processing — Z3 verifies billing invariants across 5 tiers x 5 tax regions x promo codes x line items. Catches volume pricing bug.",
+      "modules": [
+        "std/list",
+        "std/string"
+      ]
     },
     {
       "path": "runnable/contracts/list_verify.ail",
@@ -1231,7 +1466,10 @@
         "lists",
         "z3-sequence-theory"
       ],
-      "description": "List contract verification \u2014 Z3 proves properties about list length, head, nth, cons using sequence theory"
+      "description": "List contract verification — Z3 proves properties about list length, head, nth, cons using sequence theory",
+      "modules": [
+        "std/list"
+      ]
     },
     {
       "path": "runnable/contracts/nested_record_verify.ail",
@@ -1244,7 +1482,7 @@
         "nested-records",
         "field-access"
       ],
-      "description": "Nested record contract verification \u2014 Z3 proves properties about nested record field access (o.pos.x) with dependency-ordered type declarations"
+      "description": "Nested record contract verification — Z3 proves properties about nested record field access (o.pos.x) with dependency-ordered type declarations"
     },
     {
       "path": "runnable/contracts/park.ail",
@@ -1271,7 +1509,7 @@
         "pattern-matching",
         "record-patterns"
       ],
-      "description": "Record pattern matching in contracts \u2014 Z3 verifies match expressions that destructure records into field bindings"
+      "description": "Record pattern matching in contracts — Z3 verifies match expressions that destructure records into field bindings"
     },
     {
       "path": "runnable/contracts/record_verify.ail",
@@ -1285,7 +1523,7 @@
         "cross-function-calls",
         "record-construction"
       ],
-      "description": "Record contract verification \u2014 Z3 proves properties about record field access, construction, cross-function calls with records, and counterexample generation"
+      "description": "Record contract verification — Z3 proves properties about record field access, construction, cross-function calls with records, and counterexample generation"
     },
     {
       "path": "runnable/contracts/scoring.ail",
@@ -1297,7 +1535,7 @@
         "complex",
         "scoring"
       ],
-      "description": "Multi-factor scoring system \u2014 Z3 finds score exceeds 100 in specific enum combination"
+      "description": "Multi-factor scoring system — Z3 finds score exceeds 100 in specific enum combination"
     },
     {
       "path": "runnable/contracts/showcase.ail",
@@ -1313,7 +1551,11 @@
         "cross-function-calls",
         "showcase"
       ],
-      "description": "Comprehensive verification showcase \u2014 combines enums, records, strings, lists, and cross-function calls in one file"
+      "description": "Comprehensive verification showcase — combines enums, records, strings, lists, and cross-function calls in one file",
+      "modules": [
+        "std/list",
+        "std/string"
+      ]
     },
     {
       "path": "runnable/contracts/string_verify.ail",
@@ -1325,7 +1567,10 @@
         "strings",
         "z3-string-theory"
       ],
-      "description": "String contract verification \u2014 Z3 proves properties about string concatenation, equality, and prefix operations"
+      "description": "String contract verification — Z3 proves properties about string concatenation, equality, and prefix operations",
+      "modules": [
+        "std/string"
+      ]
     },
     {
       "path": "runnable/contracts/temperature.ail",
@@ -1353,6 +1598,10 @@
         "flatMap"
       ],
       "description": "Effectful list combinators smoke test: mapE, filterE, foldlE, flatMapE, forEachE, and pure flatMap",
+      "modules": [
+        "std/io",
+        "std/list"
+      ],
       "broken": {
         "reason": "effect-row inference regression: show() in effectful-lambda interpolation collapses effect row to closed-empty (conflicts with foldlE {IO})",
         "error_code": "TC_EFFECT_ROW",
@@ -1371,7 +1620,11 @@
         "regression",
         "std/list"
       ],
-      "description": "Type inference regression T1: mapE basic type inference"
+      "description": "Type inference regression T1: mapE basic type inference",
+      "modules": [
+        "std/io",
+        "std/list"
+      ]
     },
     {
       "path": "runnable/effectful_list_t2_filterE_bool.ail",
@@ -1384,7 +1637,11 @@
         "regression",
         "std/list"
       ],
-      "description": "Type inference regression T2: filterE infers predicate returns bool"
+      "description": "Type inference regression T2: filterE infers predicate returns bool",
+      "modules": [
+        "std/io",
+        "std/list"
+      ]
     },
     {
       "path": "runnable/effectful_list_t3_foldlE_acc.ail",
@@ -1397,7 +1654,11 @@
         "regression",
         "std/list"
       ],
-      "description": "Type inference regression T3: foldlE accumulator type inference"
+      "description": "Type inference regression T3: foldlE accumulator type inference",
+      "modules": [
+        "std/io",
+        "std/list"
+      ]
     },
     {
       "path": "runnable/effectful_list_t4_flatMapE_expand.ail",
@@ -1410,7 +1671,11 @@
         "regression",
         "std/list"
       ],
-      "description": "Type inference regression T4: flatMapE list expansion"
+      "description": "Type inference regression T4: flatMapE list expansion",
+      "modules": [
+        "std/io",
+        "std/list"
+      ]
     },
     {
       "path": "runnable/effectful_list_t5_forEachE_unit.ail",
@@ -1423,7 +1688,11 @@
         "regression",
         "std/list"
       ],
-      "description": "Type inference regression T5: forEachE returns unit"
+      "description": "Type inference regression T5: forEachE returns unit",
+      "modules": [
+        "std/io",
+        "std/list"
+      ]
     },
     {
       "path": "runnable/effectful_list_t6_pure_flatMap.ail",
@@ -1435,7 +1704,11 @@
         "regression",
         "std/list"
       ],
-      "description": "Type inference regression T6: pure flatMap (no effects)"
+      "description": "Type inference regression T6: pure flatMap (no effects)",
+      "modules": [
+        "std/io",
+        "std/list"
+      ]
     },
     {
       "path": "runnable/effectful_list_t7_chain_combinators.ail",
@@ -1449,6 +1722,10 @@
         "std/list"
       ],
       "description": "Type inference regression T7: chaining multiple effectful combinators",
+      "modules": [
+        "std/io",
+        "std/list"
+      ],
       "broken": {
         "reason": "effect-row inference regression: chained effectful combinators with show()-interpolation over-constrain the effect row",
         "error_code": "TC_EFFECT_ROW",
@@ -1468,7 +1745,12 @@
         "std/list",
         "std/string"
       ],
-      "description": "Type inference regression T8: effectful combinators on string lists"
+      "description": "Type inference regression T8: effectful combinators on string lists",
+      "modules": [
+        "std/io",
+        "std/list",
+        "std/string"
+      ]
     },
     {
       "path": "runnable/fnv1a.ail",
@@ -1481,7 +1763,10 @@
         "charCode",
         "benchmark"
       ],
-      "description": "FNV-1a hash function using bitwise XOR, charCode, and foldChars \u2014 demonstrates character-level string processing and deterministic hashing"
+      "description": "FNV-1a hash function using bitwise XOR, charCode, and foldChars — demonstrates character-level string processing and deterministic hashing",
+      "modules": [
+        "std/string"
+      ]
     },
     {
       "path": "runnable/html_parser.ail",
@@ -1497,6 +1782,14 @@
         "std/xml"
       ],
       "description": "HTML5 parsing with std/html: lenient parse of unclosed tags, boolean attributes, mixed-case tags; returns same XmlNode ADT as std/xml",
+      "modules": [
+        "std/html",
+        "std/io",
+        "std/list",
+        "std/option",
+        "std/result",
+        "std/xml"
+      ],
       "run_flags": [
         "--caps",
         "IO"
@@ -1512,7 +1805,13 @@
         "data-structures",
         "option"
       ],
-      "description": "Hash map operations: fromList, lookup (Option), member, size, keys, insert, remove"
+      "description": "Hash map operations: fromList, lookup (Option), member, size, keys, insert, remove",
+      "modules": [
+        "std/io",
+        "std/map",
+        "std/option",
+        "std/string"
+      ]
     },
     {
       "path": "runnable/parser_block_trailing_record.ail",
@@ -1525,6 +1824,9 @@
         "if-then-else"
       ],
       "description": "Demonstrates the M-PARSER-BLOCK-TR fix (inbox c8813647): a block expression with `;`-separated effect statements followed by a trailing record literal now parses cleanly inside if-then-else branches.",
+      "modules": [
+        "std/io"
+      ],
       "run_flags": [
         "--caps",
         "IO",
@@ -1541,7 +1843,10 @@
         "type-inference",
         "m-poly-adt"
       ],
-      "description": "Polymorphic ADT with mixed field types: Result[a] = Ok(a) | Err(string)"
+      "description": "Polymorphic ADT with mixed field types: Result[a] = Ok(a) | Err(string)",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "runnable/polymorphic_adt.ail",
@@ -1556,7 +1861,11 @@
         "either",
         "functional"
       ],
-      "description": "Comprehensive polymorphic ADT examples: Result, Either, mapResult, bindResult, Option integration"
+      "description": "Comprehensive polymorphic ADT examples: Result, Either, mapResult, bindResult, Option integration",
+      "modules": [
+        "std/option",
+        "std/string"
+      ]
     },
     {
       "path": "runnable/process_demo.ail",
@@ -1569,6 +1878,11 @@
         "security"
       ],
       "description": "External command execution with Process effect: exec, error handling, completion semantics",
+      "modules": [
+        "std/bytes",
+        "std/io",
+        "std/process"
+      ],
       "expected": {
         "stdout": "=== Echo test ===\nstdout: hello from AILANG\n\n=== Non-zero exit ===\nexitCode: 1\n=== NotFound test ===\nnot found: nonexistent_cmd_xyz\n=== Stderr test ===\nstderr: stderr_msg\n\nDone!\n",
         "exit_code": 0
@@ -1585,6 +1899,11 @@
         "M-ASYNC-IO"
       ],
       "description": "Write data to subprocess stdin via spawnProcess + writeProcessStdin (M-ASYNC-IO Phase 3)",
+      "modules": [
+        "std/bytes",
+        "std/process",
+        "std/result"
+      ],
       "expected": {
         "stdout": "hello from AILANG\nstreaming to subprocess\ndone!\nwrote line 1\nwrote line 2\nwrote line 3\n",
         "exit_code": 0
@@ -1599,7 +1918,10 @@
         "width-subtyping",
         "types"
       ],
-      "description": "Record width subtyping via open record types ({a: T | r} and {a: T, ...})"
+      "description": "Record width subtyping via open record types ({a: T | r} and {a: T, ...})",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "runnable/std_deflate_pdf_objstm.ail",
@@ -1614,6 +1936,13 @@
         "std/deflate"
       ],
       "description": "Decode a PDF FlateDecode /ObjStm payload via std/deflate.inflateZlib (3 annotation dicts)",
+      "modules": [
+        "std/bytes",
+        "std/deflate",
+        "std/io",
+        "std/option",
+        "std/result"
+      ],
       "run_flags": [
         "--caps",
         "IO",
@@ -1632,6 +1961,11 @@
         "pure"
       ],
       "description": "std/embedding headline: cosine-similarity ranking + pure vector ops (magnitude, normalize)",
+      "modules": [
+        "std/embedding",
+        "std/io",
+        "std/list"
+      ],
       "expected": {
         "stdout": "cosine scores: [0.9999999999999998, 0.0, 0.9999999999999998]\nbest match: cat (score 0.9999999999999998)\nmagnitude([3,4]): 5.0\nnormalize([3,4]): [0.6, 0.8]\n",
         "exit_code": 0
@@ -1648,6 +1982,10 @@
         "capability"
       ],
       "description": "std/game headline: frame-rate-independent movement with a fixed timestep + Clock frame_count()",
+      "modules": [
+        "std/game",
+        "std/io"
+      ],
       "expected": {
         "stdout": "frame_count at start: 0\nposition after 60 frames @ dt=0.016: 95.99999999999991\n",
         "exit_code": 0
@@ -1664,6 +2002,12 @@
         "base64"
       ],
       "description": "std/gzip headline: lossless compress -> decompress round-trip over base64 bytes",
+      "modules": [
+        "std/bytes",
+        "std/gzip",
+        "std/io",
+        "std/result"
+      ],
       "expected": {
         "stdout": "original bytes: 55\nround-trip lossless: true\n",
         "exit_code": 0
@@ -1680,6 +2024,12 @@
         "capability"
       ],
       "description": "std/sharedindex headline: namespace-partitioned SimHash index + deterministic similarity query",
+      "modules": [
+        "std/io",
+        "std/list",
+        "std/sharedindex",
+        "std/simhash"
+      ],
       "expected": {
         "stdout": "namespaces: [docs]\nentry count: 3\nquery hits: 3\n",
         "exit_code": 0
@@ -1696,6 +2046,10 @@
         "pure"
       ],
       "description": "std/simhash headline: SimHash fingerprints + Hamming-distance near-duplicate classification",
+      "modules": [
+        "std/io",
+        "std/simhash"
+      ],
       "expected": {
         "stdout": "edit vs base: somewhat similar\nother vs base: different\ndist(base, edit) = 4\ndist(base, other) = 35\n",
         "exit_code": 0
@@ -1712,6 +2066,10 @@
         "dispatch"
       ],
       "description": "std/smoke headline: dispatchAllTools/dispatchTool/okSuite package boot-probe pattern",
+      "modules": [
+        "std/io",
+        "std/smoke"
+      ],
       "expected": {
         "stdout": "  -> exercised search\nOK: tool search dispatched without crash\n  -> exercised fetch\nOK: tool fetch dispatched without crash\n  -> exercised summarize\nOK: tool summarize dispatched without crash\n  -> exercised healthcheck\nOK: tool healthcheck dispatched without crash\nOK: demo_package smoke complete\n",
         "exit_code": 0
@@ -1728,6 +2086,10 @@
         "M-ASYNC-IO"
       ],
       "description": "Multi-source event multiplexing: stdin + selectEvents (M-ASYNC-IO)",
+      "modules": [
+        "std/result",
+        "std/stream"
+      ],
       "broken": {
         "reason": "effect-row inference regression: show()-interpolation in effectful lambda collapses effect row",
         "error_code": "TC_EFFECT_ROW",
@@ -1746,6 +2108,10 @@
         "M-ASYNC-IO"
       ],
       "description": "Subprocess stdout as SourceBytes events via asyncExecProcess (M-ASYNC-IO Phase 2)",
+      "modules": [
+        "std/bytes",
+        "std/stream"
+      ],
       "broken": {
         "reason": "effect-row inference regression: show()-interpolation in effectful lambda collapses effect row",
         "error_code": "TC_EFFECT_ROW",
@@ -1760,7 +2126,11 @@
         "string",
         "stdlib"
       ],
-      "description": "Demonstrates std/string contains and find functions"
+      "description": "Demonstrates std/string contains and find functions",
+      "modules": [
+        "std/io",
+        "std/string"
+      ]
     },
     {
       "path": "runnable/structured_ai_basic.ail",
@@ -1771,7 +2141,13 @@
         "json",
         "structured-output"
       ],
-      "description": "Demonstrates callJsonSimple: AI returns valid JSON without schema enforcement"
+      "description": "Demonstrates callJsonSimple: AI returns valid JSON without schema enforcement",
+      "modules": [
+        "std/ai",
+        "std/io",
+        "std/json",
+        "std/result"
+      ]
     },
     {
       "path": "runnable/structured_ai_schema.ail",
@@ -1782,7 +2158,13 @@
         "json",
         "structured-output"
       ],
-      "description": "Demonstrates callJson: AI returns schema-enforced JSON output"
+      "description": "Demonstrates callJson: AI returns schema-enforced JSON output",
+      "modules": [
+        "std/ai",
+        "std/io",
+        "std/json",
+        "std/result"
+      ]
     },
     {
       "path": "runnable/tar_gzip_reader.ail",
@@ -1798,6 +2180,11 @@
         "std/gzip"
       ],
       "description": "Read entries from a .tar.gz bundle and demonstrate tarbomb defence (std/tar + std/gzip)",
+      "modules": [
+        "std/io",
+        "std/result",
+        "std/tar"
+      ],
       "run_flags": [
         "--caps",
         "IO,FS"
@@ -1816,6 +2203,10 @@
         "std/net"
       ],
       "description": "URL percent-encoding via std/net.urlEncode and form-body construction via std/net.urlEncodeForm (OAuth2 token-exchange pattern)",
+      "modules": [
+        "std/io",
+        "std/net"
+      ],
       "run_flags": [
         "--caps",
         "IO",
@@ -1834,7 +2225,11 @@
         "performance",
         "std/xml"
       ],
-      "description": "XML fold: process elements one-at-a-time via parseFold without building a result list"
+      "description": "XML fold: process elements one-at-a-time via parseFold without building a result list",
+      "modules": [
+        "std/result",
+        "std/xml"
+      ]
     },
     {
       "path": "runnable/xml_parser.ail",
@@ -1848,7 +2243,11 @@
         "option",
         "std/xml"
       ],
-      "description": "XML parsing with std/xml builtins: parse XML strings, query elements, extract text and attributes"
+      "description": "XML parsing with std/xml builtins: parse XML strings, query elements, extract text and attributes",
+      "modules": [
+        "std/result",
+        "std/xml"
+      ]
     },
     {
       "path": "runnable/xml_walk_perf.ail",
@@ -1861,7 +2260,16 @@
         "getAttrMap",
         "std/xml"
       ],
-      "description": "Wallclock comparison of classic getChildren+getAttr walks vs new foldChildren+getAttrMap walks (M-STDLIB-XML-WALK-PERF)"
+      "description": "Wallclock comparison of classic getChildren+getAttr walks vs new foldChildren+getAttrMap walks (M-STDLIB-XML-WALK-PERF)",
+      "modules": [
+        "std/clock",
+        "std/list",
+        "std/map",
+        "std/option",
+        "std/result",
+        "std/string",
+        "std/xml"
+      ]
     },
     {
       "path": "runnable/zip_reader.ail",
@@ -1875,6 +2283,10 @@
         "std/zip"
       ],
       "description": "ZIP archive reading with std/zip builtins: list entries, read text/binary content",
+      "modules": [
+        "std/result",
+        "std/zip"
+      ],
       "run_flags": [
         "--caps",
         "IO,FS"
@@ -1893,7 +2305,13 @@
         "std/zip",
         "std/xml"
       ],
-      "description": "Streaming ZIP+XML fold: extract shared strings from XLSX-like ZIP without OOM"
+      "description": "Streaming ZIP+XML fold: extract shared strings from XLSX-like ZIP without OOM",
+      "modules": [
+        "std/list",
+        "std/result",
+        "std/xml",
+        "std/zip"
+      ]
     },
     {
       "path": "simple.ail",
@@ -1915,7 +2333,10 @@
       "tags": [
         "pattern-matching"
       ],
-      "description": "Simple Func Match example"
+      "description": "Simple Func Match example",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "stdlib_demo.ail",
@@ -1923,7 +2344,13 @@
       "tags": [
         "demo"
       ],
-      "description": "Standard library demo: string functions and options"
+      "description": "Standard library demo: string functions and options",
+      "modules": [
+        "std/io",
+        "std/list",
+        "std/option",
+        "std/string"
+      ]
     },
     {
       "path": "stdlib_demo_simple.ail",
@@ -1940,7 +2367,12 @@
         "parsing",
         "string"
       ],
-      "description": "Demonstrates string-to-number parsing with Option types"
+      "description": "Demonstrates string-to-number parsing with Option types",
+      "modules": [
+        "std/io",
+        "std/option",
+        "std/string"
+      ]
     },
     {
       "path": "string_split.ail",
@@ -1949,7 +2381,10 @@
         "parsing",
         "string"
       ],
-      "description": "String Split example"
+      "description": "String Split example",
+      "modules": [
+        "std/string"
+      ]
     },
     {
       "path": "test_cli_io.ail",
@@ -1965,7 +2400,10 @@
       "tags": [
         "testing"
       ],
-      "description": "Integration Test: FizzBuzz"
+      "description": "Integration Test: FizzBuzz",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "test_guard_bool.ail",
@@ -1981,7 +2419,10 @@
       "tags": [
         "testing"
       ],
-      "description": "Test Import Func example"
+      "description": "Test Import Func example",
+      "modules": [
+        "std/option"
+      ]
     },
     {
       "path": "test_io_builtins.ail",
@@ -2053,6 +2494,9 @@
         "demo"
       ],
       "description": "Web API demo: string and JSON functions (hello, farewell, welcome) served via ailang serve-api",
+      "modules": [
+        "std/json"
+      ],
       "run_mode": "serve-api"
     },
     {

--- a/examples/runnable/stdlib_embedding.ail
+++ b/examples/runnable/stdlib_embedding.ail
@@ -1,0 +1,46 @@
+-- std/embedding — vector embedding utilities (headline pattern: semantic similarity search)
+-- Capabilities: IO only (all std/embedding functions are pure)
+--
+-- Pattern: rank a set of candidate document vectors against a query vector by
+-- cosine similarity, then report the best match. This is the core of any
+-- retrieval / nearest-neighbour step, done with pure vector math.
+module examples/runnable/stdlib_embedding
+
+import std/io (println)
+import std/embedding (cosine, magnitude, normalize)
+import std/list (map, foldl)
+
+-- Score each (label, vector) against the query, keeping the running best.
+export func bestMatch(
+  query: list[float],
+  docs: list[{label: string, vec: list[float]}]
+) -> {label: string, score: float} {
+  foldl(
+    \acc doc. {
+      let s = cosine(query, doc.vec);
+      if s > acc.score then {label: doc.label, score: s} else acc
+    },
+    {label: "(none)", score: -1.0},
+    docs
+  )
+}
+
+export func main() -> () ! {IO} {
+  let query = [1.0, 0.0, 1.0];
+  let docs = [
+    {label: "cat", vec: [1.0, 0.0, 1.0]},
+    {label: "dog", vec: [0.0, 1.0, 0.0]},
+    {label: "kitten", vec: [2.0, 0.0, 2.0]}
+  ];
+
+  -- Headline: similarity ranking
+  let scores = map(\d. cosine(query, d.vec), docs);
+  println("cosine scores: ${show(scores)}");
+
+  let best = bestMatch(query, docs);
+  println("best match: ${best.label} (score ${show(best.score)})");
+
+  -- Supporting pure vector ops
+  println("magnitude([3,4]): ${show(magnitude([3.0, 4.0]))}");
+  println("normalize([3,4]): ${show(normalize([3.0, 4.0]))}")
+}

--- a/examples/runnable/stdlib_game.ail
+++ b/examples/runnable/stdlib_game.ail
@@ -1,0 +1,31 @@
+-- std/game — frame-timing utilities for game loops
+-- Capabilities: IO, Clock  (run with:  ailang run --caps IO,Clock ...)
+--
+-- Pattern: a frame-rate-independent update step. delta_time/total_time read the
+-- host wall clock (non-deterministic), so this example demonstrates the headline
+-- pattern — advancing simulation state by a delta — using a FIXED delta so the
+-- output is deterministic, and reads frame_count() (starts at 0) from the Clock
+-- capability to show the effectful call site.
+module examples/runnable/stdlib_game
+
+import std/io (println)
+import std/game (frame_count)
+
+-- Advance a 1-D position by velocity * dt for each simulated frame.
+-- Pure: the caller supplies the fixed dt so the demo is reproducible.
+export func simulate(frames: int, velocity: float, dt: float) -> float {
+  if frames <= 0 then 0.0
+  else simulate(frames - 1, velocity, dt) + velocity * dt
+}
+
+export func main() -> () ! {IO, Clock} {
+  -- Effectful Clock read — frame_count() is 0 at program start.
+  let f = frame_count();
+  println("frame_count at start: ${show(f)}");
+
+  -- Headline: frame-rate-independent movement with a fixed timestep.
+  let dt = 0.016;          -- ~60fps
+  let velocity = 100.0;    -- units per second
+  let after60 = simulate(60, velocity, dt);
+  println("position after 60 frames @ dt=${show(dt)}: ${show(after60)}")
+}

--- a/examples/runnable/stdlib_gzip.ail
+++ b/examples/runnable/stdlib_gzip.ail
@@ -1,0 +1,39 @@
+-- std/gzip — gzip compression / decompression
+-- Capabilities: IO only (compress/decompress are pure; decompressFile needs FS)
+--
+-- Pattern: a compress -> decompress round-trip. All binary data crosses the
+-- AILANG boundary as base64-encoded strings, so std/bytes converts between
+-- UTF-8 text, raw bytes, and base64. Highly repetitive text compresses well,
+-- which the example verifies (compressed base64 is shorter than the input).
+module examples/runnable/stdlib_gzip
+
+import std/io (println)
+import std/gzip (compress, decompress)
+import std/bytes (fromString, toString, toBase64, fromBase64, length)
+import std/result (Result)
+
+-- Compress text, then decompress it, returning the recovered text (or an error).
+export func roundTrip(text: string) -> Result[string, string] {
+  let b64In = toBase64(fromString(text));
+  match compress(b64In, 9) {
+    Err(e) => Err("compress: ${e}"),
+    Ok(gzB64) => match decompress(gzB64) {
+      Err(e2) => Err("decompress: ${e2}"),
+      Ok(outB64) => match fromBase64(outB64) {
+        None => Err("bad base64 from decompress"),
+        Some(b) => Ok(toString(b))
+      }
+    }
+  }
+}
+
+export func main() -> () ! {IO} {
+  let original = "AILANG AILANG AILANG AILANG AILANG AILANG AILANG AILANG";
+  println("original bytes: ${show(length(fromString(original)))}");
+
+  -- Headline: verify a lossless round-trip.
+  match roundTrip(original) {
+    Err(e) => println("error: ${e}"),
+    Ok(recovered) => println("round-trip lossless: ${show(recovered == original)}")
+  }
+}

--- a/examples/runnable/stdlib_sharedindex.ail
+++ b/examples/runnable/stdlib_sharedindex.ail
@@ -1,0 +1,29 @@
+-- std/sharedindex — namespace-partitioned similarity index
+-- Capabilities: IO, SharedIndex  (run with: ailang run --caps IO,SharedIndex ...)
+--
+-- Pattern: build a small in-process semantic index keyed by SimHash fingerprint,
+-- then run a deterministic similarity query. Entries live in a named namespace so
+-- unrelated collections don't interfere. findSimhash with deterministic=true
+-- returns a stable ordering, which is what makes this example reproducible.
+module examples/runnable/stdlib_sharedindex
+
+import std/io (println)
+import std/sharedindex (upsert, findSimhash, entryCount, namespaces)
+import std/simhash (simhash)
+import std/list (length)
+
+export func main() -> () ! {IO, SharedIndex} {
+  let ns = "docs";
+
+  -- Headline: index three documents by their SimHash fingerprints.
+  upsert(ns, "greeting", simhash("hello world"), 1, 1000);
+  upsert(ns, "farewell", simhash("goodbye world"), 1, 1001);
+  upsert(ns, "unrelated", simhash("quarterly revenue report"), 1, 1002);
+
+  println("namespaces: ${show(namespaces(()))}");
+  println("entry count: ${show(entryCount(ns))}");
+
+  -- Deterministic similarity query: how many hits for a "hello"-like query?
+  let hits = findSimhash(ns, simhash("hello there world"), 3, 0, true);
+  println("query hits: ${show(length(hits))}")
+}

--- a/examples/runnable/stdlib_simhash.ail
+++ b/examples/runnable/stdlib_simhash.ail
@@ -1,0 +1,32 @@
+-- std/simhash — locality-sensitive hashing (near-duplicate detection)
+-- Capabilities: IO only (all std/simhash functions are pure)
+--
+-- Pattern: fingerprint documents, then use Hamming distance between fingerprints
+-- as a cheap near-duplicate signal. Similar text -> low distance; different
+-- text -> high distance. No embedding model required.
+module examples/runnable/stdlib_simhash
+
+import std/io (println)
+import std/simhash (simhash, hammingDistance)
+
+-- Classify two documents by the Hamming distance of their SimHash fingerprints.
+export func relatedness(a: string, b: string) -> string {
+  let d = hammingDistance(simhash(a), simhash(b));
+  if d <= 3 then "near-duplicate"
+  else if d <= 10 then "somewhat similar"
+  else "different"
+}
+
+export func main() -> () ! {IO} {
+  let base = "the quick brown fox jumps over the lazy dog";
+  let edit = "the quick brown fox jumps over the lazy dogs";  -- one char added
+  let other = "completely unrelated sentence about databases";
+
+  -- Headline: fingerprint + distance-based classification.
+  println("edit vs base: ${relatedness(base, edit)}");
+  println("other vs base: ${relatedness(base, other)}");
+
+  -- Raw distances for transparency.
+  println("dist(base, edit) = ${show(hammingDistance(simhash(base), simhash(edit)))}");
+  println("dist(base, other) = ${show(hammingDistance(simhash(base), simhash(other)))}")
+}

--- a/examples/runnable/stdlib_smoke.ail
+++ b/examples/runnable/stdlib_smoke.ail
@@ -1,0 +1,27 @@
+-- std/smoke — helpers for package _smoke.ail boot probes
+-- Capabilities: IO only
+--
+-- Pattern: the canonical "exercise every advertised tool once" probe that AILANG
+-- packages put in their _smoke.ail (the v0.19.0 pre-publish smoke gate). Instead
+-- of a hand-rolled fold, dispatchAllTools iterates the tool names and calls a
+-- caller-supplied dispatch closure for each, printing an OK marker per tool.
+-- okSuite prints the conventional final "OK:" line the gate greps for.
+module examples/runnable/stdlib_smoke
+
+import std/io (println)
+import std/smoke (dispatchAllTools, dispatchTool, okSuite)
+
+-- A package under test typically wires `dispatch` to its real tool handler;
+-- here it just records that each advertised tool was reached without crashing.
+export func main() -> () ! {IO} {
+  let tools = ["search", "fetch", "summarize"];
+
+  -- Headline: exercise every advertised tool with one call.
+  dispatchAllTools(tools, \name. println("  -> exercised ${name}"));
+
+  -- Single-tool variant for opt-in probing.
+  dispatchTool("healthcheck", \name. println("  -> exercised ${name}"));
+
+  -- Conventional suite-complete marker.
+  okSuite("demo_package")
+}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -27,6 +27,10 @@ const (
 	StatusWorking      Status = "working"
 	StatusBroken       Status = "broken"
 	StatusExperimental Status = "experimental"
+	// StatusAspirational marks VISION-ONLY examples that are not expected to
+	// type-check or run against the current compiler (examples/experimental/*).
+	// They carry no expected output and are skipped by validators.
+	StatusAspirational Status = "aspirational"
 )
 
 // Mode represents how an example should be executed
@@ -72,6 +76,10 @@ type Example struct {
 	Broken           *BrokenInfo  `json:"broken,omitempty"`
 	RequiresFeatures []string     `json:"requires_features,omitempty"`
 	SkipReason       string       `json:"skip_reason,omitempty"`
+	// Modules is the set of std/* modules this example imports, backfilled by
+	// scripts/backfill_manifest_modules.go and drift-checked by
+	// scripts/validate_manifest.go. Powers `ailang docs --examples <module>`.
+	Modules []string `json:"modules,omitempty"`
 }
 
 // Statistics provides aggregate information about examples
@@ -200,36 +208,40 @@ func (m *Manifest) validateExample(ex Example) error {
 	if ex.Status == "" {
 		return fmt.Errorf("missing status")
 	}
-	if ex.Mode == "" {
-		return fmt.Errorf("missing mode")
-	}
+	// Mode is optional: the canonical examples/manifest.json does not carry a
+	// per-example execution mode (the verifier auto-detects run vs repl). When
+	// absent, default to file mode below rather than rejecting the manifest.
 
 	// Validate status
 	switch ex.Status {
 	case StatusWorking:
-		if ex.Expected == nil {
-			return fmt.Errorf("working example missing expected output")
-		}
+		// Expected output is optional here: verify_examples.go is the source of
+		// truth for actual program output. The canonical examples/manifest.json
+		// carries `expected` on many but not all working entries; requiring it
+		// on every entry would reject the real manifest. We only forbid the
+		// contradictory case (a working example also carrying broken info).
 		if ex.Broken != nil {
 			return fmt.Errorf("working example should not have broken info")
 		}
 	case StatusBroken:
-		if ex.Broken == nil {
-			return fmt.Errorf("broken example missing broken info")
+		// Broken info (reason/error_code/tracked_issue) is recommended but not
+		// mandatory at load time: a handful of legacy bugs/* entries predate the
+		// structured broken block. New quarantines SHOULD carry it (see the
+		// M-DX-EXAMPLES-COVERAGE entries), but the loader stays lenient so the
+		// real manifest loads; enforcement of richer invariants lives in --ci.
+		if ex.Broken != nil && ex.Broken.ErrorCode == "" {
+			return fmt.Errorf("broken example has broken info but missing error code")
 		}
-		if ex.Broken.ErrorCode == "" {
-			return fmt.Errorf("broken example missing error code")
-		}
-	case StatusExperimental:
-		// Experimental can have various states
+	case StatusExperimental, StatusAspirational:
+		// Experimental / aspirational (VISION-ONLY) can have various states
 	default:
 		return fmt.Errorf("invalid status: %s", ex.Status)
 	}
 
-	// Validate mode
+	// Validate mode (optional; empty means file mode)
 	switch ex.Mode {
-	case ModeFile, ModeREPL:
-		// Valid
+	case "", ModeFile, ModeREPL:
+		// Valid (empty defaults to file)
 	default:
 		return fmt.Errorf("invalid mode: %s", ex.Mode)
 	}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -91,18 +91,45 @@ func TestManifestValidation(t *testing.T) {
 			errMsg:  "invalid status",
 		},
 		{
-			name: "working without expected",
+			// Expected output is now OPTIONAL for working examples: verify_examples.go
+			// is the source of truth for actual output, and the canonical manifest
+			// carries `expected` on only some working entries. Loading must not reject
+			// a working entry that omits it. (M-DX-EXAMPLES-COVERAGE)
+			name: "working without expected is valid",
 			modify: func(m *Manifest) {
 				m.Examples = []Example{
 					{Path: "test.ail", Status: StatusWorking, Mode: ModeFile},
 				}
 				m.UpdateStatistics()
 			},
-			wantErr: true,
-			errMsg:  "missing expected output",
+			wantErr: false,
 		},
 		{
-			name: "broken without error code",
+			// Mode is optional; empty defaults to file mode. (M-DX-EXAMPLES-COVERAGE)
+			name: "working without mode is valid",
+			modify: func(m *Manifest) {
+				m.Examples = []Example{
+					{Path: "test.ail", Status: StatusWorking, Expected: &Expected{}},
+				}
+				m.UpdateStatistics()
+			},
+			wantErr: false,
+		},
+		{
+			// Aspirational (VISION-ONLY) is a valid status. (M-DX-EXAMPLES-COVERAGE)
+			name: "aspirational status is valid",
+			modify: func(m *Manifest) {
+				m.Examples = []Example{
+					{Path: "test.ail", Status: StatusAspirational, Mode: ModeFile},
+				}
+				m.UpdateStatistics()
+			},
+			wantErr: false,
+		},
+		{
+			// Broken info is optional at load time (legacy entries predate it), but
+			// if present it must carry an error code. (M-DX-EXAMPLES-COVERAGE)
+			name: "broken with info but no error code",
 			modify: func(m *Manifest) {
 				m.Examples = []Example{
 					{Path: "test.ail", Status: StatusBroken, Mode: ModeFile,
@@ -112,6 +139,16 @@ func TestManifestValidation(t *testing.T) {
 			},
 			wantErr: true,
 			errMsg:  "missing error code",
+		},
+		{
+			name: "broken without any broken info is valid (legacy)",
+			modify: func(m *Manifest) {
+				m.Examples = []Example{
+					{Path: "test.ail", Status: StatusBroken, Mode: ModeFile},
+				}
+				m.UpdateStatistics()
+			},
+			wantErr: false,
 		},
 		{
 			name: "non-ail extension",

--- a/make/examples.mk
+++ b/make/examples.mk
@@ -4,7 +4,7 @@
 
 .PHONY: verify-examples verify-examples-toplevel verify-examples-all verify-examples-trace verify-cli-examples examples-status
 .PHONY: update-readme update-trace-baselines flag-broken freeze-stdlib verify-stdlib
-.PHONY: compile-examples-go verify-examples-gate-selftest backfill-manifest-modules
+.PHONY: compile-examples-go verify-examples-gate-selftest backfill-manifest-modules validate-manifest-selftest
 
 # Example verification (parallel by default, ~8s vs ~3min sequential)
 #
@@ -52,6 +52,23 @@ verify-examples-gate-selftest: build ## Prove the verify-examples gate fails (an
 # Regenerate the manifest `modules` field (parser-backed). Commit the result.
 backfill-manifest-modules: ## Backfill examples/manifest.json `modules` field from actual imports
 	@go run ./scripts/backfill_manifest_modules.go
+
+# Drift-lint self-test: prove validate_manifest --ci turns non-zero when a
+# committed `modules` entry disagrees with the actual imports (same guard pattern
+# as the gate self-test). Uses a temp copy; never mutates the real manifest.
+validate-manifest-selftest: build ## Prove the manifest modules drift-lint fails on a drifted entry
+	@echo "Drift-lint self-test: injecting a deliberately-drifted modules entry..."
+	@tmp=$$(mktemp); \
+	trap "rm -f $$tmp" EXIT; \
+	go run ./scripts/backfill_manifest_modules.go >/dev/null 2>&1; \
+	python3 -c "import json,sys; d=json.load(open('examples/manifest.json')); \
+[e.update({'modules':['std/DRIFT']}) for e in d['examples'] if e['path']=='runnable/stdlib_gzip.ail']; \
+json.dump(d,open('$$tmp','w'),indent=2)"; \
+	if go run ./scripts/validate_manifest.go --manifest $$tmp --ci >/dev/null 2>&1; then \
+		echo "❌ SELF-TEST FAIL: drift-lint exited 0 on a drifted modules entry"; exit 1; \
+	else \
+		echo "✅ drift-lint self-test passed: drifted modules entry -> non-zero exit"; \
+	fi
 
 # Gate the TOP-LEVEL examples/*.ail directory, which verify-examples (above)
 # does NOT cover — it only checks examples/runnable/. That gap let 8 examples

--- a/make/examples.mk
+++ b/make/examples.mk
@@ -4,14 +4,54 @@
 
 .PHONY: verify-examples verify-examples-toplevel verify-examples-all verify-examples-trace verify-cli-examples examples-status
 .PHONY: update-readme update-trace-baselines flag-broken freeze-stdlib verify-stdlib
-.PHONY: compile-examples-go
+.PHONY: compile-examples-go verify-examples-gate-selftest backfill-manifest-modules
 
 # Example verification (parallel by default, ~8s vs ~3min sequential)
-verify-examples: build ## Verify examples in examples/runnable/ (CI mode)
+#
+# This is a REAL gate: it exits non-zero when any example fails, while STILL
+# writing both report artifacts unconditionally (5+ consumers: tools/build-snapshot,
+# scripts/update_readme.go, scripts/flag_broken_examples.go, scripts/update_docs_examples.go,
+# docusaurus-deploy.yml). The verifier's own exit code (non-zero on failure) is
+# captured and re-raised AFTER the status markdown is printed. Also runs the
+# manifest `modules` drift-lint (validate_manifest --ci) so a stale/new example
+# whose manifest entry is out of date turns the gate red too.
+verify-examples: build ## Verify examples in examples/runnable/ (CI gate — fails on any red example)
 	@echo "Verifying examples..."
-	@go run ./scripts/verify_examples.go --parallel 8 --json > examples_report.json 2>&1 || true
+	@go run ./scripts/verify_examples.go --parallel 8 --json > examples_report.json 2>&1; echo $$? > .examples_rc.tmp
 	@go run ./scripts/verify_examples.go --parallel 8 --markdown > examples_status.md 2>&1 || true
 	@if [ -f examples_status.md ]; then cat examples_status.md; fi
+	@echo "Validating manifest (schema + modules drift)..."
+	@go run ./scripts/validate_manifest.go --ci; echo $$? > .manifest_rc.tmp
+	@rc=$$(cat .examples_rc.tmp); mrc=$$(cat .manifest_rc.tmp); rm -f .examples_rc.tmp .manifest_rc.tmp; \
+		if [ "$$rc" != "0" ]; then echo "❌ verify-examples: one or more examples failed (exit $$rc)"; exit $$rc; fi; \
+		if [ "$$mrc" != "0" ]; then echo "❌ verify-examples: manifest modules drift (exit $$mrc)"; exit $$mrc; fi; \
+		echo "✅ verify-examples: all examples pass and manifest is in sync"
+
+# Gate self-test: guard the CALL-SITE, not just the helper (env-forward lesson).
+# Drops a deliberately-broken fixture into examples/runnable/, runs the verifier
+# the same way the gate does, and asserts (a) non-zero exit AND (b) both report
+# artifacts were STILL written. Always removes the fixture, even on failure.
+verify-examples-gate-selftest: build ## Prove the verify-examples gate fails (and still writes artifacts) on a broken example
+	@echo "Gate self-test: injecting a deliberately-broken example..."
+	@fixture=examples/runnable/_gate_selftest_broken.ail; \
+	rpt=$$(mktemp); md=$$(mktemp); \
+	printf 'module examples/runnable/_gate_selftest_broken\nexport func main() -> int = "not an int"\n' > $$fixture; \
+	trap "rm -f $$fixture $$rpt $$md" EXIT; \
+	go run ./scripts/verify_examples.go --parallel 8 --json > $$rpt 2>&1; rc=$$?; \
+	go run ./scripts/verify_examples.go --parallel 8 --markdown > $$md 2>&1 || true; \
+	fail=0; \
+	if [ "$$rc" = "0" ]; then echo "❌ SELF-TEST FAIL: verifier exited 0 on a broken example"; fail=1; \
+		else echo "✓ verifier exited non-zero ($$rc) on the broken example"; fi; \
+	if [ ! -s $$rpt ]; then echo "❌ SELF-TEST FAIL: examples_report.json not written"; fail=1; \
+		else echo "✓ examples_report.json written on failure"; fi; \
+	if [ ! -s $$md ]; then echo "❌ SELF-TEST FAIL: examples_status.md not written"; fail=1; \
+		else echo "✓ examples_status.md written on failure"; fi; \
+	if [ "$$fail" != "0" ]; then exit 1; fi; \
+	echo "✅ gate self-test passed: broken example -> non-zero exit AND artifacts written"
+
+# Regenerate the manifest `modules` field (parser-backed). Commit the result.
+backfill-manifest-modules: ## Backfill examples/manifest.json `modules` field from actual imports
+	@go run ./scripts/backfill_manifest_modules.go
 
 # Gate the TOP-LEVEL examples/*.ail directory, which verify-examples (above)
 # does NOT cover — it only checks examples/runnable/. That gap let 8 examples

--- a/scripts/backfill_manifest_modules.go
+++ b/scripts/backfill_manifest_modules.go
@@ -1,0 +1,130 @@
+//go:build ignore
+// +build ignore
+
+// backfill_manifest_modules.go populates the `modules` field on every
+// examples/manifest.json entry using the shared, parser-backed extractor
+// (scripts/internal/importextract). Run once at development time and COMMIT the
+// result — `ailang docs --examples <module>` reads the committed field, never a
+// runtime scan. The SAME extractor backs the validate_manifest drift assertion,
+// so the CI authority cannot disagree with the language.
+//
+//	go run ./scripts/backfill_manifest_modules.go            # write in place
+//	go run ./scripts/backfill_manifest_modules.go --check    # report drift only
+//
+// All manifest fields (run_mode, run_flags, requires, broken, statistics,
+// milestones, schema…) are preserved; only each entry's `modules` is (re)set.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/sunholo-data/ailang/scripts/internal/importextract"
+)
+
+const (
+	manifestPath = "examples/manifest.json"
+	examplesDir  = "examples"
+)
+
+// entry mirrors every field present in examples/manifest.json so a round-trip
+// loses nothing. Field order here defines the serialized key order.
+type entry struct {
+	Path        string          `json:"path"`
+	Status      string          `json:"status"`
+	Tags        []string        `json:"tags,omitempty"`
+	Description string          `json:"description,omitempty"`
+	Modules     []string        `json:"modules,omitempty"`
+	Expected    json.RawMessage `json:"expected,omitempty"`
+	Broken      json.RawMessage `json:"broken,omitempty"`
+	Requires    json.RawMessage `json:"requires,omitempty"`
+	RunMode     json.RawMessage `json:"run_mode,omitempty"`
+	RunFlags    json.RawMessage `json:"run_flags,omitempty"`
+	SkipReason  string          `json:"skip_reason,omitempty"`
+}
+
+// doc mirrors the top-level manifest, preserving unknown blocks verbatim.
+type doc struct {
+	Schema        json.RawMessage `json:"schema,omitempty"`
+	SchemaVersion json.RawMessage `json:"schema_version,omitempty"`
+	GeneratedAt   json.RawMessage `json:"generated_at,omitempty"`
+	Generator     json.RawMessage `json:"generator,omitempty"`
+	Examples      []entry         `json:"examples"`
+	Statistics    json.RawMessage `json:"statistics,omitempty"`
+	Milestones    json.RawMessage `json:"milestones,omitempty"`
+}
+
+func main() {
+	checkOnly := false
+	for _, a := range os.Args[1:] {
+		if a == "--check" {
+			checkOnly = true
+		}
+	}
+
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read manifest: %v\n", err)
+		os.Exit(1)
+	}
+
+	var d doc
+	if err := json.Unmarshal(raw, &d); err != nil {
+		fmt.Fprintf(os.Stderr, "parse manifest: %v\n", err)
+		os.Exit(1)
+	}
+
+	changed, skipped := 0, 0
+	for i := range d.Examples {
+		e := &d.Examples[i]
+		full, ok := importextract.ResolvePath(examplesDir, e.Path)
+		if !ok {
+			skipped++ // missing file — validate_manifest flags it separately
+			continue
+		}
+		mods, err := importextract.ExtractModules(full)
+		if err != nil {
+			skipped++ // unparseable — already red via the verify gate; never guess
+			continue
+		}
+		if mods == nil {
+			mods = []string{}
+		}
+		sort.Strings(mods)
+		if !importextract.Equal(e.Modules, mods) {
+			changed++
+		}
+		if len(mods) == 0 {
+			e.Modules = nil // omitempty: keep entries without std imports clean
+		} else {
+			e.Modules = mods
+		}
+	}
+
+	if checkOnly {
+		if changed > 0 {
+			fmt.Printf("modules drift: %d entr(ies) out of date\n", changed)
+			fmt.Println("regenerate with: go run ./scripts/backfill_manifest_modules.go")
+			os.Exit(1)
+		}
+		fmt.Println("modules field up to date")
+		return
+	}
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(&d); err != nil {
+		fmt.Fprintf(os.Stderr, "encode manifest: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(manifestPath, buf.Bytes(), 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "write manifest: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("backfilled modules for %d entr(ies) (%d skipped: missing/unparseable)\n", changed, skipped)
+}

--- a/scripts/internal/importextract/importextract.go
+++ b/scripts/internal/importextract/importextract.go
@@ -1,0 +1,109 @@
+// Package importextract provides the single, parser-backed implementation for
+// discovering the std/* modules an AILANG example imports. Both the one-time
+// manifest `modules` backfill and the validate_manifest drift assertion call
+// ExtractModules so the CI authority can never disagree with the language:
+// aliases, selective imports, comments, and duplicates are handled by the same
+// grammar the compiler uses (internal/parser -> ast.File.Imports), never by
+// line/regex scanning.
+package importextract
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/sunholo-data/ailang/internal/lexer"
+	"github.com/sunholo-data/ailang/internal/parser"
+)
+
+// ResolvePath maps a manifest entry path to an on-disk file under examplesDir.
+// The canonical manifest carries a mix of "runnable/foo.ail" and bare "foo.ail"
+// entries (legacy drift); the latter live under examplesDir/runnable/. Both are
+// tried, in that order. Returns ("", false) if neither exists.
+func ResolvePath(examplesDir, entryPath string) (string, bool) {
+	direct := filepath.Join(examplesDir, entryPath)
+	if _, err := os.Stat(direct); err == nil {
+		return direct, true
+	}
+	underRunnable := filepath.Join(examplesDir, "runnable", entryPath)
+	if _, err := os.Stat(underRunnable); err == nil {
+		return underRunnable, true
+	}
+	return "", false
+}
+
+// ExtractModulesFromSource parses AILANG source and returns the sorted, de-duplicated
+// set of std/* module paths it imports (e.g. ["std/io", "std/list"]).
+// Only std/* imports are reported (the docs --examples lookup is std-module keyed).
+func ExtractModulesFromSource(source, filename string) ([]string, error) {
+	l := lexer.New(source, filename)
+	p := parser.New(l)
+	file := p.ParseFile()
+	if errs := p.Errors(); len(errs) > 0 {
+		// A file that fails to parse is already red via the verify gate; the
+		// extractor never guesses at malformed input.
+		return nil, fmt.Errorf("parse error in %s: %s", filename, errs[0])
+	}
+	if file == nil {
+		return nil, fmt.Errorf("nil AST for %s", filename)
+	}
+
+	seen := make(map[string]struct{})
+	for _, imp := range file.Imports {
+		if imp == nil {
+			continue
+		}
+		if strings.HasPrefix(imp.Path, "std/") {
+			seen[imp.Path] = struct{}{}
+		}
+	}
+
+	mods := make([]string, 0, len(seen))
+	for m := range seen {
+		mods = append(mods, m)
+	}
+	sort.Strings(mods)
+	return mods, nil
+}
+
+// ExtractModules reads a file and returns its imported std/* modules.
+func ExtractModules(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return ExtractModulesFromSource(string(data), path)
+}
+
+// Equal reports whether two module slices are equal as sets (order-independent).
+// Both are expected to already be sorted+deduped by ExtractModules, but we
+// normalize defensively so a manifest entry stored in any order still matches.
+func Equal(a, b []string) bool {
+	na := normalize(a)
+	nb := normalize(b)
+	if len(na) != len(nb) {
+		return false
+	}
+	for i := range na {
+		if na[i] != nb[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func normalize(xs []string) []string {
+	seen := make(map[string]struct{}, len(xs))
+	out := make([]string, 0, len(xs))
+	for _, x := range xs {
+		if _, ok := seen[x]; ok {
+			continue
+		}
+		seen[x] = struct{}{}
+		out = append(out, x)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/scripts/internal/importextract/importextract_test.go
+++ b/scripts/internal/importextract/importextract_test.go
@@ -1,0 +1,80 @@
+package importextract
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractModules(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "selective imports",
+			src: `module t
+import std/io (println)
+import std/list (map, foldl)
+export func main() -> () ! {IO} { println("hi") }`,
+			want: []string{"std/io", "std/list"},
+		},
+		{
+			name: "module alias",
+			src: `module t
+import std/list as L
+export func main() -> () ! {IO} { () }`,
+			want: []string{"std/list"},
+		},
+		{
+			name: "duplicate imports deduped",
+			src: `module t
+import std/io (println)
+import std/io (print)
+export func main() -> () ! {IO} { println("x") }`,
+			want: []string{"std/io"},
+		},
+		{
+			name: "non-std imports excluded",
+			src: `module t
+import std/io (println)
+export func main() -> () ! {IO} { println("x") }`,
+			want: []string{"std/io"},
+		},
+		{
+			name: "no imports",
+			src: `module t
+export func main() -> int = 42`,
+			want: []string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ExtractModulesFromSource(tc.src, tc.name+".ail")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractModules_ParseError(t *testing.T) {
+	// Malformed source must error, never silently return partial results.
+	_, err := ExtractModulesFromSource("module t\nimport std/io (", "bad.ail")
+	if err == nil {
+		t.Fatal("expected parse error, got nil")
+	}
+}
+
+func TestEqual(t *testing.T) {
+	if !Equal([]string{"std/io", "std/list"}, []string{"std/list", "std/io"}) {
+		t.Error("Equal should be order-independent")
+	}
+	if Equal([]string{"std/io"}, []string{"std/io", "std/list"}) {
+		t.Error("differing sets must not be equal")
+	}
+}

--- a/scripts/validate_manifest.go
+++ b/scripts/validate_manifest.go
@@ -1,400 +1,112 @@
-// validate_manifest.go validates examples against the manifest.
-// It ensures documentation stays in sync with reality.
+// validate_manifest.go validates examples/manifest.json against reality.
+// It ensures documentation stays in sync with the codebase:
+//
+//  1. Schema: the manifest loads under internal/manifest (valid statuses, no
+//     duplicate paths, .ail extensions, consistent statistics).
+//  2. Modules drift: every entry's committed `modules` field matches the actual
+//     std/* imports discovered by the SHARED parser-backed extractor
+//     (scripts/internal/importextract) — the same function the backfill uses, so
+//     the CI authority cannot disagree with the language. A stale/missing
+//     `modules` entry fails with the exact regeneration command.
+//
+// It deliberately does NOT re-run each example (verify_examples.go owns actual
+// program output). Files listed in the manifest but absent on disk are reported
+// as warnings (pre-existing stale entries), not hard failures, so a legacy drift
+// doesn't wedge CI — modules drift on a RESOLVABLE file is the hard gate.
+//
+//	go run ./scripts/validate_manifest.go            # report
+//	go run ./scripts/validate_manifest.go --ci       # non-zero on drift
 package main
 
 import (
-	"bytes"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"regexp"
-	"strings"
-	"time"
 
 	"github.com/fatih/color"
 	"github.com/sunholo-data/ailang/internal/manifest"
+	"github.com/sunholo-data/ailang/scripts/internal/importextract"
 )
 
 var (
 	green  = color.New(color.FgGreen).SprintFunc()
 	red    = color.New(color.FgRed).SprintFunc()
 	yellow = color.New(color.FgYellow).SprintFunc()
-	cyan   = color.New(color.FgCyan).SprintFunc()
 	bold   = color.New(color.Bold).SprintFunc()
 )
 
-type ValidationResult struct {
-	Path    string
-	Status  manifest.Status
-	Passed  bool
-	Message string
-	Output  string
-}
+const regenCmd = "go run ./scripts/backfill_manifest_modules.go"
 
 func main() {
 	var (
 		manifestPath = flag.String("manifest", "examples/manifest.json", "Path to manifest file")
 		examplesDir  = flag.String("dir", "examples", "Examples directory")
-		updateFlag   = flag.Bool("update", false, "Update manifest with actual results")
-		verboseFlag  = flag.Bool("verbose", false, "Verbose output")
-		ciMode       = flag.Bool("ci", false, "CI mode (fail on any mismatch)")
+		ciMode       = flag.Bool("ci", false, "CI mode (non-zero exit on any drift)")
+		verbose      = flag.Bool("verbose", false, "Verbose output")
 	)
 	flag.Parse()
 
-	// Load manifest
-	m, err := manifest.Load(*manifestPath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s Failed to load manifest: %v\n", red("Error:"), err)
-		os.Exit(1)
-	}
-
-	fmt.Printf("%s AILANG Example Validator\n", bold("🔍"))
-	fmt.Printf("Manifest: %s\n", *manifestPath)
-	fmt.Printf("Examples: %d (Working: %d, Broken: %d, Experimental: %d)\n\n",
-		m.Statistics.Total, m.Statistics.Working, m.Statistics.Broken, m.Statistics.Experimental)
-
-	// Validate each example
-	var results []ValidationResult
-	failed := 0
-
-	// Set deterministic environment
+	// Deterministic environment for any downstream tooling.
 	os.Setenv("LC_ALL", "C.UTF-8")
 	os.Setenv("TZ", "UTC")
 	os.Setenv("AILANG_SEED", "0")
 
-	for _, example := range m.Examples {
-		result := validateExample(*examplesDir, example, *verboseFlag)
-		results = append(results, result)
-
-		if !result.Passed {
-			failed++
-			fmt.Printf("%s %s: %s\n", red("✗"), result.Path, result.Message)
-			if *verboseFlag && result.Output != "" {
-				fmt.Printf("  Output:\n%s\n", indent(result.Output, "    "))
-			}
-		} else {
-			fmt.Printf("%s %s\n", green("✓"), result.Path)
-		}
-
-		// Check header in file matches manifest
-		if err := validateHeader(*examplesDir, example); err != nil {
-			fmt.Printf("  %s Header mismatch: %v\n", yellow("⚠"), err)
-			if *ciMode {
-				failed++
-			}
-		}
-	}
-
-	// Summary
-	fmt.Printf("\n%s\n", strings.Repeat("─", 60))
-	passed := len(results) - failed
-	fmt.Printf("Results: %s passed, %s failed\n",
-		green(fmt.Sprintf("%d", passed)),
-		red(fmt.Sprintf("%d", failed)))
-
-	// Update manifest if requested
-	if *updateFlag {
-		fmt.Printf("\n%s Updating manifest...\n", cyan("→"))
-		updateManifest(m, results)
-		m.GeneratedAt = time.Now().UTC()
-		if err := m.Save(*manifestPath); err != nil {
-			fmt.Fprintf(os.Stderr, "%s Failed to save manifest: %v\n", red("Error:"), err)
-			os.Exit(1)
-		}
-		fmt.Printf("%s Manifest updated\n", green("✓"))
-	}
-
-	// Generate README section
-	readmePath := filepath.Join(filepath.Dir(*manifestPath), "..", "README.md")
-	if err := updateREADME(readmePath, m); err != nil {
-		fmt.Fprintf(os.Stderr, "%s Failed to update README: %v\n", yellow("Warning:"), err)
-	} else {
-		fmt.Printf("%s README status table updated\n", green("✓"))
-	}
-
-	// Exit with error in CI mode if any failures
-	if *ciMode && failed > 0 {
+	// (1) Schema: loading validates statuses, dup paths, extensions, statistics.
+	m, err := manifest.Load(*manifestPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s manifest failed schema validation: %v\n", red("✗"), err)
 		os.Exit(1)
 	}
-}
 
-func validateExample(dir string, example manifest.Example, verbose bool) ValidationResult {
-	result := ValidationResult{
-		Path:   example.Path,
-		Status: example.Status,
-		Passed: true,
-	}
+	fmt.Printf("%s AILANG Manifest Validator\n", bold("🔍"))
+	fmt.Printf("Manifest: %s\n", *manifestPath)
+	fmt.Printf("Examples: %d (working %d, broken %d, experimental %d)\n\n",
+		m.Statistics.Total, m.Statistics.Working, m.Statistics.Broken, m.Statistics.Experimental)
 
-	examplePath := filepath.Join(dir, example.Path)
-
-	// Check if file exists
-	if _, err := os.Stat(examplePath); os.IsNotExist(err) {
-		result.Passed = false
-		result.Message = "File not found"
-		return result
-	}
-
-	// Skip experimental examples
-	if example.Status == manifest.StatusExperimental {
-		result.Message = "Skipped (experimental)"
-		return result
-	}
-
-	// Run the example
-	cmd := exec.Command("bin/ailang", "run", examplePath)
-
-	// Set environment if specified
-	if example.Environment != nil {
-		if example.Environment.Seed != 0 {
-			cmd.Env = append(cmd.Env, fmt.Sprintf("AILANG_SEED=%d", example.Environment.Seed))
-		}
-		if example.Environment.Locale != "" {
-			cmd.Env = append(cmd.Env, fmt.Sprintf("LC_ALL=%s", example.Environment.Locale))
-		}
-		if example.Environment.Timezone != "" {
-			cmd.Env = append(cmd.Env, fmt.Sprintf("TZ=%s", example.Environment.Timezone))
-		}
-	}
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-	exitCode := 0
-	if exitErr, ok := err.(*exec.ExitError); ok {
-		exitCode = exitErr.ExitCode()
-	}
-
-	// Combine output for debugging
-	result.Output = fmt.Sprintf("STDOUT:\n%s\nSTDERR:\n%s\nExit: %d",
-		stdout.String(), stderr.String(), exitCode)
-
-	// Validate based on status
-	switch example.Status {
-	case manifest.StatusWorking:
-		if example.Expected == nil {
-			result.Passed = false
-			result.Message = "Missing expected output in manifest"
-			return result
-		}
-
-		// Check exit code
-		if exitCode != example.Expected.ExitCode {
-			result.Passed = false
-			result.Message = fmt.Sprintf("Exit code mismatch: got %d, expected %d",
-				exitCode, example.Expected.ExitCode)
-			return result
-		}
-
-		// Check stdout (normalize line endings)
-		expectedStdout := normalizeOutput(example.Expected.Stdout)
-		actualStdout := normalizeOutput(stdout.String())
-		if expectedStdout != actualStdout {
-			result.Passed = false
-			result.Message = fmt.Sprintf("Stdout mismatch:\n  Expected: %q\n  Got: %q",
-				expectedStdout, actualStdout)
-			return result
-		}
-
-		// Check stderr
-		expectedStderr := normalizeOutput(example.Expected.Stderr)
-		actualStderr := normalizeOutput(stderr.String())
-		if expectedStderr != actualStderr {
-			result.Passed = false
-			result.Message = fmt.Sprintf("Stderr mismatch:\n  Expected: %q\n  Got: %q",
-				expectedStderr, actualStderr)
-			return result
-		}
-
-		result.Message = "Output matches expected"
-
-	case manifest.StatusBroken:
-		if example.Expected == nil {
-			result.Passed = false
-			result.Message = "Missing expected error in manifest"
-			return result
-		}
-
-		// Should fail with non-zero exit
-		if exitCode == 0 {
-			result.Passed = false
-			result.Message = "Expected failure but succeeded"
-			return result
-		}
-
-		// Check error pattern if specified
-		if example.Expected.ErrorPattern != "" {
-			pattern := regexp.MustCompile(example.Expected.ErrorPattern)
-			combined := stdout.String() + stderr.String()
-			if !pattern.MatchString(combined) {
-				result.Passed = false
-				result.Message = fmt.Sprintf("Error pattern not found: %s",
-					example.Expected.ErrorPattern)
-				return result
-			}
-		}
-
-		result.Message = "Failed as expected"
-	}
-
-	return result
-}
-
-func validateHeader(dir string, example manifest.Example) error {
-	examplePath := filepath.Join(dir, example.Path)
-	content, err := os.ReadFile(examplePath)
-	if err != nil {
-		return err
-	}
-
-	// Look for header comment
-	lines := strings.Split(string(content), "\n")
-	var headerJSON string
-	inHeader := false
-
-	for _, line := range lines {
-		if strings.HasPrefix(line, "--! {") {
-			inHeader = true
-			headerJSON = strings.TrimPrefix(line, "--! ")
-		} else if inHeader && strings.HasPrefix(line, "--!") {
-			headerJSON += strings.TrimPrefix(line, "--!")
-		} else if inHeader && !strings.HasPrefix(line, "--") {
-			break
-		}
-	}
-
-	if headerJSON == "" {
-		// No header is OK for working examples
-		if example.Status == manifest.StatusWorking {
-			return nil
-		}
-		return fmt.Errorf("missing header for %s example", example.Status)
-	}
-
-	// Parse header
-	var header map[string]interface{}
-	if err := json.Unmarshal([]byte(headerJSON), &header); err != nil {
-		return fmt.Errorf("invalid header JSON: %w", err)
-	}
-
-	// Validate status matches
-	if status, ok := header["status"].(string); ok {
-		if manifest.Status(status) != example.Status {
-			return fmt.Errorf("status mismatch: header=%s, manifest=%s", status, example.Status)
-		}
-	}
-
-	// For broken examples, check error code
-	if example.Status == manifest.StatusBroken && example.Broken != nil {
-		if code, ok := header["error_code"].(string); ok {
-			if code != example.Broken.ErrorCode {
-				return fmt.Errorf("error code mismatch: header=%s, manifest=%s",
-					code, example.Broken.ErrorCode)
-			}
-		}
-	}
-
-	return nil
-}
-
-func updateManifest(m *manifest.Manifest, results []ValidationResult) {
-	for _, result := range results {
-		example, found := m.FindExample(result.Path)
-		if !found {
+	// (2) Modules drift, via the shared parser-backed extractor.
+	driftCount := 0
+	missingCount := 0
+	checked := 0
+	for _, ex := range m.Examples {
+		full, ok := importextract.ResolvePath(*examplesDir, ex.Path)
+		if !ok {
+			missingCount++
+			fmt.Printf("%s %s: file not found on disk (stale manifest entry)\n", yellow("⚠"), ex.Path)
 			continue
 		}
-
-		// Update status based on result
-		if result.Passed {
-			if example.Status == manifest.StatusBroken && result.Status == manifest.StatusBroken {
-				// Still broken as expected
-			} else if example.Status == manifest.StatusBroken {
-				// Was broken, now working!
-				fmt.Printf("  %s %s is now working!\n", green("🎉"), result.Path)
-				example.Status = manifest.StatusWorking
-				example.Broken = nil
-			}
-		} else {
-			if example.Status == manifest.StatusWorking {
-				// Was working, now broken
-				fmt.Printf("  %s %s is now broken\n", red("⚠"), result.Path)
-				example.Status = manifest.StatusBroken
-				example.Broken = &manifest.BrokenInfo{
-					Reason:    result.Message,
-					ErrorCode: "PAR001", // Default, should be extracted from actual error
-				}
-			}
+		actual, err := importextract.ExtractModules(full)
+		if err != nil {
+			// Unparseable — already red via the verify gate; do not double-fail.
+			fmt.Printf("%s %s: unparseable (covered by verify-examples): %v\n", yellow("⚠"), ex.Path, err)
+			continue
+		}
+		checked++
+		if !importextract.Equal(ex.Modules, actual) {
+			driftCount++
+			fmt.Printf("%s %s: modules drift\n    manifest: %v\n    actual:   %v\n",
+				red("✗"), ex.Path, ex.Modules, actual)
+		} else if *verbose {
+			fmt.Printf("%s %s %v\n", green("✓"), ex.Path, actual)
 		}
 	}
 
-	// Recalculate statistics
-	m.UpdateStatistics()
-}
+	fmt.Printf("\n%s modules checked, %s drift, %s missing-on-disk\n",
+		green(fmt.Sprintf("%d", checked)),
+		func() string {
+			if driftCount > 0 {
+				return red(fmt.Sprintf("%d", driftCount))
+			}
+			return green("0")
+		}(),
+		yellow(fmt.Sprintf("%d", missingCount)))
 
-func updateREADME(readmePath string, m *manifest.Manifest) error {
-	// Read current README
-	content, err := os.ReadFile(readmePath)
-	if err != nil {
-		return err
-	}
-
-	// Find the example status section
-	readme := string(content)
-	statusSection := m.GenerateREADMESection()
-
-	// Look for existing section markers
-	startMarker := "## Example Status"
-	endMarker := "_Last updated:"
-
-	startIdx := strings.Index(readme, startMarker)
-	if startIdx == -1 {
-		// Add new section before first ## or at end
-		firstSection := strings.Index(readme, "\n## ")
-		if firstSection != -1 {
-			readme = readme[:firstSection] + "\n" + statusSection + "\n" + readme[firstSection:]
-		} else {
-			readme += "\n" + statusSection
+	if driftCount > 0 {
+		fmt.Fprintf(os.Stderr, "\n%s %d manifest `modules` entr(ies) are out of date.\n", red("DRIFT:"), driftCount)
+		fmt.Fprintf(os.Stderr, "Regenerate with:\n    %s\n", regenCmd)
+		if *ciMode {
+			os.Exit(1)
 		}
 	} else {
-		// Replace existing section
-		endIdx := strings.Index(readme[startIdx:], endMarker)
-		if endIdx == -1 {
-			// Find next section
-			nextSection := strings.Index(readme[startIdx+1:], "\n## ")
-			if nextSection != -1 {
-				endIdx = nextSection
-			} else {
-				endIdx = len(readme) - startIdx
-			}
-		} else {
-			// Include the end marker line
-			endLineIdx := strings.Index(readme[startIdx+endIdx:], "\n")
-			if endLineIdx != -1 {
-				endIdx += endLineIdx
-			}
-		}
-		readme = readme[:startIdx] + statusSection + readme[startIdx+endIdx:]
+		fmt.Printf("%s manifest `modules` field is in sync with actual imports\n", green("✓"))
 	}
-
-	return os.WriteFile(readmePath, []byte(readme), 0644)
-}
-
-func normalizeOutput(s string) string {
-	// Normalize line endings
-	s = strings.ReplaceAll(s, "\r\n", "\n")
-	// Trim trailing whitespace
-	s = strings.TrimRight(s, " \t\n")
-	return s
-}
-
-func indent(s string, prefix string) string {
-	lines := strings.Split(s, "\n")
-	for i := range lines {
-		lines[i] = prefix + lines[i]
-	}
-	return strings.Join(lines, "\n")
 }

--- a/scripts/verify_examples.go
+++ b/scripts/verify_examples.go
@@ -174,6 +174,7 @@ func runExample(filename string) reporttypes.ExampleResult {
 		{name: "Debug", imports: []string{"import std/debug"}},
 		{name: "Process", imports: []string{"import std/process"}},
 		{name: "Stream", imports: []string{"import std/stream"}},
+		{name: "SharedIndex", imports: []string{"import std/sharedindex"}},
 	}
 
 	for _, spec := range capSpecs {

--- a/scripts/verify_examples.go
+++ b/scripts/verify_examples.go
@@ -90,6 +90,17 @@ var skippedExamples = map[string]string{
 	"examples/runnable/secrets/gated_secret.ail":                 "M-SECRET-EFFECT: needs the Secret capability + 1Password op CLI + a human approval to run; type-checks clean (asserted in TestSecretExamples_IFC)",
 	"examples/runnable/secrets/leak_attempt.ail":                 "M-SECRET-EFFECT: intentionally FAILS `ailang check` to demo IFC leak prevention (asserted in TestSecretExamples_IFC)",
 	"examples/runnable/secrets/secret_demo.ail":                  "M-SECRET-EFFECT: runnable demo — needs the Secret capability + 1Password op CLI to run; type-checks clean (asserted in TestSecretExamples_IFC)",
+	// QUARANTINE (M-DX-EXAMPLES-COVERAGE Phase 1, iter 29): genuine effect-row
+	// inference regression — show() in an effectful-lambda interpolation collapses
+	// the combinator effect row to closed-empty, conflicting with an explicit {IO}.
+	// mcp_tools is a separate regression (getString now returns Option[string]).
+	// Type-system fix is out of scope for this DX sprint (Conflict Surface forbids
+	// internal/types + internal/effects). Owned by the follow-up issue below.
+	"examples/runnable/effectful_list.ail":                      "quarantined: effect-row inference regression — https://github.com/sunholo-data/ailang/issues/386",
+	"examples/runnable/effectful_list_t7_chain_combinators.ail": "quarantined: effect-row inference regression — https://github.com/sunholo-data/ailang/issues/386",
+	"examples/runnable/mcp_tools.ail":                           "quarantined: getString now returns Option[string], example compares to bare string — https://github.com/sunholo-data/ailang/issues/386",
+	"examples/runnable/stream_multi_source.ail":                 "quarantined: effect-row inference regression — https://github.com/sunholo-data/ailang/issues/386",
+	"examples/runnable/stream_process_source.ail":               "quarantined: effect-row inference regression — https://github.com/sunholo-data/ailang/issues/386",
 }
 
 // ailangBinary returns the path to a pre-built ailang binary.


### PR DESCRIPTION
Fixes #341

Closes the examples-coverage gap (issue #341 absorbed as Phase 1). Sprint **M-DX-EXAMPLES-COVERAGE**, mission iteration 29. Work done in an isolated worktree; sequencing 1 → (2,3) → 4 → 5 respected (M3 lands with/after M1, never a permanently-red gate).

## Milestones

**M1 — Triage the 5 red examples** (`3b6ab098f`)
Bisect (v0.13.0 → HEAD) was **inconclusive**: it flagged docs-only `607b5b5df`, but on a clean rebuild that commit AND its parent both pass — the automated run was corrupted by stale-binary caching under `2>/dev/null`. Per the decision rule, inconclusive → genuine-regression branch. In-file bisection root-caused the real trigger: `show()` inside a string interpolation inside an effectful lambda body collapses the combinator effect row to closed-empty, conflicting with an explicit `{IO}` (replacing the nested `${show(x)}` with a plain string makes the identical structure pass). `std/list` combinators are unchanged since v0.13.0. mcp_tools is a separate regression (`getString` → `Option[string]`). Fixing this lives in `internal/types`/`internal/effects` — **forbidden** in this DX sprint, so the 5 files are **quarantined** (skippedExamples reason = issue URL + manifest `status: broken`) and owned by follow-up issue **#386** (bisect result + owner + 5-file closing checklist). `make verify-examples` → 0 failed.

**M2 — Coverage for the 6 zero-importer modules** (`d8b43e7c0`)
`stdlib_{embedding,game,gzip,sharedindex,simhash,smoke}.ail` — each headline pattern, deterministic (2-run stable), manifest `expected` populated, capability header notes. Verifier taught the `SharedIndex` cap. All 6 pass `check` + `run`; all 6 modules now have ≥1 importer.

**M3 — Make the gate real** (`a283caafd`)
`make/examples.mk` captures the verifier exit code, writes BOTH artifacts unconditionally, re-raises non-zero. `ci.yml`: dropped `|| true` + the unmatchable `Failed: 0` grep + unused `status` output; added `if: always()` to the trace step. Reconciled `internal/manifest` so it can load the real manifest (Mode optional, `expected` optional for working, `aspirational` status, broken-info optional but error-code-required-if-present) and wired `validate_manifest --ci` into the gate. Added the parser-backed shared extractor (`scripts/internal/importextract`, unit-tested). **Gate self-test** (`make verify-examples-gate-selftest`): broken fixture → non-zero exit AND artifacts still written = proven.

**M4 — Wire `docs --examples`** (`6352c6d35`)
Additive `modules []string` on `internal/manifest.Example` + `ExampleEntry`, backfilled for 108 entries by a one-time parser-backed script (committed, zero non-modules field loss). `validate_manifest`'s drift assertion uses the SAME extractor; **drift-lint self-test** (`make validate-manifest-selftest`) proves a drifted entry turns `--ci` red. `ailang docs --examples <module>` prints a "Try it" section (path — description — run command); flagless output byte-identical; no-match explicit; resolution failure prints the explicit error as a note. **Installed-binary integration test** (built binary + `AILANG_EXAMPLES` temp download-layout + CWD outside repo, no network) passes.

**M5 — CHANGELOG + issue** (`b40d976f8`)
`changelogs/v0.18-current.md` entry covering all 4 phases; sprint JSON created in-worktree, `status: completed`.

## Deviations (all declared)

1. **Bisect inconclusive** (stale-binary corruption) → took the genuine-regression/quarantine branch per the decision rule; additionally root-caused the real trigger via in-file bisection.
2. **`validate_manifest.go` rewritten** rather than extended: its legacy per-example re-run path was fundamentally broken against the current repo (wrong path prefixes, no `--caps`, a nil-deref README panic) and could not even Load the real manifest. Repurposed to schema + `modules`-drift validation (its stated purpose), which the verifier's run-validation complements. Required relaxing `internal/manifest.Validate` (mode/expected/broken-info optional; `aspirational` added) — out-of-date tests updated per the no-back-compat policy.
3. **Verifier gained a `SharedIndex` cap spec** (small, in-scope `scripts/verify_examples.go` change) so the sharedindex example runs under the gate. No `internal/types`/`internal/effects` changes anywhere.
4. **7 pre-existing stale manifest entries** (files deleted upstream) are reported by validate_manifest as warnings, not hard failures — not introduced here, and not in scope to fix.

## Test evidence

- `make verify-examples` → **0 failed** (5 quarantined show as SKIP), exit 0, both artifacts written.
- `make verify-examples-gate-selftest` → PASS (broken fixture → non-zero + artifacts written).
- `make validate-manifest-selftest` → PASS (drifted modules entry → non-zero).
- `go test ./internal/manifest/ ./scripts/internal/importextract/ ./cmd/ailang/` (manifest, extractor, docs-examples integration) → ok.
- `go vet` clean on all touched packages.
- 6 new examples deterministic across two runs.

Do NOT fix the effect-row regression here — it is owned by #386.


## Note on `make test`

The full `make test` run is green **except** `TestNetHttpPost/httpPost_to_httpbin.org` in `internal/effects` (a package this PR never touches), which fails because httpbin.org returned **HTTP 503 Service Temporarily Unavailable** — an external-service outage, not a regression. Every test in the packages this PR touches (`internal/manifest`, `scripts/internal/importextract`, `cmd/ailang` docs-examples integration) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



**Round-2 hardening** (`881711325`, evaluator round-1 score 81/100): Windows slash-form Try-it paths (fixes TestDocsExamples_InstalledBinaryLayout on windows CI), mcp_tools.ail quarantine manifest entry + stats recalc.