### PR TITLE
fix(docs): re-pin @mermaid-js/layout-elk to ^0.1.9 (un-red dev docs build)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -12,7 +12,7 @@
         "@docusaurus/preset-classic": "3.10.2",
         "@docusaurus/theme-mermaid": "3.10.2",
         "@mdx-js/react": "^3.0.0",
-        "@mermaid-js/layout-elk": "^0.2.2",
+        "@mermaid-js/layout-elk": "^0.1.9",
         "clsx": "^2.0.0",
         "lucide-react": "^1.25.0",
         "prism-react-renderer": "^2.3.0",
@@ -4632,9 +4632,9 @@
       }
     },
     "node_modules/@mermaid-js/layout-elk": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/layout-elk/-/layout-elk-0.2.2.tgz",
-      "integrity": "sha512-vnH3gtqfhyBiRVKNpT8iDENTw18q/OF0GF/SfYfHN43KZpu+6eZDEOMHTfNYAkpmUWJNgtRQFIS6BTc7vH/DYQ==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/layout-elk/-/layout-elk-0.1.9.tgz",
+      "integrity": "sha512-HuvaqFZBr6yT9PpWYockvKAZPJVd89yn/UjOYPxhzbZxlybL2v+2BjVCg7MVH6vRs1irUohb/s42HEdec1CCZw==",
       "license": "MIT",
       "dependencies": {
         "d3": "^7.9.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -22,7 +22,7 @@
     "@docusaurus/preset-classic": "3.10.2",
     "@docusaurus/theme-mermaid": "3.10.2",
     "@mdx-js/react": "^3.0.0",
-    "@mermaid-js/layout-elk": "^0.2.2",
+    "@mermaid-js/layout-elk": "^0.1.9",
     "clsx": "^2.0.0",
     "lucide-react": "^1.25.0",
     "prism-react-renderer": "^2.3.0",


### PR DESCRIPTION
## Problem

Dependabot #429 (`9039805e4`) bumped `@mermaid-js/layout-elk` `^0.1.9` → `^0.2.2`, re-introducing the peer-dependency conflict that #391 had previously pinned away. `@docusaurus/theme-mermaid@3.10.2` declares `peerOptional @mermaid-js/layout-elk@^0.1.9`, so `make docs-install` (`npm install`) fails:

```
npm error Conflicting peer dependency: @mermaid-js/layout-elk@0.1.9
npm error   peerOptional @mermaid-js/layout-elk@"^0.1.9" from @docusaurus/theme-mermaid@3.10.2
```

This reds the **Deploy Documentation `build`** job — a **required** status check (`test`/`lint`/`build`) — so it blocks every open PR whose test-merge inherits dev's `package.json` (observed on #434).

## Fix

Re-pin to `^0.1.9` (matching the peer) and regenerate the lockfile — mirrors the prior fix #391. Verified locally: `cd docs && npm install` exits 0, lockfile resolves `layout-elk@0.1.9`.

## Why not just bump theme-mermaid
theme-mermaid is pinned at `3.10.2` (the whole docusaurus group), and `0.2.x` of layout-elk isn't in its peer range. Re-pinning layout-elk is the minimal, proven fix. A future coordinated docusaurus-group bump can lift both together.

Found + fixed during mission-control iteration 70 (un-red dev is the mission's job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)