### PR TITLE
feat(exec): reachable gemini agentic lane via managed_agents + M1c fleet recipe

### DIFF
--- a/.claude/skills/mission-control/SKILL.md
+++ b/.claude/skills/mission-control/SKILL.md
@@ -248,8 +248,29 @@ value matches `^([a-z_]+):(.+)$`, DO NOT use the Agent tool. Split it (`PROVIDER
   generator≠judge holds) if the sonnet evaluator's verdicts look lenient — that switch needs the
   charter's ≥3-datapoint evidence rule, not vibes. Quota note: a probe-failed Fable (weekly bucket
   gone) falls back gracefully — never wedge on the scarce model.
-- **Any other `PROVIDER`** (motoko/opencode/pi/gemini): NOT wired in M1b (motoko needs the GPU
-  `rig.lock`, out of scope). Treat as unavailable → fall back to `$MODEL` + FLAG.
+- **`PROVIDER=gemini`** (added 2026-07-16 iteration 33, M1c — the managed_agents lane): reached via
+  `ailang exec gemini "directive"`. **The agentic `gemini` provider routes to the `managed_agents`
+  executor** (Vertex AI Managed Agents API via ADC) — the successor to the Gemini CLI retired in
+  v0.22.0 (wired this iteration: `resolveAgenticExecutorName` in `cmd/ailang/exec.go`, PR from
+  `sprint/m-gemini-exec-lane`; before it, `ailang exec gemini` failed `unknown executor: gemini` —
+  the fleet directive's "wiring-only, no new plumbing" claim was REFUTED). Requires **ADC**
+  (`gcloud auth application-default print-access-token` must succeed — probe it first; unset ADC →
+  fall back to `$MODEL` + FLAG). `--model` selects the Vertex **agent** name (default
+  `antigravity-preview-05-2026`), NOT a gemini-model string. Same probe/cap/fallback discipline as
+  codex: ADC-gated 1-token probe (`ailang exec gemini "reply with exactly: ok"` under a bounded
+  `date +%s` deadline; only proceed on rc=0), the real run backgrounded with a bounded ≤30-min cap,
+  fall back to `$MODEL` + FLAG on probe-fail/cap.
+  - **CRITICAL — CapRemoteSandbox (role-scope limit):** managed_agents runs the agent in a
+    Google-hosted server-side sandbox, so **file edits do NOT touch the local worktree** — they
+    return ONLY in the agent's TEXT output. This lane therefore fits **READ-ONLY roles**
+    (evaluator / reviewer / quorum-verifier — the item-(c) agentic-verify lane) that read the repo
+    and emit a verdict/text. It is **NOT usable for the file-editing EXECUTOR role** without a
+    bridge (see the eval harness's `managed_agents_bridge.go`, which parses artifacts back out of
+    the text response). Do NOT pin `MISSION_EXECUTOR_MODEL=gemini:…` expecting worktree edits — that
+    is a follow-up (bridge work), not this lane. generator≠judge: gemini (Google) is a distinct
+    provider from any Anthropic/OpenAI executor, so it is a valid independent evaluator/reviewer.
+- **Any other `PROVIDER`** (motoko/opencode/pi): NOT wired (motoko needs the GPU `rig.lock`, out of
+  scope). Treat as unavailable → fall back to `$MODEL` + FLAG.
 
 If a pinned model is quota-limited or unavailable/rejected, fall back to `$MODEL` for that role and
 FLAG it in the Gate-5 report — never wedge the loop on a role-model outage. **EXCEPTION — the

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,20 @@
 
 ## [Unreleased]
 
+### Fixed — `ailang exec gemini` agentic lane reachable (M1c gemini fleet lane)
+
+`ailang exec gemini "..."` (agentic, i.e. without `--api-only`) now routes to the
+`managed_agents` executor (Vertex AI Managed Agents API via ADC) instead of failing
+with `unknown executor: gemini`. The Gemini CLI was retired in v0.22.0 and its
+successor registers in the executor factory under `managed_agents`; a small
+`resolveAgenticExecutorName` mapping in the agentic path (`gemini` → `managed_agents`,
+identity otherwise) bridges the CLI-facing provider name to the registry name. The
+`--api-only` single-shot gemini `generateContent` path (via `internal/ai/gemini`) is
+untouched. The stale `exec` help text describing the retired "Gemini CLI" (and its
+`--model gemini-2.5-pro` example) was corrected to describe the server-side sandbox —
+file edits are bridged via the agent's text output, not written locally — and `--model`
+now selects the Vertex agent name (default `antigravity-preview-05-2026`).
+
 ### Added — `ailang run --caps auto` capability inference (auto_caps M1, mission iter 32)
 
 `--caps auto` infers the run entrypoint's declared effect row and grants exactly those

--- a/cmd/ailang/exec.go
+++ b/cmd/ailang/exec.go
@@ -304,10 +304,30 @@ func runExec() {
 	}
 }
 
-// executeCLI uses the CLI executor (Claude Code, Gemini CLI)
+// resolveAgenticExecutorName maps the CLI provider name to the executor-factory
+// registry name for the AGENTIC (non --api-only) path.
+//
+// The Gemini CLI executor was retired in v0.22.0 (M-MANAGED-AGENTS). Its
+// successor agentic lane is the `managed_agents` package (Vertex AI Managed
+// Agents API via ADC), which registers itself in the factory under the name
+// "managed_agents" — not "gemini". So the CLI-facing `gemini` provider must be
+// translated to that registry name here. Every other provider maps to itself
+// (identity). Note: this affects ONLY the agentic path; the --api-only path
+// (executeAPI, single-shot gemini generateContent) is untouched.
+func resolveAgenticExecutorName(provider string) string {
+	if provider == "gemini" {
+		return "managed_agents"
+	}
+	return provider
+}
+
+// executeCLI uses the agentic executor (Claude Code CLI, Vertex Managed Agents, ...)
 func executeCLI(ctx context.Context, provider, directive, workspace, model, systemPrompt, taskID string, timeout time.Duration, streamJSON bool) (*executor.Result, error) {
-	// Get executor from factory
-	exec, err := executor.GlobalFactory().GetExecutor(provider)
+	// Get executor from factory. The CLI provider name is translated to the
+	// executor-factory registry name for the agentic path (e.g. gemini →
+	// managed_agents); see resolveAgenticExecutorName.
+	execName := resolveAgenticExecutorName(provider)
+	exec, err := executor.GlobalFactory().GetExecutor(execName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get executor for %s: %w", provider, err)
 	}
@@ -641,7 +661,9 @@ Execute an AI task using the specified provider.
 
 Providers:
   claude      Claude Code CLI (agentic coding with file editing)
-  gemini      Gemini CLI (agentic coding with file editing)
+  gemini      Vertex AI Managed Agents API via ADC (agentic). Runs the agent in
+              a Google-hosted sandbox: file edits are bridged via the agent's
+              text output, NOT written to your local workspace.
   openai      OpenAI API (text generation only, use --api-only)
   anthropic   Anthropic API (text generation only, use --api-only)
   ollama      Ollama (local models, text generation only, use --api-only)
@@ -667,8 +689,9 @@ Examples:
   # Run Claude Code to fix a bug
   ailang exec claude "Fix the null pointer in parser.go" --workspace /repo
 
-  # Run Gemini CLI with specific model
-  ailang exec gemini "Add tests for the login function" --model gemini-2.5-pro
+  # Run the Vertex Managed Agents lane (--model selects the Vertex agent name;
+  # omit it to use the default antigravity-preview-05-2026)
+  ailang exec gemini "Add tests for the login function" --model antigravity-preview-05-2026
 
   # Use OpenAI API for text generation
   ailang exec openai "Explain recursion" --api-only

--- a/cmd/ailang/exec_test.go
+++ b/cmd/ailang/exec_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/executor"
+	// Blank-imported so the managed_agents executor registers itself in the
+	// global factory (mirrors the blank import in exec.go). Required for
+	// TestResolveAgenticExecutorNameReachable below.
+	_ "github.com/sunholo-data/ailang/internal/executor/managed_agents"
+)
+
+// TestResolveAgenticExecutorName verifies the CLI-provider → executor-registry
+// name mapping for the agentic path. In particular, "gemini" must resolve to
+// "managed_agents" (Gemini CLI was retired in v0.22.0); everything else is
+// identity.
+func TestResolveAgenticExecutorName(t *testing.T) {
+	cases := []struct {
+		provider string
+		want     string
+	}{
+		{"gemini", "managed_agents"},
+		{"claude", "claude"},
+		{"openai", "openai"},
+		{"managed_agents", "managed_agents"},
+	}
+	for _, tc := range cases {
+		if got := resolveAgenticExecutorName(tc.provider); got != tc.want {
+			t.Errorf("resolveAgenticExecutorName(%q) = %q, want %q", tc.provider, got, tc.want)
+		}
+	}
+}
+
+// TestResolveAgenticExecutorNameReachable proves the gemini agentic lane is now
+// reachable: resolving "gemini" and looking it up in the global executor
+// factory returns the managed_agents executor with no error. This is a pure
+// registry lookup — it makes NO network call to Vertex.
+func TestResolveAgenticExecutorNameReachable(t *testing.T) {
+	name := resolveAgenticExecutorName("gemini")
+	exec, err := executor.GlobalFactory().GetExecutor(name)
+	if err != nil {
+		t.Fatalf("GetExecutor(%q) returned error: %v", name, err)
+	}
+	if exec == nil {
+		t.Fatalf("GetExecutor(%q) returned nil executor", name)
+	}
+	if got := exec.Name(); got != "managed_agents" {
+		t.Errorf("executor.Name() = %q, want %q", got, "managed_agents")
+	}
+}


### PR DESCRIPTION
## What

Fleet rollout **item (b) — M1c gemini `managed_agents` recipe branch** (mission iteration 33).

Gate-2 reality-check **refuted** the directive's "wiring-only, no new plumbing" claim: `ailang exec gemini "..."` (agentic) failed with `unknown executor: gemini`, because the successor to the retired (v0.22.0) Gemini CLI — the `managed_agents` executor (Vertex AI Managed Agents API via ADC) — registers under the name `managed_agents` with **no `gemini` alias**. The gemini agentic lane was therefore unreachable via `ailang exec`.

## Changes

- **`cmd/ailang/exec.go`**: new `resolveAgenticExecutorName(provider)` helper maps the agentic `gemini` provider → `managed_agents` executor (identity for all others). `executeCLI` uses it. The `--api-only` gemini path (single-shot `internal/ai/gemini`) is **untouched**. Stale "Gemini CLI" help text + `--model gemini-2.5-pro` example corrected (Vertex agent name; server-side sandbox note).
- **`cmd/ailang/exec_test.go`** (new): table test for the mapping + a real factory-lookup test asserting `Name()=="managed_agents"` (no network).
- **`.claude/skills/mission-control/SKILL.md`**: Gate-3 `PROVIDER=gemini` recipe branch — ADC-gated probe + bounded cap + fallback, scoped to **read-only roles** (evaluator/reviewer/quorum-verifier) per **CapRemoteSandbox** (server-side sandbox → no local worktree edits; file-editing executor role needs a bridge → follow-up / item (c)).
- CHANGELOG entry.

## Verification

- Executor (Opus): 2 unit tests PASS, `go build`/`go vet`/`gofmt` clean, dry-run accepts `gemini`.
- Evaluator (Sonnet, generator≠judge — fable pin unenforceable + Opus controller → F1 re-route to sonnet, FLAGGED): **PASS 96/100 round 1**, no blockers. Confirmed: lane reachable, `--api-only` untouched, help honest about CapRemoteSandbox, no collateral provider mis-routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)