### PR TITLE
feat(run): --caps auto capability inference (auto_caps M1, iter 32 — codex live-fire)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 For the latest version, see [changelogs/v0.18-current.md](changelogs/v0.18-current.md).
 
+## Added
+
+- Add `ailang run --caps auto` to grant exactly the entrypoint's declared effects as capabilities.
+
 ## Changelog Archives
 
 The full changelog has been split into themed files for searchability and readability:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 For the latest version, see [changelogs/v0.18-current.md](changelogs/v0.18-current.md).
 
-## Added
-
-- Add `ailang run --caps auto` to grant exactly the entrypoint's declared effects as capabilities.
-
 ## Changelog Archives
 
 The full changelog has been split into themed files for searchability and readability:

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,18 @@
 
 ## [Unreleased]
 
+### Added — `ailang run --caps auto` capability inference (auto_caps M1, mission iter 32)
+
+`--caps auto` infers the run entrypoint's declared effect row and grants exactly those
+capabilities (nothing more), printing `auto-granted capabilities: <sorted,comma-joined>`
+(or `none` for a pure entrypoint) to stderr. Removes the #1 friction of having to
+remember/spell the `--caps` list for a program you just wrote. Reuses the existing
+`iface`/`TFunc2`/`EffectRow` machinery (the same path `DetermineDeclaredAIMode` walks) —
+no new analysis pass. Secure-by-default is unchanged: with no `--caps` flag a program that
+needs a capability still fails loudly. First slice of the auto_caps design doc; the
+standalone `--auto-caps` flag, `AILANG_AUTO_CAPS` env, always-on preflight, and
+benchmark-harness integration remain follow-ups.
+
 ### Added / Fixed — One-shot stdlib discovery for AI agents (M-DX-AI-DISCOVERY, mission iter 30)
 
 Three self-contained CLI/error-path surfaces so an agent (or human) can discover the

--- a/cmd/ailang/main_run.go
+++ b/cmd/ailang/main_run.go
@@ -31,7 +31,7 @@ func runCommand() {
 	printFlag := fs.Bool("print", true, "Print return value (even for unit type)")
 	noPrintFlag := fs.Bool("no-print", false, "Suppress output (exit code only)")
 	batchFlag := fs.Bool("batch", false, "Batch mode: compile once, run entrypoint per input (remaining args are inputs)")
-	capsFlag := fs.String("caps", "", "Enable capabilities (comma-separated: IO,FS,Net,Env,Process)")
+	capsFlag := fs.String("caps", "", "Enable capabilities (comma-separated: IO,FS,Net,Env,Process; or 'auto' to infer from the entrypoint)")
 	maxRecursionDepthFlag := fs.Int("max-recursion-depth", 10000, "Maximum recursion depth (default: 10000)")
 
 	// Stdlib resolution flags

--- a/cmd/ailang/main_run_exec.go
+++ b/cmd/ailang/main_run_exec.go
@@ -276,6 +276,15 @@ func runFile(filename string, programArgs []string, trace bool, seed int, virtua
 	// Entrypoint resolution and execution
 	// Only attempt entrypoint resolution if the module has exports
 	if result.Interface != nil && len(result.Interface.Exports) > 0 {
+		if caps == "auto" {
+			autoCaps := resolveAutoCaps(result.Interface, entry)
+			caps = strings.Join(autoCaps, ",")
+			if len(autoCaps) == 0 {
+				fmt.Fprintln(os.Stderr, "auto-granted capabilities: none")
+			} else {
+				fmt.Fprintf(os.Stderr, "auto-granted capabilities: %s\n", caps)
+			}
+		}
 
 		// M-PERF7: Batch mode -- compile once, execute entrypoint per input
 		// In batch mode, programArgs are treated as inputs (one execution per arg).

--- a/cmd/ailang/run_helpers.go
+++ b/cmd/ailang/run_helpers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -110,6 +111,27 @@ func setupEnvContext(effCtx *effects.EffContext, flags envFlags) bool {
 	}
 
 	return false // Continue execution
+}
+
+func resolveAutoCaps(moduleIface *iface.Iface, entry string) []string {
+	if moduleIface == nil {
+		return []string{}
+	}
+	item, ok := moduleIface.GetExport(entry)
+	if !ok || item == nil || item.Type == nil {
+		return []string{}
+	}
+	funcType, ok := item.Type.Type.(*types.TFunc2)
+	if !ok || funcType == nil || funcType.EffectRow == nil {
+		return []string{}
+	}
+
+	caps := make([]string, 0, len(funcType.EffectRow.Labels))
+	for name := range funcType.EffectRow.Labels {
+		caps = append(caps, name)
+	}
+	sort.Strings(caps)
+	return caps
 }
 
 // grantCapabilities parses capability string and grants them to the effect context

--- a/cmd/ailang/run_helpers_auto_caps_test.go
+++ b/cmd/ailang/run_helpers_auto_caps_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/iface"
+	"github.com/sunholo-data/ailang/internal/types"
+)
+
+func TestResolveAutoCaps(t *testing.T) {
+	moduleIface := iface.NewIface("test")
+	moduleIface.AddExport("main", &types.Scheme{
+		Type: &types.TFunc2{
+			EffectRow: &types.Row{
+				Kind: types.EffectRow,
+				Labels: map[string]types.Type{
+					"IO": types.Unit(),
+					"FS": types.Unit(),
+				},
+			},
+			Return: types.Unit(),
+		},
+	}, false)
+
+	want := []string{"FS", "IO"}
+	if got := resolveAutoCaps(moduleIface, "main"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("resolveAutoCaps() = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
M1 of **auto_caps** (`design_docs/planned/v0_29_0/20251013_auto_caps_capability_inference.md`). Adds `ailang run --caps auto`: when `--caps` is exactly `auto`, infer the entrypoint's declared effect row and grant exactly those capabilities, printing `auto-granted capabilities: <sorted>` (or `none`) to stderr. Removes the #1 friction of remembering/spelling `--caps` for a program you just wrote.

Reuses the existing `iface`/`TFunc2`/`EffectRow` machinery (the path `DetermineDeclaredAIMode` already walks) — **no new analysis pass** (the design doc's proposed ~200 LOC of new `internal/effects/analysis.go` + `internal/runtime/preflight.go` was refuted by the planner as redundant). Net: 74 insertions across 5 files.

Secure-by-default is unchanged: with no `--caps`, a program needing a capability still fails loudly.

## Mission provenance — first cross-provider live-fire
- **Executor: OpenAI codex `gpt-5.6-sol`** (mission-control iteration 32, `MISSION_EXECUTOR_MODEL=codex:gpt-5.6-sol`). First metered cross-provider executor run.
- **Planner: Opus** (right-sized to M1, refuted the doc's mechanism).
- **Evaluator: Sonnet** (generator≠judge: anthropic ≠ openai; fable pin unenforceable in the Agent tool → re-routed to sonnet). **PASS 98/100 round 1**, no blockers.

## Scope deferred (still in the doc)
Standalone `--auto-caps` flag, `AILANG_AUTO_CAPS` env, always-on preflight display + exit-code-2, benchmark-harness integration, capability manifest.

## Verification
- `resolveAutoCaps` unit test (multi-effect IO+FS → sorted `[FS, IO]`).
- Acceptance (independently re-run by the evaluator against a base binary for non-vacuity): `--caps auto` grants+runs; `--caps IO` no regression; no-caps still fails exit 1; pure program → `none`; multi-effect → `FS,IO`; `--entry`-specific (no cross-entry bleed); batch path covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)