### PR TITLE
fix(quorum): reasoning-model reviews no longer truncate silently at the token cap (mission iter 43)

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,28 @@
 
 ## [Unreleased]
 
+### Fixed — `design-quorum` reasoning-model reviews truncated silently at the 4096-token cap (mission iter 43)
+
+A reasoning reviewer (Gemini 3.x — "2× reasoning") whose thinking tokens count against
+`maxOutputTokens` could exhaust the quorum's `reviewMaxTokens = 4096` cap mid-verdict, returning
+a valid-but-cut-off JSON body. `ParseReviewResult` rejected it as "malformed JSON" and the
+reviewer was silently dropped, degrading the two-provider quorum to N−1 (observed live mission
+iter 42: `gemini-3-1-pro` `finishReason=MAX_TOKENS` on a substantive objection). Intermittent —
+it fired cleanly whenever the review happened to be terse.
+
+- **Root-cause fix:** `reviewMaxTokens` raised 4096 → 16384, leaving genuine thinking headroom
+  above the ~1–2K structured verdict. Output is billed per actual token (a short verdict stays in
+  cents) and the pre-flight budget cap uses a fixed `expectedOutputTokens` estimate, so the
+  ceiling change does not alter budget gating (`internal/mission/quorum/call.go`).
+- **Fail loudly (Principle 2):** a residual `finish_reason == "length"` truncation now surfaces as
+  an explicit `"reviewer output truncated at N tokens … raise reviewMaxTokens"` error instead of an
+  opaque parse failure (`internal/mission/quorum/run.go`).
+- **Provider signal wired:** the Gemini `Generate` path was discarding `finishReason`; it now
+  populates the normalized `ai.Response.FinishReason` (`MAX_TOKENS → length`, `STOP → stop`, safety
+  reasons → `content_filter`) so all Gemini callers can see truncation
+  (`internal/ai/gemini/generate.go`). Regression tests: `TestNormalizeGeminiFinishReason`,
+  `TestRunReviewerWith_TruncatedOutputFailsLoudly`.
+
 ### Fixed — `design-quorum` cross-provider schema: OpenAI reviewers were silently dropped (mission iter 41)
 
 The mission pick-time `design-quorum` gate ran with only ONE reviewer present on every

--- a/internal/ai/gemini/generate.go
+++ b/internal/ai/gemini/generate.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/sunholo-data/ailang/internal/ai"
 )
@@ -141,8 +142,31 @@ func (c *Client) generateContent(ctx context.Context, req *ai.Request) (*ai.Resp
 		OutputTokens: outputTokens,
 		TotalTokens:  result.UsageMetadata.TotalTokenCount,
 		ReasonTokens: reasoningTokens,
+		FinishReason: normalizeGeminiFinishReason(result.Candidates[0].FinishReason),
 		Model:        req.Model,
 	}, nil
+}
+
+// normalizeGeminiFinishReason maps the Gemini/Vertex finishReason vocabulary
+// into the normalized ai.Response.FinishReason values (see provider.go). The
+// critical case is "MAX_TOKENS" → "length": a reasoning model whose thinking
+// tokens exhaust maxOutputTokens returns MAX_TOKENS with a truncated body, and
+// callers (e.g. the quorum reviewer) need that signal to fail LOUDLY instead of
+// reporting a generic "malformed JSON". Empty input maps to "" (back-compat with
+// legacy responses that omit the field).
+func normalizeGeminiFinishReason(r string) string {
+	switch r {
+	case "STOP":
+		return "stop"
+	case "MAX_TOKENS":
+		return "length"
+	case "SAFETY", "RECITATION", "BLOCKLIST", "PROHIBITED_CONTENT", "SPII":
+		return "content_filter"
+	case "":
+		return ""
+	default:
+		return strings.ToLower(r)
+	}
 }
 
 // buildParts converts a user prompt into Gemini API parts.

--- a/internal/ai/gemini/generate_finishreason_test.go
+++ b/internal/ai/gemini/generate_finishreason_test.go
@@ -1,0 +1,24 @@
+package gemini
+
+import "testing"
+
+// TestNormalizeGeminiFinishReason locks the mapping from the Gemini/Vertex
+// finishReason vocabulary to the normalized ai.Response.FinishReason values.
+// The load-bearing row is MAX_TOKENS→length: the quorum reviewer keys its
+// loud truncation error off "length" (mission iter 42 regression guard).
+func TestNormalizeGeminiFinishReason(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"STOP", "stop"},
+		{"MAX_TOKENS", "length"},
+		{"SAFETY", "content_filter"},
+		{"RECITATION", "content_filter"},
+		{"PROHIBITED_CONTENT", "content_filter"},
+		{"", ""},
+		{"OTHER", "other"}, // unknown → lowercased, never dropped
+	}
+	for _, c := range cases {
+		if got := normalizeGeminiFinishReason(c.in); got != c.want {
+			t.Errorf("normalizeGeminiFinishReason(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/mission/quorum/call.go
+++ b/internal/mission/quorum/call.go
@@ -63,9 +63,19 @@ func (c *handlerCaller) CallJSON(sysPrompt, userPrompt, schema string) (string, 
 	return strings.TrimSpace(resp.Text), resp, nil
 }
 
-// reviewMaxTokens caps reviewer output. Reviews are short structured JSON;
-// this both bounds cost and leaves reasoning headroom for the frontier models.
-const reviewMaxTokens = 4096
+// reviewMaxTokens caps reviewer output. Reviews are short structured JSON, but
+// the frontier reviewers are REASONING models whose thinking tokens count
+// against maxOutputTokens (Gemini 3.x especially — "2x reasoning"). At the old
+// 4096 cap the thinking trace could consume the whole budget and truncate the
+// JSON answer mid-object, so the review was silently dropped as
+// "malformed JSON" and the quorum degraded to N-1 (observed live, mission iter
+// 42: gemini-3-1-pro finishReason=MAX_TOKENS on a substantive objection). 16384
+// leaves genuine thinking headroom above the ~1-2K structured verdict. Cost is
+// billed per ACTUAL token emitted (a short verdict stays in cents) and the
+// pre-flight budget cap uses a fixed expectedOutputTokens estimate, so raising
+// this ceiling does not change budget gating. A residual truncation now fails
+// LOUDLY via resp.FinishReason == "length" (see runReviewerWith), never silently.
+const reviewMaxTokens = 16384
 
 // ResolveCaller builds a JSONCaller for a models.yml model id, wiring the
 // correct provider + auth from the shipped registry:

--- a/internal/mission/quorum/reviewer_test.go
+++ b/internal/mission/quorum/reviewer_test.go
@@ -200,6 +200,32 @@ func TestRunReviewerWith_MalformedResponseIsInvalidAbsence(t *testing.T) {
 	}
 }
 
+// TestRunReviewerWith_TruncatedOutputFailsLoudly guards the mission-iter-42
+// regression: a reasoning model (gemini-3.x) whose thinking exhausts
+// maxOutputTokens returns a valid-but-cut-off JSON body (finish_reason=length)
+// that ParseReviewResult rejects. The absence must be reported as a specific
+// truncation error, not an opaque "malformed JSON" (Principle 2: fail loudly).
+func TestRunReviewerWith_TruncatedOutputFailsLoudly(t *testing.T) {
+	stub := &stubCaller{
+		// A verdict object cut off mid-string — exactly what a MAX_TOKENS
+		// truncation produces.
+		raw:  `{"verdict":"reject","strongest_objection":"the design wires the check to return`,
+		resp: &ai.Response{InputTokens: 1200, OutputTokens: 16384, FinishReason: "length"},
+	}
+	out := &ReviewerOutcome{Model: "gemini-3-1-pro"}
+	got := runReviewerWith(stub, cheapModel(), out, "doc.md", "body", DefaultMaxCostUSD)
+
+	if got.Present {
+		t.Fatalf("expected absent for truncated response")
+	}
+	if got.AbsentReason != ReasonInvalid {
+		t.Errorf("absent reason = %q, want %q", got.AbsentReason, ReasonInvalid)
+	}
+	if !strings.Contains(got.Err, "truncated") || !strings.Contains(got.Err, "finish_reason=length") {
+		t.Errorf("truncation must be surfaced explicitly; got err = %q", got.Err)
+	}
+}
+
 func TestRunReviewerWith_UnreachableProvider(t *testing.T) {
 	stub := &stubCaller{err: errors.New("connection refused")}
 	out := &ReviewerOutcome{Model: "test-model"}

--- a/internal/mission/quorum/run.go
+++ b/internal/mission/quorum/run.go
@@ -140,7 +140,16 @@ func runReviewerWith(caller JSONCaller, mc *eval_harness.ModelConfig, out *Revie
 	result, perr := ParseReviewResult(raw)
 	if perr != nil {
 		out.AbsentReason = ReasonInvalid
-		out.Err = perr.Error()
+		// Fail LOUDLY on a max_tokens truncation: a reasoning model whose
+		// thinking exhausted the output cap returns a valid-but-cut-off body
+		// that ParseReviewResult rejects as malformed JSON. Surfacing the
+		// finish reason turns an opaque "non-JSON" into an actionable
+		// "output truncated at N tokens — raise reviewMaxTokens" (Principle 2).
+		if resp.FinishReason == "length" {
+			out.Err = fmt.Sprintf("reviewer output truncated at %d tokens (finish_reason=length) — reasoning likely exhausted the %d-token cap; raise reviewMaxTokens. Parse error: %v", resp.OutputTokens, reviewMaxTokens, perr)
+		} else {
+			out.Err = perr.Error()
+		}
 		return out
 	}
 


### PR DESCRIPTION
## Summary

Makes the `design-quorum` gemini reviewer reliable — the last blocker for using Gemini (Google) as a mission reviewer/evaluator (gap **G1**).

A reasoning reviewer (Gemini 3.x, "2× reasoning") counts its **thinking tokens against `maxOutputTokens`**. At the quorum's `reviewMaxTokens = 4096` cap the thinking trace could consume the whole budget and truncate the JSON verdict mid-object. `ParseReviewResult` then rejected it as "malformed JSON" and the reviewer was **silently dropped**, degrading the two-provider quorum to N−1. Observed live mission iter 42: `gemini-3-1-pro` returned `finishReason=MAX_TOKENS` on a substantive objection. Intermittent — it fired cleanly whenever the review was terse (which is why G1/G2 sometimes looked fine).

## Changes

- **Root cause** — `reviewMaxTokens` 4096 → 16384 (`internal/mission/quorum/call.go`). Genuine thinking headroom above the ~1–2K structured verdict; per-token billing keeps a short verdict in cents; the pre-flight budget cap uses a fixed `expectedOutputTokens` estimate so budget gating is unchanged.
- **Fail loudly** (Principle 2) — a residual `finish_reason == "length"` truncation now surfaces an explicit `"output truncated at N tokens … raise reviewMaxTokens"` error instead of an opaque parse failure (`internal/mission/quorum/run.go`).
- **Wire the provider signal** — the Gemini `Generate` path was discarding `finishReason`; it now populates the normalized `ai.Response.FinishReason` (`MAX_TOKENS→length`, `STOP→stop`, safety→`content_filter`) so all Gemini callers can see truncation (`internal/ai/gemini/generate.go`).

## Tests

- `TestNormalizeGeminiFinishReason` — locks the finishReason mapping (load-bearing row `MAX_TOKENS→length`).
- `TestRunReviewerWith_TruncatedOutputFailsLoudly` — a cut-off body with `finish_reason=length` must surface an explicit truncation error, not "malformed JSON".
- gofmt clean; `internal/mission/quorum` + `internal/ai/gemini` package tests green.

## Verification note (calibrated)

The truncation is **intermittent** and cannot be deterministically reproduced live, so a single post-fix quorum run cannot *prove* its absence. What is proven: the unit tests cover the surfacing + mapping logic deterministically, and the 4× cap raise directly addresses the measured root cause (iter-42 gemini wanted > 4096; it now has 16384). A live post-fix quorum ran clean (both reviewers present, gemini `reject`, $0.023).

🤖 Generated with [Claude Code](https://claude.com/claude-code)