### PR TITLE
M-FMT-PROPERTIES-PRINTER-ROUNDTRIP: contract-clause printer round-trip + silent-deletion fix

### DIFF
--- a/.ailang/state/sprints/sprint_M-FMT-PROPERTIES-PRINTER-ROUNDTRIP.json
+++ b/.ailang/state/sprints/sprint_M-FMT-PROPERTIES-PRINTER-ROUNDTRIP.json
@@ -1,0 +1,59 @@
+{
+  "sprint_id": "M-FMT-PROPERTIES-PRINTER-ROUNDTRIP",
+  "design_doc": "design_docs/planned/v0_30_0/m-fmt-properties-printer-roundtrip.md",
+  "plan_path": "design_docs/planned/v0_30_0/m-fmt-properties-printer-roundtrip.md",
+  "created": "2026-07-20",
+  "worktree": "/Users/voightkampff/dev/sunholo-data/ailang-wt-fmt-properties",
+  "branch": "sprint/m-fmt-properties-printer-roundtrip",
+  "scope_note": "Printer-only contract-clause round-trip fix + one-line parser clobber fix. Non-goals honored: no AST split of contracts out of FuncDecl.Properties, no comment-attachment carve-out work, no properties[...] grammar changes, no fmt adoption/CI enforcement. Sprint-plan markdown and sprint JSON were absent from the worktree at start; the design doc is the contract per the executor prompt, and this JSON was created by the executor to satisfy the completion gate.",
+  "github_issues": [399],
+  "velocity": {
+    "target_loc_per_day": 200,
+    "estimated_total_loc": 200,
+    "estimated_days": 1
+  },
+  "risk_level": "low",
+  "status": "completed",
+  "non_goals": [
+    "AST refactor splitting contracts out of FuncDecl.Properties",
+    "comment-attachment carve-out (inbox_injection_v2.ail, inbox_v2_app.ail stay fail-closed)",
+    "properties [...] grammar changes",
+    "fmt adoption / CI formatting enforcement"
+  ],
+  "milestones": [
+    {
+      "id": "M1_PRINTER_SPLIT_PARSER_FIX",
+      "description": "Partition FuncDecl.Properties by ContractKind in funcDecl; emit requires/ensures merged clauses in signature position; refactor testsAndProperties to take a pre-filtered PropertyKind-only slice; fix parser_func.go properties-block clobber (= -> append). 7 round-trip fixtures (requires-only, ensures-only, both, multi-predicate, ensures+ForallExpr, genuine properties block, contracts+properties combined) + parse-partition test. ALSO fixed two adjacent pre-existing Phase-1 printer round-trip bugs the corpus gate exposed: precedence-unaware startsWithStatementStarter (paren-leading statement separator) and @verify(depth: N) key-drop on print.",
+      "estimated_loc": 130,
+      "dependencies": [],
+      "files": [
+        "internal/format/decl.go",
+        "internal/format/format.go",
+        "internal/parser/parser_func.go",
+        "internal/format/contracts_test.go (new)",
+        "internal/format/node_coverage_test.go"
+      ],
+      "passes": true,
+      "completed": "2026-07-20",
+      "commit": "58eadd3b5",
+      "notes": "All 7 M1 fixtures + parse-partition + paren-separator + @verify tests pass. Repros verified: cf_contract.ail exit 2 -> exit 1; both.ail no longer silently deletes requires. go test ./internal/format ./internal/parser green. Two extra printer fixes made scoring.ail + per_function_depth_verify.ail formattable too, taking preExistingRT from 28 to 0 (vs the doc's 28-file target — MORE coverage)."
+    },
+    {
+      "id": "M2_REGRESSION_GUARD_CORPUS_GREEN",
+      "description": "New internal/format/testdata/contracts_and_properties.ail fixture + acceptance-gated TestCombinedContractsAndPropertiesPipeline (four assertion groups: checks-clean+ai-check-verify, contract reaches DeclMeta.Contracts exactly 1 requires + 1 ensures + 0 from forall, fn.Properties exactly [Requires,Ensures,Property] + collector emits exactly one PropertyKind case, exact-count no-dup/no-omission + fmt round-trip with requires present). Harden corpus_comment_test preExistingRT into the t.Fatalf condition. fmt --write over the 30 now-eligible files in a dedicated commit; ailang check (+ ai-check for verify-corpus) re-passes. CHANGELOG entry noting the silent-deletion data-loss fix.",
+      "estimated_loc": 200,
+      "dependencies": ["M1_PRINTER_SPLIT_PARSER_FIX"],
+      "files": [
+        "internal/format/testdata/contracts_and_properties.ail (new)",
+        "internal/format/combined_pipeline_test.go (new)",
+        "internal/format/corpus_comment_test.go",
+        "examples/runnable/contracts/*.ail (30 reformatted)",
+        "examples/ai_devtools_workflow/discount_calculator.ail",
+        "changelogs/v0.18-current.md"
+      ],
+      "passes": true,
+      "completed": "2026-07-20",
+      "notes": "TestCombinedContractsAndPropertiesPipeline passes all four groups. Corpus gate hardened: preexisting-Phase1-rt-bug=0 and now a hard failure. Acceptance sweep: only inbox_injection_v2.ail + inbox_v2_app.ail remain exit-2 (carve-out, unchanged); all 30 reformatted files exit 0 and ailang check clean (discount_calculator.ail has a PRE-EXISTING unrelated ++ type error at both original and reformatted — expected-fail demo, not a regression). ai-check verify-corpus errors=0. make test green (one flaky httpbin.org network test on first run, passed on re-run). make verify-examples green, 0 drift."
+    }
+  ]
+}

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,40 @@
 
 ## [Unreleased]
 
+### Fixed — `ailang fmt` contract-clause round-trip + silent contract-deletion data loss (m-fmt-properties-printer-roundtrip)
+
+Makes the entire Z3-verified contract corpus formatter-eligible and closes a
+latent data-loss bug where `fmt --write` could **silently delete verified
+`requires`/`ensures` clauses**.
+
+- **Contract-clause emission (`internal/format/decl.go`)** — the Phase-1 printer now
+  treats `FuncDecl.Properties` as a mixed-kind slice: `RequiresKind`/`EnsuresKind`
+  entries are emitted as merged `requires { … }` / `ensures { … }` clauses in
+  signature position (after the effect row, before tests/properties and the body),
+  and only `PropertyKind` (forall) entries route through the `properties [...]`
+  block. Previously every `Properties` entry was printed as a bare `properties`
+  predicate, which the parser rejects (`expected forall in property`), so every file
+  using `requires`/`ensures` failed `fmt --check` with exit 2 (fail-closed). 30
+  contract examples (`examples/runnable/contracts/*.ail` + `discount_calculator.ail`)
+  are now formattable and have been reformatted.
+- **Silent contract-deletion fix (`internal/parser/parser_func.go`)** — the
+  properties-block parse used assignment (`fn.Properties = …`), clobbering the
+  already-parsed `requires`/`ensures` entries whenever a function carried BOTH
+  contracts and a `properties [...]` block. `fmt --write` would then exit 0 while
+  **destroying the verified contract** (the loss happened at parse time, before the
+  fail-closed round-trip check could see it). Now appends, preserving contracts.
+- **Two adjacent Phase-1 printer round-trip bugs** the contract corpus exposed, fixed
+  so the corpus gate reaches zero: `startsWithStatementStarter` ignored
+  precedence-driven parenthesisation (a statement rendered `(a + b) * c` got no `;`
+  separator and re-parsed as a call); and `@verify(depth: N)` dropped the `depth:`
+  key at parse, so the printer emitted `@verify(N)` which failed to re-parse.
+- **Regression guard** — new acceptance-gated `TestCombinedContractsAndPropertiesPipeline`
+  locks the combined contracts+properties case end-to-end (contracts reach
+  `core.DeclMeta.Contracts` and Z3 verification, the forall reaches only the property
+  pipeline, exact-count no-duplication assertions, fmt round-trip preserves the
+  `requires` clause). `TestCorpusCommentGate` is hardened: `preexisting-Phase1-rt-bug`
+  dropped 28 → 0 and any future non-zero count now FAILS the test.
+
 ### Added — OS leaderboard release evolution + automatic release pickup
 
 Answers "does each AILANG release move the needle for local models?" directly on

--- a/design_docs/implemented/v0_30_0/m-fmt-properties-printer-roundtrip.md
+++ b/design_docs/implemented/v0_30_0/m-fmt-properties-printer-roundtrip.md
@@ -1,9 +1,6 @@
 # m-fmt-properties-printer-roundtrip — Contract-Clause Printer Round-Trip Fix
 
-**Status**: **UNPARKED — Mark 2026-07-20 ("yes lets finish off ailang fmt")**: the one persistent
-R2 objection is DATA-REFUTED (controller data-check, iter 66 — recorded in the Quorum Record); a
-text reviewer rejecting against measured data does not outrank the data. Route to sprint-planner;
-no re-quorum. fmt is a weak-model accessibility lever — finish the polish set.
+**Status**: **IMPLEMENTED** — sprint completed 2026-07-20, evaluation score 98/100 PASS (evaluator: claude-sonnet-4-6, round 1). Moved from planned/ by sprint-evaluator.
 **Target**: v0.30.0 (fmt Phase-1 correctness follow-up)
 **Priority**: P1
 **Estimated**: ~1 day

--- a/design_docs/planned/v0_30_0/m-fmt-properties-printer-roundtrip.md
+++ b/design_docs/planned/v0_30_0/m-fmt-properties-printer-roundtrip.md
@@ -245,18 +245,18 @@ emission is right.
 
 ### Implementation Plan
 
-**M1: Printer emission split + parser clobber fix** (~4h)
-- [ ] `internal/format/decl.go`: in `funcDecl`, after the effect row, partition `d.Properties`
+**M1: Printer emission split + parser clobber fix** (~4h) — ✅ IMPLEMENTED (commit 58eadd3b5)
+- [x] `internal/format/decl.go`: in `funcDecl`, after the effect row, partition `d.Properties`
       by `Kind`; emit `requires { … }` / `ensures { … }` clauses (comma-separated predicates,
       slice order). **Refactor `testsAndProperties` to accept a PRE-FILTERED
       `[]*ast.Property` (PropertyKind-only) parameter** instead of reading `d.Properties`
       itself — so it structurally CANNOT re-emit the contract clauses already printed in
       signature position (reviewer nit, gemini-3-1-pro).
-- [ ] `internal/parser/parser_func.go:169`: `fn.Properties = p.parsePropertiesBlock()` →
+- [x] `internal/parser/parser_func.go:169`: `fn.Properties = p.parsePropertiesBlock()` →
       `fn.Properties = append(fn.Properties, p.parsePropertiesBlock()...)` — explicit slice
       unpacking (reviewer nit, gemini-3-1-pro); preserves contracts when a `properties [...]`
       block follows; append order matches print order.
-- [ ] Unit tests (`internal/format/`): round-trip fixtures for (a) requires-only, (b) ensures-only,
+- [x] Unit tests (`internal/format/`): round-trip fixtures for (a) requires-only, (b) ensures-only,
       (c) both, (d) multi-predicate `requires { a, b }`, (e) ensures containing `ForallExpr`,
       (f) genuine `forall(...)` properties block (no parse-valid corpus file exercises this —
       verified: only `examples/experimental/factorial.ail` contains `properties [` and it does
@@ -264,8 +264,8 @@ emission is right.
       round-trip (must assert the `requires` entry survives; the same fixture also feeds the
       acceptance-gated integration test in M2).
 
-**M2: Regression guard + corpus green** (~3h)
-- [ ] **Acceptance-gated combined-case integration test** (blocks acceptance; see Success
+**M2: Regression guard + corpus green** (~3h) — ✅ IMPLEMENTED
+- [x] **Acceptance-gated combined-case integration test** (blocks acceptance; see Success
       Criteria): check in a synthetic fixture `internal/format/testdata/contracts_and_properties.ail`
       containing BOTH a contract and a genuine properties block on one function:
       `export func f(x: int) -> int ! {}` with `requires { x >= 0 }`, `ensures { result >= 0 }`,
@@ -288,12 +288,15 @@ emission is right.
         (`== 1`, not `>= 1`); the test completing without panic covers panic-freedom; plus
         the M1(g) fmt round-trip on the same fixture asserts `cmp.Diff` AST identity with the
         `requires` clause present in the output.
-- [ ] `internal/format/corpus_comment_test.go`: harden the gate — `preExistingRT` moves from
+- [x] `internal/format/corpus_comment_test.go`: harden the gate — `preExistingRT` moves from
       logged-and-tolerated into the `t.Fatalf` condition (`preExistingRT != 0` fails).
-- [ ] Run `ailang fmt --write` over the 28 now-eligible files; verify `ailang check` (and for the
-      verify-corpus files, `ailang ai-check --json`) still passes on every reformatted file.
-- [ ] Acceptance sweep (see Success Criteria).
-- [ ] CHANGELOG.md entry; note the silent-deletion fix explicitly.
+- [x] Run `ailang fmt --write` over the now-eligible files (30, not 28 — two adjacent Phase-1
+      printer bugs were also fixed, making `scoring.ail` + `per_function_depth_verify.ail`
+      formattable); verified `ailang check` (and `ailang ai-check` for the verify-corpus files)
+      still passes on every reformatted file. `discount_calculator.ail` retains a PRE-EXISTING,
+      unrelated `++`-on-string type error (expected-fail demo), not a reformat regression.
+- [x] Acceptance sweep (see Success Criteria) — passes.
+- [x] CHANGELOG.md entry; silent-deletion data-loss fix noted explicitly.
 
 ### Files to Modify/Create
 
@@ -387,24 +390,24 @@ after the split only `forall`-carrying `PropertyKind` entries may appear there.
 
 ## Success Criteria
 
-- [ ] The minimal repro (`cf_contract.ail` above) formats: `fmt --check` exits 1 (needs
-      reformat) or 0 — never exit 2 — and `fmt` output re-parses with identical AST.
-- [ ] The contracts+properties combined file round-trips WITHOUT losing the `requires` clause.
-- [ ] **Acceptance-gated**: `TestCombinedContractsAndPropertiesPipeline` (M2) passes — the
+- [x] The minimal repro (`cf_contract.ail` above) formats: `fmt --check` exits 1 (needs
+      reformat) or 0 — never exit 2 — and `fmt` output re-parses with identical AST. (Verified: exit 1.)
+- [x] The contracts+properties combined file round-trips WITHOUT losing the `requires` clause.
+- [x] **Acceptance-gated**: `TestCombinedContractsAndPropertiesPipeline` (M2) passes — the
       combined fixture checks clean, the contract reaches `DeclMeta.Contracts` (and `ai-check`
       verification), the forall reaches only the property pipeline, with exact-count
       (no-duplication/no-omission) assertions and no panic.
-- [ ] `for f in examples/runnable/contracts/*.ail examples/ai_devtools_workflow/*.ail` —
+- [x] `for f in examples/runnable/contracts/*.ail examples/ai_devtools_workflow/*.ail` —
       zero exit-2 results from `ailang fmt --check`, excepting exactly
       `inbox_injection_v2.ail` and `inbox_v2_app.ail` (comment-attachment carve-out, unchanged
       error message).
-- [ ] After `fmt --write` on the 28 eligible files: `ailang fmt --check` on them exits **0**, and
-      `ailang check` passes on every one (verify-corpus files also re-pass `ailang ai-check`).
-- [ ] `go test ./internal/format/`: `TestCorpusCommentGate` reports
+- [x] After `fmt --write` on the eligible files (30): `ailang fmt --check` on them exits **0**, and
+      `ailang check` passes on every one (verify-corpus files also re-pass `ailang ai-check`;
+      `discount_calculator.ail` retains a pre-existing unrelated `++` type error).
+- [x] `go test ./internal/format/`: `TestCorpusCommentGate` reports
       `preexisting-Phase1-rt-bug=0` and the hardened gate fails on any future non-zero count.
-- [ ] `make test` green; `make verify-examples` green (watch for manifest-drift, not type
-      regressions, if red).
-- [ ] CHANGELOG.md updated.
+- [x] `make test` green; `make verify-examples` green (0 drift).
+- [x] CHANGELOG.md updated.
 
 ## Testing Strategy
 

--- a/examples/ai_devtools_workflow/discount_calculator.ail
+++ b/examples/ai_devtools_workflow/discount_calculator.ail
@@ -10,8 +10,7 @@ type Tier = Bronze | Silver | Gold | Platinum
 
 -- Calculate discount percentage based on tier
 export func discountPercent(tier: Tier) -> int ! {}
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   match tier {
     Bronze => 5,
     Silver => 10,
@@ -23,33 +22,27 @@ ensures { result >= 0 }
 -- Apply discount to a price (returns discounted price)
 export func applyDiscount(price: int, tier: Tier) -> int ! {}
 requires { price >= 0 }
-ensures { result >= 0 }
-{
-  let discount = discountPercent(tier);
-  price - (price * discount / 100)
+ensures { result >= 0 } {
+  let discount = discountPercent(tier)
+  price - price * discount / 100
 }
 
 -- Check if a customer qualifies for free shipping
 export func freeShipping(totalAfterDiscount: int) -> bool ! {}
 requires { totalAfterDiscount >= 0 }
-ensures { result == (totalAfterDiscount >= 50) }
-{
+ensures { result == totalAfterDiscount >= 50 } {
   totalAfterDiscount >= 50
 }
 
 -- Entry point: demonstrate the calculator
 export func main() -> () ! {IO} = {
-  let price = 100;
-
-  let bronzePrice = applyDiscount(price, Bronze);
-  println("Bronze: " ++ show(bronzePrice));
-
-  let goldPrice = applyDiscount(price, Gold);
-  println("Gold: " ++ show(goldPrice));
-
-  let platinumPrice = applyDiscount(price, Platinum);
-  println("Platinum: " ++ show(platinumPrice));
-
-  let ships = freeShipping(goldPrice);
+  let price = 100
+  let bronzePrice = applyDiscount(price, Bronze)
+  println("Bronze: " ++ show(bronzePrice))
+  let goldPrice = applyDiscount(price, Gold)
+  println("Gold: " ++ show(goldPrice))
+  let platinumPrice = applyDiscount(price, Platinum)
+  println("Platinum: " ++ show(platinumPrice))
+  let ships = freeShipping(goldPrice)
   println("Gold free shipping: " ++ show(ships))
 }

--- a/examples/runnable/contracts/access_control.ail
+++ b/examples/runnable/contracts/access_control.ail
@@ -13,8 +13,7 @@ export type Permission = GRANTED | DENIED
 -- Map role to numeric access level (0-100)
 -- Z3 proves: level is always within bounds
 export func accessLevel(role: Role) -> int ! {}
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   match role {
     ADMIN => 100,
     EDITOR => 50,
@@ -24,8 +23,7 @@ ensures { result >= 0 }
 
 -- Check if a role has sufficient access — CALLS accessLevel (cross-function!)
 export func canAccess(role: Role, requiredLevel: int) -> Permission ! {}
-requires { requiredLevel >= 0 }
-{
+requires { requiredLevel >= 0 } {
   if accessLevel(role) >= requiredLevel then GRANTED else DENIED
 }
 
@@ -33,17 +31,15 @@ requires { requiredLevel >= 0 }
 -- CALLS accessLevel — Z3 inlines it and proves result >= 0
 export func effectiveLevel(role: Role, penalty: int) -> int ! {}
 requires { penalty >= 0 }
-ensures { result >= 0 }
-{
-  let base = accessLevel(role);
+ensures { result >= 0 } {
+  let base = accessLevel(role)
   if base >= penalty then base - penalty else 0
 }
 
 -- Entry point for testing
-export func main() -> int ! {}
-{
-  let adminLevel = accessLevel(ADMIN);        -- 100
-  let viewerLevel = accessLevel(VIEWER);      -- 10
-  let effective = effectiveLevel(EDITOR, 20); -- 30
+export func main() -> int ! {} {
+  let adminLevel = accessLevel(ADMIN)  -- 100
+  let viewerLevel = accessLevel(VIEWER)  -- 10
+  let effective = effectiveLevel(EDITOR, 20)  -- 30
   adminLevel + viewerLevel + effective
 }

--- a/examples/runnable/contracts/basic.ail
+++ b/examples/runnable/contracts/basic.ail
@@ -11,43 +11,36 @@ export type Status = OK | FAIL
 -- requires: x must be non-negative
 export func absolute(x: int) -> int ! {}
 requires { x >= 0 }
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   x
 }
 
 -- Function with multiple requires predicates
 export func safeDivide(dividend: int, divisor: int) -> int ! {}
 requires { divisor != 0 }
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   dividend / divisor
 }
 
 -- Function with both requires and ensures
 export func increment(x: int, max: int) -> int ! {}
 requires { x >= 0 }
-ensures { result > x }
-{
+ensures { result > x } {
   if x + 1 > max then max else x + 1
 }
 
 -- Function demonstrating 'result' in ensures
 export func clamp(value: int, minVal: int, maxVal: int) -> int ! {}
 requires { minVal <= maxVal }
-ensures { result >= minVal }
-{
-  if value < minVal then minVal
-  else if value > maxVal then maxVal
-  else value
+ensures { result >= minVal } {
+  if value < minVal then minVal else if value > maxVal then maxVal else value
 }
 
 -- Simple entry point for testing
-export func main() -> int ! {}
-{
-  let a = absolute(5);
-  let b = safeDivide(10, 2);
-  let c = increment(5, 100);
-  let d = clamp(150, 0, 100);
+export func main() -> int ! {} {
+  let a = absolute(5)
+  let b = safeDivide(10, 2)
+  let c = increment(5, 100)
+  let d = clamp(150, 0, 100)
   a + b + c + d
 }

--- a/examples/runnable/contracts/cross_function.ail
+++ b/examples/runnable/contracts/cross_function.ail
@@ -7,12 +7,12 @@ module examples/runnable/contracts/cross_function
 
 -- Delivery pricing with layered business rules
 export type Region = DOMESTIC | INTERNATIONAL
+
 export type Priority = EXPRESS | STANDARD | ECONOMY
 
 -- Base shipping cost depends on region
 export func baseCost(region: Region) -> int ! {}
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   match region {
     DOMESTIC => 5,
     INTERNATIONAL => 15
@@ -21,8 +21,7 @@ ensures { result >= 0 }
 
 -- Priority multiplier (1x, 2x, or 3x)
 export func priorityMultiplier(priority: Priority) -> int ! {}
-ensures { result >= 1 }
-{
+ensures { result >= 1 } {
   match priority {
     ECONOMY => 1,
     STANDARD => 2,
@@ -33,8 +32,7 @@ ensures { result >= 1 }
 -- Total shipping cost — CALLS baseCost AND priorityMultiplier
 -- Z3 inlines both callees and proves result >= 0
 export func shippingCost(region: Region, priority: Priority) -> int ! {}
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   baseCost(region) * priorityMultiplier(priority)
 }
 
@@ -43,17 +41,15 @@ ensures { result >= 0 }
 -- Z3 verifies the full 3-function call chain
 export func discountedCost(region: Region, priority: Priority, discount: int) -> int ! {}
 requires { discount >= 0 }
-ensures { result >= 0 }
-{
-  let total = shippingCost(region, priority);
+ensures { result >= 0 } {
+  let total = shippingCost(region, priority)
   if total >= discount then total - discount else 0
 }
 
 -- Entry point for testing
-export func main() -> int ! {}
-{
-  let domestic = shippingCost(DOMESTIC, STANDARD);       -- 10
-  let intl = shippingCost(INTERNATIONAL, EXPRESS);       -- 45
-  let discounted = discountedCost(DOMESTIC, ECONOMY, 3); -- 2
+export func main() -> int ! {} {
+  let domestic = shippingCost(DOMESTIC, STANDARD)  -- 10
+  let intl = shippingCost(INTERNATIONAL, EXPRESS)  -- 45
+  let discounted = discountedCost(DOMESTIC, ECONOMY, 3)  -- 2
   domestic + intl + discounted
 }

--- a/examples/runnable/contracts/cross_module_functions.ail
+++ b/examples/runnable/contracts/cross_module_functions.ail
@@ -23,8 +23,7 @@ import examples/runnable/contracts/cross_module_functions_lib (double, sumTo)
 -- Z3 sees: double(x) = x + x, so double(double(n)) = 4*n.
 -- Proves result == n * 4.
 export func quadruple(n: int) -> int ! {}
-ensures { result == n * 4 }
-{
+ensures { result == n * 4 } {
   double(double(n))
 }
 
@@ -33,8 +32,7 @@ ensures { result == n * 4 }
 -- From that axiom, result >= 0 follows immediately. Proved.
 export func sumBound(n: int) -> int ! {}
 requires { n >= 0 }
-ensures  { result >= 0 }
-{
+ensures { result >= 0 } {
   sumTo(n)
 }
 
@@ -45,14 +43,12 @@ ensures  { result >= 0 }
 -- Z3 proves result >= 0 from those two constraints.
 export func mixed(n: int) -> int ! {}
 requires { n >= 0 }
-ensures  { result >= 0 }
-{
+ensures { result >= 0 } {
   double(n) + sumTo(n)
 }
 
-export func main() -> int ! {}
-{
-  let q = quadruple(3);   -- 12
-  let s = sumBound(4);    -- some non-negative value
+export func main() -> int ! {} {
+  let q = quadruple(3)  -- 12
+  let s = sumBound(4)  -- some non-negative value
   q + s
 }

--- a/examples/runnable/contracts/cross_module_functions_lib.ail
+++ b/examples/runnable/contracts/cross_module_functions_lib.ail
@@ -13,8 +13,7 @@ module examples/runnable/contracts/cross_module_functions_lib
 -- Non-recursive, so the verifier inlines its body as a define-fun
 -- into any caller function, enabling compositional proof.
 export func double(n: int) -> int ! {}
-ensures { result == n + n }
-{
+ensures { result == n + n } {
   n + n
 }
 
@@ -26,7 +25,6 @@ ensures { result == n + n }
 -- so callers that only need result >= 0 can still be verified.
 export func sumTo(n: int) -> int ! {}
 requires { n >= 0 }
-ensures  { result >= 0 }
-{
+ensures { result >= 0 } {
   if n <= 0 then 0 else n + sumTo(n - 1)
 }

--- a/examples/runnable/contracts/cross_module_types.ail
+++ b/examples/runnable/contracts/cross_module_types.ail
@@ -16,7 +16,9 @@
 module examples/runnable/contracts/cross_module_types
 
 import examples/runnable/contracts/cross_module_types_lib (Cell, Tree)
+
 import std/list (length as listLength)
+
 import std/string (trim)
 
 -- M1 + M3a: parameter `text` shares its name with Cell.text accessor.
@@ -25,8 +27,7 @@ import std/string (trim)
 -- unambiguous to Z3.
 export pure func makeCell(text: string, count: int) -> Cell ! {}
 requires { count >= 0 }
-ensures  { result.count >= 0 }
-{
+ensures { result.count >= 0 } {
   { text: text, count: count }
 }
 
@@ -34,8 +35,7 @@ ensures  { result.count >= 0 }
 -- the alias map down to {Cell} for THIS function — Tree never appears in
 -- its preamble, so the recursion in Tree cannot cascade-poison verification.
 export pure func emptyCell() -> Cell ! {}
-ensures { result.count == 0 }
-{
+ensures { result.count == 0 } {
   { text: "", count: 0 }
 }
 
@@ -43,9 +43,8 @@ ensures { result.count == 0 }
 -- declare-datatypes (plural) for the Tree <-> Record_label_subtrees cycle.
 -- Pre-M2 this would SKIP with "sort 'Tree' referenced in declaration of
 -- 'Record_label_subtrees' is not declared".
-export pure func countNodes(subtrees: [Tree]) -> int ! {}
-ensures { result >= 0 }
-{
+export pure func countNodes(subtrees: list[Tree]) -> int ! {}
+ensures { result >= 0 } {
   listLength(subtrees)
 }
 
@@ -53,8 +52,7 @@ ensures { result >= 0 }
 -- works the same as makeCell above.
 export pure func bumpCount(c: Cell, count: int) -> int ! {}
 requires { c.count >= 0, count >= 0 }
-ensures  { result >= c.count }
-{
+ensures { result >= c.count } {
   c.count + count
 }
 
@@ -64,16 +62,14 @@ ensures  { result >= c.count }
 -- Without M4 the message would be the generic "uses types not encodable in
 -- SMT (list, unsupported string operations)" — leaving the user guessing.
 export pure func trimText(s: string) -> string ! {}
-ensures { result == result }
-{
+ensures { result == result } {
   trim(s)
 }
 
 -- Entry point.
-export func main() -> int ! {}
-{
-  let c = makeCell("hello", 3);
-  let bumped = bumpCount(c, 5);
-  let nodes = countNodes([]);
+export func main() -> int ! {} {
+  let c = makeCell("hello", 3)
+  let bumped = bumpCount(c, 5)
+  let nodes = countNodes([])
   bumped + nodes
 }

--- a/examples/runnable/contracts/cross_module_types_lib.ail
+++ b/examples/runnable/contracts/cross_module_types_lib.ail
@@ -10,10 +10,7 @@ module examples/runnable/contracts/cross_module_types_lib
 --   (declare-datatype Cell ((mk_Cell (text String) (count Int))))
 -- only into functions that actually reference it, thanks to per-function
 -- demand-driven filtering (M1).
-export type Cell = {
-  text: string,
-  count: int
-}
+export type Cell = { text: string, count: int }
 
 -- Self-recursive ADT — the SectionNode variant references its own type via
 -- an inline record. Pre-sprint, the inline record would have referenced
@@ -21,5 +18,4 @@ export type Cell = {
 -- Post-M2, this is encoded as a single
 --   (declare-datatypes ((Tree 0) (Record_label_subtrees 0)) (...))
 -- block, which Z3 accepts.
-export type Tree = LeafNode({value: int})
-                 | SectionNode({label: string, subtrees: [Tree]})
+export type Tree = LeafNode({ value: int }) | SectionNode({ label: string, subtrees: list[Tree] })

--- a/examples/runnable/contracts/ensures_violation_demo.ail
+++ b/examples/runnable/contracts/ensures_violation_demo.ail
@@ -14,20 +14,14 @@ module examples/runnable/contracts/ensures_violation_demo
 
 -- INTENTIONAL BUG: returns -1 for negative inputs (violates `result >= 0`).
 export pure func clampBuggy(x: int) -> int
-  ensures { result >= 0 && result <= 10 }
-{
-  if x < 0 then -1
-  else if x > 10 then 10
-  else x
+ensures { result >= 0 && result <= 10 } {
+  if x < 0 then -1 else if x > 10 then 10 else x
 }
 
 -- Correct implementation; same `ensures` clause; should pass.
 export pure func clampOk(x: int) -> int
-  ensures { result >= 0 && result <= 10 }
-{
-  if x < 0 then 0
-  else if x > 10 then 10
-  else x
+ensures { result >= 0 && result <= 10 } {
+  if x < 0 then 0 else if x > 10 then 10 else x
 }
 
 export func main() -> int ! {} {

--- a/examples/runnable/contracts/finance.ail
+++ b/examples/runnable/contracts/finance.ail
@@ -11,8 +11,7 @@ export type TaxBracket = STANDARD | REDUCED | EXEMPT
 -- Z3 proves: tax is always non-negative AND never exceeds income
 export func calculateTax(income: int, bracket: TaxBracket) -> int ! {}
 requires { income >= 0 }
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   match bracket {
     EXEMPT => 0,
     REDUCED => income / 10,
@@ -24,8 +23,7 @@ ensures { result >= 0 }
 -- Z3 inlines calculateTax as (define-fun) and proves netIncome >= 0
 export func netIncome(gross: int, bracket: TaxBracket) -> int ! {}
 requires { gross >= 0 }
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   gross - calculateTax(gross, bracket)
 }
 
@@ -33,17 +31,15 @@ ensures { result >= 0 }
 -- Z3 will find inputs where discount > price, violating ensures { result >= 0 }
 export func brokenDiscount(price: int, discount: int) -> int ! {}
 requires { price >= 0 }
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   price - discount
 }
 
 -- Entry point for testing
-export func main() -> int ! {}
-{
-  let tax1 = calculateTax(1000, STANDARD);   -- 200
-  let tax2 = calculateTax(1000, REDUCED);    -- 100
-  let tax3 = calculateTax(1000, EXEMPT);     -- 0
-  let net = netIncome(5000, STANDARD);       -- 4000
+export func main() -> int ! {} {
+  let tax1 = calculateTax(1000, STANDARD)  -- 200
+  let tax2 = calculateTax(1000, REDUCED)  -- 100
+  let tax3 = calculateTax(1000, EXEMPT)  -- 0
+  let net = netIncome(5000, STANDARD)  -- 4000
   tax1 + tax2 + tax3 + net
 }

--- a/examples/runnable/contracts/hof_verify.ail
+++ b/examples/runnable/contracts/hof_verify.ail
@@ -12,25 +12,22 @@ import std/list (length as listLength, map, filter)
 -- Increment all elements: map(\x. x + 1, xs)
 -- The SMT verifier specializes this into a recursive function
 -- and proves that the result length equals the input length.
-export func incrementAll(xs: [int]) -> [int] ! {}
-ensures { listLength(result) >= 0 }
-{
+export func incrementAll(xs: list[int]) -> list[int] ! {}
+ensures { listLength(result) >= 0 } {
   map(\x. x + 1, xs)
 }
 
 -- Filter positive elements: filter(\x. x > 0, xs)
 -- Verifies that the filtered result has non-negative length.
-export func positives(xs: [int]) -> [int] ! {}
-ensures { listLength(result) >= 0 }
-{
+export func positives(xs: list[int]) -> list[int] ! {}
+ensures { listLength(result) >= 0 } {
   filter(\x. x > 0, xs)
 }
 
 -- Entry point
-export func main() -> int ! {}
-{
-  let xs = [1, 2, 3, 4, 5];
-  let incremented = incrementAll(xs);
-  let pos = positives(xs);
+export func main() -> int ! {} {
+  let xs = [1, 2, 3, 4, 5]
+  let incremented = incrementAll(xs)
+  let pos = positives(xs)
   listLength(incremented) + listLength(pos)
 }

--- a/examples/runnable/contracts/inbox_injection.ail
+++ b/examples/runnable/contracts/inbox_injection.ail
@@ -37,15 +37,13 @@ type SendAction = { to: string, body: string }
 -- email". A real summariser would expose a length bound or alphabet
 -- restriction instead; the shape of the proof is the same.
 export pure func summarize(emailBody: string) -> string ! {}
-ensures { result == "[summary]" }
-{
+ensures { result == "[summary]" } {
   "[summary]"
 }
 
 -- Domain check: only @company.com recipients are internal.
 export pure func isInternal(addr: string) -> bool ! {}
-ensures { result == endsWith(addr, "@company.com") }
-{
+ensures { result == endsWith(addr, "@company.com") } {
   endsWith(addr, "@company.com")
 }
 
@@ -58,8 +56,7 @@ ensures { result == endsWith(addr, "@company.com") }
 --   2. result.body equals "[summary]" -- the raw email never reaches the wire
 export pure func safeForward(rawEmail: string, recipient: string) -> SendAction ! {}
 requires { endsWith(recipient, "@company.com") }
-ensures  { endsWith(result.to, "@company.com"), result.body == "[summary]" }
-{
+ensures { endsWith(result.to, "@company.com"), result.body == "[summary]" } {
   { to: recipient, body: summarize(rawEmail) }
 }
 
@@ -72,8 +69,7 @@ ensures  { endsWith(result.to, "@company.com"), result.body == "[summary]" }
 -- the paper, caught without running anything.
 export pure func injectedForward(rawEmail: string, recipient: string) -> SendAction ! {}
 requires { endsWith(recipient, "@company.com") }
-ensures  { endsWith(result.to, "@company.com"), result.body == "[summary]" }
-{
+ensures { endsWith(result.to, "@company.com"), result.body == "[summary]" } {
   { to: recipient, body: rawEmail }
 }
 
@@ -86,8 +82,7 @@ ensures  { endsWith(result.to, "@company.com"), result.body == "[summary]" }
 -- "send_email to a forbidden domain" guardians automaton case as a
 -- straight Z3 string-suffix check.
 export pure func externalLeak(rawEmail: string) -> SendAction ! {}
-ensures { endsWith(result.to, "@company.com"), result.body == "[summary]" }
-{
+ensures { endsWith(result.to, "@company.com"), result.body == "[summary]" } {
   { to: "attacker@evil.com", body: summarize(rawEmail) }
 }
 
@@ -95,8 +90,7 @@ ensures { endsWith(result.to, "@company.com"), result.body == "[summary]" }
 -- Entry point
 -- ----------------------------------------------------------------------------
 
-export func main() -> int ! {}
-{
-  let action = safeForward("any-email-content", "alice@company.com");
+export func main() -> int ! {} {
+  let action = safeForward("any-email-content", "alice@company.com")
   if isInternal(action.to) then strLength(action.body) else 0
 }

--- a/examples/runnable/contracts/inbox_v2_lib.ail
+++ b/examples/runnable/contracts/inbox_v2_lib.ail
@@ -16,7 +16,4 @@ module examples/runnable/contracts/inbox_v2_lib
 -- The label travels cross-module through the iface JSON: the importing
 -- module sees `body: string<email>` even though the underlying value
 -- is a plain string at runtime.
-export type Mail = {
-  body: string<email>,
-  subject: string<email>
-}
+export type Mail = { body: string<email>, subject: string<email> }

--- a/examples/runnable/contracts/insurance.ail
+++ b/examples/runnable/contracts/insurance.ail
@@ -27,8 +27,7 @@ export type Region = URBAN | SUBURBAN | RURAL
 -- Base premium by age band (cents to avoid floats)
 -- Z3 proves: base premium is always positive and bounded
 export func basePremium(age: AgeBand) -> int ! {}
-ensures { result >= 100 }
-{
+ensures { result >= 100 } {
   match age {
     YOUTH => 200,
     ADULT => 150,
@@ -40,39 +39,37 @@ ensures { result >= 100 }
 -- Risk multiplier as percentage (100 = 1.0x, 200 = 2.0x)
 -- Z3 proves: multiplier is always at least 100% (no discounts below base)
 export func riskMultiplier(tier: RiskTier, history: ClaimHistory) -> int ! {}
-ensures { result >= 100 }
-{
+ensures { result >= 100 } {
   let tierBase = match tier {
     LOW => 100,
     MEDIUM => 150,
     HIGH => 250,
     CRITICAL => 400
-  };
+  }
   let historyAdj = match history {
     CLEAN => 0,
     MINOR => 25,
     MAJOR => 75,
     MULTIPLE => 150
-  };
+  }
   tierBase + historyAdj
 }
 
 -- Coverage surcharge (added to final premium)
 -- Z3 proves: surcharge is non-negative
 export func coverageSurcharge(cov: Coverage, region: Region) -> int ! {}
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   let covBase = match cov {
     BASIC => 0,
     STANDARD => 50,
     PREMIUM => 150,
     PLATINUM => 350
-  };
+  }
   let regionAdj = match region {
     URBAN => 40,
     SUBURBAN => 20,
     RURAL => 0
-  };
+  }
   covBase + regionAdj
 }
 
@@ -81,37 +78,36 @@ ensures { result >= 0 }
 -- This is the key function: 5 enum inputs, 4*4*4*4*3 = 768 paths
 -- Manual verification would require checking every combination
 export func calculatePremium(age: AgeBand, tier: RiskTier, history: ClaimHistory, cov: Coverage, region: Region) -> int ! {}
-ensures { result >= 100 }
-{
+ensures { result >= 100 } {
   let base = match age {
     YOUTH => 200,
     ADULT => 150,
     SENIOR => 300,
     ELDERLY => 500
-  };
+  }
   let mult = match tier {
     LOW => 100,
     MEDIUM => 150,
     HIGH => 250,
     CRITICAL => 400
-  };
+  }
   let histAdj = match history {
     CLEAN => 0,
     MINOR => 25,
     MAJOR => 75,
     MULTIPLE => 150
-  };
+  }
   let covBase = match cov {
     BASIC => 0,
     STANDARD => 50,
     PREMIUM => 150,
     PLATINUM => 350
-  };
+  }
   let regionAdj = match region {
     URBAN => 40,
     SUBURBAN => 20,
     RURAL => 0
-  };
+  }
   base * (mult + histAdj) / 100 + covBase + regionAdj
 }
 
@@ -121,32 +117,30 @@ ensures { result >= 100 }
 -- Z3 will find the exact combination that breaks it.
 export func applyDiscount(age: AgeBand, tier: RiskTier, discountPercent: int) -> int ! {}
 requires { discountPercent >= 0 }
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   let base = match age {
     YOUTH => 200,
     ADULT => 150,
     SENIOR => 300,
     ELDERLY => 500
-  };
+  }
   let mult = match tier {
     LOW => 100,
     MEDIUM => 150,
     HIGH => 250,
     CRITICAL => 400
-  };
-  let premium = base * mult / 100;
-  let discount = premium * discountPercent / 100;
+  }
+  let premium = base * mult / 100
+  let discount = premium * discountPercent / 100
   -- Bug: should be "if discount > premium then 0 else premium - discount"
   -- but the developer forgot to cap discountPercent, so if > 100, result < 0
   premium - discount
 }
 
 -- Entry point
-export func main() -> int ! {}
-{
-  let p1 = calculatePremium(YOUTH, HIGH, CLEAN, STANDARD, URBAN);
-  let p2 = calculatePremium(ELDERLY, CRITICAL, MULTIPLE, PLATINUM, URBAN);
-  let p3 = calculatePremium(ADULT, LOW, CLEAN, BASIC, RURAL);
+export func main() -> int ! {} {
+  let p1 = calculatePremium(YOUTH, HIGH, CLEAN, STANDARD, URBAN)
+  let p2 = calculatePremium(ELDERLY, CRITICAL, MULTIPLE, PLATINUM, URBAN)
+  let p3 = calculatePremium(ADULT, LOW, CLEAN, BASIC, RURAL)
   p1 + p2 + p3
 }

--- a/examples/runnable/contracts/invoice.ail
+++ b/examples/runnable/contracts/invoice.ail
@@ -25,6 +25,7 @@
 module examples/runnable/contracts/invoice
 
 import std/string (length as strLength, startsWith)
+
 import std/list (length as listLength)
 
 -- ============================================================================
@@ -32,6 +33,7 @@ import std/list (length as listLength)
 -- ============================================================================
 
 export type CustomerTier = ENTERPRISE | BUSINESS | STARTER | TRIAL | FREE
+
 export type TaxRegion = US_STANDARD | US_REDUCED | EU_STANDARD | EU_REDUCED | TAX_EXEMPT
 
 -- ============================================================================
@@ -41,14 +43,13 @@ export type TaxRegion = US_STANDARD | US_REDUCED | EU_STANDARD | EU_REDUCED | TA
 -- Tax rate by region
 -- Z3 proves: rate is always non-negative and bounded ≤ 2000
 export func taxRate(region: TaxRegion) -> int ! {}
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   match region {
     US_STANDARD => 875,
-    US_REDUCED  => 400,
+    US_REDUCED => 400,
     EU_STANDARD => 2000,
-    EU_REDUCED  => 700,
-    TAX_EXEMPT  => 0
+    EU_REDUCED => 700,
+    TAX_EXEMPT => 0
   }
 }
 
@@ -56,8 +57,7 @@ ensures { result >= 0 }
 -- Z3 inlines taxRate and proves tax is non-negative for any amount ≥ 0
 export func calculateTax(amount: int, region: TaxRegion) -> int ! {}
 requires { amount >= 0 }
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   amount * taxRate(region) / 10000
 }
 
@@ -68,14 +68,13 @@ ensures { result >= 0 }
 -- Discount rate by customer tier (basis points)
 -- Z3 proves: discount is bounded and non-negative
 export func tierDiscountRate(tier: CustomerTier) -> int ! {}
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   match tier {
     ENTERPRISE => 2500,
-    BUSINESS   => 1500,
-    STARTER    => 500,
-    TRIAL      => 1000,
-    FREE       => 0
+    BUSINESS => 1500,
+    STARTER => 500,
+    TRIAL => 1000,
+    FREE => 0
   }
 }
 
@@ -83,8 +82,7 @@ ensures { result >= 0 }
 -- Z3 proves: discounted amount is non-negative AND never exceeds original
 export func applyTierDiscount(amount: int, tier: CustomerTier) -> int ! {}
 requires { amount >= 0 }
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   amount - amount * tierDiscountRate(tier) / 10000
 }
 
@@ -95,8 +93,7 @@ ensures { result >= 0 }
 -- Validate promo code format: must start with "PROMO-" and be ≥ 8 chars
 -- Z3 proves this is equivalent to the conjunction (tautology check)
 export func isValidPromo(code: string) -> bool ! {}
-ensures { result == (startsWith(code, "PROMO-") && strLength(code) >= 8) }
-{
+ensures { result == (startsWith(code, "PROMO-") && strLength(code) >= 8) } {
   startsWith(code, "PROMO-") && strLength(code) >= 8
 }
 
@@ -104,11 +101,8 @@ ensures { result == (startsWith(code, "PROMO-") && strLength(code) >= 8) }
 -- Z3 proves: rebate is non-negative and bounded by the amount
 export func promoRebate(code: string, amount: int) -> int ! {}
 requires { amount >= 0 }
-ensures { result >= 0 }
-{
-  if startsWith(code, "PROMO-") && strLength(code) >= 8
-  then amount / 10
-  else 0
+ensures { result >= 0 } {
+  if startsWith(code, "PROMO-") && strLength(code) >= 8 then amount / 10 else 0
 }
 
 -- ============================================================================
@@ -116,17 +110,15 @@ ensures { result >= 0 }
 -- ============================================================================
 
 -- Count items in invoice — Z3 proves count is non-negative
-export func itemCount(items: [int]) -> int ! {}
-ensures { result >= 0 }
-{
+export func itemCount(items: list[int]) -> int ! {}
+ensures { result >= 0 } {
   listLength(items)
 }
 
 -- Adding a line item always increases count by exactly 1
 -- Z3 proves using sequence theory: len(x :: xs) = len(xs) + 1
-export func addItem(price: int, items: [int]) -> int ! {}
-ensures { result == listLength(items) + 1 }
-{
+export func addItem(price: int, items: list[int]) -> int ! {}
+ensures { result == listLength(items) + 1 } {
   listLength(price :: items)
 }
 
@@ -136,10 +128,9 @@ ensures { result == listLength(items) + 1 }
 
 -- Validate invoice summary record — Z3 proves net is always non-negative
 -- when discount doesn't exceed subtotal (a key business invariant)
-export func netFromSummary(inv: {subtotal: int, tax: int, discount: int}) -> int ! {}
+export func netFromSummary(inv: { subtotal: int, tax: int, discount: int }) -> int ! {}
 requires { inv.subtotal >= 0, inv.tax >= 0, inv.discount >= 0, inv.discount <= inv.subtotal }
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   inv.subtotal - inv.discount + inv.tax
 }
 
@@ -156,11 +147,10 @@ ensures { result >= 0 }
 -- = effectively infinite input space, but Z3 proves it in milliseconds
 export func invoiceTotal(subtotal: int, tier: CustomerTier, region: TaxRegion, promoCode: string) -> int ! {}
 requires { subtotal >= 0 }
-ensures { result >= 0 }
-{
-  let afterDiscount = applyTierDiscount(subtotal, tier);
-  let tax = calculateTax(afterDiscount, region);
-  let rebate = promoRebate(promoCode, afterDiscount);
+ensures { result >= 0 } {
+  let afterDiscount = applyTierDiscount(subtotal, tier)
+  let tax = calculateTax(afterDiscount, region)
+  let rebate = promoRebate(promoCode, afterDiscount)
   afterDiscount + tax - rebate
 }
 
@@ -176,10 +166,9 @@ ensures { result >= 0 }
 -- Z3 catches this before it ever reaches production.
 export func brokenVolumePrice(unitPrice: int, qty: int) -> int ! {}
 requires { unitPrice >= 0, qty >= 0 }
-ensures { result >= 0 }
-{
-  let lineTotal = unitPrice * qty;
-  let volumeDiscount = qty * 50;
+ensures { result >= 0 } {
+  let lineTotal = unitPrice * qty
+  let volumeDiscount = qty * 50
   lineTotal - volumeDiscount
 }
 
@@ -187,11 +176,10 @@ ensures { result >= 0 }
 -- Entry point
 -- ============================================================================
 
-export func main() -> int ! {}
-{
-  let enterprise = invoiceTotal(100000, ENTERPRISE, EU_STANDARD, "PROMO-LAUNCH");
-  let starter = invoiceTotal(5000, STARTER, US_STANDARD, "");
-  let net = netFromSummary({subtotal: 10000, tax: 800, discount: 500});
-  let items = itemCount([1000, 2000, 3000, 500]);
+export func main() -> int ! {} {
+  let enterprise = invoiceTotal(100000, ENTERPRISE, EU_STANDARD, "PROMO-LAUNCH")
+  let starter = invoiceTotal(5000, STARTER, US_STANDARD, "")
+  let net = netFromSummary({ subtotal: 10000, tax: 800, discount: 500 })
+  let items = itemCount([1000, 2000, 3000, 500])
   enterprise + starter + net + items
 }

--- a/examples/runnable/contracts/list_recursive_verify.ail
+++ b/examples/runnable/contracts/list_recursive_verify.ail
@@ -7,26 +7,23 @@ module examples/runnable/contracts/list_recursive_verify
 import std/list (length as listLength)
 
 -- Element containment: if a list contains an element, it has positive length
-export func containsImpliesNonEmpty(xs: [int], elem: int) -> bool ! {}
+export func containsImpliesNonEmpty(xs: list[int], elem: int) -> bool ! {}
 requires { _list_contains(xs, elem) == true }
-ensures { result == true }
-{
+ensures { result == true } {
   listLength(xs) > 0
 }
 
 -- Extract preserves bounds: extracted sublist length <= original
-export func extractBounded(xs: [int], offset: int, len: int) -> bool ! {}
+export func extractBounded(xs: list[int], offset: int, len: int) -> bool ! {}
 requires { offset >= 0, len >= 0, offset + len <= listLength(xs) }
-ensures { result == true }
-{
+ensures { result == true } {
   listLength(_list_extract(xs, offset, len)) <= listLength(xs)
 }
 
 -- Entry point
-export func main() -> int ! {}
-{
-  let xs = [10, 20, 30, 40, 50];
-  let has20 = _list_contains(xs, 20);
-  let sub = _list_extract(xs, 1, 2);
+export func main() -> int ! {} {
+  let xs = [10, 20, 30, 40, 50]
+  let has20 = _list_contains(xs, 20)
+  let sub = _list_extract(xs, 1, 2)
   if has20 then listLength(sub) else 0
 }

--- a/examples/runnable/contracts/list_verify.ail
+++ b/examples/runnable/contracts/list_verify.ail
@@ -8,16 +8,14 @@ module examples/runnable/contracts/list_verify
 import std/list (length as listLength)
 
 -- Length of a list is always non-negative
-export func safeListLength(xs: [int]) -> int ! {}
-ensures { result >= 0 }
-{
+export func safeListLength(xs: list[int]) -> int ! {}
+ensures { result >= 0 } {
   listLength(xs)
 }
 
 -- Prepending an element increases length by 1
-export func prependLength(x: int, xs: [int]) -> int ! {}
-ensures { result == listLength(xs) + 1 }
-{
+export func prependLength(x: int, xs: list[int]) -> int ! {}
+ensures { result == listLength(xs) + 1 } {
   listLength(x :: xs)
 }
 
@@ -25,35 +23,31 @@ ensures { result == listLength(xs) + 1 }
 -- Note: _list_head and _list_nth are used directly because
 -- the stdlib versions (std/list.head, std/list.nth) return Option,
 -- which has different semantics for contract verification.
-export func headIsNth0(xs: [int]) -> bool ! {}
+export func headIsNth0(xs: list[int]) -> bool ! {}
 requires { listLength(xs) > 0 }
-ensures { result == true }
-{
+ensures { result == true } {
   _list_head(xs) == _list_nth(xs, 0)
 }
 
 -- A singleton list always has length 1
 export func singletonLength(x: int) -> int ! {}
-ensures { result == 1 }
-{
+ensures { result == 1 } {
   listLength([x])
 }
 
 -- Intentionally BROKEN: claims all list elements are positive
 -- Z3 will find counterexample: a list with non-positive head
-export func brokenAllPositive(xs: [int]) -> bool ! {}
+export func brokenAllPositive(xs: list[int]) -> bool ! {}
 requires { listLength(xs) > 0 }
-ensures { result == true }
-{
+ensures { result == true } {
   _list_head(xs) > 0
 }
 
 -- Entry point
-export func main() -> int ! {}
-{
-  let xs = [10, 20, 30];
-  let len = safeListLength(xs);
-  let plen = prependLength(5, xs);
-  let eq = headIsNth0(xs);
+export func main() -> int ! {} {
+  let xs = [10, 20, 30]
+  let len = safeListLength(xs)
+  let plen = prependLength(5, xs)
+  let eq = headIsNth0(xs)
   if eq then len + plen else 0
 }

--- a/examples/runnable/contracts/nested_record_verify.ail
+++ b/examples/runnable/contracts/nested_record_verify.ail
@@ -15,27 +15,24 @@ module examples/runnable/contracts/nested_record_verify
 
 -- Extract the X coordinate from a nested position record
 -- Z3 proves: if inner.x >= 0, then result >= 0
-export func getInnerX(o: {name: string, pos: {x: int, y: int}}) -> int ! {}
+export func getInnerX(o: { name: string, pos: { x: int, y: int } }) -> int ! {}
 requires { o.pos.x >= 0 }
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   o.pos.x
 }
 
 -- Compute manhattan distance from nested position
 -- Z3 proves: if both inner coords are non-negative, sum is non-negative
-export func nestedManhattan(o: {name: string, pos: {x: int, y: int}}) -> int ! {}
+export func nestedManhattan(o: { name: string, pos: { x: int, y: int } }) -> int ! {}
 requires { o.pos.x >= 0, o.pos.y >= 0 }
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   o.pos.x + o.pos.y
 }
 
 -- Entry point
-export func main() -> int ! {}
-{
-  let obj = {name: "origin", pos: {x: 3, y: 4}};
-  let x = getInnerX(obj);
-  let m = nestedManhattan(obj);
+export func main() -> int ! {} {
+  let obj = { name: "origin", pos: { x: 3, y: 4 } }
+  let x = getInnerX(obj)
+  let m = nestedManhattan(obj)
   x + m
 }

--- a/examples/runnable/contracts/park.ail
+++ b/examples/runnable/contracts/park.ail
@@ -10,7 +10,9 @@ module examples/runnable/contracts/park
 
 -- Type vocabulary (matching ARC's datatypes/variables)
 export type Season = LOW_SEASON | HIGH_SEASON
+
 export type AgeClass = CHILD | ADULT | SENIOR
+
 export type AdmissionDecision = ADMIT | DENY
 
 -- Core policy function with contracts
@@ -18,16 +20,10 @@ export type AdmissionDecision = ADMIT | DENY
 -- ARC rule: "Children under 5 free in low season"
 export func admissionFee(age: int, season: Season) -> int ! {}
 requires { age >= 0 }
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   match season {
-    LOW_SEASON =>
-      if age < 5 then 0
-      else if age >= 65 then 5
-      else 15,
-    HIGH_SEASON =>
-      if age >= 65 then 10
-      else 20
+    LOW_SEASON => if age < 5 then 0 else if age >= 65 then 5 else 15,
+    HIGH_SEASON => if age >= 65 then 10 else 20
   }
 }
 
@@ -35,16 +31,14 @@ ensures { result >= 0 }
 -- Z3 proves: if budget >= 20, admission is ALWAYS granted (cross-function with admissionFee)
 export func canEnterPark(age: int, season: Season, budget: int) -> bool ! {}
 requires { age >= 0, budget >= 0 }
-ensures { result == (budget >= admissionFee(age, season)) }
-{
+ensures { result == budget >= admissionFee(age, season) } {
   budget >= admissionFee(age, season)
 }
 
 -- Senior discount: Z3 proves seniors ALWAYS pay less than adults
 -- Cross-function verification: inlines admissionFee for both calls
 export func seniorDiscount(season: Season) -> bool ! {}
-ensures { result == true }
-{
+ensures { result == true } {
   admissionFee(70, season) < admissionFee(30, season)
 }
 
@@ -52,22 +46,17 @@ ensures { result == true }
 -- Z3 proves: classification is exhaustive and consistent
 export func classifyAge(age: int) -> AgeClass ! {}
 requires { age >= 0 }
-ensures { result == (if age < 5 then CHILD else if age >= 65 then SENIOR else ADULT) }
-{
-  if age < 5 then CHILD
-  else if age >= 65 then SENIOR
-  else ADULT
+ensures { result == (if age < 5 then CHILD else if age >= 65 then SENIOR else ADULT) } {
+  if age < 5 then CHILD else if age >= 65 then SENIOR else ADULT
 }
 
 -- Entry point for testing
-export func main() -> int ! {}
-{
+export func main() -> int ! {} {
   -- Test cases from ARC paper scenarios
-  let seniorLow = admissionFee(70, LOW_SEASON);     -- Expected: 5
-  let seniorHigh = admissionFee(70, HIGH_SEASON);   -- Expected: 10
-  let childLow = admissionFee(3, LOW_SEASON);       -- Expected: 0
-  let adultHigh = admissionFee(30, HIGH_SEASON);    -- Expected: 20
-
+  let seniorLow = admissionFee(70, LOW_SEASON)  -- Expected: 5
+  let seniorHigh = admissionFee(70, HIGH_SEASON)  -- Expected: 10
+  let childLow = admissionFee(3, LOW_SEASON)  -- Expected: 0
+  let adultHigh = admissionFee(30, HIGH_SEASON)  -- Expected: 20
   -- Sum of all fees (5 + 10 + 0 + 20 = 35)
   seniorLow + seniorHigh + childLow + adultHigh
 }

--- a/examples/runnable/contracts/per_function_depth_verify.ail
+++ b/examples/runnable/contracts/per_function_depth_verify.ail
@@ -15,8 +15,7 @@ module examples/runnable/contracts/per_function_depth_verify
 @verify(depth: 5)
 export func fibonacci(n: int) -> int ! {}
 requires { n >= 0 }
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   if n <= 1 then n else fibonacci(n - 1) + fibonacci(n - 2)
 }
 
@@ -25,8 +24,7 @@ ensures { result >= 0 }
 @verify(depth: 2)
 export func factorial(n: int) -> int ! {}
 requires { n >= 0 }
-ensures { result >= 1 }
-{
+ensures { result >= 1 } {
   if n <= 0 then 1 else n * factorial(n - 1)
 }
 
@@ -34,17 +32,14 @@ ensures { result >= 1 }
 -- Uses the global --verify-recursive-depth default
 export func clamp(x: int, lo: int, hi: int) -> int ! {}
 requires { lo <= hi }
-ensures { result >= lo, result <= hi }
-{
-  if x < lo then lo
-  else if x > hi then hi
-  else x
+ensures { result >= lo, result <= hi } {
+  if x < lo then lo else if x > hi then hi else x
 }
 
 -- Entry point to make this runnable (not just verify-only)
 export func main() -> int ! {} {
-  let f5 = fibonacci(5);
-  let f4 = factorial(4);
-  let c = clamp(100, 0, 50);
+  let f5 = fibonacci(5)
+  let f4 = factorial(4)
+  let c = clamp(100, 0, 50)
   f5 + f4 + c
 }

--- a/examples/runnable/contracts/quantifier_verify.ail
+++ b/examples/runnable/contracts/quantifier_verify.ail
@@ -9,8 +9,7 @@ module examples/runnable/contracts/quantifier_verify
 -- some property holds.
 export func positiveRange(n: int) -> int ! {}
 requires { n >= 0 }
-ensures { forall i: 0..n => i >= 0 }
-{
+ensures { forall i: 0..n => i >= 0 } {
   n
 }
 
@@ -18,8 +17,7 @@ ensures { forall i: 0..n => i >= 0 }
 -- Verifies that the result is always >= every index in the range
 export func doubleRange(n: int) -> int ! {}
 requires { n >= 0 }
-ensures { result >= n }
-{
+ensures { result >= n } {
   n * 2
 }
 
@@ -27,15 +25,14 @@ ensures { result >= n }
 -- Multiple contract predicates work alongside forall
 export func clampedAdd(x: int, y: int) -> int ! {}
 requires { x >= 0, y >= 0 }
-ensures { result >= x }
-{
+ensures { result >= x } {
   x + y
 }
 
 -- Entry point to make this runnable (not just verify-only)
 export func main() -> int ! {} {
-  let p = positiveRange(5);
-  let d = doubleRange(3);
-  let c = clampedAdd(10, 20);
+  let p = positiveRange(5)
+  let d = doubleRange(3)
+  let c = clampedAdd(10, 20)
   p + d + c
 }

--- a/examples/runnable/contracts/record_discovery_verify.ail
+++ b/examples/runnable/contracts/record_discovery_verify.ail
@@ -14,10 +14,9 @@ module examples/runnable/contracts/record_discovery_verify
 -- Previously caused "unknown record type" ERROR
 -- ============================================================================
 
-export func makePoint(px: int, py: int) -> {x: int, y: int} ! {}
+export func makePoint(px: int, py: int) -> { x: int, y: int } ! {}
 requires { px >= 0, py >= 0 }
-ensures { result.x == px, result.y == py }
-{
+ensures { result.x == px, result.y == py } {
   { x: px, y: py }
 }
 
@@ -27,10 +26,9 @@ ensures { result.x == px, result.y == py }
 -- Return record type must be discovered separately from param record
 -- ============================================================================
 
-export func transform(input: {a: int, b: int}) -> {x: int, y: int} ! {}
+export func transform(input: { a: int, b: int }) -> { x: int, y: int } ! {}
 requires { input.a >= 0 }
-ensures { result.x >= 1 }
-{
+ensures { result.x >= 1 } {
   { x: input.a + 1, y: input.b * 2 }
 }
 
@@ -39,18 +37,16 @@ ensures { result.x >= 1 }
 -- Tests that the record type from return annotation is correctly matched
 -- ============================================================================
 
-export func swapXY(p: {x: int, y: int}) -> {x: int, y: int} ! {}
+export func swapXY(p: { x: int, y: int }) -> { x: int, y: int } ! {}
 requires { p.x >= 0, p.y >= 0 }
-ensures { result.x == p.y, result.y == p.x }
-{
+ensures { result.x == p.y, result.y == p.x } {
   { x: p.y, y: p.x }
 }
 
 -- Entry point
-export func main() -> int ! {}
-{
-  let p = makePoint(3, 4);
-  let t = transform({a: 5, b: 6});
-  let s = swapXY(p);
+export func main() -> int ! {} {
+  let p = makePoint(3, 4)
+  let t = transform({ a: 5, b: 6 })
+  let s = swapXY(p)
   p.x + t.x + s.x
 }

--- a/examples/runnable/contracts/record_pattern_verify.ail
+++ b/examples/runnable/contracts/record_pattern_verify.ail
@@ -10,28 +10,25 @@ module examples/runnable/contracts/record_pattern_verify
 
 -- Sum both fields of a point using record pattern matching
 -- The match destructures the record, binding x and y as local vars
-export func sumFields(p: {x: int, y: int}) -> int ! {}
+export func sumFields(p: { x: int, y: int }) -> int ! {}
 requires { p.x >= 0, p.y >= 0 }
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   match p {
-    {x, y} => x + y
+    { x: x, y: y } => x + y
   }
 }
 
 -- Extract x coordinate via record pattern
-export func getXCoord(p: {x: int, y: int}) -> int ! {}
+export func getXCoord(p: { x: int, y: int }) -> int ! {}
 requires { p.x >= 0 }
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   match p {
-    {x, y} => x
+    { x: x, y: y } => x
   }
 }
 
 -- Entry point
-export func main() -> int ! {}
-{
-  let p = {x: 3, y: 4};
+export func main() -> int ! {} {
+  let p = { x: 3, y: 4 }
   sumFields(p) + getXCoord(p)
 }

--- a/examples/runnable/contracts/record_verify.ail
+++ b/examples/runnable/contracts/record_verify.ail
@@ -14,18 +14,16 @@ module examples/runnable/contracts/record_verify
 -- ============================================================================
 
 -- Extract the X coordinate (proving non-negativity preserved)
-export func getX(p: {x: int, y: int}) -> int ! {}
+export func getX(p: { x: int, y: int }) -> int ! {}
 requires { p.x >= 0 }
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   p.x
 }
 
 -- Manhattan distance from origin (always non-negative when both coords are)
-export func manhattan(p: {x: int, y: int}) -> int ! {}
+export func manhattan(p: { x: int, y: int }) -> int ! {}
 requires { p.x >= 0, p.y >= 0 }
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   p.x + p.y
 }
 
@@ -34,10 +32,9 @@ ensures { result >= 0 }
 -- ============================================================================
 
 -- Move a point right: new x is always greater than original
-export func moveRight(p: {x: int, y: int}, dx: int) -> {x: int, y: int} ! {}
+export func moveRight(p: { x: int, y: int }, dx: int) -> { x: int, y: int } ! {}
 requires { dx > 0, p.x >= 0 }
-ensures { result.x > p.x }
-{
+ensures { result.x > p.x } {
   { x: p.x + dx, y: p.y }
 }
 
@@ -48,10 +45,9 @@ ensures { result.x > p.x }
 -- Check if a first-quadrant point is near the origin
 -- CALLS manhattan (cross-function with records!)
 -- Z3 inlines manhattan and proves: when true, manhattan <= radius
-export func isNearOrigin(p: {x: int, y: int}, radius: int) -> bool ! {}
+export func isNearOrigin(p: { x: int, y: int }, radius: int) -> bool ! {}
 requires { p.x >= 0, p.y >= 0, radius >= 0 }
-ensures { result == (manhattan(p) <= radius) }
-{
+ensures { result == manhattan(p) <= radius } {
   manhattan(p) <= radius
 }
 
@@ -60,19 +56,17 @@ ensures { result == (manhattan(p) <= radius) }
 -- Z3 finds large coordinates (e.g., x=50, y=50) that violate this
 -- ============================================================================
 
-export func brokenDistance(p: {x: int, y: int}) -> bool ! {}
+export func brokenDistance(p: { x: int, y: int }) -> bool ! {}
 requires { p.x >= 0, p.y >= 0 }
-ensures { result == true }
-{
+ensures { result == true } {
   p.x + p.y < 100
 }
 
 -- Entry point
-export func main() -> int ! {}
-{
-  let p = {x: 3, y: 4};
-  let moved = moveRight(p, 10);
-  let m = manhattan(p);
-  let near = isNearOrigin(p, 10);
+export func main() -> int ! {} {
+  let p = { x: 3, y: 4 }
+  let moved = moveRight(p, 10)
+  let m = manhattan(p)
+  let near = isNearOrigin(p, 10)
   if near then m + moved.x else m
 }

--- a/examples/runnable/contracts/recursive_verify.ail
+++ b/examples/runnable/contracts/recursive_verify.ail
@@ -12,8 +12,7 @@ module examples/runnable/contracts/recursive_verify
 -- With --verify-recursive-depth 5, Z3 proves this for n in [0..4]
 export func factorial(n: int) -> int ! {}
 requires { n >= 0, n <= 4 }
-ensures { result >= 1 }
-{
+ensures { result >= 1 } {
   if n <= 0 then 1 else n * factorial(n - 1)
 }
 
@@ -21,26 +20,21 @@ ensures { result >= 1 }
 -- Base case returns 0 (>= 0), recursive case adds n (>= 1)
 export func sumTo(n: int) -> int ! {}
 requires { n >= 0, n <= 4 }
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   if n <= 0 then 0 else n + sumTo(n - 1)
 }
 
 -- Fibonacci: always non-negative for small non-negative input
 export func fib(n: int) -> int ! {}
 requires { n >= 0, n <= 4 }
-ensures { result >= 0 }
-{
-  if n <= 0 then 0
-  else if n <= 1 then 1
-  else fib(n - 1) + fib(n - 2)
+ensures { result >= 0 } {
+  if n <= 0 then 0 else if n <= 1 then 1 else fib(n - 1) + fib(n - 2)
 }
 
 -- Entry point for testing
-export func main() -> int ! {}
-{
-  let f4 = factorial(4);    -- 24
-  let s4 = sumTo(4);        -- 10
-  let fib4 = fib(4);        -- 3
-  f4 + s4 + fib4            -- 37
+export func main() -> int ! {} {
+  let f4 = factorial(4)  -- 24
+  let s4 = sumTo(4)  -- 10
+  let fib4 = fib(4)  -- 3
+  f4 + s4 + fib4  -- 37
 }

--- a/examples/runnable/contracts/scoring.ail
+++ b/examples/runnable/contracts/scoring.ail
@@ -25,8 +25,7 @@ export type Tenure = NEW | JUNIOR | MID | SENIOR_TENURE
 -- Base skill score (0-100 range)
 -- Z3 proves: always within bounds
 export func skillScore(level: SkillLevel) -> int ! {}
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   match level {
     NOVICE => 20,
     INTERMEDIATE => 45,
@@ -38,8 +37,7 @@ ensures { result >= 0 }
 -- Performance modifier (-20 to +30 range)
 -- Z3 proves: bounded modifier range
 export func perfModifier(perf: Performance) -> int ! {}
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   match perf {
     POOR => 0,
     AVERAGE => 10,
@@ -52,8 +50,7 @@ ensures { result >= 0 }
 -- Some departments weight scores differently
 -- Z3 proves: weight is always reasonable (no zero division risk)
 export func deptWeight(dept: Department) -> int ! {}
-ensures { result >= 80 }
-{
+ensures { result >= 80 } {
   match dept {
     ENGINEERING => 110,
     SALES => 95,
@@ -65,8 +62,7 @@ ensures { result >= 80 }
 -- Tenure bonus (added to final score)
 -- Z3 proves: bonus is non-negative
 export func tenureBonus(tenure: Tenure) -> int ! {}
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   match tenure {
     NEW => 0,
     JUNIOR => 5,
@@ -80,26 +76,25 @@ ensures { result >= 0 }
 -- Z3 proves: composite score is always non-negative
 -- This has 4*4*4*4 = 256 input combinations
 export func compositeScore(level: SkillLevel, perf: Performance, dept: Department, tenure: Tenure) -> int ! {}
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   let skill = match level {
     NOVICE => 20,
     INTERMEDIATE => 45,
     ADVANCED => 70,
     EXPERT => 95
-  };
+  }
   let perfAdj = match perf {
     POOR => 0,
     AVERAGE => 10,
     GOOD => 20,
     EXCELLENT => 30
-  };
+  }
   let weight = match dept {
     ENGINEERING => 110,
     SALES => 95,
     SUPPORT => 85,
     RESEARCH => 120
-  };
+  }
   let bonus = match tenure {
     NEW => 0,
     JUNIOR => 5,
@@ -112,33 +107,32 @@ ensures { result >= 0 }
 -- Ranking comparison: returns positive if candidate A outranks B
 -- Z3 proves: if A has strictly better inputs, A outranks B
 -- This is the interesting contract: it checks a *relational* property
-export func rankDifference(levelA: SkillLevel, perfA: Performance, levelB: SkillLevel, perfB: Performance) -> int ! {}
-{
+export func rankDifference(levelA: SkillLevel, perfA: Performance, levelB: SkillLevel, perfB: Performance) -> int ! {} {
   let scoreA = match levelA {
     NOVICE => 20,
     INTERMEDIATE => 45,
     ADVANCED => 70,
     EXPERT => 95
-  };
+  }
   let adjA = match perfA {
     POOR => 0,
     AVERAGE => 10,
     GOOD => 20,
     EXCELLENT => 30
-  };
+  }
   let scoreB = match levelB {
     NOVICE => 20,
     INTERMEDIATE => 45,
     ADVANCED => 70,
     EXPERT => 95
-  };
+  }
   let adjB = match perfB {
     POOR => 0,
     AVERAGE => 10,
     GOOD => 20,
     EXCELLENT => 30
-  };
-  (scoreA + adjA) - (scoreB + adjB)
+  }
+  scoreA + adjA - (scoreB + adjB)
 }
 
 -- INTENTIONALLY BROKEN: Normalized score should be 0-100
@@ -147,26 +141,25 @@ export func rankDifference(levelA: SkillLevel, perfA: Performance, levelB: Skill
 -- EXPERT(95) + EXCELLENT(30) = 125, × RESEARCH(120%) = 150, + SENIOR(25) = 175
 -- Z3 finds the exact combination that breaks ensures { result <= 100 }
 export func normalizedScore(level: SkillLevel, perf: Performance, dept: Department, tenure: Tenure) -> int ! {}
-ensures { result <= 100 }
-{
+ensures { result <= 100 } {
   let skill = match level {
     NOVICE => 20,
     INTERMEDIATE => 45,
     ADVANCED => 70,
     EXPERT => 95
-  };
+  }
   let perfAdj = match perf {
     POOR => 0,
     AVERAGE => 10,
     GOOD => 20,
     EXCELLENT => 30
-  };
+  }
   let weight = match dept {
     ENGINEERING => 110,
     SALES => 95,
     SUPPORT => 85,
     RESEARCH => 120
-  };
+  }
   let bonus = match tenure {
     NEW => 0,
     JUNIOR => 5,
@@ -178,10 +171,9 @@ ensures { result <= 100 }
 }
 
 -- Entry point
-export func main() -> int ! {}
-{
-  let s1 = compositeScore(EXPERT, EXCELLENT, RESEARCH, SENIOR_TENURE);
-  let s2 = compositeScore(NOVICE, POOR, SUPPORT, NEW);
-  let diff = rankDifference(EXPERT, EXCELLENT, NOVICE, POOR);
+export func main() -> int ! {} {
+  let s1 = compositeScore(EXPERT, EXCELLENT, RESEARCH, SENIOR_TENURE)
+  let s2 = compositeScore(NOVICE, POOR, SUPPORT, NEW)
+  let diff = rankDifference(EXPERT, EXCELLENT, NOVICE, POOR)
   s1 + s2 + diff
 }

--- a/examples/runnable/contracts/showcase.ail
+++ b/examples/runnable/contracts/showcase.ail
@@ -11,6 +11,7 @@
 module examples/runnable/contracts/showcase
 
 import std/string (length as strLength, startsWith as strStartsWith)
+
 import std/list (length as listLength)
 
 -- ============================================================================
@@ -25,8 +26,7 @@ export type Priority = RUSH | NORMAL | LOW
 
 -- Surcharge is always non-negative
 export func surcharge(p: Priority) -> int ! {}
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   match p {
     RUSH => 500,
     NORMAL => 100,
@@ -41,8 +41,7 @@ ensures { result >= 0 }
 -- Z3 inlines surcharge via define-fun, proves total >= 0
 export func lineTotal(unitPrice: int, qty: int, p: Priority) -> int ! {}
 requires { unitPrice >= 0, qty >= 0 }
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   unitPrice * qty + surcharge(p)
 }
 
@@ -51,10 +50,9 @@ ensures { result >= 0 }
 -- ============================================================================
 
 -- Z3 proves: value is non-negative when discount doesn't exceed subtotal
-export func orderValue(order: {subtotal: int, tax: int, discount: int}) -> int ! {}
+export func orderValue(order: { subtotal: int, tax: int, discount: int }) -> int ! {}
 requires { order.subtotal >= 0, order.tax >= 0, order.discount >= 0, order.discount <= order.subtotal }
-ensures { result >= 0 }
-{
+ensures { result >= 0 } {
   order.subtotal - order.discount + order.tax
 }
 
@@ -64,16 +62,14 @@ ensures { result >= 0 }
 
 -- Non-empty strings have positive length (tautology Z3 proves instantly)
 export func hasContent(s: string) -> bool ! {}
-ensures { result == (strLength(s) > 0) }
-{
+ensures { result == strLength(s) > 0 } {
   strLength(s) > 0
 }
 
 -- Prefixed string is always longer than the prefix itself
 export func prefixedLength(prefix: string, body: string) -> int ! {}
-ensures { result >= strLength(prefix) }
-{
-  strLength("${prefix}${body}")
+ensures { result >= strLength(prefix) } {
+  strLength(concat_String(show(prefix), show(body)))
 }
 
 -- ============================================================================
@@ -81,16 +77,14 @@ ensures { result >= strLength(prefix) }
 -- ============================================================================
 
 -- List length is always non-negative
-export func itemCount(items: [int]) -> int ! {}
-ensures { result >= 0 }
-{
+export func itemCount(items: list[int]) -> int ! {}
+ensures { result >= 0 } {
   listLength(items)
 }
 
 -- Prepending preserves the original elements (head of new list is the added item)
-export func prependAndCheck(x: int, xs: [int]) -> bool ! {}
-ensures { result == true }
-{
+export func prependAndCheck(x: int, xs: list[int]) -> bool ! {}
+ensures { result == true } {
   _list_head(x :: xs) == x
 }
 
@@ -101,8 +95,7 @@ ensures { result == true }
 -- All examples above use stdlib imports (strLength, strStartsWith, listLength).
 -- Z3 resolves these transparently: std/string.length → str.len, etc.
 export func validateOrderCode(code: string) -> bool ! {}
-ensures { result == (strStartsWith(code, "ORD-") && strLength(code) >= 8) }
-{
+ensures { result == (strStartsWith(code, "ORD-") && strLength(code) >= 8) } {
   strStartsWith(code, "ORD-") && strLength(code) >= 8
 }
 
@@ -113,8 +106,7 @@ ensures { result == (strStartsWith(code, "ORD-") && strLength(code) >= 8) }
 -- Claims every string starts with "ORD-" — obviously false!
 -- Z3 finds a counterexample string that doesn't start with "ORD-"
 export func brokenPrefixCheck(code: string) -> bool ! {}
-ensures { result == true }
-{
+ensures { result == true } {
   strStartsWith(code, "ORD-")
 }
 
@@ -122,11 +114,10 @@ ensures { result == true }
 -- Entry point
 -- ============================================================================
 
-export func main() -> int ! {}
-{
-  let total = lineTotal(1000, 3, RUSH);
-  let value = orderValue({subtotal: 5000, tax: 500, discount: 200});
-  let count = itemCount([10, 20, 30]);
-  let prefLen = prefixedLength("ORD-", "12345");
+export func main() -> int ! {} {
+  let total = lineTotal(1000, 3, RUSH)
+  let value = orderValue({ subtotal: 5000, tax: 500, discount: 200 })
+  let count = itemCount([10, 20, 30])
+  let prefLen = prefixedLength("ORD-", "12345")
   total + value + count + prefLen
 }

--- a/examples/runnable/contracts/string_verify.ail
+++ b/examples/runnable/contracts/string_verify.ail
@@ -10,28 +10,24 @@ import std/string (length as strLength, startsWith)
 -- Concatenation always produces a longer-or-equal result
 export func safeConcat(a: string, b: string) -> string ! {}
 requires { strLength(a) >= 0, strLength(b) >= 0 }
-ensures { strLength(result) >= strLength(a) }
-{
-  "${a}${b}"
+ensures { strLength(result) >= strLength(a) } {
+  concat_String(show(a), show(b))
 }
 
 -- String equality is reflexive (trivially provable)
 export func isEqual(s: string, t: string) -> bool ! {}
-ensures { result == (s == t) }
-{
+ensures { result == (s == t) } {
   s == t
 }
 
 -- Intentionally BROKEN: claims prefix is always shorter, but equal strings violate this
 export func brokenPrefixCheck(s: string, prefix: string) -> bool ! {}
-ensures { result == true }
-{
+ensures { result == true } {
   startsWith(s, prefix)
 }
 
 -- Entry point
-export func main() -> int ! {}
-{
-  let greeting = safeConcat("hello", " world");
+export func main() -> int ! {} {
+  let greeting = safeConcat("hello", " world")
   if isEqual(greeting, greeting) then 1 else 0
 }

--- a/examples/runnable/contracts/temperature.ail
+++ b/examples/runnable/contracts/temperature.ail
@@ -11,14 +11,12 @@ export type Scale = CELSIUS | FAHRENHEIT
 -- Z3 proves: for non-negative Celsius, Fahrenheit is always >= Celsius
 export func celsiusToFahrenheit(c: int) -> int ! {}
 requires { c >= 0 }
-ensures { result >= c }
-{
+ensures { result >= c } {
   c * 9 / 5 + 32
 }
 
 -- Check if temperature is at or below freezing point
-export func isFreezing(temp: int, scale: Scale) -> bool ! {}
-{
+export func isFreezing(temp: int, scale: Scale) -> bool ! {} {
   match scale {
     CELSIUS => temp <= 0,
     FAHRENHEIT => temp <= 32
@@ -29,18 +27,14 @@ export func isFreezing(temp: int, scale: Scale) -> bool ! {}
 -- Z3 proves: result is always within [lo, hi]
 export func clampTemp(temp: int, lo: int, hi: int) -> int ! {}
 requires { lo <= hi }
-ensures { result >= lo }
-{
-  if temp < lo then lo
-  else if temp > hi then hi
-  else temp
+ensures { result >= lo } {
+  if temp < lo then lo else if temp > hi then hi else temp
 }
 
 -- Entry point for testing
-export func main() -> int ! {}
-{
-  let boiling = celsiusToFahrenheit(100);  -- 212
-  let freezing = celsiusToFahrenheit(0);   -- 32
-  let clamped = clampTemp(150, 0, 100);    -- 100
+export func main() -> int ! {} {
+  let boiling = celsiusToFahrenheit(100)  -- 212
+  let freezing = celsiusToFahrenheit(0)  -- 32
+  let clamped = clampTemp(150, 0, 100)  -- 100
   boiling + freezing + clamped
 }

--- a/examples/runnable/contracts/unencodable_callee_skip.ail
+++ b/examples/runnable/contracts/unencodable_callee_skip.ail
@@ -10,8 +10,7 @@ import std/option (Option, Some, None)
 
 -- Callee returns Option[float] — a parametric ADT application the encoder can't
 -- monomorphize into a concrete SMT sort.
-export func convertTo(x: float, target: string) -> Option[float] ! {}
-{
+export func convertTo(x: float, target: string) -> Option[float] ! {} {
   Some(x * 2.0)
 }
 
@@ -19,15 +18,13 @@ export func convertTo(x: float, target: string) -> Option[float] ! {}
 -- `convertTo`'s signature uses Option[float]. It does NOT emit a Z3 error.
 export func gradeNumeric(x: float) -> float ! {}
 requires { x >= 0.0 }
-ensures { result >= 0.0 }
-{
+ensures { result >= 0.0 } {
   match convertTo(x, "F") {
     Some(v) => v,
     None => 0.0
   }
 }
 
-export func main() -> () ! {IO}
-{
-  println("gradeNumeric(3.5) = ${show(gradeNumeric(3.5))}")
+export func main() -> () ! {IO} {
+  println(concat_String("gradeNumeric(3.5) = ", show(show(gradeNumeric(3.5)))))
 }

--- a/internal/format/combined_pipeline_test.go
+++ b/internal/format/combined_pipeline_test.go
@@ -1,0 +1,141 @@
+package format
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sunholo-data/ailang/internal/ast"
+	"github.com/sunholo-data/ailang/internal/core"
+	"github.com/sunholo-data/ailang/internal/elaborate"
+	"github.com/sunholo-data/ailang/internal/lexer"
+	"github.com/sunholo-data/ailang/internal/parser"
+	aitesting "github.com/sunholo-data/ailang/internal/testing"
+)
+
+// combined_pipeline_test.go is the M2 acceptance-gated integration test for
+// m-fmt-properties-printer-roundtrip. It locks the combined contracts+properties
+// case end to end against testdata/contracts_and_properties.ail:
+//
+//	(a) checks clean — the fixture elaborates without error;
+//	(b) the contract reaches contract verification — DeclMeta.Contracts holds
+//	    EXACTLY one RequiresKind + one EnsuresKind and NOTHING from the forall;
+//	(c) the forall reaches ONLY the property pipeline — fn.Properties is EXACTLY
+//	    [RequiresKind, EnsuresKind, PropertyKind] and the collector emits EXACTLY
+//	    one PropertyCase whose Property.Kind is PropertyKind (the forall);
+//	(d) no duplication/omission/panic — all counts are exact (== not >=), the
+//	    test completing proves panic-freedom, and the fmt round-trip asserts AST
+//	    identity with the requires clause present in the output.
+const combinedFixturePath = "testdata/contracts_and_properties.ail"
+
+func TestCombinedContractsAndPropertiesPipeline(t *testing.T) {
+	data, err := os.ReadFile(combinedFixturePath)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	src := string(data)
+
+	// --- Parse: source-of-truth ordering (c, parse-level) ---
+	p := parser.New(lexer.New(src, combinedFixturePath))
+	file := p.ParseFile()
+	if errs := p.Errors(); len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	fn := findFunc(t, file, "f")
+
+	wantKinds := []ast.ContractKind{ast.RequiresKind, ast.EnsuresKind, ast.PropertyKind}
+	if len(fn.Properties) != len(wantKinds) {
+		t.Fatalf("fn.Properties = %v, want exactly [Requires, Ensures, Property]", propKinds(fn.Properties))
+	}
+	for i, want := range wantKinds {
+		if fn.Properties[i].Kind != want {
+			t.Fatalf("fn.Properties[%d].Kind = %v, want %v (full: %v)", i, fn.Properties[i].Kind, want, propKinds(fn.Properties))
+		}
+	}
+
+	// --- Elaborate: (a) checks clean + (b) contract reaches DeclMeta.Contracts ---
+	elab := elaborate.NewElaborator()
+	prog, err := elab.ElaborateFile(file)
+	if err != nil {
+		t.Fatalf("elaboration error (fixture must check clean): %v", err)
+	}
+	meta, ok := prog.Meta["f"]
+	if !ok {
+		t.Fatalf("no DeclMeta for f")
+	}
+	var reqN, ensN, otherN int
+	for _, c := range meta.Contracts {
+		switch c.Kind {
+		case core.RequiresKind:
+			reqN++
+		case core.EnsuresKind:
+			ensN++
+		default:
+			otherN++
+		}
+	}
+	if reqN != 1 || ensN != 1 || otherN != 0 || len(meta.Contracts) != 2 {
+		t.Fatalf("DeclMeta.Contracts = %d total (requires=%d ensures=%d other=%d), want exactly 1 requires + 1 ensures + 0 from the forall",
+			len(meta.Contracts), reqN, ensN, otherN)
+	}
+
+	// --- Collect: (c) forall reaches ONLY the property pipeline ---
+	suite := aitesting.NewCollector(combinedFixturePath).Collect(file)
+	var forallN, contractCaseN int
+	for _, pc := range suite.Properties {
+		if pc.FunctionCtx != "f" {
+			continue
+		}
+		if pc.Property.Kind == ast.PropertyKind {
+			forallN++
+		} else {
+			contractCaseN++
+		}
+	}
+	if forallN != 1 {
+		t.Fatalf("collector emitted %d PropertyKind property cases for f, want exactly 1 (the forall)", forallN)
+	}
+	// The collector also emits a PropertyCase per requires/ensures entry (today's
+	// pre-existing behavior, audit site 5); those are Kind-filtered downstream by
+	// the runner. We assert they are exactly the two contract entries — no more, no
+	// fewer — proving no duplication or omission through the collector.
+	if contractCaseN != 2 {
+		t.Fatalf("collector emitted %d non-property (contract) property cases for f, want exactly 2 (requires+ensures)", contractCaseN)
+	}
+
+	// --- fmt round-trip: (d) AST identity + requires clause survives in output ---
+	out := assertIdempotentAndRoundTrips(t, src, combinedFixturePath)
+	if !strings.Contains(out, "requires {") {
+		t.Errorf("fmt output lost the requires clause:\n%s", out)
+	}
+	if !strings.Contains(out, "ensures {") {
+		t.Errorf("fmt output lost the ensures clause:\n%s", out)
+	}
+	if !strings.Contains(out, "properties [") {
+		t.Errorf("fmt output lost the properties block:\n%s", out)
+	}
+
+	// Belt-and-suspenders: re-parse the formatted output and confirm the kind
+	// partition is still exactly [Requires, Ensures, Property] (no clobber, no dup).
+	rp := parser.New(lexer.New(out, combinedFixturePath))
+	refile := rp.ParseFile()
+	if errs := rp.Errors(); len(errs) > 0 {
+		t.Fatalf("re-parse of formatted output failed: %v", errs)
+	}
+	refn := findFunc(t, refile, "f")
+	if diff := cmp.Diff(propKinds(fn.Properties), propKinds(refn.Properties)); diff != "" {
+		t.Errorf("property-kind order changed across fmt round-trip (-orig +formatted):\n%s", diff)
+	}
+}
+
+func findFunc(t *testing.T, file *ast.File, name string) *ast.FuncDecl {
+	t.Helper()
+	for _, d := range file.Decls {
+		if fd, ok := d.(*ast.FuncDecl); ok && fd.Name == name {
+			return fd
+		}
+	}
+	t.Fatalf("func %q not found", name)
+	return nil
+}

--- a/internal/format/contracts_test.go
+++ b/internal/format/contracts_test.go
@@ -1,0 +1,191 @@
+package format
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/ast"
+)
+
+// contracts_test.go holds the M1 round-trip fixtures for the contract-clause
+// printer fix (m-fmt-properties-printer-roundtrip): requires/ensures contract
+// clauses must be emitted in signature position and re-parse to an identical
+// AST, and a properties block must not clobber contract entries.
+//
+// Each case asserts parse -> print -> re-parse cmp.Diff AST identity AND
+// idempotence via assertIdempotentAndRoundTrips.
+
+// TestContractRoundTrips covers the seven M1 fixtures (a)-(g).
+func TestContractRoundTrips(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		// mustContain is a set of substrings the canonical output MUST contain,
+		// verifying the emitted surface form (e.g. contract survived, not dropped).
+		mustContain []string
+	}{
+		{
+			name: "a_requires_only",
+			src: "module m\n" +
+				"export func absolute(x: int) -> int ! {}\n" +
+				"requires { x >= 0 }\n" +
+				"{\n  x\n}\n",
+			mustContain: []string{"requires {"},
+		},
+		{
+			name: "b_ensures_only",
+			src: "module m\n" +
+				"export func absolute(x: int) -> int ! {}\n" +
+				"ensures { result >= 0 }\n" +
+				"{\n  x\n}\n",
+			mustContain: []string{"ensures {"},
+		},
+		{
+			name: "c_both",
+			src: "module m\n" +
+				"export func absolute(x: int) -> int ! {}\n" +
+				"requires { x >= 0 }\n" +
+				"ensures { result >= 0 }\n" +
+				"{\n  x\n}\n",
+			mustContain: []string{"requires {", "ensures {"},
+		},
+		{
+			name: "d_multi_predicate_requires",
+			src: "module m\n" +
+				"export func safeDivide(a: int, b: int) -> int ! {}\n" +
+				"requires { a >= 0, b > 0 }\n" +
+				"{\n  a / b\n}\n",
+			mustContain: []string{"requires {"},
+		},
+		{
+			name: "e_ensures_forall_expr",
+			src: "module m\n" +
+				"export func fill(n: int) -> int ! {}\n" +
+				"ensures { forall i: 0..n => i >= 0 }\n" +
+				"{\n  n\n}\n",
+			mustContain: []string{"ensures {", "forall"},
+		},
+		{
+			name: "f_genuine_properties_block",
+			src: "module m\n" +
+				"export func f(x: int) -> int ! {}\n" +
+				"  properties [\n" +
+				"    forall(y: int) => f(y) >= 0\n" +
+				"  ]\n" +
+				"{\n  x\n}\n",
+			mustContain: []string{"properties ["},
+		},
+		{
+			name: "g_contracts_and_properties_combined",
+			src: "module m\n" +
+				"export func f(x: int) -> int ! {}\n" +
+				"requires { x >= 0 }\n" +
+				"ensures { result >= 0 }\n" +
+				"  properties [\n" +
+				"    forall(y: int) => f(y) >= 0\n" +
+				"  ]\n" +
+				"{\n  x\n}\n",
+			// The combined case is the silent-deletion regression guard: the
+			// requires clause MUST survive fmt output.
+			mustContain: []string{"requires {", "ensures {", "properties ["},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := assertIdempotentAndRoundTrips(t, tc.src, "test://"+tc.name)
+			for _, want := range tc.mustContain {
+				if !strings.Contains(out, want) {
+					t.Errorf("%s: output missing %q\n--- output ---\n%s", tc.name, want, out)
+				}
+			}
+		})
+	}
+}
+
+// TestContractKindPartitionInParse locks the parse-level source-of-truth
+// ordering for the combined case: fn.Properties is EXACTLY
+// [RequiresKind, EnsuresKind, PropertyKind] in that order, proving the parser
+// append fix preserves contract entries when a properties block follows.
+func TestContractKindPartitionInParse(t *testing.T) {
+	src := "module m\n" +
+		"export func f(x: int) -> int ! {}\n" +
+		"requires { x >= 0 }\n" +
+		"ensures { result >= 0 }\n" +
+		"  properties [\n" +
+		"    forall(y: int) => f(y) >= 0\n" +
+		"  ]\n" +
+		"{\n  x\n}\n"
+	prog := parseProg(t, src, "test://partition")
+
+	var fn *ast.FuncDecl
+	for _, d := range prog.File.Decls {
+		if fd, ok := d.(*ast.FuncDecl); ok && fd.Name == "f" {
+			fn = fd
+			break
+		}
+	}
+	if fn == nil {
+		t.Fatalf("func f not found in parsed decls")
+	}
+	wantKinds := []ast.ContractKind{ast.RequiresKind, ast.EnsuresKind, ast.PropertyKind}
+	if len(fn.Properties) != len(wantKinds) {
+		t.Fatalf("fn.Properties length = %d, want %d (kinds: %v)", len(fn.Properties), len(wantKinds), propKinds(fn.Properties))
+	}
+	for i, want := range wantKinds {
+		if fn.Properties[i].Kind != want {
+			t.Errorf("fn.Properties[%d].Kind = %v, want %v", i, fn.Properties[i].Kind, want)
+		}
+	}
+}
+
+// TestParenStatementSeparatorRoundTrips locks the pre-existing Phase-1 printer bug
+// surfaced by scoring.ail: a block statement whose RENDERED form begins with `(`
+// (because a low-precedence left operand is parenthesised) must be `;`-separated
+// from the preceding statement, or re-parse glues it as a call. startsWithStatementStarter
+// walked BinaryOp.Left ignoring parenthesisation and wrongly reported "starter".
+func TestParenStatementSeparatorRoundTrips(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{
+			// (a + b) * c: left of `*` is a parenthesised `+`, so the statement
+			// renders starting with `(`.
+			"paren_left_binop",
+			"module m\nfunc f(a: int, b: int, c: int) -> int { let x = a; (a + b) * c }",
+		},
+		{
+			// match then a paren-leading bare expression (the scoring.ail shape).
+			"match_then_paren_expr",
+			"module m\nfunc f(a: int, b: int, w: int) -> int {\n" +
+				"  let s = match a { 0 => 1, _ => 2 };\n" +
+				"  (s + b) * w / 100 + s\n" +
+				"}",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertIdempotentAndRoundTrips(t, tc.src, "test://"+tc.name)
+		})
+	}
+}
+
+// TestVerifyAnnotationRoundTrips locks the @verify(depth: N) annotation round-trip:
+// the parser stores only the int literal (dropping the `depth:` key), so the printer
+// must re-synthesise the key or re-parse fails with PAR_VERIFY_ATTR_KEY.
+func TestVerifyAnnotationRoundTrips(t *testing.T) {
+	src := "module m\n@verify(depth: 5)\nexport func f(x: int) -> int ! {}\nrequires { x >= 0 }\n{\n  x\n}\n"
+	out := assertIdempotentAndRoundTrips(t, src, "test://verify_annotation")
+	if !strings.Contains(out, "@verify(depth: 5)") {
+		t.Errorf("output missing @verify(depth: 5):\n%s", out)
+	}
+}
+
+func propKinds(props []*ast.Property) []ast.ContractKind {
+	ks := make([]ast.ContractKind, len(props))
+	for i, p := range props {
+		ks[i] = p.Kind
+	}
+	return ks
+}

--- a/internal/format/corpus_comment_test.go
+++ b/internal/format/corpus_comment_test.go
@@ -114,14 +114,17 @@ func TestCorpusCommentGate(t *testing.T) {
 		t.Logf("  PRE-EXISTING Phase-1 printer bug (round-trip fails comment-free too, caught fail-closed by fmt.go): %s", p)
 	}
 
-	// HARD GATE: zero Phase-2 defects. interp-refusal and let-in-refusal are the
-	// enumerated evidence-gated fail-closed carve-outs; preExistingRT are Phase-1
-	// printer bugs the comment work merely EXPOSED (they fail round-trip comment-free
-	// too, and fmt.go's round-trip check refuses them fail-closed — no silent
-	// breakage). Everything genuinely attributable to Phase-2 must be zero.
-	if otherRefusal != 0 || roundTripFail != 0 || markerFail != 0 {
-		t.Fatalf("corpus comment gate FAILED (Phase-2 defects): other-refusal=%d PHASE2-rt-regression=%d marker-fail=%d (see DEFECT logs)",
-			otherRefusal, roundTripFail, markerFail)
+	// HARD GATE: zero Phase-2 defects AND zero pre-existing Phase-1 round-trip bugs.
+	// interp-refusal and let-in-refusal are the enumerated evidence-gated fail-closed
+	// carve-outs. preExistingRT WAS a logged-and-tolerated exception (the contract
+	// corpus's Phase-1 printer bugs); m-fmt-properties-printer-roundtrip drove it to
+	// zero (contract-clause emission + parser clobber fix + the two adjacent
+	// paren-separator / @verify-annotation printer fixes), so it is now a HARD
+	// failure — any future non-zero count means a printer round-trip regression
+	// silently regrew the exception class.
+	if otherRefusal != 0 || roundTripFail != 0 || markerFail != 0 || preExistingRT != 0 {
+		t.Fatalf("corpus comment gate FAILED: other-refusal=%d PHASE2-rt-regression=%d marker-fail=%d preexisting-Phase1-rt-bug=%d (see DEFECT logs; preExistingRT must stay 0 after m-fmt-properties-printer-roundtrip)",
+			otherRefusal, roundTripFail, markerFail, preExistingRT)
 	}
 	// Record the interpolation refusal rate for the design doc's Verification Log.
 	t.Logf("INTERPOLATION REFUSAL RATE: %d/%d parse-valid files (%.2f%%)",

--- a/internal/format/decl.go
+++ b/internal/format/decl.go
@@ -77,7 +77,21 @@ func (p *printer) funcDecl(d *ast.FuncDecl) error {
 	if eff := formatEffectRow(d.Effects); eff != "" {
 		p.w.write(" " + eff)
 	}
-	if err := p.testsAndProperties(d); err != nil {
+	// FuncDecl.Properties is a mixed-kind slice: RequiresKind/EnsuresKind contract
+	// clauses (parsed by parseContractBlocks, signature position) and PropertyKind
+	// forall properties (parsed from a `properties [...]` block). Partition by Kind
+	// and emit each in the ONLY position the parser accepts:
+	//   - requires/ensures contract clauses go in SIGNATURE position (after the
+	//     effect row, before tests/properties and the body);
+	//   - PropertyKind entries route through the existing `properties [...]` block.
+	requires, ensures, props := partitionProperties(d.Properties)
+	if err := p.contractClauses("requires", requires); err != nil {
+		return err
+	}
+	if err := p.contractClauses("ensures", ensures); err != nil {
+		return err
+	}
+	if err := p.testsAndProperties(d.Tests, props); err != nil {
 		return err
 	}
 	// Extern functions have no body.
@@ -164,39 +178,98 @@ func (p *printer) funcBody(body ast.Expr) error {
 
 func (p *printer) annotation(a *ast.Annotation) error {
 	p.w.write("@" + a.Name)
-	if len(a.Args) > 0 {
-		p.w.write("(")
-		for i, arg := range a.Args {
-			if i > 0 {
-				p.w.write(", ")
-			}
-			if err := p.expr(arg, precLowest); err != nil {
-				return err
-			}
+	if len(a.Args) == 0 {
+		return nil
+	}
+	// @verify parses the surface form `@verify(depth: N)` but stores only the int
+	// literal N in Args (the `depth:` key is dropped by parseVerifyAnnotation). The
+	// generic positional emission below would print `@verify(N)`, which the parser
+	// then rejects (PAR_VERIFY_ATTR_KEY: "expected 'depth' key"). Re-emit the key so
+	// the annotation round-trips.
+	if a.Name == "verify" && len(a.Args) == 1 {
+		p.w.write("(depth: ")
+		if err := p.expr(a.Args[0], precLowest); err != nil {
+			return err
 		}
 		p.w.write(")")
+		return nil
 	}
+	p.w.write("(")
+	for i, arg := range a.Args {
+		if i > 0 {
+			p.w.write(", ")
+		}
+		if err := p.expr(arg, precLowest); err != nil {
+			return err
+		}
+	}
+	p.w.write(")")
+	return nil
+}
+
+// partitionProperties splits a mixed-kind FuncDecl.Properties slice into its
+// requires clauses, ensures clauses, and remaining (PropertyKind) properties,
+// each preserving the original relative order. InvariantKind is not produced by
+// the current grammar; any non-requires/ensures entry is treated as a property
+// so it routes through the `properties [...]` block rather than being silently
+// dropped.
+func partitionProperties(all []*ast.Property) (requires, ensures, props []*ast.Property) {
+	for _, pr := range all {
+		switch pr.Kind {
+		case ast.RequiresKind:
+			requires = append(requires, pr)
+		case ast.EnsuresKind:
+			ensures = append(ensures, pr)
+		default:
+			props = append(props, pr)
+		}
+	}
+	return requires, ensures, props
+}
+
+// contractClauses prints one merged `requires { p1, p2, … }` / `ensures { … }`
+// clause in signature position (column 0, matching the prevailing corpus style),
+// or nothing when the slice is empty. Duplicate requires/ensures blocks are a
+// parse-time diagnostic, so emitting a single merged block per kind is canonical
+// and re-parses to the identical slice order.
+func (p *printer) contractClauses(keyword string, preds []*ast.Property) error {
+	if len(preds) == 0 {
+		return nil
+	}
+	p.w.hardline()
+	p.w.write(keyword + " { ")
+	for i, pr := range preds {
+		if i > 0 {
+			p.w.write(", ")
+		}
+		if err := p.property(pr); err != nil {
+			return err
+		}
+	}
+	p.w.write(" }")
 	return nil
 }
 
 // testsAndProperties prints inline `tests [...]` and `properties [...]` blocks on
-// their own indented lines before the function body.
-func (p *printer) testsAndProperties(d *ast.FuncDecl) error {
-	if len(d.Tests) > 0 {
+// their own indented lines before the function body. props MUST be pre-filtered to
+// PropertyKind entries only (contract clauses are emitted separately in signature
+// position by contractClauses), so this cannot re-emit contract predicates.
+func (p *printer) testsAndProperties(tests []*ast.TestCase, props []*ast.Property) error {
+	if len(tests) > 0 {
 		p.w.hardline()
 		var err error
 		p.w.indented(func() {
-			err = p.testsBlock(d.Tests)
+			err = p.testsBlock(tests)
 		})
 		if err != nil {
 			return err
 		}
 	}
-	if len(d.Properties) > 0 {
+	if len(props) > 0 {
 		p.w.hardline()
 		var err error
 		p.w.indented(func() {
-			err = p.propertiesBlock(d.Properties)
+			err = p.propertiesBlock(props)
 		})
 		if err != nil {
 			return err

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -381,22 +381,54 @@ func (p *printer) blockBraced(b *ast.Block) error {
 // statement starter (let, letrec, if, match, or an identifier). This mirrors
 // parser.peekStartsBlockStatement. When false, the preceding statement must be
 // `;`-terminated so the two do not merge on re-parse.
+//
+// A block statement is rendered at precLowest, so the recursion tracks the
+// parent precedence: if a subexpression renders PARENTHESISED (its own
+// precedence is below the parent's required minimum), its first token is `(`,
+// which is NOT a statement starter. Ignoring parenthesisation was a latent
+// round-trip bug — e.g. `(a + b) * c` starts with `(` at the statement level,
+// but its BinaryOp.Left recursion reaches the identifier `a` and wrongly
+// reported "starter", so no `;` was emitted and re-parse glued it as a call.
 func startsWithStatementStarter(e ast.Expr) bool {
+	return startsWithStatementStarterAt(e, precLowest)
+}
+
+// startsWithStatementStarterAt mirrors the precedence-driven parenthesisation in
+// expr.go (wrap/binaryOp/funcCall/recordAccess) to determine the first RENDERED
+// token of e when emitted at parentPrec.
+func startsWithStatementStarterAt(e ast.Expr, parentPrec int) bool {
 	switch n := e.(type) {
 	case *ast.Let, *ast.LetRec, *ast.If, *ast.Match, *ast.Identifier:
 		return true
 	case *ast.BinaryOp:
-		return startsWithStatementStarter(n.Left)
-	case *ast.FuncCall:
-		// Cons `a :: b` renders infix, starting with its left operand.
-		if id, ok := n.Func.(*ast.Identifier); ok && id.Name == "::" && len(n.Args) == 2 {
-			return startsWithStatementStarter(n.Args[0])
+		prec := binaryPrecedence(n.Op)
+		if prec < parentPrec {
+			return false // renders parenthesised → starts with '('
 		}
-		return startsWithStatementStarter(n.Func)
+		leftMin := prec
+		if rightAssociative(n.Op) {
+			leftMin = prec + 1
+		}
+		return startsWithStatementStarterAt(n.Left, leftMin)
+	case *ast.FuncCall:
+		// Cons `a :: b` renders infix at precCons, starting with its left operand.
+		if id, ok := n.Func.(*ast.Identifier); ok && id.Name == "::" && len(n.Args) == 2 {
+			if precCons < parentPrec {
+				return false
+			}
+			return startsWithStatementStarterAt(n.Args[0], precCons+1)
+		}
+		if precCall < parentPrec {
+			return false
+		}
+		return startsWithStatementStarterAt(n.Func, precCall)
 	case *ast.RecordAccess:
-		return startsWithStatementStarter(n.Record)
+		if precDotAccess < parentPrec {
+			return false
+		}
+		return startsWithStatementStarterAt(n.Record, precDotAccess)
 	case *ast.Send:
-		return startsWithStatementStarter(n.Channel)
+		return startsWithStatementStarterAt(n.Channel, precLowest+1)
 	default:
 		return false
 	}

--- a/internal/format/node_coverage_test.go
+++ b/internal/format/node_coverage_test.go
@@ -256,7 +256,9 @@ func TestDeclNodeCoverage(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		mustContain(t, got, "@verify(1)")
+		// @verify re-emits the `depth:` key so the annotation round-trips
+		// (parseVerifyAnnotation requires it).
+		mustContain(t, got, "@verify(depth: 1)")
 	})
 
 	t.Run("FuncDecl_tests", func(t *testing.T) {

--- a/internal/format/testdata/contracts_and_properties.ail
+++ b/internal/format/testdata/contracts_and_properties.ail
@@ -1,0 +1,20 @@
+-- contracts_and_properties.ail
+-- Acceptance fixture for m-fmt-properties-printer-roundtrip (M2).
+-- A single function carrying BOTH requires/ensures contract clauses AND a
+-- genuine forall properties block — the combined case the parser previously
+-- clobbered (silent contract deletion) and the printer previously failed to
+-- round-trip. No corpus example combines both forms, so this fixture locks the
+-- combined pipeline: contracts must reach core.DeclMeta.Contracts, the forall
+-- must reach only the property pipeline, and fmt must preserve the requires
+-- clause.
+
+module examples/format/contracts_and_properties
+
+export func f(x: int) -> int ! {}
+requires { x >= 0 }
+ensures { result >= 0 }
+  properties [
+    forall(y: int) => f(y) >= 0
+  ] {
+  x
+}

--- a/internal/parser/parser_func.go
+++ b/internal/parser/parser_func.go
@@ -166,7 +166,11 @@ func (p *Parser) parseFunctionDeclaration(isPure bool, isExport bool) *ast.FuncD
 			p.report("PAR_UNEXPECTED_TOKEN", "expected [ after properties keyword", "Check syntax")
 		} else {
 			p.nextToken() // move to LBRACKET, now cur=[, peek=first_property_token
-			fn.Properties = p.parsePropertiesBlock()
+			// Append (do NOT assign): contract entries (requires/ensures) were
+			// appended to fn.Properties above (lines 124-125). Assignment here would
+			// silently clobber them when a function has BOTH contracts and a
+			// properties block, causing fmt --write to delete verified contracts.
+			fn.Properties = append(fn.Properties, p.parsePropertiesBlock()...)
 			// parsePropertiesBlock leaves us at RBRACKET, move past it
 			if p.curTokenIs(lexer.RBRACKET) {
 				p.nextToken()


### PR DESCRIPTION
Fixes `ailang fmt` on the contract corpus (mission iteration 69; unparked by Mark #422).

## Two bugs fixed (both live-reproduced at HEAD)
1. **`requires`/`ensures` files fail `fmt --check` with exit-2 "formatter defect."** The printer routed ALL `FuncDecl.Properties` through `properties [...]`, but contract entries (binder-less, no `forall`) can't re-parse there. Fix: printer now partitions by `ContractKind` and emits `requires {…}` / `ensures {…}` clauses in signature position; only `PropertyKind` goes through `properties [...]`.
2. **Silent contract deletion (data loss, exit 0).** `parser_func.go:169` used `=` instead of `append`, clobbering already-parsed contract entries when a `properties [...]` block followed → `fmt --write` silently erased verified `requires` clauses. Fix: `=` → `append`.

## Milestones
- **M1** (`58eadd3b5`): printer emission split + parser clobber fix + 7 round-trip unit fixtures.
- **M2** (`1e7815c95`, `ec331062e`): reformatted contract corpus with `fmt --write`; acceptance-gated `TestCombinedContractsAndPropertiesPipeline`; hardened `TestCorpusCommentGate` (`preexisting-Phase1-rt-bug` 28→0, now fails on any non-zero); CHANGELOG.

## Scope note
The gate→0 condition transitively required fixing two additional pre-existing Phase-1 printer bugs surfaced by the full-corpus sweep (precedence-driven `;`-separation in `startsWithStatementStarter`; `@verify(depth:)` key re-synthesis). No AST/grammar/comment-carve-out changes (Non-Goals respected).

## Verification (independent, sonnet evaluator — generator≠judge)
- Acceptance sweep: 30 files exit-0, exactly the 2 comment-carve-out files remain exit-2.
- `go test ./internal/format/` green, `preexisting-Phase1-rt-bug=0`.
- `make test`, `make verify-examples`, `make lint`, `make check-boundaries` all green.
- **Evaluator PASS 98/100 round 1.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)