### PR TITLE
feat(eval): gemini evaluator diff-bridge — sandboxed gemini can review sprint worktree changes (fleet c1)

### DIFF
--- a/.ailang/state/sprints/sprint_M-GEMINI-EVALUATOR-DIFF-BRIDGE.json
+++ b/.ailang/state/sprints/sprint_M-GEMINI-EVALUATOR-DIFF-BRIDGE.json
@@ -1,0 +1,229 @@
+{
+  "sprint_id": "M-GEMINI-EVALUATOR-DIFF-BRIDGE",
+  "title": "Inject a sprint diff bundle into a sandboxed gemini evaluator (INJECT-IN inverse of the extract-out managed_agents bridge)",
+  "design_doc": "design_docs/planned/v0_30_0/m-gemini-evaluator-diff-bridge.md",
+  "mission_iteration": 39,
+  "target_version": "v0.30.x",
+  "base_version_at_plan": "v0.29.2",
+  "priority": "P1",
+  "risk_level": "low",
+  "github_issues": [
+    399
+  ],
+  "created": "2026-07-17",
+  "created_at_head": "2bdf4e9e7eae969649c0a6422eafbc35100e5bfb",
+  "origin_dev_at_plan": "2bdf4e9e7eae969649c0a6422eafbc35100e5bfb",
+  "executor_constraints": {
+    "worktree": "Work in an isolated git worktree branched from origin/dev. NEVER the shared main tree. Commit each milestone promptly (concurrent-agent safety — a sibling agent shares the working tree).",
+    "executor_policy_free": "ZERO code changes to internal/executor/managed_agents/. The executor stays policy-free (managed_agents.go:158-163). All new code lives in internal/eval_harness/ (the POLICY layer), mirroring the sibling managed_agents_bridge.go rationale (file header lines 8-11). The diff bundle goes into the EXISTING task.Directive / task.SystemPrompt fields the executor already reads verbatim.",
+    "frozen_quorum_contract": "internal/mission/quorum/ is BYTE-IDENTICAL untouched. Do NOT import quorum into eval_harness, do NOT add fields to ReviewResult, do NOT add Verdict enum values. GeminiVerdict is a SEPARATE type in a DIFFERENT domain (sprint eval vs design-doc review). go test ./internal/mission/quorum/... must pass unchanged (quorum_test.go, reviewer_test.go, agentic_caller_test.go, escalate_test.go, tier2_test.go).",
+    "no_exec_go_change": "No change to cmd/ailang/exec.go. resolveAgenticExecutorName(\"gemini\")==\"managed_agents\" and the --json shape already exist (verified exec.go:281-294, 317-322). The default runner consumes the EXISTING seam.",
+    "no_live_vertex": "NO live Vertex / managed_agents call in ANY test. RunGeminiEvaluator takes an INJECTABLE runner func; unit tests pass a stub returning canned --json output. The default (production) runner shells `ailang exec gemini --json` but is never exercised by the test suite.",
+    "no_silent_fallback": "CLAUDE.md Principle 2. Truncation, binary/generated drop, AND backend error each set an EXPLICIT VerificationDegraded marker (caller-enforced, NOT model-trusted). A malformed verdict is a HARD ERROR, never a coerced pass. A stub/model pass:true under truncation STILL surfaces VerificationDegraded==true.",
+    "non_vacuous_tests": "Every listed Go test references a symbol absent on the base binary, so `go test` fails to compile/pass BEFORE implementation and passes AFTER. Verify non-vacuity by confirming the test compiles against the new symbols only.",
+    "fence_helper_discipline": "Conflict-Surface seam 4: when sharing lastFencedBlock, follow coding-standards 'rename definitions too, test between each change'. Prefer adding an EXPORTED thin wrapper (LastFencedBlock) over the existing unexported lastFencedBlock (zero behavior change, no rename of the internal call site in extractCode) — the lowest-risk option. TestLastFencedBlock_UnchangedForExtractOut guards it."
+  },
+  "velocity": {
+    "target_loc_per_day": 350,
+    "estimated_total_loc": 705,
+    "estimated_days": 2,
+    "basis": "Design estimates ~2d across 3 milestones (M1 bundle builder ~0.75d; M2 directive + verdict parse ~0.75d; M3 caller seam ~0.5d). Recent mission sprints (iters 30-38) are 1-2d single-iteration full-loop items landing round-1 (M-PRELUDE-OPTION-RESULT, M-XMOD-ALIAS-POLY single-milestone same-day; M-QUORUM-AGENTIC-VERIFY core M1-M3 in one iteration). This is three PURE, independently-testable functions + a thin caller over an ALREADY-VERIFIED executor seam and an EXISTING fence helper — mostly wiring + policy, no new subsystem. LOC est ~320 impl + ~380 test + ~5 export = ~705. Low risk: no external-network unknown (M0-style probe not needed — tests are stub-only), no core/executor/quorum change."
+  },
+  "premise_verification": {
+    "status": "ALL CITED SEAMS VERIFIED at HEAD 2bdf4e9e7 (2026-07-17). One SCHEMA-CLAIM discrepancy found (GeminiVerdict does NOT byte-mirror evaluation_report_schema.md field names — it is a defensible adaptation); no phantom seams; no blocking discrepancy. Plan adjusted to acknowledge the adaptation (see schema_adaptation_note).",
+    "checks": [
+      "managed_agents request body carries ONLY Input=[task.Directive] + SystemInstruction=task.SystemPrompt, no repo/file upload. CONFIRMED at managed_agents.go:164-176 (doc-cited lines exact).",
+      "Executor deliberately policy-free; harness owns bridging. CONFIRMED managed_agents.go:158-163 + managed_agents_bridge.go:8-11 (file header).",
+      "managed_agents_bridge.go EXISTS as the extract-out precedent (managedAgentsBridgeInstruction const + extractCode + writeSolutionFromResponse). CONFIRMED.",
+      "lastFencedBlock helper exists and is UNEXPORTED at managed_agents_bridge.go:168. CONFIRMED — the doc's plan to export/share it is valid. Single internal call site is extractCode (line 116). Recommend exported thin wrapper over rename (lowest risk).",
+      "quorum.ReviewResult is a design-doc-review verdict {Verdict pass|reject, StrongestObjection, Catch, ProposedFix} at reviewer.go:39-61 (doc-cited lines exact); ParseReviewResult (reviewer.go:116) + ValidateReviewResult (reviewer.go:136) exist. CONFIRMED it is a DIFFERENT domain from sprint eval; the doc's decision to NOT overload it is correct.",
+      "cmd/ailang/exec.go: resolveAgenticExecutorName(\"gemini\")==\"managed_agents\" at exec.go:317-322 (doc-cited); --json emits {success,output,error,input_tokens,output_tokens,cost_usd,duration_ms,num_turns} at exec.go:281-294 (doc-cited). CONFIRMED — no routing change needed.",
+      "No existing VerificationDegraded / verification_degraded / bundle_truncated marker anywhere in internal/. CONFIRMED zero hits — this marker is new (matches doc Verification Log).",
+      "Target version folder design_docs/planned/v0_30_0/ exists and holds the design doc. CONFIRMED."
+    ],
+    "discrepancies": [
+      {
+        "severity": "minor / non-blocking",
+        "claim": "The doc (lines 74-94, 216, 264) states GeminiVerdict 'mirrors the sprint-evaluator skill's evaluation_report_schema.md (score/result/blockers)'.",
+        "finding": "REFUTED as a byte-for-byte mirror. The actual schema (.claude/skills/sprint-evaluator/resources/evaluation_report_schema.md) uses `total_score` (int), `result` (string \"pass\"/\"fail\"), `hard_fails[]`, and `feedback[]`. There is NO `blockers` field and NO boolean `pass` field. GeminiVerdict{Score int, Pass bool, Blockers []string} is a defensible COMPACT ADAPTATION for a reasoning-only single-shot verdict, not a mirror.",
+        "resolution": "KEEP the doc's chosen GeminiVerdict shape — it is the frozen acceptance-test contract for M2 (TestParseGeminiVerdict_ExtractsFencedJSON, TestValidateGeminiVerdict_RejectsMalformed reference exactly {score,pass,blockers}). Do NOT switch to total_score/result to chase the skill schema mid-sprint (that would break the doc's own tests). REQUIRED: add a code doc-comment on GeminiVerdict noting it is an ADAPTATION of evaluation_report_schema.md (compact score/pass/blockers), not a field-name mirror, so a future reader is not misled. This surfaces the discrepancy in code without silently rewriting the design."
+      }
+    ],
+    "schema_adaptation_note": "GeminiVerdict.Score maps to the skill's total_score; GeminiVerdict.Pass corresponds to result==\"pass\"; GeminiVerdict.Blockers is a compact stand-in for hard_fails + high-severity feedback. Threshold 70 (pass>=70 AND no blockers) matches the skill's pass_threshold. The adaptation is intentional for a single-shot reasoning-only verdict; the full evaluation_report_schema.md remains the shape for the local sonnet sprint-evaluator, not the sandboxed gemini one."
+  },
+  "features": [
+    {
+      "id": "M1_DIFF_BUNDLE_BUILDER",
+      "phase": 1,
+      "description": "BuildDiffBundle(worktree string, opts BundleOptions) (Bundle, error) in the NEW file internal/eval_harness/gemini_evaluator_bridge.go, plus Bundle, BundleOptions, DegradationInfo types. Enumerates the changed-file set via `git -C <wt> status --porcelain -z` (modified + staged + UNTRACKED ??), runs `git -C <wt> diff` + `git -C <wt> diff --cached` for tracked changes (ALWAYS included, never dropped), synthesizes `+++ NEW FILE: <path>` headers + bodies for untracked files (git diff alone misses them — quorum gemini-3-1-pro catch 2026-07-16), appends full contents of changed non-binary non-generated files, applies drop-order + byte ceiling with LOUD truncation markers.",
+      "estimated_loc": 260,
+      "estimated_hours": 6,
+      "dependencies": [],
+      "blocks": [
+        "M3_CALLER_SEAM_DEGRADATION"
+      ],
+      "implementation": {
+        "types": "Bundle{Text string, Truncated bool, DroppedFiles []string, Bytes int}; BundleOptions{MaxBytes int (default 256*1024), ...}; DegradationInfo{Truncated bool, DroppedFiles []string, BackendError string} carrying the degradation signal to M3.",
+        "enumeration": "git -C <wt> status --porcelain -z parses modified/staged/untracked (?? = untracked). For tracked changes use git -C <wt> diff (unstaged) + git -C <wt> diff --cached (staged). For untracked files synthesize a `+++ NEW FILE: <path>` header followed by full contents; de-dupe against tracked appendices.",
+        "always_included": "The unified diff of tracked changes + the untracked-file `+++ NEW FILE` HEADER lines are ALWAYS first and never dropped (the change signal is load-bearing). Only full-file-content appendices (and a new file's BODY) are subject to the ceiling. A dropped new file KEEPS its header line so it is never silently invisible.",
+        "drop_order": "(1) binary files (NUL byte in first 8 KiB) — never included, only listed; (2) generated/vendored (path globs: *.pb.go, dist/, vendor/, *.min.js, *_generated.go, go.sum); (3) if still over ceiling, largest remaining changed files by byte size, dropped WHOLE (never mid-file), until under ceiling.",
+        "loud_marker": "Every drop appends a line to Bundle.Text AND Bundle.DroppedFiles: `=== BUNDLE TRUNCATED: dropped <path> (<size>, <reason>) — NOT shown to evaluator ===`. No silent drop. Bundle.Truncated=true propagates to DegradationInfo.",
+        "deterministic": "Drop order is stable/sorted so two calls on the same worktree yield byte-identical Text (git status output sorted; drop candidates sorted by (size desc, path) with a stable tiebreak)."
+      },
+      "files": [
+        "internal/eval_harness/gemini_evaluator_bridge.go (new: BuildDiffBundle + Bundle + BundleOptions + DegradationInfo)",
+        "internal/eval_harness/gemini_evaluator_bridge_test.go (new: table tests, each builds a real temp git repo via git init + git add/commit + modify)"
+      ],
+      "acceptance_criteria": [
+        "TestBuildDiffBundle_IncludesDiffAndFiles: temp git repo with 2 modified .go files => Bundle.Text contains BOTH the unified diff AND both files' full contents",
+        "TestBuildDiffBundle_IncludesUntrackedNewFiles (quorum catch): temp git repo with a brand-new untracked .go file => Bundle.Text contains a `+++ NEW FILE: <path>` header AND the file's contents (proves git diff alone would miss it)",
+        "TestBuildDiffBundle_DropsBinaryAndGenerated: a modified *.pb.go and a NUL-containing file => both in DroppedFiles, NOT in Text, and a LOUD marker line present for each",
+        "TestBuildDiffBundle_TruncatesOverCeiling: MaxBytes small + one large changed file => Truncated==true, file in DroppedFiles, marker present, and the git diff itself STILL present (never dropped)",
+        "TestBuildDiffBundle_Deterministic: two calls on the same worktree => byte-identical Text (stable/sorted drop order)"
+      ],
+      "test_requirements": [
+        "Each test constructs a REAL temp git repo (t.TempDir() + git init/add/commit) — no mocking of git; deterministic across runs",
+        "Binary detection asserted via a file with an embedded NUL byte in the first 8 KiB",
+        "Generated detection asserted via at least one path glob (*.pb.go)",
+        "The git diff / +++ NEW FILE headers are proven present EVEN in the truncation test (never-dropped invariant)"
+      ],
+      "passes": true,
+      "started": "2026-07-16T23:18:39Z",
+      "completed": "2026-07-16T23:18:39Z",
+      "notes": "BuildDiffBundle + Bundle/BundleOptions/DegradationInfo. git status --porcelain -z enumeration incl untracked ?? (+++ NEW FILE views); tracked diff always first/never dropped; drop-order binary->generated->largest-whole-file under 256KiB ceiling; LOUD === BUNDLE TRUNCATED === markers; deterministic (sorted). 5 tests pass."
+    },
+    {
+      "id": "M2_DIRECTIVE_AND_VERDICT_PARSE",
+      "phase": 2,
+      "description": "BuildEvaluatorDirective (reasoning-only directive composition, mirrors managedAgentsBridgeInstruction), the GeminiVerdict type, ParseGeminiVerdict (reuses the shared fence helper), ValidateGeminiVerdict (hard error on malformed — mirrors ParseReviewResult/ValidateReviewResult discipline), and the shared/exported fence helper. GeminiVerdict is a COMPACT ADAPTATION of evaluation_report_schema.md (score/pass/blockers) — see schema_adaptation_note; add a doc-comment saying so (do NOT claim a byte-mirror).",
+      "estimated_loc": 200,
+      "estimated_hours": 6,
+      "dependencies": [],
+      "blocks": [
+        "M3_CALLER_SEAM_DEGRADATION"
+      ],
+      "implementation": {
+        "directive": "BuildEvaluatorDirective(designDoc, sprintPlan, acceptanceCriteria string, bundle Bundle) string composes: a compile-time const reasoning-only instruction (NO repo/test access, judge ONLY from the bundle, do NOT claim you ran a test, END with a single fenced ```json verdict {score(0-100), pass(bool), blockers(string[])}), the bundle text, and the design/plan/criteria. If bundle.Truncated, append the 'note in blockers which unseen files limit your confidence' line.",
+        "verdict_type": "GeminiVerdict{Score int `json:\"score\"`, Pass bool `json:\"pass\"`, Blockers []string `json:\"blockers\"`, VerificationDegraded bool `json:\"verification_degraded\"`, DegradedReason string `json:\"degraded_reason,omitempty\"`}. Doc-comment: this is a COMPACT ADAPTATION of the sprint-evaluator skill's evaluation_report_schema.md (total_score->Score, result->Pass, hard_fails/feedback->Blockers), NOT a field-name mirror, and is DISTINCT from quorum.ReviewResult (different domain).",
+        "parse": "ParseGeminiVerdict(response string, degraded DegradationInfo) (GeminiVerdict, error): extract the LAST fenced json block via the shared helper, json.Unmarshal, call ValidateGeminiVerdict, then STAMP VerificationDegraded/DegradedReason from `degraded` (truncation/drop/backend-error). Missing fence or non-JSON => hard error (never a coerced pass).",
+        "validate": "ValidateGeminiVerdict enforces: Score in [0,100]; if len(Blockers)>0 then Pass==false; if VerificationDegraded then DegradedReason non-empty. Any violation => hard error (Principle 2).",
+        "fence_share": "Add an EXPORTED thin wrapper LastFencedBlock(s string) string in managed_agents_bridge.go delegating to the existing unexported lastFencedBlock (zero behavior change, no rename of the extractCode call site — the lowest-risk option per Conflict-Surface seam 4)."
+      },
+      "files": [
+        "internal/eval_harness/gemini_evaluator_bridge.go (add: BuildEvaluatorDirective, GeminiVerdict, ParseGeminiVerdict, ValidateGeminiVerdict, reasoning-only const)",
+        "internal/eval_harness/gemini_evaluator_bridge_test.go (add: directive + parse + validate + fence-regression tests)",
+        "internal/eval_harness/managed_agents_bridge.go (MODIFY small: export LastFencedBlock thin wrapper, ~5 LOC, no behavior change)"
+      ],
+      "acceptance_criteria": [
+        "TestBuildEvaluatorDirective_ReasoningOnly: directive contains the reasoning-only instruction, the bundle text, the design-doc/criteria, and the fenced-json verdict-schema instruction; a truncated bundle adds the 'note unseen files in blockers' line",
+        "TestParseGeminiVerdict_ExtractsFencedJSON: response with prose + a final ```json verdict => parsed {score,pass,blockers}",
+        "TestValidateGeminiVerdict_RejectsMalformed: score>100, OR blockers non-empty with pass==true, OR degraded with empty reason => hard error (never coerced pass); also non-JSON / missing fence => error",
+        "TestLastFencedBlock_UnchangedForExtractOut: the shared/exported helper returns IDENTICAL results for the extract-out cases in managed_agents_bridge_test.go (regression guard for Conflict-Surface seam 4)",
+        "GeminiVerdict carries a doc-comment acknowledging it is an ADAPTATION of evaluation_report_schema.md (not a byte-mirror) and is distinct from quorum.ReviewResult"
+      ],
+      "test_requirements": [
+        "Directive test asserts the reasoning-only const substring, the bundle substring, and the fenced-json instruction substring are all present",
+        "Parse test uses a response with intermediate scratch + a final json fence (proves LAST-fence selection)",
+        "Validate table covers each failure mode as a distinct hard-error case",
+        "Fence regression: the same inputs used by managed_agents_bridge_test.go extract-out cases yield identical output through the exported wrapper"
+      ],
+      "passes": true,
+      "started": "2026-07-16T23:18:39Z",
+      "completed": "2026-07-16T23:18:39Z",
+      "notes": "BuildEvaluatorDirective (reasoning-only const + truncation note), GeminiVerdict (doc-commented compact adaptation of evaluation_report_schema.md, distinct from quorum.ReviewResult), ParseGeminiVerdict/ValidateGeminiVerdict (hard error on malformed, never coerced pass), LastFencedBlock exported thin wrapper delegating to lastFencedBlock (no call-site rename). 4 tests pass incl extract-out regression guard."
+    },
+    {
+      "id": "M3_CALLER_SEAM_DEGRADATION",
+      "phase": 3,
+      "description": "RunGeminiEvaluator(ctx, worktree, designDoc, sprintPlan string, opts EvalOptions) (*GeminiVerdict, error) with an INJECTABLE runner func, plus EvalOptions. Composes BuildDiffBundle -> BuildEvaluatorDirective -> injected runner -> ParseGeminiVerdict, and CALLER-STAMPS VerificationDegraded from truncation/drop/backend-error. The default (production) runner shells `ailang exec gemini --json`; tests inject a STUB (no live Vertex call). Mirrors quorum.RunAgenticReviewer's policy-layer boundary.",
+      "estimated_loc": 245,
+      "estimated_hours": 4,
+      "dependencies": [
+        "M1_DIFF_BUNDLE_BUILDER",
+        "M2_DIRECTIVE_AND_VERDICT_PARSE"
+      ],
+      "blocks": [],
+      "implementation": {
+        "options": "EvalOptions carries BundleOptions (MaxBytes etc.), the acceptance criteria, and an injectable Runner func (e.g. func(ctx, directive, systemPrompt string) (execOutput, error) returning the --json fields {Success, Output, Error, cost, turns}). Default Runner = a production impl that shells `ailang exec gemini --json --workspace <tmp>` (or calls the executor factory as executeCLI does). The default runner is NEVER exercised by the test suite.",
+        "flow": "1) BuildDiffBundle => Bundle + DegradationInfo(Truncated, DroppedFiles). 2) BuildEvaluatorDirective => directive. 3) invoke injected runner. On runner error OR Success==false: set DegradationInfo.BackendError = executor error text. 4) ParseGeminiVerdict(output, degradation) => validated verdict with degradation stamped.",
+        "caller_enforced_degradation": "VerificationDegraded is stamped by the CALLER, not trusted from the model. A stub verdict of pass:true UNDER truncation still returns VerificationDegraded==true + non-empty reason. A backend error returns VerificationDegraded==true with the executor error text and is NOT a fabricated pass (Principle 2).",
+        "no_live_vertex": "Every test injects a stub runner returning canned output. NO test makes a live managed_agents/Vertex call."
+      },
+      "files": [
+        "internal/eval_harness/gemini_evaluator_bridge.go (add: RunGeminiEvaluator, EvalOptions, default production runner)",
+        "internal/eval_harness/gemini_evaluator_bridge_test.go (add: stub-runner happy path, truncation-stamps-degraded, backend-error-is-degraded-not-pass)"
+      ],
+      "acceptance_criteria": [
+        "TestRunGeminiEvaluator_StubHappyPath: stub runner returns a valid fenced verdict => RunGeminiEvaluator returns it with VerificationDegraded==false",
+        "TestRunGeminiEvaluator_TruncationStampsDegraded: bundle over ceiling => returned verdict has VerificationDegraded==true + non-empty reason, EVEN IF the stub verdict said pass:true (caller-enforced, not model-trusted)",
+        "TestRunGeminiEvaluator_BackendErrorIsDegradedNotPass: stub runner returns Success==false => verdict is VerificationDegraded==true with the executor error text; result is NOT a fabricated pass (Principle 2)",
+        "No live Vertex / managed_agents call in ANY test (stub runner only) — asserted by construction (the runner is an injected func; the default production runner is untouched by tests)"
+      ],
+      "test_requirements": [
+        "Stub runner is an injected func returning a canned {Success, Output} — no HTTP, no executor factory call in tests",
+        "Truncation test forces a small MaxBytes + a large changed file so DegradationInfo.Truncated==true, then asserts the stamp overrides a stub pass:true",
+        "Backend-error test sets stub Success=false + Error text and asserts VerificationDegraded + reason + NOT pass",
+        "The default production runner exists and shells `ailang exec gemini --json` but is NEVER invoked by the test suite"
+      ],
+      "passes": true,
+      "started": "2026-07-16T23:18:39Z",
+      "completed": "2026-07-16T23:18:39Z",
+      "notes": "RunGeminiEvaluator with injectable EvalRunner (stub in tests, DefaultGeminiRunner shells ailang exec gemini --json in prod, never exercised by tests). Caller-enforced VerificationDegraded on truncation OR backend error; stub pass:true under truncation still degraded; backend error -> degraded non-pass carrying error text, never fabricated pass. 3 tests pass, no live Vertex call."
+    }
+  ],
+  "phase_sequencing": {
+    "constraint": "M1 (bundle builder) and M2 (directive + verdict parse) are INDEPENDENT and may proceed in parallel; M3 (caller seam) depends on BOTH. Each milestone is independently committable.",
+    "hard_rules": [
+      "Executor stays policy-free: ZERO changes to internal/executor/managed_agents/. All new code in internal/eval_harness/.",
+      "The frozen quorum.ReviewResult contract is BYTE-IDENTICAL untouched; do NOT import quorum into eval_harness. go test ./internal/mission/quorum/... passes unchanged.",
+      "No change to cmd/ailang/exec.go — the gemini->managed_agents routing and --json shape already exist.",
+      "No silent fallback: truncation/drop/backend-error => caller-stamped VerificationDegraded (never model-trusted); malformed verdict => hard error, never a coerced pass.",
+      "No live Vertex/managed_agents call in any test — RunGeminiEvaluator takes an injectable runner; tests use a stub.",
+      "Fence helper: add an EXPORTED thin wrapper (LastFencedBlock) over the existing unexported lastFencedBlock; do NOT rename the internal extractCode call site (lowest-risk); TestLastFencedBlock_UnchangedForExtractOut guards it.",
+      "Every listed Go test is non-vacuous: references a symbol absent on the base binary (fails before, passes after)."
+    ]
+  },
+  "success_criteria_rollup": [
+    "M1: BuildDiffBundle returns deterministic Text = tracked diff + untracked +++ NEW FILE views + full changed-file contents, with binary/generated dropped and a LOUD marker + Truncated flag over a 256 KiB ceiling; the git diff is never dropped; untracked new files are included (quorum catch).",
+    "M2: reasoning-only directive const + GeminiVerdict (compact score/pass/blockers adaptation, doc-commented, distinct from quorum.ReviewResult) + ParseGeminiVerdict/ValidateGeminiVerdict with hard-error-on-malformed; lastFencedBlock shared via an exported wrapper with a regression guard.",
+    "M3: RunGeminiEvaluator with an injectable stub runner; caller-enforced VerificationDegraded on truncation/drop/backend-error (a stub pass:true under truncation still surfaces degraded); no live Vertex call in tests.",
+    "go test ./internal/eval_harness/... green (each new test fails on base binary, passes after); go test ./internal/mission/quorum/... unchanged; internal/executor/managed_agents/ untouched; make lint + make check-file-sizes green.",
+    "CHANGELOG entry added (grouped) for the inject-in gemini evaluator bridge capability."
+  ],
+  "risks": [
+    {
+      "risk": "GeminiVerdict field-name confusion: the doc claims it 'mirrors' evaluation_report_schema.md but that schema uses total_score/result/hard_fails/feedback, NOT score/pass/blockers.",
+      "mitigation": "RESOLVED at plan time: keep the doc's {score,pass,blockers} shape (it is the M2 acceptance-test contract) but add a code doc-comment marking it a COMPACT ADAPTATION (not a byte-mirror). Do NOT switch field names mid-sprint (would break the doc's own tests). Surfaced as a de-risking finding to the controller.",
+      "severity": "low"
+    },
+    {
+      "risk": "Sharing lastFencedBlock accidentally changes extract-out behavior (the Import System Disaster failure mode).",
+      "mitigation": "Add an EXPORTED thin wrapper over the existing unexported function (no rename, no call-site change). TestLastFencedBlock_UnchangedForExtractOut asserts identical output for the extract-out cases. Run go test ./internal/eval_harness/... after the change.",
+      "severity": "low"
+    },
+    {
+      "risk": "Non-deterministic bundle Text (git output ordering / map iteration) breaks TestBuildDiffBundle_Deterministic.",
+      "mitigation": "Sort git status entries and drop candidates with a stable total order (size desc, path asc); never range over a map for output. The determinism test is a hard gate.",
+      "severity": "low"
+    },
+    {
+      "risk": "A test accidentally makes a live Vertex/managed_agents call (billed, flaky, network-dependent).",
+      "mitigation": "RunGeminiEvaluator takes the runner as an injected func; ALL tests pass a stub. The default production runner is never referenced by the test suite. Hard rule + reviewer check.",
+      "severity": "low"
+    },
+    {
+      "risk": "Untracked-file handling drifts back to git-diff-only (the quorum gemini-3-1-pro catch), making the evaluator blind to the sprint's most important additions (new files).",
+      "mitigation": "Enumerate via git status --porcelain -z; synthesize +++ NEW FILE views; TestBuildDiffBundle_IncludesUntrackedNewFiles is a dedicated guard.",
+      "severity": "medium"
+    }
+  ],
+  "handoff": {
+    "worktree_required": true,
+    "branch_from": "origin/dev",
+    "estimated_duration": "2 days (~16 hours across 3 milestones)",
+    "total_loc_estimate": 705,
+    "risk_level": "low",
+    "recommendation": "Execute M1 and M2 in parallel (independent), then M3 (depends on both). Each milestone is independently committable. NO phase-gate/STOP-POINT needed (unlike M-QUORUM-AGENTIC-VERIFY) — there is no external-network unknown here: all tests are stub-only, no live Vertex call, no core/executor/quorum change. Land all 3 milestones in one iteration (matches iters 30-38 velocity). Before committing, verify: (1) internal/executor/managed_agents/ shows zero diff, (2) internal/mission/quorum/ shows zero diff, (3) cmd/ailang/exec.go shows zero diff, (4) the GeminiVerdict doc-comment acknowledges the schema adaptation. Ship the CAPABILITY only — do NOT wire it into mission routing (that is m-mission-agentic-provider-routing.md, out of scope) and do NOT make gemini the default evaluator (stays sonnet-5)."
+  },
+  "status": "completed"
+}

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,54 @@
 
 ## [Unreleased]
 
+### Added — Inject a sprint diff bundle into a sandboxed gemini evaluator (M-GEMINI-EVALUATOR-DIFF-BRIDGE, M1–M3)
+
+A policy-layer bridge (`internal/eval_harness/gemini_evaluator_bridge.go`) so a sandboxed
+gemini sprint EVALUATOR (Vertex Managed Agents, `executor.CapRemoteSandbox`) can review a
+sprint's UNCOMMITTED worktree changes. This is the INVERSE of the extract-out
+`managed_agents_bridge.go`: the managed_agents executor sends only `Directive` +
+`SystemInstruction` with no repo upload, so this INJECTS a git-diff bundle INTO the
+directive. Reasoning-only (no local test re-runs). The executor stays policy-free (zero
+changes to `internal/executor/managed_agents/`); the frozen `quorum.ReviewResult`
+design-review contract is untouched (`GeminiVerdict` is a SEPARATE type in the sprint-eval
+domain).
+
+- **M1 — `BuildDiffBundle`.** Enumerates the changed-file set via
+  `git status --porcelain -z` (modified + staged + **UNTRACKED** — new files are
+  load-bearing: a sprint frequently CREATES files and `git diff` alone misses them),
+  emits the tracked unified diff (`git diff` + `git diff --cached`, ALWAYS included /
+  never dropped) plus `+++ NEW FILE:` views of untracked files, then appends full
+  changed-file contents under a configurable **256 KiB** ceiling. Drop order:
+  binary (NUL in first 8 KiB) → generated/vendored (`*.pb.go`, `vendor/`, `dist/`,
+  `*.min.js`, `*_generated.go`, `go.sum`) → largest-remaining-whole-file. Every drop
+  emits a LOUD `=== BUNDLE TRUNCATED: … — NOT shown to evaluator ===` marker (no silent
+  drop) and a dropped new file keeps its `+++ NEW FILE` header. Deterministic (sorted
+  drop order).
+- **M2 — reasoning-only directive + structured verdict.** `BuildEvaluatorDirective`
+  composes a compile-time reasoning-only instruction (NO repo/test access, emit a fenced
+  `json` verdict) + the design doc / plan / criteria + the bundle; a truncated bundle
+  appends a "note unseen files in blockers" line. `GeminiVerdict{Score, Pass, Blockers,
+  VerificationDegraded, DegradedReason}` is a COMPACT ADAPTATION of the sprint-evaluator
+  skill's `evaluation_report_schema.md` (documented as such; distinct from
+  `quorum.ReviewResult`). `ParseGeminiVerdict`/`ValidateGeminiVerdict` hard-error on a
+  malformed verdict (missing fence, non-JSON, score out of `[0,100]`, `pass==true` with
+  blockers, degraded without a reason) — never a lenient/coerced pass. Fence parsing is
+  shared via a new exported thin wrapper `LastFencedBlock` DELEGATING to the existing
+  unexported `lastFencedBlock` (no rename of the extract-out call site).
+- **M3 — `RunGeminiEvaluator` caller seam.** Takes an INJECTABLE runner func (tests pass
+  a stub — NO live Vertex call in the suite; the default `DefaultGeminiRunner` shells
+  `ailang exec gemini --json`). The caller ENFORCES degradation: on bundle truncation OR a
+  backend error it stamps `VerificationDegraded=true` with a reason, and a model/stub
+  `pass:true` under degradation can NEVER stand as a real pass (CLAUDE.md "no silent
+  fallbacks"). A backend error yields a degraded NON-PASS verdict carrying the error text,
+  never a fabricated pass.
+
+Ships the CAPABILITY only — routing gemini as the evaluator lives in
+`m-mission-agentic-provider-routing.md` (out of scope) and the mission default stays
+sonnet-5. Tests: `gemini_evaluator_bridge_test.go` (12 new, each references a symbol
+absent on the base binary → non-vacuous; the 5 extract-out `TestExtractCode_*` and the
+new `TestLastFencedBlock_UnchangedForExtractOut` guard the shared fence helper).
+
 ### Fixed — Thread GCP project/location env into `ailang exec` Task (M-GEMINI-EXEC-PROJECT-PLUMBING)
 
 `ailang exec gemini "<directive>"` failed with `managed_agents: GCP project not set`

--- a/design_docs/implemented/v0_30_0/m-gemini-evaluator-diff-bridge.md
+++ b/design_docs/implemented/v0_30_0/m-gemini-evaluator-diff-bridge.md
@@ -1,6 +1,6 @@
 # M-GEMINI-EVALUATOR-DIFF-BRIDGE: inject a sprint diff bundle into a sandboxed gemini evaluator
 
-**Status**: Planned
+**Status**: Implemented (2026-07-17, mission iteration 39 — PASS 96/100 round 1)
 **Target**: v0.30.x — mission infrastructure
 **Priority**: P1 (model-diversity capability for the mission evaluator; unblocks generator≠judge)
 **Estimated**: ~2 days (M1 bundle builder ~0.75d; M2 directive + verdict parse ~0.75d; M3 caller seam + degradation ~0.5d)

--- a/design_docs/planned/v0_30_0/m-gemini-evaluator-diff-bridge.md
+++ b/design_docs/planned/v0_30_0/m-gemini-evaluator-diff-bridge.md
@@ -1,0 +1,273 @@
+# M-GEMINI-EVALUATOR-DIFF-BRIDGE: inject a sprint diff bundle into a sandboxed gemini evaluator
+
+**Status**: Planned
+**Target**: v0.30.x — mission infrastructure
+**Priority**: P1 (model-diversity capability for the mission evaluator; unblocks generator≠judge)
+**Estimated**: ~2 days (M1 bundle builder ~0.75d; M2 directive + verdict parse ~0.75d; M3 caller seam + degradation ~0.5d)
+**Dependencies**:
+- `internal/executor/managed_agents/managed_agents.go` (the sandboxed executor; `CapRemoteSandbox`, `Input=[Directive]` + `SystemInstruction`, no repo upload — verified at HEAD, lines 164–176)
+- `internal/eval_harness/managed_agents_bridge.go` (the EXTRACT-OUT precedent this doc mirrors, INVERSE direction)
+- `cmd/ailang/exec.go` (`ailang exec gemini` → `resolveAgenticExecutorName("gemini")=="managed_agents"`, verified line 317–322; `--json` output shape verified line 281–294)
+- `internal/mission/quorum/*` (the frozen Go verdict contract `quorum.ReviewResult` and its `AgenticRunner` seam — for boundary reference, NOT reuse; see Conflict Surface)
+**Author**: Designer role, mission-control fleet item c1 (Mark directive on issue #399, 2026-07-17)
+
+**Requested by**: Mark on bookkeeping issue #399 — "once we have gemini via managed agents and openai we can use one of those instead for evaluator? so default can be gemini (if able to git clone the codebase etc)? otherwise sonnet-5." This iteration confirmed the Vertex Managed Agents backend now returns reliably (4/4 bounded `ailang exec gemini` probes, 8–11s, ~$0.01/call) — the operational blocker from iterations 36/37/38 has cleared.
+
+---
+
+## Problem statement
+
+The mission wants the Google/gemini provider (via Vertex Managed Agents) usable as a sprint **EVALUATOR** — model diversity so the generator (Opus/codex) is not also the judge. But the managed_agents executor runs the agent in a **Google-hosted server-side sandbox** (`executor.CapRemoteSandbox`). Verified at HEAD (`managed_agents.go:164–176`), the interaction request body carries ONLY:
+
+```go
+Input: []inputBlock{{Type: "user_input", Content: []contentBlock{{Type: "text", Text: task.Directive}}}},
+SystemInstruction: task.SystemPrompt,
+```
+
+There is **no repo/file upload**. So a gemini evaluator sees **no local repo**: it cannot inspect a sprint's UNCOMMITTED worktree changes, nor re-run local tests. This is exactly Mark's "if able to git clone the codebase" gap — and note that even a `git clone` of public `origin/dev` would NOT contain the sprint's local, uncommitted diff (a sprint is evaluated in a worktree before its branch is pushed).
+
+**The precedent to mirror (INVERSE direction).** `internal/eval_harness/managed_agents_bridge.go` already bridges the sandbox for the EXECUTOR use case in the **extract-out** direction: it appends `managedAgentsBridgeInstruction` to the system prompt so the agent dumps its solution as a fenced code block, then `extractCode`/`writeSolutionFromResponse` parse it back out. It deliberately lives in the harness (not the executor) because it is caller POLICY — "the executor stays policy-free" (file header, lines 8–11; echoed in `managed_agents.go:163`).
+
+This doc builds the **INVERSE: INJECT-IN**. Given a sprint worktree, produce a size-bounded "diff bundle" and inject it INTO the evaluator directive text, so the sandboxed gemini agent can read and reason about the changes. The agent is **reasoning-only** (no local test re-runs) and must emit a **structured verdict** a parser can extract, mirroring how the extract-out bridge parses a fenced block.
+
+### What is NOT the problem (premises re-checked against the repo)
+
+- **The verdict is not already a frozen Go struct for sprint evaluation.** Re-checking the brief's design-question 2: the only frozen Go verdict contract is `quorum.ReviewResult` (`internal/mission/quorum/reviewer.go:39–61`) — verdict ∈ {pass,reject} + `strongest_objection` + `catch` + optional `proposed_fix`. That is a **design-doc review** verdict, a different domain from **sprint evaluation** (score 0–100, pass≥70, per-criterion + blockers — the sprint-evaluator skill's `evaluation_report_schema.md`). The brief's phrase "frozen verdict JSON via the coordinator executor layer" refers to `quorum`'s design-review contract, which we must **not overload**. See design-question 2 resolution and the Conflict Surface for how we avoid competing with it.
+- **`ailang exec gemini` already routes to managed_agents.** Verified `exec.go:317` — no new routing needed; the seam exists. `--json` already emits `{success, output, error, input_tokens, output_tokens, cost_usd, duration_ms, num_turns}` (line 281–294) — the bundle-in path uses the existing `Directive`/`SystemPrompt` fields, nothing new in the executor.
+
+---
+
+## Goals
+
+**Primary goal**: Ship a reasoning-only gemini sprint-evaluation CAPABILITY — a policy-layer bridge that packages a sprint worktree's uncommitted diff into a bounded bundle, injects it into a managed_agents directive, and parses a structured verdict back out — WITHOUT touching the executor's policy-free contract or the frozen `quorum.ReviewResult` design-review contract.
+
+**Success metrics**:
+1. Given a worktree with N changed files, `BuildDiffBundle` returns deterministic text: `git diff` of uncommitted changes + full contents of changed files, truncated with a LOUD marker over a byte ceiling.
+2. Truncation, binary/generated-file drop, and backend error each set an explicit `VerificationDegraded` marker on the verdict — a partial/lenient gemini verdict can never masquerade as a full pass.
+3. A structured verdict (`score`, `pass`, `blockers[]`) is parseable from the agent's fenced-block response, with a hard error (never a silent coerced pass) on malformed output — mirroring `ParseReviewResult`.
+4. Every element independently covered by `go test ./internal/eval_harness/...`; each test fails on a base binary (feature absent) and passes after.
+
+---
+
+## Non-Goals (explicit scope boundary — reasoning-only)
+
+- **OUT: local test re-runs by gemini.** The sandbox cannot see the repo; the directive states the agent is reasoning-only over the supplied bundle. It reasons about the diff, it does not execute it.
+- **OUT: multi-turn sandbox reuse** (the `managed_agents.go:154` M2.5 follow-up). One bounded interaction per evaluation.
+- **OUT: making gemini the DEFAULT evaluator.** This ships the capability; the mission default stays sonnet-5. Flipping the default is a separate routing-policy change gated on evidence (see `m-mission-agentic-provider-routing.md`), not this doc.
+- **OUT: GCS upload of the repo / real file bridging.** Bundle-in-directive only, byte-bounded. A future doc may add GCS if the ceiling proves too tight.
+- **OUT: reusing/overloading `quorum.ReviewResult`.** The sprint verdict is a distinct shape; extending the frozen design-review contract is out of scope (see Conflict Surface).
+
+---
+
+## Solution design
+
+### Overview
+
+A new policy-layer file `internal/eval_harness/gemini_evaluator_bridge.go` (mirroring `managed_agents_bridge.go`'s location and rationale) with three pure, independently-testable pieces:
+
+1. **`BuildDiffBundle(worktree string, opts BundleOptions) (Bundle, error)`** — walks `git diff` + changed-file contents, applies the size/truncation policy, returns a `Bundle{Text string, Truncated bool, DroppedFiles []string, Bytes int}`.
+2. **`BuildEvaluatorDirective(designDoc, sprintPlan, acceptanceCriteria string, bundle Bundle) string`** — composes the reasoning-only evaluator directive: the bundle + the design/plan/criteria + a LOUD reasoning-only instruction + a fenced-verdict-schema instruction (mirrors `managedAgentsBridgeInstruction`).
+3. **`ParseGeminiVerdict(response string, degraded DegradationInfo) (GeminiVerdict, error)`** — extracts the fenced JSON verdict (reusing the fence logic from the sibling bridge), validates it, and stamps the `VerificationDegraded` marker from `degraded` (bundle truncation / drop / backend error). Malformed → hard error, never a coerced pass.
+
+The **caller** (a thin `mission-evaluator` helper, see design-question 1) wires these onto `ailang exec gemini --json` (or the executor factory directly), reading the worktree, invoking the executor with the composed directive, and parsing the verdict.
+
+### The new verdict type (distinct from quorum.ReviewResult, mirrors the sprint-evaluator skill schema)
+
+```go
+// GeminiVerdict is the reasoning-only sprint-evaluation verdict returned by a
+// sandboxed gemini evaluator. It intentionally mirrors the sprint-evaluator
+// skill's evaluation_report_schema.md (score/result/blockers), NOT
+// quorum.ReviewResult (pass/reject/strongest_objection) — those are different
+// domains (sprint eval vs design-doc review) and must not be conflated.
+type GeminiVerdict struct {
+    Score    int      `json:"score"`               // 0..100, pass threshold 70 (sprint-evaluator convention)
+    Pass     bool     `json:"pass"`                // score >= 70 AND no blockers
+    Blockers []string `json:"blockers"`            // hard-fail reasons; non-empty ⇒ Pass=false regardless of score
+
+    // VerificationDegraded is set (with a non-empty reason) whenever the
+    // bundle was truncated / files were dropped / the backend errored, so a
+    // partial or lenient verdict can NEVER masquerade as a full pass.
+    // (Carried watch-item from fleet item (c); CLAUDE.md "no silent fallbacks".)
+    VerificationDegraded bool   `json:"verification_degraded"`
+    DegradedReason       string `json:"degraded_reason,omitempty"`
+}
+```
+
+`ValidateGeminiVerdict` enforces: `Score` ∈ [0,100]; if `len(Blockers)>0` then `Pass==false`; if `VerificationDegraded` then `DegradedReason` non-empty. Any violation is a hard error (Principle 2). **A degraded verdict may still carry a Pass value from the model, but the caller MUST treat `VerificationDegraded==true` as "not a full pass" for routing decisions** — the marker is the guard, exactly as the fleet (c) watch-item requires.
+
+### Size / truncation policy (design-question 3)
+
+- **Byte ceiling**: `BundleOptions.MaxBytes`, default **256 KiB** of bundle text (well under managed_agents token limits; a real gemini context is ~1M tokens but the directive competes with the design doc + plan, so we stay conservative and configurable).
+- **Drop order (largest-blast-radius first)**: (1) binary files (detected via NUL byte in first 8 KiB) — never included, only listed; (2) generated/vendored files (path globs: `*.pb.go`, `dist/`, `vendor/`, `*.min.js`, `*_generated.go`, `go.sum`); (3) then, if still over ceiling, the largest remaining changed files by byte size, dropped whole (never mid-file) until under ceiling.
+- **LOUD truncation marker**: every drop appends a line to the bundle text AND to `Bundle.DroppedFiles`:
+  ```
+  === BUNDLE TRUNCATED: dropped internal/foo/big_generated.go (412 KiB, generated) — NOT shown to evaluator ===
+  ```
+  No silent drop. `Bundle.Truncated=true` propagates to `DegradationInfo` → `GeminiVerdict.VerificationDegraded`.
+- **Untracked (new) files are INCLUDED (quorum catch, gemini-3-1-pro 2026-07-16).** `git diff` and `git diff --cached` do NOT show untracked files, and a sprint frequently CREATES new files (this very sprint adds two new bridge files). Omitting them would make the evaluator blind to the sprint's most important additions. The bundle therefore captures the complete changed-file set via `git -C <wt> status --porcelain -z` (which enumerates modified, staged, AND untracked `??` entries), and for untracked files it synthesizes a diff-equivalent view (a `+++ NEW FILE: <path>` header followed by the full file contents), then de-dupes against the tracked-file appendices. Acceptance test `TestBuildDiffBundle_IncludesUntrackedNewFiles` guards this.
+- The unified diff of tracked changes (`git -C <wt> diff` + `git -C <wt> diff --cached`) plus the untracked-file headers are ALWAYS included first and are never dropped; only full-file-content appendices are subject to the ceiling (the change signal is load-bearing; whole-file context is the enrichment). A new/untracked file's own body IS subject to the ceiling (it can be arbitrarily large), but its `+++ NEW FILE` header line is retained even when its body is dropped, so a dropped new file is never silently invisible.
+
+### Reasoning-only directive (design-question 4, mirrors managedAgentsBridgeInstruction)
+
+The directive appends a constant instruction (compile-time const, like `managedAgentsBridgeInstruction`):
+
+```
+IMPORTANT — Reasoning-only sprint evaluation. You are running in a sandbox with NO access
+to the repository or local tests. Everything you can inspect is in the DIFF BUNDLE below.
+Do NOT claim you ran any test. Judge ONLY from the supplied diff + file contents against the
+design doc's acceptance criteria. At the very END of your response, output your verdict as a
+single fenced ```json block with fields: score (0-100), pass (bool), blockers (string[]).
+If the bundle is marked TRUNCATED, note in blockers which unseen files limit your confidence.
+```
+
+### Caller seam (design-question 1)
+
+A thin `RunGeminiEvaluator(ctx, worktree, designDoc, sprintPlan string, opts EvalOptions) (*GeminiVerdict, error)` helper in `eval_harness` (policy layer — mirrors `RunAgenticReviewer`'s boundary in `quorum`), which:
+1. Calls `BuildDiffBundle` → gets `Bundle` + `DegradationInfo`.
+2. Calls `BuildEvaluatorDirective` → directive text.
+3. Invokes the managed_agents executor via an injected runner function (default impl shells `ailang exec gemini --json --workspace <tmp>`; unit tests inject a stub returning canned output — no live Vertex call in tests). On executor error, `DegradationInfo.BackendError` is set → verdict is `VerificationDegraded` with the error, NEVER a fabricated pass.
+4. Calls `ParseGeminiVerdict` → validated verdict, degradation stamped.
+
+**Consumed by**: the mission-control Gate-4 evaluator lane, when routing chooses gemini (per `m-mission-agentic-provider-routing.md`). That routing wiring is out of scope here; this doc ships the callable capability + its Go tests. Executor stays policy-free; the frozen `quorum.ReviewResult` is untouched.
+
+### Files to create / modify
+
+| File | Change | LOC (est) |
+|------|--------|-----------|
+| `internal/eval_harness/gemini_evaluator_bridge.go` | NEW — `BuildDiffBundle`, `BuildEvaluatorDirective`, `ParseGeminiVerdict`, `ValidateGeminiVerdict`, `GeminiVerdict`, `Bundle`, `BundleOptions`, `DegradationInfo`, `EvalOptions`, `RunGeminiEvaluator` | ~320 |
+| `internal/eval_harness/gemini_evaluator_bridge_test.go` | NEW — table tests for bundle build/truncation/drop-order, directive composition, verdict parse/validate, degradation stamping, RunGeminiEvaluator with stub runner | ~380 |
+| `internal/eval_harness/managed_agents_bridge.go` | MODIFY (small) — export `lastFencedBlock` as `LastFencedBlock` (or add a tiny shared helper) so the inject-in parser reuses the extract-out fence logic; no behavior change | ~5 |
+
+No changes to `internal/executor/` (policy-free preserved). No changes to `internal/mission/quorum/` (frozen contract preserved). No changes to `cmd/ailang/exec.go` (seam already exists).
+
+---
+
+## Conflict Surface (MANDATORY)
+
+This item touches executor invocation + evaluator wiring + sits adjacent to a frozen verdict contract. Enumerated seams and how each is protected:
+
+### 1. Executor policy-free contract (`internal/executor/managed_agents/`)
+- **What already lives here**: the executor builds `Input=[Directive]` + `SystemInstruction` and is DELIBERATELY policy-free (`managed_agents.go:158–163`; "The executor itself stays policy-free"). The eval harness owns bridging.
+- **How we avoid breaking it**: we add ZERO code to the executor. The diff bundle goes into `task.Directive` (or `SystemPrompt`) — the exact fields the executor already reads and forwards verbatim. The bridge lives in `eval_harness/`, mirroring `managed_agents_bridge.go`'s stated rationale. Verified boundary: the sibling extract-out bridge already sets a precedent of harness-side-only bridging with no executor edits.
+
+### 2. The frozen `quorum.ReviewResult` design-review contract (`internal/mission/quorum/reviewer.go`)
+- **What already lives here**: `ReviewResult{Verdict pass|reject, StrongestObjection, Catch, ProposedFix}`, its `reviewSchema`, `ValidateReviewResult`, and the `AgenticRunner`/`agenticCaller` seam. Explicitly frozen ("The verdict CONTRACT is untouched", `agentic_caller.go:56`; "NOT part of the frozen verdict contract", `reviewer.go:54`).
+- **The conflict**: the brief says "reuse the existing quorum/evaluator verdict JSON shape … do NOT invent a competing schema." Re-checked: `quorum.ReviewResult` is a **design-doc review** verdict (pass/reject), NOT a **sprint-evaluation** verdict (score/pass/blockers). Forcing sprint evaluation into `ReviewResult` would either (a) mutate the frozen contract, or (b) lose the score/blockers granularity the sprint-evaluator skill requires. **Resolution**: introduce a SEPARATE `GeminiVerdict` that mirrors the **sprint-evaluator skill's `evaluation_report_schema.md`** (the actual sprint-eval contract), not `quorum.ReviewResult`. This is not "inventing a competing schema" — it is matching the correct existing schema for this domain (sprint eval) while leaving the design-review frozen contract byte-identical. We add NO fields to `ReviewResult`, no new `Verdict` enum values, and do not import `quorum` into `eval_harness`.
+- **Fixtures that MUST still pass unchanged**: `go test ./internal/mission/quorum/...` (all — we touch nothing here). Specifically `quorum_test.go`, `reviewer_test.go`, `agentic_caller_test.go`, `escalate_test.go`, `tier2_test.go`.
+
+### 3. `ailang exec gemini` routing (`cmd/ailang/exec.go`)
+- **What already lives here**: `resolveAgenticExecutorName("gemini")=="managed_agents"` (line 317), `--json` output shape (line 281–294), `executeCLI` sets `GCPProject`/`GCPLocation` from env (line 354–355).
+- **How we avoid breaking it**: no code change to exec.go. The default `RunGeminiEvaluator` runner SHELLS `ailang exec gemini --json` (or calls the executor factory directly, same as `executeCLI` does) — it consumes the existing seam. If we call the factory directly we replicate `executeCLI`'s task construction; either way exec.go's contract is unchanged, and `exec_test.go` continues to pass.
+
+### 4. The shared fence-parsing helper (`managed_agents_bridge.go:lastFencedBlock`)
+- **The overlap**: both the extract-out (code block) and inject-in (verdict JSON block) paths need "last fenced block". Rather than duplicate, we export/share it.
+- **Risk**: renaming a used unexported symbol. **Mitigation**: keep `lastFencedBlock` and add an exported thin wrapper (or rename + update the single internal call site in `extractCode`), then run `go test ./internal/eval_harness/...` to confirm `writeSolutionFromResponse`/`extractCode` behavior is unchanged. This is the "rename definitions too, test between each change" discipline from coding-standards.
+
+### 5. Intentional (non-)changes
+- **Deliberately unchanged**: the executor, the quorum contract, exec.go routing, the sprint-evaluator skill's markdown schema.
+- **Deliberately new**: `GeminiVerdict` (sprint-eval domain), the diff-bundle builder, the reasoning-only directive const, the `VerificationDegraded` marker (no such marker exists today — grep confirmed zero hits for `VerificationDegraded`/`verification_degraded`/`bundle_truncated` in `internal/`).
+
+**The honest answer is not "no conflicts":** the real conflict is the schema-domain confusion in the brief (sprint-eval vs design-review), resolved above by matching the correct existing schema instead of overloading the frozen one.
+
+---
+
+## Milestone breakdown
+
+### M1 — Diff bundle builder + size/truncation policy (~0.75d)
+
+**Deliverable**: `BuildDiffBundle(worktree, BundleOptions) (Bundle, error)` in `gemini_evaluator_bridge.go`, plus `Bundle`, `BundleOptions`, `DegradationInfo` types.
+
+**Behavior**: enumerates the changed-file set via `git -C <wt> status --porcelain -z` (modified + staged + untracked), runs `git -C <wt> diff` + `git -C <wt> diff --cached` for tracked changes, synthesizes `+++ NEW FILE` headers + bodies for untracked files, appends full contents of changed (non-binary, non-generated) files, applies drop-order + byte ceiling, emits LOUD truncation markers.
+
+**Acceptance criteria (each a Go test; each fails on base binary, passes after)**:
+- `TestBuildDiffBundle_IncludesDiffAndFiles`: a temp git repo with 2 modified `.go` files → bundle contains both the unified diff and both files' full contents.
+- `TestBuildDiffBundle_IncludesUntrackedNewFiles` (quorum catch): a temp git repo with a brand-new untracked `.go` file → bundle contains a `+++ NEW FILE: <path>` header AND the file's contents (proves `git diff` alone would have missed it).
+- `TestBuildDiffBundle_DropsBinaryAndGenerated`: a modified `*.pb.go` and a NUL-containing file → both listed in `DroppedFiles`, NOT in `Text`, and a LOUD marker line present for each.
+- `TestBuildDiffBundle_TruncatesOverCeiling`: `MaxBytes` set small, one large changed file → `Truncated==true`, file in `DroppedFiles`, marker present, and the `git diff` itself is STILL present (never dropped).
+- `TestBuildDiffBundle_Deterministic`: two calls on the same worktree → byte-identical `Text` (drop order is stable/sorted).
+
+### M2 — Reasoning-only directive + structured verdict parse/validate (~0.75d)
+
+**Deliverable**: `BuildEvaluatorDirective`, `GeminiVerdict`, `ParseGeminiVerdict`, `ValidateGeminiVerdict`; `lastFencedBlock` shared/exported.
+
+**Acceptance criteria**:
+- `TestBuildEvaluatorDirective_ReasoningOnly`: directive contains the reasoning-only instruction, the bundle text, the design-doc/criteria, and the fenced-json verdict-schema instruction; a truncated bundle adds the "note unseen files in blockers" line.
+- `TestParseGeminiVerdict_ExtractsFencedJSON`: response with prose + a final ```json verdict → parsed `{score,pass,blockers}`.
+- `TestValidateGeminiVerdict_RejectsMalformed`: score>100, or blockers non-empty with `pass==true`, or degraded with empty reason → hard error (never coerced pass). Also: non-JSON / missing fence → error.
+- `TestLastFencedBlock_UnchangedForExtractOut`: the shared/renamed helper still returns identical results for the extract-out cases in `managed_agents_bridge_test.go` (regression guard for Conflict-Surface seam 4).
+
+### M3 — Caller seam + degradation stamping (~0.5d)
+
+**Deliverable**: `RunGeminiEvaluator(ctx, worktree, designDoc, sprintPlan, opts)` with an injectable runner; degradation from truncation/drop/backend-error stamped onto the verdict.
+
+**Acceptance criteria**:
+- `TestRunGeminiEvaluator_StubHappyPath`: stub runner returns a valid fenced verdict → `RunGeminiEvaluator` returns it, `VerificationDegraded==false`.
+- `TestRunGeminiEvaluator_TruncationStampsDegraded`: bundle over ceiling → returned verdict has `VerificationDegraded==true` + non-empty reason, EVEN IF the stub's verdict said `pass:true` (the marker is caller-enforced, not model-trusted).
+- `TestRunGeminiEvaluator_BackendErrorIsDegradedNotPass`: stub runner returns `Success=false` → verdict is `VerificationDegraded==true` with the executor error text; result is NOT a fabricated pass (Principle 2). No live Vertex call in any test (stub only).
+
+**Non-vacuity note**: every test above references a symbol that does not exist on the base binary, so `go test` fails to compile/pass before implementation and passes after — the design-doc-creator non-vacuity gate.
+
+---
+
+## Design questions — resolved answers
+
+1. **Where does the evaluator path get invoked?** A new policy-layer helper `RunGeminiEvaluator` in `internal/eval_harness/` (mirroring `managed_agents_bridge.go`'s harness-side location and `quorum.RunAgenticReviewer`'s boundary), consuming the existing `ailang exec gemini`→managed_agents seam via an injectable runner. NOT a coordinator-level path; NOT an executor change. The mission-control Gate-4 evaluator lane calls it when routing selects gemini (routing wiring is out of scope — `m-mission-agentic-provider-routing.md`). Executor stays policy-free.
+
+2. **Verdict contract**: introduce a SEPARATE `GeminiVerdict` (score/pass/blockers + degradation marker) that matches the **sprint-evaluator skill's `evaluation_report_schema.md`** — the correct existing schema for the sprint-eval domain. We do NOT overload `quorum.ReviewResult` (verified to be a design-doc-review verdict: pass/reject/strongest_objection, a different domain); its frozen contract stays byte-identical. This resolves the brief's "don't invent a competing schema" by matching the right existing schema, not the wrong frozen one.
+
+3. **Size/truncation policy**: 256 KiB default ceiling (configurable via `BundleOptions.MaxBytes`); drop order = binary → generated/vendored → largest-remaining-whole-file; the `git diff` is never dropped; every drop emits a LOUD `=== BUNDLE TRUNCATED: … ===` marker in-text and in `DroppedFiles`. No silent drop.
+
+4. **Degradation marker**: `GeminiVerdict.VerificationDegraded` (+ `DegradedReason`), stamped by the CALLER whenever the bundle truncated / dropped files / the backend errored. Caller-enforced (not model-trusted): a stub/model `pass:true` under truncation still surfaces `VerificationDegraded==true`. A degraded verdict is never treated as a full pass for routing. (Carried fleet-(c) watch-item; CLAUDE.md "no silent fallbacks".)
+
+5. **Scope boundary**: reasoning-only. Explicitly OUT: local test re-runs by gemini, multi-turn sandbox reuse, making gemini the DEFAULT evaluator, GCS file bridging, overloading `quorum.ReviewResult`. This doc ships the CAPABILITY; the default stays sonnet-5.
+
+---
+
+## Axiom compliance
+
+| Axiom | Score | Justification |
+|-------|-------|---------------|
+| A1 minimal frozen core | 0 | No core change; no executor change. |
+| A2 route-to-extension bias | +1 | Pure eval-harness policy layer; the archetypal extension, mirroring the existing bridge. |
+| A3 no silent fallbacks | +1 | LOUD truncation markers + `VerificationDegraded` marker; degraded/backend-error never coerced to pass. |
+| A4 deterministic | +1 | `BuildDiffBundle` is deterministic (sorted drop order, `TestBuildDiffBundle_Deterministic`). |
+| A5 bounded waits | +1 | Reuses the executor's per-task timeout + bounded single interaction; no unbounded loop. |
+| A6 semantic transparency | +1 | Structured verdict (score/pass/blockers) + explicit degradation reason. |
+| A7 no core-floor violation | 0 | None. |
+| A8 reuse over rebuild | +1 | Reuses managed_agents executor, `ailang exec gemini` seam, `lastFencedBlock`, sprint-eval schema. |
+| A9 testability | +1 | Every element unit-tested with stub runner; no live Vertex in tests. |
+| A10 observability | +1 | Verdict + degradation surfaced; executor already emits cost/turns via `--json`. |
+| A11 composability | +1 | Three pure functions + a thin caller; composes with future routing. |
+| A12 fail-loud | +1 | Malformed verdict = hard error; backend error = degraded, never silent pass. |
+
+**Net**: +10, no −1 on A1/A3/A4/A7. Passes.
+
+---
+
+## Related documents
+
+- `internal/eval_harness/managed_agents_bridge.go` — the EXTRACT-OUT precedent this doc mirrors (inverse).
+- `design_docs/planned/v0_30_0/m-mission-agentic-provider-routing.md` — the routing layer that will later CHOOSE gemini as evaluator (out of scope here; this ships the capability it routes to).
+- `design_docs/planned/v0_30_0/m-mission-quorum-agentic-verify.md` — the design-doc-review quorum whose frozen `ReviewResult` this doc deliberately does NOT overload.
+- `.claude/skills/sprint-evaluator/resources/evaluation_report_schema.md` — the sprint-eval schema `GeminiVerdict` mirrors.
+
+## Verification log
+
+| Claim | Method | Result |
+|-------|--------|--------|
+| managed_agents request carries only Input+SystemInstruction, no repo upload | Read `managed_agents.go:164–176` | Confirmed |
+| Executor is deliberately policy-free; harness owns bridging | Read `managed_agents.go:158–163`, `managed_agents_bridge.go:8–11` | Confirmed |
+| Extract-out bridge appends instruction + parses fenced block | Read `managed_agents_bridge.go:38–46,110–190` | Confirmed |
+| `ailang exec gemini` routes to managed_agents | Read `exec.go:317–322` | Confirmed |
+| `--json` output shape (success/output/tokens/cost/turns) | Read `exec.go:281–294` | Confirmed |
+| `quorum.ReviewResult` is pass/reject design-review, NOT score/blockers sprint-eval | Read `reviewer.go:20–61`, `agentic_caller.go` | Confirmed — brief's "reuse quorum verdict" premise is a domain mismatch; resolved by matching sprint-eval schema instead |
+| Sprint-eval verdict shape is score/pass/blockers (0–100, pass≥70) | Read `evaluation_report_schema.md` | Confirmed |
+| No existing `VerificationDegraded`/`bundle_truncated` marker | `grep -rn` in `internal/` | Confirmed zero hits — this marker is new |
+| Target version folder exists | `ls design_docs/planned/v0_30_0/` | Confirmed |
+| `git diff`/`diff --cached` omit untracked files; sprints create new files | design-quorum reviewer gemini-3-1-pro objection 2026-07-16 (git semantics) | Confirmed — doc CORRECTED to enumerate via `git status --porcelain` + synthesize `+++ NEW FILE` view; `TestBuildDiffBundle_IncludesUntrackedNewFiles` added |
+
+## Quorum record
+
+Run 2026-07-16T23:03:39Z (`.ailang/state/mission-quorum/m-gemini-evaluator-diff-bridge-2026-07-16T23-03-39Z.json`), reviewers `gpt5-6-sol,gemini-3-1-pro`, controller in-session verdict `pass`. Synthesis: **proceed** (exit 0) on controller verdict with BOTH external reviewers degraded to absent (N−1→N−2): `gpt5-6-sol` unreachable (OpenAI structured-output infra bug — `response_format` requires `proposed_fix` in `required`, an env-side schema mismatch, not a doc objection); `gemini-3-1-pro` `invalid` (response truncated mid-JSON). The gemini reviewer's partial objection was nonetheless VALID and actionable — untracked files are invisible to `git diff` — and has been incorporated (untracked-file inclusion + new acceptance test) rather than waved through. This is exactly the reject-by-default value: a degraded/partial reviewer still surfaced a real gap.
+
+**DESIGN_DOC_PATH**: `design_docs/planned/v0_30_0/m-gemini-evaluator-diff-bridge.md`

--- a/internal/eval_harness/gemini_evaluator_bridge.go
+++ b/internal/eval_harness/gemini_evaluator_bridge.go
@@ -563,3 +563,133 @@ func ValidateGeminiVerdict(v *GeminiVerdict) error {
 	}
 	return nil
 }
+
+// ============================================================================
+// M3 — Caller seam + caller-enforced degradation stamping
+// ============================================================================
+
+// EvalRunnerOutput is the minimal executor result the caller needs: it mirrors
+// the fields `ailang exec gemini --json` already emits (exec.go:281-294) that
+// matter for verdict extraction and degradation. The default production runner
+// populates it from the executor; unit tests return a canned value.
+type EvalRunnerOutput struct {
+	// Success is false when the backend errored — the caller stamps
+	// VerificationDegraded and NEVER treats the result as a real pass.
+	Success bool
+	// Output is the agent's raw text response (contains the fenced verdict).
+	Output string
+	// Error is the executor/backend error text (surfaced in DegradedReason).
+	Error string
+}
+
+// EvalRunner invokes the sandboxed evaluator with a composed directive +
+// system prompt and returns its output. It is INJECTABLE so tests pass a stub
+// and NEVER make a live Vertex/managed_agents call. The default production
+// runner (DefaultGeminiRunner) shells `ailang exec gemini --json`.
+type EvalRunner func(directive, systemPrompt string) (EvalRunnerOutput, error)
+
+// EvalOptions configures RunGeminiEvaluator.
+type EvalOptions struct {
+	// Bundle configures BuildDiffBundle (byte ceiling etc.).
+	Bundle BundleOptions
+	// AcceptanceCriteria is the criteria text folded into the directive.
+	AcceptanceCriteria string
+	// SystemPrompt is passed through to the runner (executor SystemInstruction).
+	SystemPrompt string
+	// Runner is the injectable executor seam. If nil, DefaultGeminiRunner is
+	// used (production path — shells `ailang exec gemini --json`; NEVER
+	// exercised by the test suite).
+	Runner EvalRunner
+}
+
+// RunGeminiEvaluator composes the reasoning-only evaluation end-to-end:
+// BuildDiffBundle → BuildEvaluatorDirective → injected runner →
+// ParseGeminiVerdict, and CALLER-ENFORCES degradation. On bundle truncation OR
+// a backend error, the returned verdict has VerificationDegraded==true with a
+// non-empty reason — a model/stub pass:true under degradation can NEVER stand
+// as a real pass (CLAUDE.md "no silent fallbacks", Principle 2). Mirrors
+// quorum.RunAgenticReviewer's policy-layer boundary.
+func RunGeminiEvaluator(worktree, designDoc, sprintPlan string, opts EvalOptions) (*GeminiVerdict, error) {
+	bundle, err := BuildDiffBundle(worktree, opts.Bundle)
+	if err != nil {
+		return nil, fmt.Errorf("RunGeminiEvaluator: build bundle: %w", err)
+	}
+
+	// Seed degradation from the bundle (truncation / dropped files).
+	degraded := DegradationInfo{
+		Truncated:    bundle.Truncated,
+		DroppedFiles: bundle.DroppedFiles,
+	}
+
+	directive := BuildEvaluatorDirective(designDoc, sprintPlan, opts.AcceptanceCriteria, bundle)
+
+	runner := opts.Runner
+	if runner == nil {
+		runner = DefaultGeminiRunner
+	}
+	out, runErr := runner(directive, opts.SystemPrompt)
+	if runErr != nil {
+		degraded.BackendError = runErr.Error()
+	} else if !out.Success {
+		msg := strings.TrimSpace(out.Error)
+		if msg == "" {
+			msg = "executor reported failure with no error text"
+		}
+		degraded.BackendError = msg
+	}
+
+	// On a backend error we have no trustworthy model verdict at all. Return a
+	// degraded, NON-PASS verdict carrying the error — never a fabricated pass.
+	if strings.TrimSpace(degraded.BackendError) != "" {
+		v := &GeminiVerdict{
+			Score:                0,
+			Pass:                 false,
+			Blockers:             []string{"backend error: no verdict obtained"},
+			VerificationDegraded: true,
+			DegradedReason:       degraded.reason(),
+		}
+		return v, nil
+	}
+
+	// Backend OK: parse the model verdict, then the caller-supplied degradation
+	// (bundle truncation) is stamped inside ParseGeminiVerdict — so a stub/model
+	// pass:true UNDER truncation still surfaces VerificationDegraded==true.
+	v, err := ParseGeminiVerdict(out.Output, degraded)
+	if err != nil {
+		return nil, fmt.Errorf("RunGeminiEvaluator: parse verdict: %w", err)
+	}
+	return &v, nil
+}
+
+// DefaultGeminiRunner is the production runner: it shells
+// `ailang exec gemini --json` (which routes to the managed_agents executor,
+// exec.go:317-322) and parses the --json envelope. It is the default when
+// EvalOptions.Runner is nil and is NEVER invoked by the test suite (all tests
+// inject a stub) — so no test makes a live Vertex/managed_agents call.
+func DefaultGeminiRunner(directive, systemPrompt string) (EvalRunnerOutput, error) {
+	args := []string{"exec", "gemini", "--json", "--prompt", directive}
+	if strings.TrimSpace(systemPrompt) != "" {
+		args = append(args, "--system-prompt", systemPrompt)
+	}
+	cmd := exec.Command("ailang", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+
+	// The --json envelope from exec.go:281-294.
+	var env struct {
+		Success bool   `json:"success"`
+		Output  string `json:"output"`
+		Error   string `json:"error"`
+	}
+	if jerr := json.Unmarshal(stdout.Bytes(), &env); jerr != nil {
+		// No parseable envelope — surface the raw failure loudly.
+		return EvalRunnerOutput{}, fmt.Errorf("ailang exec gemini: unparseable --json output: %v (stderr: %s)",
+			jerr, strings.TrimSpace(stderr.String()))
+	}
+	if runErr != nil && env.Error == "" {
+		env.Error = strings.TrimSpace(stderr.String())
+	}
+	return EvalRunnerOutput{Success: env.Success, Output: env.Output, Error: env.Error}, nil
+}

--- a/internal/eval_harness/gemini_evaluator_bridge.go
+++ b/internal/eval_harness/gemini_evaluator_bridge.go
@@ -1,0 +1,432 @@
+// INJECT-IN diff bundle bridge for a sandboxed gemini sprint EVALUATOR.
+//
+// This is the INVERSE of managed_agents_bridge.go (the extract-out bridge).
+// The managed_agents executor runs the agent in a Google-hosted sandbox with
+// NO repo/file upload — the request body carries only Directive + SystemPrompt
+// (managed_agents.go:164-176). So a gemini evaluator sees no local repo and
+// cannot inspect a sprint's UNCOMMITTED worktree changes.
+//
+// This file packages a sprint worktree's uncommitted diff into a size-bounded
+// "diff bundle" and injects it INTO the evaluator directive, so the sandboxed
+// agent can read and REASON about the changes (reasoning-only: no local test
+// re-runs). It then parses a structured verdict back out of the agent's fenced
+// response (mirroring how the extract-out bridge parses a fenced block).
+//
+// Lives in eval_harness/ (not the executor) because this is caller POLICY, the
+// same rationale as the sibling managed_agents_bridge.go (file header lines
+// 8-11): the executor stays policy-free. This file touches ZERO executor code
+// and does NOT import internal/mission/quorum (GeminiVerdict is a SEPARATE type
+// in a different domain — see its doc-comment).
+package eval_harness
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// defaultBundleMaxBytes is the default bundle-text ceiling (256 KiB). Well
+// under managed_agents token limits; the directive also competes with the
+// design doc + plan, so we stay conservative and configurable.
+const defaultBundleMaxBytes = 256 * 1024
+
+// binaryScanBytes is how many leading bytes we scan for a NUL to classify a
+// file as binary.
+const binaryScanBytes = 8 * 1024
+
+// BundleOptions configures BuildDiffBundle.
+type BundleOptions struct {
+	// MaxBytes is the ceiling for total bundle text. Full-file-content
+	// appendices (and an untracked file's body) are dropped whole to stay
+	// under it; the diff + NEW-FILE headers are never dropped. Zero means the
+	// default (256 KiB).
+	MaxBytes int
+}
+
+// maxBytes returns the effective ceiling, applying the default.
+func (o BundleOptions) maxBytes() int {
+	if o.MaxBytes <= 0 {
+		return defaultBundleMaxBytes
+	}
+	return o.MaxBytes
+}
+
+// Bundle is the result of packaging a worktree's uncommitted changes.
+type Bundle struct {
+	// Text is the deterministic bundle: the unified diff of tracked changes,
+	// `+++ NEW FILE` views of untracked files, and full changed-file contents,
+	// with LOUD truncation markers for anything dropped.
+	Text string
+	// Truncated is true if any file content was dropped (binary/generated/
+	// over-ceiling). Propagates to DegradationInfo.
+	Truncated bool
+	// DroppedFiles lists every dropped path with its reason (also echoed as a
+	// marker line in Text). No silent drops.
+	DroppedFiles []string
+	// Bytes is len(Text).
+	Bytes int
+}
+
+// DegradationInfo carries the degradation signal from bundle building (and,
+// via the caller, a backend error) into the verdict. Any set field means the
+// verdict is VerificationDegraded — a partial/lenient verdict can never
+// masquerade as a full pass (CLAUDE.md "no silent fallbacks").
+type DegradationInfo struct {
+	// Truncated is true if the bundle dropped any file content.
+	Truncated bool
+	// DroppedFiles mirrors Bundle.DroppedFiles.
+	DroppedFiles []string
+	// BackendError is non-empty if the executor runner errored / returned
+	// Success==false. Set by the caller (RunGeminiEvaluator), not the builder.
+	BackendError string
+}
+
+// degraded reports whether any degradation signal is present.
+func (d DegradationInfo) degraded() bool {
+	return d.Truncated || len(d.DroppedFiles) > 0 || strings.TrimSpace(d.BackendError) != ""
+}
+
+// reason composes a human-readable degradation reason (non-empty iff degraded).
+func (d DegradationInfo) reason() string {
+	var parts []string
+	if strings.TrimSpace(d.BackendError) != "" {
+		parts = append(parts, "backend error: "+strings.TrimSpace(d.BackendError))
+	}
+	if d.Truncated || len(d.DroppedFiles) > 0 {
+		parts = append(parts, fmt.Sprintf("bundle truncated: %d file(s) dropped and not shown to the evaluator (%s)",
+			len(d.DroppedFiles), strings.Join(d.DroppedFiles, "; ")))
+	}
+	return strings.Join(parts, " | ")
+}
+
+// generatedGlobs are path substrings/suffixes marking generated or vendored
+// files that are listed but never inlined (they carry little review signal and
+// large blast radius).
+var generatedSuffixes = []string{".pb.go", ".min.js", "_generated.go"}
+var generatedPathParts = []string{"/vendor/", "/dist/"}
+var generatedExact = []string{"go.sum"}
+
+// changedFile is one entry in the changed-file set enumerated from git status.
+type changedFile struct {
+	path      string // repo-relative path
+	untracked bool   // true if `??` (new/untracked) — git diff would miss it
+}
+
+// BuildDiffBundle packages a worktree's uncommitted changes into a bounded,
+// deterministic bundle for a reasoning-only evaluator.
+//
+// It enumerates the changed-file set via `git status --porcelain -z` (modified
+// + staged + UNTRACKED — untracked files are load-bearing: a sprint frequently
+// CREATES new files and `git diff` alone would miss them), emits the tracked
+// unified diff (`git diff` + `git diff --cached`, ALWAYS included, never
+// dropped), synthesizes `+++ NEW FILE:` headers for untracked files, then
+// appends full file contents subject to a drop-order + byte ceiling with LOUD
+// truncation markers. It never silently drops.
+func BuildDiffBundle(worktree string, opts BundleOptions) (Bundle, error) {
+	if strings.TrimSpace(worktree) == "" {
+		return Bundle{}, fmt.Errorf("BuildDiffBundle: empty worktree path")
+	}
+	files, err := enumerateChangedFiles(worktree)
+	if err != nil {
+		return Bundle{}, err
+	}
+
+	tracked := gitDiff(worktree, false) + gitDiff(worktree, true)
+
+	var b strings.Builder
+	b.WriteString("=== SPRINT DIFF BUNDLE (uncommitted worktree changes) ===\n\n")
+
+	// The tracked unified diff is ALWAYS first and never dropped (the change
+	// signal is load-bearing).
+	b.WriteString("=== UNIFIED DIFF (tracked changes) ===\n")
+	if strings.TrimSpace(tracked) == "" {
+		b.WriteString("(no tracked modifications)\n")
+	} else {
+		b.WriteString(tracked)
+		if !strings.HasSuffix(tracked, "\n") {
+			b.WriteByte('\n')
+		}
+	}
+	b.WriteByte('\n')
+
+	// Partition into inline candidates vs must-drop (binary/generated). Files
+	// are processed in a stable sorted order for determinism.
+	sort.Slice(files, func(i, j int) bool { return files[i].path < files[j].path })
+
+	type candidate struct {
+		cf      changedFile
+		content string
+		size    int
+	}
+	var inlineCandidates []candidate
+	var dropped []string
+	droppedMarkers := &strings.Builder{}
+
+	dropMarker := func(path, human, reason string) {
+		line := fmt.Sprintf("=== BUNDLE TRUNCATED: dropped %s (%s, %s) — NOT shown to evaluator ===",
+			path, human, reason)
+		droppedMarkers.WriteString(line + "\n")
+		dropped = append(dropped, fmt.Sprintf("%s (%s)", path, reason))
+	}
+
+	for _, cf := range files {
+		full := filepath.Join(worktree, cf.path)
+		data, readErr := os.ReadFile(full)
+		if readErr != nil {
+			// A staged deletion (or a race) — the file is gone. It shows in the
+			// unified diff already; nothing to inline. Not a drop.
+			continue
+		}
+		if isBinary(data) {
+			dropMarker(cf.path, humanSize(len(data)), "binary")
+			continue
+		}
+		if isGeneratedPath(cf.path) {
+			dropMarker(cf.path, humanSize(len(data)), "generated")
+			continue
+		}
+		inlineCandidates = append(inlineCandidates, candidate{cf: cf, content: string(data), size: len(data)})
+	}
+
+	// For untracked (new) files, emit a `+++ NEW FILE:` HEADER for every one
+	// (never dropped, so a new file is never silently invisible) even if its
+	// body is later dropped for the ceiling.
+	var newFileHeaders strings.Builder
+	for _, c := range inlineCandidates {
+		if c.cf.untracked {
+			newFileHeaders.WriteString(fmt.Sprintf("+++ NEW FILE: %s\n", c.cf.path))
+		}
+	}
+	// Also emit headers for untracked files that were dropped as binary/
+	// generated so they are still visible.
+	for _, cf := range files {
+		if !cf.untracked {
+			continue
+		}
+		alreadyInline := false
+		for _, c := range inlineCandidates {
+			if c.cf.path == cf.path {
+				alreadyInline = true
+				break
+			}
+		}
+		if !alreadyInline {
+			newFileHeaders.WriteString(fmt.Sprintf("+++ NEW FILE: %s\n", cf.path))
+		}
+	}
+	if newFileHeaders.Len() > 0 {
+		b.WriteString("=== NEW (untracked) FILES ===\n")
+		b.WriteString(newFileHeaders.String())
+		b.WriteByte('\n')
+	}
+
+	// Byte-ceiling enforcement over the full-file appendices. Drop order: the
+	// binary/generated files are already dropped above; here we drop the
+	// LARGEST remaining whole files until the projected total is under the
+	// ceiling. Drop candidates are ordered (size desc, path asc) for a stable
+	// total order.
+	ceiling := opts.maxBytes()
+
+	// Build the appendix body deterministically (sorted by path).
+	renderAppendix := func(c candidate) string {
+		hdr := "----- FULL FILE: "
+		if c.cf.untracked {
+			hdr = "----- FULL FILE (new): "
+		}
+		return fmt.Sprintf("%s%s -----\n%s\n----- END FILE: %s -----\n\n",
+			hdr, c.cf.path, ensureTrailingNL(c.content), c.cf.path)
+	}
+
+	// Projected fixed prefix = everything already written + the eventual
+	// dropped-markers block. We size the appendices against the remaining
+	// budget.
+	fixedPrefix := b.Len() + len("=== FULL FILE CONTENTS ===\n\n") + droppedMarkers.Len()
+
+	// Decide which appendices to keep. Greedy: drop largest-first until the
+	// kept appendices fit the remaining budget.
+	keep := make(map[string]bool, len(inlineCandidates))
+	for _, c := range inlineCandidates {
+		keep[c.cf.path] = true
+	}
+	appendixBytes := func() int {
+		total := 0
+		for _, c := range inlineCandidates {
+			if keep[c.cf.path] {
+				total += len(renderAppendix(c))
+			}
+		}
+		return total
+	}
+	// Order for dropping: size desc, then path asc (stable total order).
+	dropOrder := make([]candidate, len(inlineCandidates))
+	copy(dropOrder, inlineCandidates)
+	sort.Slice(dropOrder, func(i, j int) bool {
+		if dropOrder[i].size != dropOrder[j].size {
+			return dropOrder[i].size > dropOrder[j].size
+		}
+		return dropOrder[i].cf.path < dropOrder[j].cf.path
+	})
+	for _, c := range dropOrder {
+		if fixedPrefix+appendixBytes() <= ceiling {
+			break
+		}
+		if keep[c.cf.path] {
+			keep[c.cf.path] = false
+			dropMarker(c.cf.path, humanSize(c.size), "over-ceiling")
+			fixedPrefix = b.Len() + len("=== FULL FILE CONTENTS ===\n\n") + droppedMarkers.Len()
+		}
+	}
+
+	// Emit dropped markers (LOUD) first, then the kept full-file appendices.
+	if droppedMarkers.Len() > 0 {
+		b.WriteString("=== DROPPED / TRUNCATED FILES ===\n")
+		b.WriteString(droppedMarkers.String())
+		b.WriteByte('\n')
+	}
+
+	// Kept appendices in stable path order.
+	keptSorted := make([]candidate, 0, len(inlineCandidates))
+	for _, c := range inlineCandidates {
+		if keep[c.cf.path] {
+			keptSorted = append(keptSorted, c)
+		}
+	}
+	sort.Slice(keptSorted, func(i, j int) bool { return keptSorted[i].cf.path < keptSorted[j].cf.path })
+	if len(keptSorted) > 0 {
+		b.WriteString("=== FULL FILE CONTENTS ===\n\n")
+		for _, c := range keptSorted {
+			b.WriteString(renderAppendix(c))
+		}
+	}
+
+	text := b.String()
+	sort.Strings(dropped)
+	return Bundle{
+		Text:         text,
+		Truncated:    len(dropped) > 0,
+		DroppedFiles: dropped,
+		Bytes:        len(text),
+	}, nil
+}
+
+// enumerateChangedFiles parses `git status --porcelain -z` into the changed
+// file set. The -z form is NUL-separated (no quoting), so paths with spaces or
+// special chars are handled safely. Renames (R) carry two paths.
+func enumerateChangedFiles(worktree string) ([]changedFile, error) {
+	out, err := runGit(worktree, "status", "--porcelain", "-z")
+	if err != nil {
+		return nil, fmt.Errorf("BuildDiffBundle: git status failed: %w", err)
+	}
+	var files []changedFile
+	seen := map[string]bool{}
+	entries := strings.Split(out, "\x00")
+	for i := 0; i < len(entries); i++ {
+		e := entries[i]
+		if len(e) < 3 {
+			continue
+		}
+		xy := e[:2]
+		path := e[3:]
+		untracked := xy == "??"
+		// Renames: `R  old\x00new` — the NEW path is the next NUL field.
+		if (xy[0] == 'R' || xy[0] == 'C') && i+1 < len(entries) {
+			path = entries[i+1]
+			i++
+		}
+		if path == "" || seen[path] {
+			continue
+		}
+		seen[path] = true
+		files = append(files, changedFile{path: path, untracked: untracked})
+	}
+	return files, nil
+}
+
+// gitDiff returns `git diff` (staged=false) or `git diff --cached`
+// (staged=true) output. Errors are swallowed to empty (a repo with no HEAD yet
+// still yields a usable bundle from untracked files).
+func gitDiff(worktree string, staged bool) string {
+	args := []string{"diff"}
+	if staged {
+		args = []string{"diff", "--cached"}
+	}
+	out, err := runGit(worktree, args...)
+	if err != nil {
+		return ""
+	}
+	return out
+}
+
+// runGit runs git in worktree with deterministic, locale-independent output.
+func runGit(worktree string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = worktree
+	// Force stable, locale-independent, color-free output for determinism.
+	cmd.Env = append(os.Environ(),
+		"LC_ALL=C",
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_PAGER=cat",
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.String(), nil
+}
+
+// isBinary reports whether data looks binary (a NUL byte in the first 8 KiB).
+func isBinary(data []byte) bool {
+	n := len(data)
+	if n > binaryScanBytes {
+		n = binaryScanBytes
+	}
+	return bytes.IndexByte(data[:n], 0) >= 0
+}
+
+// isGeneratedPath reports whether path is generated/vendored (never inlined).
+func isGeneratedPath(path string) bool {
+	slashed := "/" + filepath.ToSlash(path)
+	base := filepath.Base(path)
+	for _, exact := range generatedExact {
+		if base == exact {
+			return true
+		}
+	}
+	for _, suf := range generatedSuffixes {
+		if strings.HasSuffix(path, suf) {
+			return true
+		}
+	}
+	for _, part := range generatedPathParts {
+		if strings.Contains(slashed, part) {
+			return true
+		}
+	}
+	return false
+}
+
+// humanSize renders a byte count like "412 KiB" / "37 B".
+func humanSize(n int) string {
+	switch {
+	case n >= 1024*1024:
+		return fmt.Sprintf("%d MiB", n/(1024*1024))
+	case n >= 1024:
+		return fmt.Sprintf("%d KiB", n/1024)
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}
+
+// ensureTrailingNL guarantees s ends with exactly one newline.
+func ensureTrailingNL(s string) string {
+	if s == "" {
+		return ""
+	}
+	return strings.TrimRight(s, "\n") + "\n"
+}

--- a/internal/eval_harness/gemini_evaluator_bridge.go
+++ b/internal/eval_harness/gemini_evaluator_bridge.go
@@ -21,6 +21,7 @@ package eval_harness
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -586,7 +587,11 @@ type EvalRunnerOutput struct {
 // system prompt and returns its output. It is INJECTABLE so tests pass a stub
 // and NEVER make a live Vertex/managed_agents call. The default production
 // runner (DefaultGeminiRunner) shells `ailang exec gemini --json`.
-type EvalRunner func(directive, systemPrompt string) (EvalRunnerOutput, error)
+//
+// ctx is the caller's context: the live path MUST honor its
+// cancellation/deadline (never a fresh context.Background()) so a live Tier-2
+// fire respects caller timeout/cancellation.
+type EvalRunner func(ctx context.Context, directive, systemPrompt string) (EvalRunnerOutput, error)
 
 // EvalOptions configures RunGeminiEvaluator.
 type EvalOptions struct {
@@ -609,7 +614,10 @@ type EvalOptions struct {
 // non-empty reason — a model/stub pass:true under degradation can NEVER stand
 // as a real pass (CLAUDE.md "no silent fallbacks", Principle 2). Mirrors
 // quorum.RunAgenticReviewer's policy-layer boundary.
-func RunGeminiEvaluator(worktree, designDoc, sprintPlan string, opts EvalOptions) (*GeminiVerdict, error) {
+//
+// ctx is the caller's context: it is threaded to the runner so a live Tier-2
+// fire honors caller cancellation/timeout (never context.Background()).
+func RunGeminiEvaluator(ctx context.Context, worktree, designDoc, sprintPlan string, opts EvalOptions) (*GeminiVerdict, error) {
 	bundle, err := BuildDiffBundle(worktree, opts.Bundle)
 	if err != nil {
 		return nil, fmt.Errorf("RunGeminiEvaluator: build bundle: %w", err)
@@ -627,7 +635,7 @@ func RunGeminiEvaluator(worktree, designDoc, sprintPlan string, opts EvalOptions
 	if runner == nil {
 		runner = DefaultGeminiRunner
 	}
-	out, runErr := runner(directive, opts.SystemPrompt)
+	out, runErr := runner(ctx, directive, opts.SystemPrompt)
 	if runErr != nil {
 		degraded.BackendError = runErr.Error()
 	} else if !out.Success {
@@ -666,12 +674,17 @@ func RunGeminiEvaluator(worktree, designDoc, sprintPlan string, opts EvalOptions
 // exec.go:317-322) and parses the --json envelope. It is the default when
 // EvalOptions.Runner is nil and is NEVER invoked by the test suite (all tests
 // inject a stub) — so no test makes a live Vertex/managed_agents call.
-func DefaultGeminiRunner(directive, systemPrompt string) (EvalRunnerOutput, error) {
+//
+// ctx is the caller's context: the underlying `ailang exec gemini` process is
+// launched with exec.CommandContext(ctx, ...) so caller cancellation/deadline
+// kills the live call. It is DERIVED from the passed ctx (never a fresh
+// context.Background()).
+func DefaultGeminiRunner(ctx context.Context, directive, systemPrompt string) (EvalRunnerOutput, error) {
 	args := []string{"exec", "gemini", "--json", "--prompt", directive}
 	if strings.TrimSpace(systemPrompt) != "" {
 		args = append(args, "--system-prompt", systemPrompt)
 	}
-	cmd := exec.Command("ailang", args...)
+	cmd := exec.CommandContext(ctx, "ailang", args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/eval_harness/gemini_evaluator_bridge.go
+++ b/internal/eval_harness/gemini_evaluator_bridge.go
@@ -21,6 +21,7 @@ package eval_harness
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -429,4 +430,136 @@ func ensureTrailingNL(s string) string {
 		return ""
 	}
 	return strings.TrimRight(s, "\n") + "\n"
+}
+
+// ============================================================================
+// M2 — Reasoning-only evaluator directive + structured verdict parse/validate
+// ============================================================================
+
+// geminiPassThreshold is the sprint-evaluator convention: pass requires
+// score >= 70 (and no blockers). Matches the sprint-evaluator skill's
+// pass_threshold.
+const geminiPassThreshold = 70
+
+// evaluatorReasoningInstruction is the compile-time reasoning-only directive
+// prelude, mirroring managedAgentsBridgeInstruction's role for the extract-out
+// path. It tells the sandboxed evaluator it has NO repo/test access and must
+// judge only from the supplied bundle, then emit a fenced json verdict.
+const evaluatorReasoningInstruction = "IMPORTANT — Reasoning-only sprint evaluation. " +
+	"You are running in a sandbox with NO access to the repository or local tests. " +
+	"Everything you can inspect is in the DIFF BUNDLE below. " +
+	"Do NOT claim you ran any test. Judge ONLY from the supplied diff + file contents " +
+	"against the design doc's acceptance criteria. " +
+	"At the very END of your response, output your verdict as a single fenced ```json block " +
+	"with fields: score (0-100), pass (bool), blockers (string[])."
+
+// evaluatorTruncationNote is appended when the bundle was truncated so the
+// evaluator qualifies its confidence rather than silently over-trusting a
+// partial view.
+const evaluatorTruncationNote = "\nThe DIFF BUNDLE is marked TRUNCATED: some files were NOT shown to you. " +
+	"Note in blockers which unseen files limit your confidence."
+
+// GeminiVerdict is the reasoning-only sprint-evaluation verdict returned by a
+// sandboxed gemini evaluator.
+//
+// SCHEMA NOTE (adaptation, not a byte-mirror): this is a COMPACT ADAPTATION of
+// the sprint-evaluator skill's evaluation_report_schema.md, whose fields are
+// total_score/result/hard_fails/feedback. The mapping is:
+//
+//	total_score        -> Score   (0..100)
+//	result == "pass"   -> Pass     (at threshold 70)
+//	hard_fails + feedback -> Blockers (compact stand-in)
+//
+// It is intentionally compact for a single-shot reasoning-only verdict; the
+// full evaluation_report_schema.md remains the shape for the local sonnet
+// sprint-evaluator, not this sandboxed gemini one.
+//
+// It is DISTINCT from quorum.ReviewResult (pass/reject/strongest_objection),
+// which is a design-DOC-REVIEW verdict in a different domain and MUST NOT be
+// conflated or overloaded — GeminiVerdict does not import or extend it.
+type GeminiVerdict struct {
+	// Score is 0..100; pass threshold is 70 (sprint-evaluator convention).
+	Score int `json:"score"`
+	// Pass is score >= 70 AND no blockers.
+	Pass bool `json:"pass"`
+	// Blockers are hard-fail reasons; a non-empty Blockers ⇒ Pass==false
+	// regardless of Score.
+	Blockers []string `json:"blockers"`
+
+	// VerificationDegraded is set (with a non-empty DegradedReason) whenever
+	// the bundle was truncated / files were dropped / the backend errored, so
+	// a partial or lenient verdict can NEVER masquerade as a full pass
+	// (CLAUDE.md "no silent fallbacks"). It is stamped by the CALLER, not
+	// trusted from the model.
+	VerificationDegraded bool   `json:"verification_degraded"`
+	DegradedReason       string `json:"degraded_reason,omitempty"`
+}
+
+// BuildEvaluatorDirective composes the reasoning-only evaluator directive: the
+// reasoning-only instruction, the design doc + sprint plan + acceptance
+// criteria, and the diff bundle. A truncated bundle appends the "note unseen
+// files in blockers" line. Mirrors managedAgentsBridgeInstruction's role.
+func BuildEvaluatorDirective(designDoc, sprintPlan, acceptanceCriteria string, bundle Bundle) string {
+	var b strings.Builder
+	b.WriteString(evaluatorReasoningInstruction)
+	if bundle.Truncated {
+		b.WriteString(evaluatorTruncationNote)
+	}
+	b.WriteString("\n\n=== DESIGN DOC ===\n")
+	b.WriteString(strings.TrimSpace(designDoc))
+	b.WriteString("\n\n=== SPRINT PLAN ===\n")
+	b.WriteString(strings.TrimSpace(sprintPlan))
+	if strings.TrimSpace(acceptanceCriteria) != "" {
+		b.WriteString("\n\n=== ACCEPTANCE CRITERIA ===\n")
+		b.WriteString(strings.TrimSpace(acceptanceCriteria))
+	}
+	b.WriteString("\n\n")
+	b.WriteString(bundle.Text)
+	return b.String()
+}
+
+// ParseGeminiVerdict extracts the LAST fenced json block from the agent's
+// response, unmarshals it into a GeminiVerdict, validates it, and STAMPS the
+// caller-supplied degradation (truncation / dropped files / backend error).
+// A missing fence, non-JSON body, or gate violation is a HARD ERROR — never a
+// coerced/lenient pass (CLAUDE.md "no silent fallbacks").
+func ParseGeminiVerdict(response string, degraded DegradationInfo) (GeminiVerdict, error) {
+	block := LastFencedBlock(response)
+	if strings.TrimSpace(block) == "" {
+		return GeminiVerdict{}, fmt.Errorf("gemini verdict: no fenced ```json block found in response (%.200q)", response)
+	}
+	var v GeminiVerdict
+	if err := json.Unmarshal([]byte(strings.TrimSpace(block)), &v); err != nil {
+		return GeminiVerdict{}, fmt.Errorf("gemini verdict: fenced block is not valid JSON: %w (block: %.200q)", err, block)
+	}
+	// Stamp degradation from the caller BEFORE validating, so a degraded
+	// verdict with an empty reason cannot slip through.
+	if degraded.degraded() {
+		v.VerificationDegraded = true
+		v.DegradedReason = degraded.reason()
+	}
+	if err := ValidateGeminiVerdict(&v); err != nil {
+		return GeminiVerdict{}, err
+	}
+	return v, nil
+}
+
+// ValidateGeminiVerdict enforces the sprint-eval contract as HARD errors:
+//   - Score ∈ [0,100];
+//   - a non-empty Blockers ⇒ Pass==false (a blocker cannot coexist with pass);
+//   - VerificationDegraded ⇒ DegradedReason non-empty.
+//
+// Any violation is an error, never a coerced pass (CLAUDE.md "no silent
+// fallbacks", mirroring quorum.ValidateReviewResult discipline).
+func ValidateGeminiVerdict(v *GeminiVerdict) error {
+	if v.Score < 0 || v.Score > 100 {
+		return fmt.Errorf("gemini verdict: score %d out of range [0,100]", v.Score)
+	}
+	if len(v.Blockers) > 0 && v.Pass {
+		return fmt.Errorf("gemini verdict: pass==true with %d blocker(s) is contradictory: %v", len(v.Blockers), v.Blockers)
+	}
+	if v.VerificationDegraded && strings.TrimSpace(v.DegradedReason) == "" {
+		return fmt.Errorf("gemini verdict: verification_degraded==true requires a non-empty degraded_reason")
+	}
+	return nil
 }

--- a/internal/eval_harness/gemini_evaluator_bridge_test.go
+++ b/internal/eval_harness/gemini_evaluator_bridge_test.go
@@ -223,3 +223,110 @@ func firstN(s string, n int) string {
 	}
 	return s[:n]
 }
+
+// ============================================================================
+// M2 — directive + verdict parse/validate tests
+// ============================================================================
+
+func TestBuildEvaluatorDirective_ReasoningOnly(t *testing.T) {
+	bundle := Bundle{Text: "=== SPRINT DIFF BUNDLE ===\nSOME-DIFF-CONTENT\n"}
+	dir := BuildEvaluatorDirective("DESIGN-DOC-BODY", "SPRINT-PLAN-BODY", "CRIT-A; CRIT-B", bundle)
+
+	// reasoning-only instruction present
+	if !strings.Contains(dir, "Reasoning-only sprint evaluation") {
+		t.Errorf("directive missing reasoning-only instruction:\n%s", dir)
+	}
+	// fenced-json verdict instruction present
+	if !strings.Contains(dir, "fenced ```json block") {
+		t.Errorf("directive missing fenced-json verdict instruction")
+	}
+	// bundle text present
+	if !strings.Contains(dir, "SOME-DIFF-CONTENT") {
+		t.Errorf("directive missing bundle text")
+	}
+	// design doc + plan + criteria present
+	if !strings.Contains(dir, "DESIGN-DOC-BODY") || !strings.Contains(dir, "SPRINT-PLAN-BODY") || !strings.Contains(dir, "CRIT-A") {
+		t.Errorf("directive missing design/plan/criteria")
+	}
+	// non-truncated bundle must NOT add the truncation note
+	if strings.Contains(dir, "note in blockers") || strings.Contains(dir, "marked TRUNCATED") {
+		t.Errorf("non-truncated bundle should not add truncation note")
+	}
+
+	// truncated bundle DOES add the note
+	truncBundle := Bundle{Text: "x", Truncated: true, DroppedFiles: []string{"big.go (over-ceiling)"}}
+	dir2 := BuildEvaluatorDirective("d", "p", "c", truncBundle)
+	if !strings.Contains(dir2, "marked TRUNCATED") || !strings.Contains(dir2, "unseen files") {
+		t.Errorf("truncated bundle missing the note-unseen-files line:\n%s", dir2)
+	}
+}
+
+func TestParseGeminiVerdict_ExtractsFencedJSON(t *testing.T) {
+	resp := "Let me reason about the diff.\n\n" +
+		"Scratch verdict (ignore): ```json\n{\"score\": 10, \"pass\": false, \"blockers\": [\"draft\"]}\n```\n\n" +
+		"Final answer:\n```json\n{\"score\": 85, \"pass\": true, \"blockers\": []}\n```\n"
+	v, err := ParseGeminiVerdict(resp, DegradationInfo{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.Score != 85 || !v.Pass {
+		t.Errorf("parsed wrong (last) verdict: %+v", v)
+	}
+	if len(v.Blockers) != 0 {
+		t.Errorf("expected no blockers, got %v", v.Blockers)
+	}
+	if v.VerificationDegraded {
+		t.Errorf("clean bundle should not be degraded")
+	}
+}
+
+func TestValidateGeminiVerdict_RejectsMalformed(t *testing.T) {
+	// score out of range
+	if err := ValidateGeminiVerdict(&GeminiVerdict{Score: 101}); err == nil {
+		t.Errorf("expected error for score>100")
+	}
+	if err := ValidateGeminiVerdict(&GeminiVerdict{Score: -1}); err == nil {
+		t.Errorf("expected error for score<0")
+	}
+	// blockers non-empty with pass==true
+	if err := ValidateGeminiVerdict(&GeminiVerdict{Score: 90, Pass: true, Blockers: []string{"x"}}); err == nil {
+		t.Errorf("expected error for pass==true with blockers")
+	}
+	// degraded with empty reason
+	if err := ValidateGeminiVerdict(&GeminiVerdict{Score: 50, VerificationDegraded: true}); err == nil {
+		t.Errorf("expected error for degraded with empty reason")
+	}
+	// valid case: no error
+	if err := ValidateGeminiVerdict(&GeminiVerdict{Score: 80, Pass: true}); err != nil {
+		t.Errorf("unexpected error on valid verdict: %v", err)
+	}
+
+	// ParseGeminiVerdict hard-errors on missing fence / non-JSON
+	if _, err := ParseGeminiVerdict("no fences at all here", DegradationInfo{}); err == nil {
+		t.Errorf("expected error for missing fence")
+	}
+	if _, err := ParseGeminiVerdict("```json\nnot json at all\n```", DegradationInfo{}); err == nil {
+		t.Errorf("expected error for non-JSON fenced body")
+	}
+	// ParseGeminiVerdict must NOT coerce a malformed verdict to a pass
+	if _, err := ParseGeminiVerdict("```json\n{\"score\": 999, \"pass\": true, \"blockers\": []}\n```", DegradationInfo{}); err == nil {
+		t.Errorf("expected error for out-of-range score (never coerced pass)")
+	}
+}
+
+func TestLastFencedBlock_UnchangedForExtractOut(t *testing.T) {
+	// The exact extract-out cases from managed_agents_bridge_test.go must yield
+	// identical results through the exported wrapper (regression guard for the
+	// Conflict-Surface seam 4 sharing).
+	cases := []string{
+		"Here's my solution:\n\n```ailang\nmodule benchmark/solution\nexport func main() -> () = ()\n```\n\nDone.",
+		"First attempt:\n```\nbroken\n```\n\nFinal:\n```ailang\nmodule benchmark/solution\nexport func main() -> () = ()\n```\n",
+		"no fences here",
+		"```\njust text\n```",
+	}
+	for i, c := range cases {
+		if got, want := LastFencedBlock(c), lastFencedBlock(c); got != want {
+			t.Errorf("case %d: LastFencedBlock diverged from lastFencedBlock:\n got=%q\nwant=%q", i, got, want)
+		}
+	}
+}

--- a/internal/eval_harness/gemini_evaluator_bridge_test.go
+++ b/internal/eval_harness/gemini_evaluator_bridge_test.go
@@ -1,0 +1,225 @@
+package eval_harness
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newTempGitRepo creates a temp git repo with one committed file so `git diff`
+// has a HEAD to diff against, and returns the worktree path.
+func newTempGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test",
+			"GIT_CONFIG_NOSYSTEM=1",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	// Seed a committed file so the repo has a HEAD.
+	writeFile(t, dir, "seed.txt", "seed\n")
+	run("add", "seed.txt")
+	run("commit", "-q", "-m", "seed")
+	return dir
+}
+
+func writeFile(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	full := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func gitAdd(t *testing.T, dir string, paths ...string) {
+	t.Helper()
+	args := append([]string{"add"}, paths...)
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}
+
+func TestBuildDiffBundle_IncludesDiffAndFiles(t *testing.T) {
+	dir := newTempGitRepo(t)
+	// Two committed .go files, then modify both (tracked changes).
+	writeFile(t, dir, "alpha.go", "package a\n\nvar Alpha = 1\n")
+	writeFile(t, dir, "beta.go", "package b\n\nvar Beta = 2\n")
+	gitAdd(t, dir, "alpha.go", "beta.go")
+	// commit them so they're tracked
+	commit(t, dir, "add go files")
+	// modify both
+	writeFile(t, dir, "alpha.go", "package a\n\nvar Alpha = 100\n")
+	writeFile(t, dir, "beta.go", "package b\n\nvar Beta = 200\n")
+
+	b, err := BuildDiffBundle(dir, BundleOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Unified diff present for both.
+	if !strings.Contains(b.Text, "alpha.go") || !strings.Contains(b.Text, "beta.go") {
+		t.Fatalf("bundle missing file names:\n%s", b.Text)
+	}
+	if !strings.Contains(b.Text, "diff --git") {
+		t.Fatalf("bundle missing unified diff header:\n%s", b.Text)
+	}
+	// Full file contents present (the NEW values).
+	if !strings.Contains(b.Text, "var Alpha = 100") {
+		t.Errorf("bundle missing alpha full contents:\n%s", b.Text)
+	}
+	if !strings.Contains(b.Text, "var Beta = 200") {
+		t.Errorf("bundle missing beta full contents:\n%s", b.Text)
+	}
+	if b.Truncated {
+		t.Errorf("unexpected truncation: dropped=%v", b.DroppedFiles)
+	}
+}
+
+func TestBuildDiffBundle_IncludesUntrackedNewFiles(t *testing.T) {
+	dir := newTempGitRepo(t)
+	// A brand-new untracked file — `git diff` alone would MISS this entirely.
+	writeFile(t, dir, "newthing.go", "package n\n\nfunc Fresh() int { return 42 }\n")
+
+	b, err := BuildDiffBundle(dir, BundleOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(b.Text, "+++ NEW FILE: newthing.go") {
+		t.Fatalf("bundle missing NEW FILE header (git diff would have missed it):\n%s", b.Text)
+	}
+	if !strings.Contains(b.Text, "func Fresh() int { return 42 }") {
+		t.Fatalf("bundle missing untracked file contents:\n%s", b.Text)
+	}
+}
+
+func TestBuildDiffBundle_DropsBinaryAndGenerated(t *testing.T) {
+	dir := newTempGitRepo(t)
+	// Generated file (*.pb.go) with real text content.
+	writeFile(t, dir, "api.pb.go", "package api\n\n// generated\nvar X = 1\n")
+	// Binary file: contains a NUL byte in the first bytes.
+	writeFile(t, dir, "blob.bin", "abc\x00def-binary-content\n")
+	gitAdd(t, dir, "api.pb.go", "blob.bin")
+
+	b, err := BuildDiffBundle(dir, BundleOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !b.Truncated {
+		t.Errorf("expected Truncated=true when dropping binary/generated")
+	}
+	// Both listed in DroppedFiles.
+	joined := strings.Join(b.DroppedFiles, "\n")
+	if !strings.Contains(joined, "api.pb.go") || !strings.Contains(joined, "blob.bin") {
+		t.Errorf("DroppedFiles missing entries: %v", b.DroppedFiles)
+	}
+	// LOUD marker present for each.
+	if !strings.Contains(b.Text, "=== BUNDLE TRUNCATED: dropped api.pb.go") {
+		t.Errorf("missing LOUD marker for generated file:\n%s", b.Text)
+	}
+	if !strings.Contains(b.Text, "=== BUNDLE TRUNCATED: dropped blob.bin") {
+		t.Errorf("missing LOUD marker for binary file:\n%s", b.Text)
+	}
+	// Their CONTENT must NOT appear as an inlined full-file body.
+	if strings.Contains(b.Text, "----- FULL FILE: api.pb.go") {
+		t.Errorf("generated file was inlined but should be dropped:\n%s", b.Text)
+	}
+	if strings.Contains(b.Text, "binary-content") {
+		t.Errorf("binary content leaked into bundle:\n%s", b.Text)
+	}
+}
+
+func TestBuildDiffBundle_TruncatesOverCeiling(t *testing.T) {
+	dir := newTempGitRepo(t)
+	// One large untracked file that blows a tiny ceiling.
+	large := "package big\n\nvar Blob = \"" + strings.Repeat("x", 20*1024) + "\"\n"
+	writeFile(t, dir, "big.go", large)
+	// A small tracked change too, to prove the diff stays.
+	writeFile(t, dir, "seed.txt", "seed-modified\n")
+
+	b, err := BuildDiffBundle(dir, BundleOptions{MaxBytes: 2 * 1024})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !b.Truncated {
+		t.Fatalf("expected Truncated=true over ceiling")
+	}
+	joined := strings.Join(b.DroppedFiles, "\n")
+	if !strings.Contains(joined, "big.go") {
+		t.Errorf("big.go should be dropped: %v", b.DroppedFiles)
+	}
+	if !strings.Contains(b.Text, "=== BUNDLE TRUNCATED: dropped big.go") {
+		t.Errorf("missing over-ceiling marker:\n%s", firstN(b.Text, 800))
+	}
+	// The unified diff of the tracked change is STILL present (never dropped).
+	if !strings.Contains(b.Text, "seed-modified") {
+		t.Errorf("tracked diff was dropped — it must never be:\n%s", firstN(b.Text, 800))
+	}
+	// The dropped new file KEEPS its NEW FILE header (never silently invisible).
+	if !strings.Contains(b.Text, "+++ NEW FILE: big.go") {
+		t.Errorf("dropped new file lost its NEW FILE header:\n%s", firstN(b.Text, 800))
+	}
+	// The huge body must NOT be inlined.
+	if strings.Contains(b.Text, strings.Repeat("x", 20*1024)) {
+		t.Errorf("over-ceiling body was inlined")
+	}
+}
+
+func TestBuildDiffBundle_Deterministic(t *testing.T) {
+	dir := newTempGitRepo(t)
+	writeFile(t, dir, "zeta.go", "package z\nvar Z = 1\n")
+	writeFile(t, dir, "alpha.go", "package a\nvar A = 1\n")
+	writeFile(t, dir, "mid.go", "package m\nvar M = 1\n")
+	// Mixed: one tracked-modified, others untracked.
+	writeFile(t, dir, "seed.txt", "changed\n")
+
+	b1, err := BuildDiffBundle(dir, BundleOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b2, err := BuildDiffBundle(dir, BundleOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b1.Text != b2.Text {
+		t.Errorf("BuildDiffBundle not deterministic:\n--- b1 ---\n%s\n--- b2 ---\n%s", b1.Text, b2.Text)
+	}
+}
+
+// --- helpers ---
+
+func commit(t *testing.T, dir, msg string) {
+	t.Helper()
+	cmd := exec.Command("git", "commit", "-q", "-m", msg)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test",
+		"GIT_CONFIG_NOSYSTEM=1",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git commit failed: %v\n%s", err, out)
+	}
+}
+
+func firstN(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/internal/eval_harness/gemini_evaluator_bridge_test.go
+++ b/internal/eval_harness/gemini_evaluator_bridge_test.go
@@ -1,6 +1,7 @@
 package eval_harness
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -339,7 +340,7 @@ func TestRunGeminiEvaluator_StubHappyPath(t *testing.T) {
 	dir := newTempGitRepo(t)
 	writeFile(t, dir, "feature.go", "package f\nvar F = 1\n")
 
-	stub := func(directive, systemPrompt string) (EvalRunnerOutput, error) {
+	stub := func(_ context.Context, directive, systemPrompt string) (EvalRunnerOutput, error) {
 		// Sanity: the directive must actually carry the bundle + reasoning note.
 		if !strings.Contains(directive, "Reasoning-only sprint evaluation") {
 			t.Errorf("stub: directive missing reasoning-only instruction")
@@ -353,7 +354,7 @@ func TestRunGeminiEvaluator_StubHappyPath(t *testing.T) {
 		}, nil
 	}
 
-	v, err := RunGeminiEvaluator(dir, "design", "plan", EvalOptions{Runner: stub})
+	v, err := RunGeminiEvaluator(context.Background(), dir, "design", "plan", EvalOptions{Runner: stub})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -371,14 +372,14 @@ func TestRunGeminiEvaluator_TruncationStampsDegraded(t *testing.T) {
 	writeFile(t, dir, "huge.go", "package h\nvar H = \""+strings.Repeat("y", 20*1024)+"\"\n")
 
 	// The stub LIES with pass:true — the caller must override to degraded.
-	stub := func(directive, systemPrompt string) (EvalRunnerOutput, error) {
+	stub := func(_ context.Context, directive, systemPrompt string) (EvalRunnerOutput, error) {
 		return EvalRunnerOutput{
 			Success: true,
 			Output:  "```json\n{\"score\": 95, \"pass\": true, \"blockers\": []}\n```",
 		}, nil
 	}
 
-	v, err := RunGeminiEvaluator(dir, "design", "plan", EvalOptions{
+	v, err := RunGeminiEvaluator(context.Background(), dir, "design", "plan", EvalOptions{
 		Runner: stub,
 		Bundle: BundleOptions{MaxBytes: 2 * 1024},
 	})
@@ -401,10 +402,10 @@ func TestRunGeminiEvaluator_BackendErrorIsDegradedNotPass(t *testing.T) {
 	writeFile(t, dir, "x.go", "package x\nvar X = 1\n")
 
 	// Case 1: runner returns Success==false with error text.
-	stubFail := func(directive, systemPrompt string) (EvalRunnerOutput, error) {
+	stubFail := func(_ context.Context, directive, systemPrompt string) (EvalRunnerOutput, error) {
 		return EvalRunnerOutput{Success: false, Error: "vertex 503 unavailable"}, nil
 	}
-	v, err := RunGeminiEvaluator(dir, "design", "plan", EvalOptions{Runner: stubFail})
+	v, err := RunGeminiEvaluator(context.Background(), dir, "design", "plan", EvalOptions{Runner: stubFail})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -416,10 +417,10 @@ func TestRunGeminiEvaluator_BackendErrorIsDegradedNotPass(t *testing.T) {
 	}
 
 	// Case 2: runner returns a hard error.
-	stubErr := func(directive, systemPrompt string) (EvalRunnerOutput, error) {
+	stubErr := func(_ context.Context, directive, systemPrompt string) (EvalRunnerOutput, error) {
 		return EvalRunnerOutput{}, errStub("network down")
 	}
-	v2, err := RunGeminiEvaluator(dir, "design", "plan", EvalOptions{Runner: stubErr})
+	v2, err := RunGeminiEvaluator(context.Background(), dir, "design", "plan", EvalOptions{Runner: stubErr})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/eval_harness/gemini_evaluator_bridge_test.go
+++ b/internal/eval_harness/gemini_evaluator_bridge_test.go
@@ -330,3 +330,107 @@ func TestLastFencedBlock_UnchangedForExtractOut(t *testing.T) {
 		}
 	}
 }
+
+// ============================================================================
+// M3 — RunGeminiEvaluator caller-seam tests (stub runner only, no live Vertex)
+// ============================================================================
+
+func TestRunGeminiEvaluator_StubHappyPath(t *testing.T) {
+	dir := newTempGitRepo(t)
+	writeFile(t, dir, "feature.go", "package f\nvar F = 1\n")
+
+	stub := func(directive, systemPrompt string) (EvalRunnerOutput, error) {
+		// Sanity: the directive must actually carry the bundle + reasoning note.
+		if !strings.Contains(directive, "Reasoning-only sprint evaluation") {
+			t.Errorf("stub: directive missing reasoning-only instruction")
+		}
+		if !strings.Contains(directive, "+++ NEW FILE: feature.go") {
+			t.Errorf("stub: directive missing the new file")
+		}
+		return EvalRunnerOutput{
+			Success: true,
+			Output:  "Looks good.\n```json\n{\"score\": 88, \"pass\": true, \"blockers\": []}\n```\n",
+		}, nil
+	}
+
+	v, err := RunGeminiEvaluator(dir, "design", "plan", EvalOptions{Runner: stub})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.Score != 88 || !v.Pass {
+		t.Errorf("wrong verdict: %+v", v)
+	}
+	if v.VerificationDegraded {
+		t.Errorf("clean run should not be degraded: reason=%q", v.DegradedReason)
+	}
+}
+
+func TestRunGeminiEvaluator_TruncationStampsDegraded(t *testing.T) {
+	dir := newTempGitRepo(t)
+	// Large new file blows a tiny ceiling → bundle Truncated.
+	writeFile(t, dir, "huge.go", "package h\nvar H = \""+strings.Repeat("y", 20*1024)+"\"\n")
+
+	// The stub LIES with pass:true — the caller must override to degraded.
+	stub := func(directive, systemPrompt string) (EvalRunnerOutput, error) {
+		return EvalRunnerOutput{
+			Success: true,
+			Output:  "```json\n{\"score\": 95, \"pass\": true, \"blockers\": []}\n```",
+		}, nil
+	}
+
+	v, err := RunGeminiEvaluator(dir, "design", "plan", EvalOptions{
+		Runner: stub,
+		Bundle: BundleOptions{MaxBytes: 2 * 1024},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !v.VerificationDegraded {
+		t.Fatalf("expected VerificationDegraded==true under truncation (stub said pass:true)")
+	}
+	if strings.TrimSpace(v.DegradedReason) == "" {
+		t.Errorf("degraded verdict must carry a non-empty reason")
+	}
+	if !strings.Contains(v.DegradedReason, "huge.go") {
+		t.Errorf("degraded reason should name the dropped file: %q", v.DegradedReason)
+	}
+}
+
+func TestRunGeminiEvaluator_BackendErrorIsDegradedNotPass(t *testing.T) {
+	dir := newTempGitRepo(t)
+	writeFile(t, dir, "x.go", "package x\nvar X = 1\n")
+
+	// Case 1: runner returns Success==false with error text.
+	stubFail := func(directive, systemPrompt string) (EvalRunnerOutput, error) {
+		return EvalRunnerOutput{Success: false, Error: "vertex 503 unavailable"}, nil
+	}
+	v, err := RunGeminiEvaluator(dir, "design", "plan", EvalOptions{Runner: stubFail})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.Pass {
+		t.Errorf("backend failure must NOT be a pass: %+v", v)
+	}
+	if !v.VerificationDegraded || !strings.Contains(v.DegradedReason, "vertex 503") {
+		t.Errorf("backend error not surfaced in degraded reason: %+v", v)
+	}
+
+	// Case 2: runner returns a hard error.
+	stubErr := func(directive, systemPrompt string) (EvalRunnerOutput, error) {
+		return EvalRunnerOutput{}, errStub("network down")
+	}
+	v2, err := RunGeminiEvaluator(dir, "design", "plan", EvalOptions{Runner: stubErr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v2.Pass || !v2.VerificationDegraded {
+		t.Errorf("runner error must be degraded non-pass: %+v", v2)
+	}
+	if !strings.Contains(v2.DegradedReason, "network down") {
+		t.Errorf("runner error text not surfaced: %q", v2.DegradedReason)
+	}
+}
+
+type errStub string
+
+func (e errStub) Error() string { return string(e) }

--- a/internal/eval_harness/managed_agents_bridge.go
+++ b/internal/eval_harness/managed_agents_bridge.go
@@ -162,6 +162,16 @@ func firstCodeLineStartsWith(s, prefix string) bool {
 	return false
 }
 
+// LastFencedBlock is an exported thin wrapper over lastFencedBlock so the
+// inject-in path (gemini_evaluator_bridge.go's ParseGeminiVerdict) can reuse
+// the exact same "last fenced block" extraction as the extract-out path,
+// without renaming the unexported symbol or touching the extractCode call site
+// (Conflict-Surface seam 4: lowest-risk sharing; zero behavior change).
+// TestLastFencedBlock_UnchangedForExtractOut guards the equivalence.
+func LastFencedBlock(s string) string {
+	return lastFencedBlock(s)
+}
+
 // lastFencedBlock returns the content of the last ``` ... ``` block in s,
 // stripped of the language hint on the opening fence. Returns "" if no
 // complete fenced block is present.


### PR DESCRIPTION
## Fleet (c1) — m-gemini-evaluator-diff-bridge

Ships the **capability** for a sandboxed gemini (Vertex Managed Agents) sprint evaluator to review a sprint's **uncommitted** worktree changes — serving Mark's #399 preference for gemini-as-evaluator (model diversity: generator≠judge). The default evaluator stays **sonnet** (this PR does NOT change routing; it's gated on evidence).

### The problem
The managed_agents executor sends only `Directive`+`SystemPrompt` (no repo upload — `managed_agents.go:164-176`), so a gemini evaluator sees no local repo. This bridges the diff **IN** — the inverse of the existing extract-out `managed_agents_bridge.go`.

### What landed (all in `internal/eval_harness/`, policy layer — executor stays policy-free)
- **M1** `BuildDiffBundle` — enumerates changed files via `git status --porcelain -z` (tracked + staged + **untracked**; `git diff` alone misses new files — a quorum catch), drop-order binary→generated→largest under a 256 KiB ceiling, LOUD `=== BUNDLE TRUNCATED ===` markers (no silent drop).
- **M2** reasoning-only directive + `GeminiVerdict` + `Parse`/`Validate` (malformed → hard error), exported thin `LastFencedBlock` wrapper (no rename of the extract-out call site).
- **M3** `RunGeminiEvaluator` injectable-runner caller seam + **caller-enforced** degradation — a model `pass:true` under truncation/backend-error can NEVER stand as a real pass.
- **Hardening** — caller `ctx` threaded through to `exec.CommandContext` (fleet-(c) caller-ctx watch-item).

### Guarantees
- Frozen `quorum.ReviewResult` byte-identical; zero changes to `internal/executor/managed_agents/`, `internal/mission/quorum/`, `cmd/ailang/exec.go`.
- 12 new tests, non-vacuous (7 new symbols absent on origin/dev), no live Vertex call in tests (injectable stub).
- Sonnet evaluator: **PASS 96/100 round 1**, no blockers, non-vacuity + frozen-contract independently confirmed.

Mission iteration 39. Executor: opus. Evaluator: sonnet (generator≠judge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)