### PR TITLE
spike(g4): Phase-1 Vertex Managed Agents contract discovery — premise REFUTED

### DIFF
--- a/design_docs/planned/v0_30_0/m-gemini-repo-mount.md
+++ b/design_docs/planned/v0_30_0/m-gemini-repo-mount.md
@@ -1,10 +1,26 @@
 # M-GEMINI-REPO-MOUNT — Managed Agents repository and inline-source mounts
 
-**Status**: PARKED (needs-human-review) — Blocked pending Phase-1 VERIFIED-LIVE contract record
+**Status**: PARKED (needs-human-review) — **Phase-1 spike RUN (2026-07-17); core premise REFUTED.**
+The documented `repository` + `inline` source mounts **do not exist** on the live Vertex endpoint;
+this design cannot be implemented as written and needs a **GCS-backed redesign OR abandonment** (human
+scope decision — see the Phase-1 Spike Result section and the mission-iteration-45 report on issue #399).
 **Target**: v0.30.0
 **Priority**: P1 — mission gap G4; upgrades Gemini from reasoning-only review to in-sandbox verification
-**Estimated**: ~1 day (≤~250 LOC of Go)
+**Estimated**: ~~~1 day (≤~250 LOC of Go)~~ — invalidated; a GCS-backed approach is a larger, unscoped lift
 **Dependencies**: `managed_agents` executor / M-MANAGED-AGENTS v0.22.0
+
+> **⛔ PHASE-1 SPIKE RESULT (mission iteration 45, 2026-07-17) — PREMISE REFUTED.** Mark authorized the
+> ADC-gated live Vertex contract-discovery spike ("yep do the vertex contract spike", #399). It ran
+> against the real `interactions` endpoint (project `ailang-dev`, `global`, `Api-Revision 2026-05-20`,
+> 14 credential-free probes, all cheap request-validation `400`s — no sandbox provisioned). **Result: the
+> live API rejects both `repository` and `inline` source types outright** — `Unsupported environment data
+> source type: REPOSITORY/INLINE. Must be one of: [gcs, skill_registry]`. It further requires **network
+> egress to be enabled before ANY data source is accepted** (a fresh `{"type":"remote"}` env has egress
+> OFF). So every source-mount premise in this doc is refuted, and the encoder/CLI/limit design below is
+> moot as written. See the **Phase-1 Spike Result** section for the full VERIFIED-LIVE record and the
+> reproducible probe (`internal/executor/managed_agents/managed_agents_live_test.go`,
+> `AILANG_LIVE_MANAGED_AGENTS_MOUNT=1`). **The Phase-1 gate the quorum demanded is now satisfied — and it
+> returned a NEGATIVE. No Phase-2 code should be written against the refuted contract.**
 
 > **PARK NOTE (mission iteration 44, 2026-07-17).** This doc was authored by the `codex:gpt-5.6-sol`
 > designer (G3 designer-rotation live test) and passed through TWO 3-provider quorum rounds
@@ -62,17 +78,96 @@ instead of reviewing only a textual representation of it.
 `managed_agents`; documentation examples alone are `DOC-ONLY`. This log starts honestly below and must be
 updated by the Phase-1 spike before Phase 2 begins.
 
-| Claim | Source (doc URL + section / or "unverified") | Status (VERIFIED-LIVE \| DOC-ONLY \| ASSUMED) | Evidence / How-to-confirm |
-|-------|------------------------------------------------|--------------------------------------------------|---------------------------|
-| A config-object environment accepts an `environment.sources[]` array | `https://ai.google.dev/gemini-api/docs/agent-environment` — “The `environment` parameter” and “Mount from a source” | DOC-ONLY | Phase-1 repository-only and combined POSTs must record the accepted serialized `environment` object and successful response from the executor's real endpoint. |
-| Repository sources use fields `type`, `source`, and `target` | `https://ai.google.dev/gemini-api/docs/agent-environment` — “Mount from a source” REST example | DOC-ONLY | Phase-1 repository-only POST mounts a known public repository, then records the accepted request and agent-visible target. |
-| Inline sources use the documented field names and an exact content encoding | `https://ai.google.dev/gemini-api/docs/agent-environment` — “Mount from a source” shows `type`, `content`, and `target`, but does not prove this Vertex endpoint or SDK-independent encoding | ASSUMED | Phase-1 inline-only POST must determine the exact accepted field set and whether `content` is raw UTF-8 text, base64, or another encoding; record both request and observed file bytes. No encoder is designed before this result. |
-| Inline content has a per-file limit described as “1 MB” | `https://ai.google.dev/gemini-api/docs/agent-environment` — “Mount from a source” source-type table | DOC-ONLY | Phase-1 boundary probing must determine the endpoint's actual byte ceiling and record its response. |
-| Equality at exactly `1 << 20` bytes is accepted and `1 << 20 + 1` is rejected | unverified | ASSUMED | Phase-1 submits both sizes, records accept/reject responses, and updates the frozen constant/inequality; if the provider uses decimal MB or rejects equality, the implementation follows the live result. |
-| A public repository mounts without repository credentials | `https://ai.google.dev/gemini-api/docs/agent-environment` — “Mount from a source” public GitHub example and “Private sources” credential configuration | DOC-ONLY | Phase-1 repository-only POST omits repository credentials and verifies the mounted checkout is readable. |
-| A fresh remote environment has unrestricted outbound network by default | `https://ai.google.dev/gemini-api/docs/agent-environment` — “Network configuration” | DOC-ONLY | Phase-1 combined probe makes a bounded outbound HTTPS request without a `network` override and records success/failure; implementation/help text must follow the live result. |
+**Updated by the Phase-1 spike, mission iteration 45 (2026-07-17). Every DOC-ONLY/ASSUMED row was probed
+against the live endpoint; the net result is REFUTED.** The endpoint used is
+`aiplatform.googleapis.com` (Vertex) — NOT the `ai.google.dev` Gemini Developer API the original rows
+cited; the two contracts diverge, which is exactly the risk the quorum flagged.
+
+| Claim | Original source | Status (post-spike) | Live evidence |
+|-------|-----------------|---------------------|---------------|
+| A config-object environment accepts an `environment.sources[]` array | `ai.google.dev` docs | **PARTIALLY VERIFIED-LIVE** | The `sources[]` array IS parsed and validated (the API reads each element's `type` and validates per-source `target`, error path `environment.config.sources.target`). But the *contents* below are refuted. |
+| Repository sources use fields `type`, `source`, and `target` | `ai.google.dev` "Mount from a source" | **REFUTED (VERIFIED-LIVE)** | `HTTP 400: Unsupported environment data source type: `REPOSITORY`. Must be one of: [`gcs`, `skill_registry`].` There is **no repository/git source type** on this endpoint. |
+| Inline sources use the documented field names and an exact content encoding | `ai.google.dev` "Mount from a source" | **REFUTED (VERIFIED-LIVE)** | `HTTP 400: Unsupported environment data source type: `INLINE`. Must be one of: [`gcs`, `skill_registry`].` There is **no inline source type**; inline patch injection is impossible via `environment`. |
+| Inline content has a per-file limit described as "1 MB" | `ai.google.dev` source-type table | **N/A (VERIFIED-LIVE)** | Moot — no inline source type exists. Not probed for accept/reject size because the type itself is rejected first. |
+| Equality at exactly `1 << 20` bytes is accepted and `1 << 20 + 1` is rejected | unverified | **N/A (VERIFIED-LIVE)** | Moot — no inline source type. |
+| A public repository mounts without repository credentials | `ai.google.dev` public GitHub example | **N/A (VERIFIED-LIVE)** | Moot — no repository source type. GCS sources would use GCS/IAM auth, not git-repo credentials. |
+| A fresh remote environment has unrestricted outbound network by default | `ai.google.dev` "Network configuration" | **REFUTED (VERIFIED-LIVE)** | `HTTP 400: Network egress is not enabled for the environment. Cannot specify data sources.` A fresh `{"type":"remote"}` env has egress **OFF**, and egress must be enabled *before* any data source is accepted. |
+| **[NEW — gemini round-2 row]** A mounted repo has enough history to `git checkout` an arbitrary older SHA (not shallow) | quorum reviewer | **N/A (VERIFIED-LIVE)** | Moot — no repository mount exists to be shallow or deep. A GCS-backed redesign would ship whatever the caller uploads, so history depth becomes a tarball-contents question, not a provider-mount question. |
+| **[NEW — discovered]** The only supported `sources[].type` values | live probe | **VERIFIED-LIVE** | Exactly **`gcs`** and **`skill_registry`** (per the two rejection messages). |
+| **[NEW — discovered]** Each source requires a `target` | live probe | **VERIFIED-LIVE** | Bare `{"type":"gcs"}` / `{"type":"skill_registry"}` → `HTTP 400: `environment.config.sources.target` is required.` |
+| **[NEW — discovered]** `environment.network` is a real config object gating egress | live probe | **VERIFIED-LIVE (name undiscovered)** | `environment.network` accepts params (errors are scoped to `environment.network`), but its egress-enable field is **not** `egress`, `egress_enabled`, `enable_egress`, `enable_internet_access`, or `egress_setting` (all → `Unknown parameter … at 'environment.network'`). The exact param name needs the Vertex Managed Agents environment proto/reference — a follow-up, not blind probing. |
+
+## Phase-1 Spike Result (VERIFIED-LIVE, mission iteration 45, 2026-07-17)
+
+**Authorization:** Mark, on issue #399 — "yep do the vertex contract spike".
+
+**Method:** an env-var-guarded, in-package Go probe
+(`internal/executor/managed_agents/managed_agents_live_test.go`, gated by
+`AILANG_LIVE_MANAGED_AGENTS_MOUNT=1`) that reuses the executor's own `sendInteraction` + `parseSSE` so
+each request is byte-identical to production. It POSTs varying `environment` payloads to the exact live
+endpoint the executor uses and records the response. **14 probes were run; all were request-validation
+`HTTP 400`s that reject before a sandbox is provisioned, so the spike cost was negligible** (no agent
+run, no sandbox — the informative-rejection path). No credentials appear in requests (the ADC bearer
+token is added inside `sendInteraction` and never printed); interaction/environment IDs are redacted.
+
+- **Endpoint:** `POST https://aiplatform.googleapis.com/v1beta1/projects/ailang-dev/locations/global/interactions`
+- **Headers:** `Api-Revision: 2026-05-20`, `Authorization: Bearer <ADC>`, `Accept: text/event-stream`.
+
+**Verbatim probe transcript (credential-free):**
+
+| Probe | `environment` sent (abridged) | Live response |
+|-------|-------------------------------|---------------|
+| A repo-only | `sources:[{type:repository, source:<git url>, target:/workspace/ailang}]` | `400 Unsupported environment data source type: `REPOSITORY`. Must be one of: [`gcs`, `skill_registry`].` |
+| B inline-only | `sources:[{type:inline, target:…, content:"AILANG_INLINE_SENTINEL_v1…"}]` | `400 Unsupported environment data source type: `INLINE`. Must be one of: [`gcs`, `skill_registry`].` |
+| F gcs bare | `sources:[{type:gcs}]` | `400 `environment.config.sources.target` is required.` |
+| G gcs+source+target | `sources:[{type:gcs, source:gs://…, target:/workspace/x}]` | `400 Network egress is not enabled for the environment. Cannot specify data sources.` |
+| H skill_registry bare | `sources:[{type:skill_registry}]` | `400 `environment.config.sources.target` is required.` |
+| I–N egress-enable guesses | `network:{egress\|egress_enabled\|enable_egress\|enable_internet_access\|egress_setting: …}` | `400 Unknown parameter '<name>' at 'environment.network'.` (all six guesses rejected) |
+
+**What is now VERIFIED-LIVE:**
+
+1. **The documented `repository` and `inline` mounts do not exist on this endpoint.** The only accepted
+   `sources[].type` values are **`gcs`** and **`skill_registry`**. This refutes the entire mount model
+   this doc was built on (git-URL repository mount + inline patch injection).
+2. **Data sources are gated behind network egress.** A fresh `{"type":"remote"}` environment has egress
+   OFF; any `sources[]` on such an env is rejected with "Network egress is not enabled … Cannot specify
+   data sources." Egress must be enabled first, via some parameter under the real `environment.network`
+   object (name TBD — see #3).
+3. **`environment.network` exists but its egress-enable field name is undiscovered.** Six idiomatic
+   guesses were all rejected as unknown params scoped to `environment.network`. Discovering it (and the
+   full `gcs` source contract) requires the actual Vertex Managed Agents environment proto/reference,
+   not further blind 400-probing.
+4. Each source requires a `target`; the server normalizes `environment.sources` to
+   `environment.config.sources` internally.
+
+**Implication — this design is refuted, not merely unverified.** "Mount the caller's git repo + inject
+the uncommitted diff as an inline file" is not expressible against this API. The nearest real path is a
+**GCS-backed mount**: enable egress, upload a repo tarball/checkout (and the diff) to a GCS bucket in
+`ailang-dev`, and mount it via a `gcs` source. That is a materially different and larger design (GCS
+bucket + upload/lifecycle pipeline, IAM, egress config, tarball assembly) than the ≤250-LOC estimate
+here, and it still needs the egress-param + `gcs`-source contract pinned first.
+
+### 🔴 Decision needed (Mark) — scope, not code
+
+The spike did its job (verify-before-build) and returned a decisive negative. Three options:
+
+- **(a) Redesign around GCS-backed mounts.** Highest value (Gemini gains real in-sandbox `ailang check`),
+  but a fresh, larger design + a second contract-discovery spike (egress param + `gcs` source fields).
+  Would be re-queued as a new design-doc iteration, not a resume of this one.
+- **(b) Shelve G4; keep the prompt-packed diff bridge.** Gemini stays a reasoning-only reviewer (as
+  today). Zero further cost. The diff bridge already works and `VerificationDegraded` is stamped honestly.
+- **(c) Investigate `skill_registry`** as an alternate delivery path (unknown fit; likely for agent
+  skills, not repo code — lowest confidence).
+
+Recommendation: **(b) shelve unless mounted Gemini verification proves worth a GCS pipeline** — the
+existing bridge covers the review use case, and the mission has cheaper accessibility-queue items. Reply
+on #399 to choose. Until then the doc stays PARKED with the contract now honestly recorded.
 
 ## Goals
+
+> **NOTE (iter 45):** the Goals/Decisions/Plan below describe the REFUTED repository+inline design and are
+> retained only as the record of what the spike invalidated. Do not implement against them. A GCS-backed
+> redesign (option a) would rewrite this section.
 
 - Preserve byte-for-byte-equivalent default behavior: a task with no requested sources sends
   `{"type":"remote"}`.

--- a/internal/executor/managed_agents/managed_agents_live_test.go
+++ b/internal/executor/managed_agents/managed_agents_live_test.go
@@ -1,0 +1,279 @@
+package managed_agents
+
+// Phase-1 contract-discovery spike for M-GEMINI-REPO-MOUNT (mission gap G4).
+//
+// This is a MANUAL, live, ADC-gated probe. It is NEVER run in default CI: it
+// requires working Application Default Credentials, provisions real Google-
+// hosted sandboxes (real cost), and hits the live Vertex Managed Agents
+// `interactions` endpoint. It exists to RECORD the accepted `environment`
+// wire contract (repository/inline source field names, inline content
+// encoding, per-file byte ceiling, public-repo behavior, default outbound
+// network, and clone depth) before any encoder code is designed — see
+// design_docs/planned/v0_30_0/m-gemini-repo-mount.md, Phase 1.
+//
+// Run it with:
+//
+//	AILANG_LIVE_MANAGED_AGENTS_MOUNT=1 \
+//	  go test ./internal/executor/managed_agents/ -run TestLiveEnvironmentContract -v -timeout 20m
+//
+// Optional overrides:
+//
+//	AILANG_LIVE_MA_PROJECT   (default "ailang-dev")
+//	AILANG_LIVE_MA_LOCATION  (default "global")
+//	AILANG_LIVE_MA_REPO      (default "https://github.com/sunholo-data/ailang.git")
+//
+// The probe reuses the package's own sendInteraction + parseSSE + foldEvent so
+// the request/response handling is byte-identical to production. Interaction
+// and environment IDs are redacted from stdout so the transcript can be pasted
+// into the (public) design doc without leaking account-scoped identifiers. The
+// ADC bearer token is added inside sendInteraction and never printed.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// liveProbe describes one environment-shape experiment.
+type liveProbe struct {
+	label     string
+	envJSON   string // the raw JSON assigned to interactionRequest.Environment
+	directive string // the user_input directive; keep it a 1-step observation
+}
+
+// probeResult is the sanitized outcome of one live interaction.
+type probeResult struct {
+	label        string
+	status       string
+	stepCount    int
+	agentText    string
+	unknownCount int
+	err          error
+}
+
+func redactID(id string) string {
+	if id == "" {
+		return "<none>"
+	}
+	if len(id) <= 6 {
+		return "<redacted>"
+	}
+	return "<redacted:" + fmt.Sprintf("%d", len(id)) + "chars>"
+}
+
+func runLiveProbe(ctx context.Context, project, location string, p liveProbe) probeResult {
+	body := &interactionRequest{
+		Stream:      true,
+		Background:  true,
+		Store:       true,
+		Agent:       defaultAgent,
+		Environment: json.RawMessage(p.envJSON),
+		Input: []inputBlock{{
+			Type:    "user_input",
+			Content: []contentBlock{{Type: "text", Text: p.directive}},
+		}},
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, 4*time.Minute)
+	defer cancel()
+
+	res := probeResult{label: p.label}
+
+	reader, err := sendInteraction(reqCtx, defaultHTTPClient(), defaultTokenSource, project, location, body)
+	if err != nil {
+		// This is the INFORMATIVE path for a rejected shape: the API's 4xx
+		// error body (field-name complaints, "unknown field", size limits)
+		// tells us the real contract without provisioning a sandbox.
+		res.err = err
+		return res
+	}
+	defer reader.Close()
+
+	state := &streamState{}
+	parseErr := parseSSE(reader, func(ev sseEvent) error {
+		return foldEvent(state, ev)
+	})
+	res.status = state.Status
+	res.stepCount = state.StepCount
+	res.agentText = state.Text.String()
+	res.unknownCount = len(state.UnknownEvents)
+	if parseErr != nil {
+		res.err = parseErr
+	}
+	return res
+}
+
+func TestLiveEnvironmentContract(t *testing.T) {
+	if os.Getenv("AILANG_LIVE_MANAGED_AGENTS_MOUNT") != "1" {
+		t.Skip("live Managed Agents mount spike disabled; set AILANG_LIVE_MANAGED_AGENTS_MOUNT=1 (needs ADC, provisions real sandboxes)")
+	}
+
+	project := os.Getenv("AILANG_LIVE_MA_PROJECT")
+	if project == "" {
+		project = "ailang-dev"
+	}
+	location := os.Getenv("AILANG_LIVE_MA_LOCATION")
+	if location == "" {
+		location = "global"
+	}
+	repo := os.Getenv("AILANG_LIVE_MA_REPO")
+	if repo == "" {
+		repo = "https://github.com/sunholo-data/ailang.git"
+	}
+
+	// Sentinel that is trivially distinguishable raw-vs-base64: if the mounted
+	// file contains this literal string, content is raw UTF-8; if it contains
+	// the base64 of it, the API expects base64.
+	const inlineSentinel = "AILANG_INLINE_SENTINEL_v1_do_not_edit"
+	const inlineTarget = "/workspace/ailang_probe_inline.txt"
+
+	// A repo-observation directive that also folds in the default-network probe
+	// and the clone-depth probe (rev-list count + is-shallow) so one paid run
+	// covers three Premise Verification Log rows.
+	repoDirective := "You are in a Linux sandbox. Run EACH shell command below and paste its raw stdout+stderr verbatim, each under a line '### <n>'. Do not summarize or interpret.\n" +
+		"### 1\nls -la /workspace 2>&1\n" +
+		"### 2\nls -la /workspace/ailang 2>&1 | head -20\n" +
+		"### 3\ngit -C /workspace/ailang rev-parse HEAD 2>&1\n" +
+		"### 4\ngit -C /workspace/ailang rev-list --count HEAD 2>&1\n" +
+		"### 5\ngit -C /workspace/ailang rev-parse --is-shallow-repository 2>&1\n" +
+		"### 6\ngit -C /workspace/ailang log --oneline -3 2>&1\n" +
+		"### 7\ncurl -sS -m 10 -o /dev/null -w 'NET_HTTP_CODE=%{http_code}\\n' https://example.com 2>&1\n"
+
+	inlineDirective := "You are in a Linux sandbox. Run EACH shell command below and paste its raw stdout+stderr verbatim, each under a line '### <n>'. Do not summarize.\n" +
+		"### 1\nls -la /workspace 2>&1\n" +
+		"### 2\ncat " + inlineTarget + " 2>&1\n" +
+		"### 3\nwc -c " + inlineTarget + " 2>&1\n" +
+		"### 4\nod -c " + inlineTarget + " 2>&1 | head -5\n"
+
+	// The documented shapes (from ai.google.dev/gemini-api/docs/agent-environment).
+	// These are the ASSUMED/DOC-ONLY shapes we are here to verify or refute.
+	repoSource := fmt.Sprintf(`{"type":"repository","source":%q,"target":"/workspace/ailang"}`, repo)
+	inlineSource := fmt.Sprintf(`{"type":"inline","target":%q,"content":%q}`, inlineTarget, inlineSentinel)
+
+	// Boundary payloads: exactly 1<<20 bytes vs 1<<20+1 bytes of inline content.
+	atLimit := strings.Repeat("a", 1<<20)
+	overLimit := strings.Repeat("a", (1<<20)+1)
+	atLimitSource := fmt.Sprintf(`{"type":"inline","target":%q,"content":%q}`, "/workspace/at_limit.txt", atLimit)
+	overLimitSource := fmt.Sprintf(`{"type":"inline","target":%q,"content":%q}`, "/workspace/over_limit.txt", overLimit)
+
+	probes := []liveProbe{
+		{
+			label:     "A_repo_only",
+			envJSON:   `{"type":"remote","sources":[` + repoSource + `]}`,
+			directive: repoDirective,
+		},
+		{
+			label:     "B_inline_only",
+			envJSON:   `{"type":"remote","sources":[` + inlineSource + `]}`,
+			directive: inlineDirective,
+		},
+		{
+			label:     "C_combined",
+			envJSON:   `{"type":"remote","sources":[` + repoSource + `,` + inlineSource + `]}`,
+			directive: repoDirective + "\n### 8\ncat " + inlineTarget + " 2>&1\n",
+		},
+		{
+			label:     "D_over_limit_1MiB_plus_1",
+			envJSON:   `{"type":"remote","sources":[` + overLimitSource + `]}`,
+			directive: "reply with exactly: OVERLIMIT_ACCEPTED",
+		},
+		{
+			label:     "E_at_limit_1MiB",
+			envJSON:   `{"type":"remote","sources":[` + atLimitSource + `]}`,
+			directive: "run: wc -c /workspace/at_limit.txt 2>&1 ; reply with its raw output only",
+		},
+		// The live endpoint rejected repository/inline and named the real
+		// supported source types: `gcs` and `skill_registry`. These bare/guess
+		// probes elicit the required-field contract for each (validation 400s,
+		// no sandbox provisioned) so the redesign is grounded in the real wire
+		// shape rather than the refuted documentation.
+		{
+			label:     "F_gcs_bare",
+			envJSON:   `{"type":"remote","sources":[{"type":"gcs"}]}`,
+			directive: "reply with exactly: OK",
+		},
+		{
+			label:     "G_gcs_guess_fields",
+			envJSON:   `{"type":"remote","sources":[{"type":"gcs","source":"gs://ailang-dev-probe-nonexistent/x.tar","target":"/workspace/x"}]}`,
+			directive: "reply with exactly: OK",
+		},
+		{
+			label:     "H_skill_registry_bare",
+			envJSON:   `{"type":"remote","sources":[{"type":"skill_registry"}]}`,
+			directive: "reply with exactly: OK",
+		},
+		// Egress is the gate for ALL data sources. These probes guess the
+		// enable-egress wire shape; a change away from "Network egress is not
+		// enabled" pins the field name. The `config` wrapper is inferred from
+		// the F/H error path `environment.config.sources.target`.
+		{
+			label:     "I_config_network_egress_enabled_bool",
+			envJSON:   `{"type":"remote","config":{"network":{"egress_enabled":true},"sources":[{"type":"gcs","source":"gs://ailang-dev-probe-nonexistent/x.tar","target":"/workspace/x"}]}}`,
+			directive: "reply with exactly: OK",
+		},
+		{
+			label:     "J_config_network_egress_enum",
+			envJSON:   `{"type":"remote","config":{"network":{"egress":"ENABLED"},"sources":[{"type":"gcs","source":"gs://ailang-dev-probe-nonexistent/x.tar","target":"/workspace/x"}]}}`,
+			directive: "reply with exactly: OK",
+		},
+		{
+			label:     "K_top_network_egress",
+			envJSON:   `{"type":"remote","network":{"egress":"ENABLED"},"sources":[{"type":"gcs","source":"gs://ailang-dev-probe-nonexistent/x.tar","target":"/workspace/x"}]}`,
+			directive: "reply with exactly: OK",
+		},
+		{
+			label:     "L_network_enable_egress",
+			envJSON:   `{"type":"remote","network":{"enable_egress":true},"sources":[{"type":"gcs","source":"gs://ailang-dev-probe-nonexistent/x.tar","target":"/workspace/x"}]}`,
+			directive: "reply with exactly: OK",
+		},
+		{
+			label:     "M_network_enable_internet_access",
+			envJSON:   `{"type":"remote","network":{"enable_internet_access":true},"sources":[{"type":"gcs","source":"gs://ailang-dev-probe-nonexistent/x.tar","target":"/workspace/x"}]}`,
+			directive: "reply with exactly: OK",
+		},
+		{
+			label:     "N_network_egress_setting_enum",
+			envJSON:   `{"type":"remote","network":{"egress_setting":"EGRESS_SETTING_ALL"},"sources":[{"type":"gcs","source":"gs://ailang-dev-probe-nonexistent/x.tar","target":"/workspace/x"}]}`,
+			directive: "reply with exactly: OK",
+		},
+	}
+
+	// Allow selecting a subset via AILANG_LIVE_MA_PROBES="A,B" to control cost.
+	if sel := os.Getenv("AILANG_LIVE_MA_PROBES"); sel != "" {
+		want := map[string]bool{}
+		for _, s := range strings.Split(sel, ",") {
+			want[strings.TrimSpace(strings.ToUpper(s))] = true
+		}
+		filtered := probes[:0]
+		for _, p := range probes {
+			if want[strings.ToUpper(p.label[:1])] {
+				filtered = append(filtered, p)
+			}
+		}
+		probes = filtered
+	}
+
+	fmt.Printf("\n========== LIVE MANAGED-AGENTS ENVIRONMENT CONTRACT SPIKE ==========\n")
+	fmt.Printf("project=%s location=%s repo=%s agent=%s revision=%s\n",
+		project, location, repo, defaultAgent, apiRevision)
+	fmt.Printf("endpoint=%s\n\n", buildInteractionsURL(project, location))
+
+	ctx := context.Background()
+	for _, p := range probes {
+		fmt.Printf("---------- PROBE %s ----------\n", p.label)
+		fmt.Printf("REQUEST environment (verbatim, no credentials):\n%s\n\n", p.envJSON)
+		r := runLiveProbe(ctx, project, location, p)
+		if r.err != nil {
+			fmt.Printf("RESULT: transport/parse error (this is the informative-rejection path):\n%v\n\n", r.err)
+			continue
+		}
+		fmt.Printf("RESULT: status=%q steps=%d unknown_events=%d interaction_id=%s\n",
+			r.status, r.stepCount, r.unknownCount, redactID("x"))
+		fmt.Printf("AGENT TEXT OUTPUT (verbatim, IDs are not present here):\n%s\n\n", r.agentText)
+	}
+	fmt.Printf("========== END SPIKE ==========\n")
+}


### PR DESCRIPTION
## G4 Phase-1 contract-discovery spike — the human gate Mark authorized on #399

Mark: *"yep do the vertex contract spike"* (#399). This is the ADC-gated live contract-discovery spike the `m-gemini-repo-mount` quorum demanded before any Phase-2 code could be written.

### Result: the design's core premise is **REFUTED** (data-before-conclusions)

14 credential-free probes against the live `interactions` endpoint (project `ailang-dev`, `global`, `Api-Revision 2026-05-20`) — **all cheap request-validation `HTTP 400`s, no sandbox provisioned**:

| Finding | Live evidence |
|---|---|
| `repository`/`inline` source types **do not exist** | `Unsupported environment data source type: REPOSITORY/INLINE. Must be one of: [gcs, skill_registry].` |
| Data sources gated behind **network egress** (OFF by default) | `Network egress is not enabled for the environment. Cannot specify data sources.` |
| `environment.network` real, egress-param name **undiscovered** | 6 idiomatic guesses → `Unknown parameter '…' at 'environment.network'.` |
| Each source requires `target` | `environment.config.sources.target is required.` |

The git-repo + inline-patch mount model this doc was built on **is not expressible against this API**. Nearest real path is a GCS-backed mount — a materially larger, unscoped redesign. Doc records the full VERIFIED-LIVE contract + a scope decision (redesign / shelve / skill_registry) for Mark.

### What's in this PR (doc + CI-inert test only)
- `design_docs/planned/v0_30_0/m-gemini-repo-mount.md` — status → premise-REFUTED, Premise Verification Log updated to VERIFIED-LIVE, full Phase-1 Spike Result section + decision-for-Mark.
- `internal/executor/managed_agents/managed_agents_live_test.go` — env-var-guarded (`AILANG_LIVE_MANAGED_AGENTS_MOUNT=1`) in-package probe reusing `sendInteraction`+`parseSSE`. **SKIPS in default CI**, never hits the network without the flag. gofmt-clean, package tests green.

Independent **sonnet** evaluator verified the write-up faithful to the raw evidence, credential-safe, non-overstated (generator≠judge: opus controller authored, sonnet judged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)