### PR TITLE
eval: fmt-hook weak-model A/B — M1 prereg + M2a toggle (m-eval-fmt-weakmodel-ab)

### DIFF
--- a/.ailang/state/sprints/sprint_M-EVAL-FMT-WEAKMODEL-AB.json
+++ b/.ailang/state/sprints/sprint_M-EVAL-FMT-WEAKMODEL-AB.json
@@ -1,0 +1,111 @@
+{
+  "sprint_id": "M-EVAL-FMT-WEAKMODEL-AB",
+  "created": "2026-07-21",
+  "design_doc": "design_docs/planned/v0_31_0/m-eval-fmt-weakmodel-ab.md",
+  "sprint_plan": "design_docs/planned/v0_31_0/m-eval-fmt-weakmodel-ab-sprint-plan.md",
+  "status": "planned",
+  "risk_level": "medium",
+  "github_issues": [422],
+  "language_surface_change": false,
+  "gpu_gated": true,
+  "notes": "Human green-lit (Mark, 'Green light weakmodel ab'). NOT re-quorumed. A/B of the LANDED format_ail.sh PostToolUse fmt hook (ON vs OFF) with weak model claude-haiku-4-5. KEY FINDING: hook ON/OFF toggle does NOT exist in the harness today (agent_runner_streaming.go passes no --settings, writes no .claude/settings.json) — it must be BUILT (M2a), modeled on internal/eval_harness/microrag_mode.go. GPU (rig.lock) touches ONLY M2b execution + optional local arm; M1/M2a/M3/M4 are no-GPU headless-safe.",
+  "velocity": {
+    "target_loc_per_day": 250,
+    "estimated_total_loc": 320,
+    "estimated_days": 1.5
+  },
+  "features": [
+    {
+      "id": "M1_PREREGISTRATION",
+      "description": "Freeze benchmarks, N>=5/arm/bench, seeds/settings, exclusions, metric definitions (pass-rate delta, convergence, hook-reality), confidence method, and refutation threshold BEFORE any scored run. Cheap, no GPU, headless-safe, do first.",
+      "estimated_loc": 40,
+      "gpu": false,
+      "dependencies": [],
+      "acceptance_criteria": [
+        "Preregistration committed before any scored run",
+        "Matched benchmark set + versions frozen (prefer benchmarks that exercise .ail edits)",
+        "SAME N with N>=5 per arm per benchmark fixed",
+        "Model fixed to claude-haiku-4-5; timeouts/budgets/tools/prompt version fixed",
+        "Metrics defined: pass-rate delta (ON-OFF) w/ N/variance/CI; convergence (edits-to-first-green, green-stability, compile-stuck); hook-reality (per-turn fmt exit-0 vs refusal, vs ~8% baseline)",
+        "Confidence method and refutation threshold fixed"
+      ],
+      "passes": true,
+      "started": "2026-07-21",
+      "completed": "2026-07-21",
+      "notes": "DONE. Preregistration frozen at design_docs/planned/v0_31_0/m-eval-fmt-weakmodel-ab-prereg.md (commit cc8d98b4c). Matched set (6 ailang agent-mode benchmarks: fizzbuzz, gcd_lcm, adt_option, higher_order_functions, json_parse, cli_args) pinned to repo SHA 2bb1820d6; each justified (span easy->hard, all edit .ail so the hook fires). N=5/arm/bench; model claude-haiku-4-5; budgets/timeouts/tools from models.yml. Metrics: pass-rate delta (ON-OFF) w/ Wilson 95% CIs; convergence (edits-to-first-green, green-stability, compile-stuck) via DOCX defs; hook-reality (per-turn fmt exit-0 vs refusal, vs ~8% baseline). Refutation threshold: delta >= +0.10 AND 95% CI excludes 0, else NULL; unevaluable if treatment not delivered."
+    },
+    {
+      "id": "M2A_FMT_HOOK_TOGGLE_BUILD",
+      "description": "Build the fmt-hook ON/OFF toggle in the existing agent-mode harness (does NOT exist today). Add FmtHookMode (on/off) modeled on internal/eval_harness/microrag_mode.go; add AgentBenchmarkConfig.FmtHook field; wire a -fmt-hook CLI flag in cmd/ailang/eval_suite.go; when ON, emit workspace .claude/settings.json registering scripts/hooks/format_ail.sh as PostToolUse for Edit/Write and pass --settings to the claude command in BOTH runner paths; record resolved config (fmt_hook field) + log settings for config-diff review; capture per-turn fmt exit status (hook-reality) from stream-json. NO GPU.",
+      "estimated_loc": 220,
+      "gpu": false,
+      "dependencies": ["M1_PREREGISTRATION"],
+      "acceptance_criteria": [
+        "FmtHookMode type + ParseFmtHookMode + apply + ResolvedState with unit test (mirrors microrag_mode_test.go)",
+        "AgentBenchmarkConfig.FmtHook wired from a new -fmt-hook on|off flag (default off = current behaviour)",
+        "-fmt-hook on writes workspace .claude/settings.json + passes --settings in agent_runner_streaming.go AND agent_runner.go; hook fires on .ail edits",
+        "-fmt-hook off is byte-identical to today's path (no settings, no --settings)",
+        "Config diff between arms shows ONLY the hook",
+        "Per-turn fmt invocation + exit status banked for hook-reality metric",
+        "make test + make lint + make check-boundaries pass"
+      ],
+      "passes": true,
+      "started": "2026-07-21",
+      "completed": "2026-07-21",
+      "notes": "DONE. FmtHookMode (on/off) + ParseFmtHookMode + ResolvedState + Apply + SettingsJSON in internal/eval_harness/fmt_hook_mode.go, unit-tested (fmt_hook_mode_test.go, 6 tests, race-clean). AgentBenchmarkConfig.FmtHook field wired from new -fmt-hook on|off flag (default off) at cmd/ailang/eval_suite.go. KEY CORRECTION vs plan: the ACTIVE suite path is RunAgentBenchmarkWithExecutor (agent_runner_multi.go), NOT the two legacy runners the plan named — the claude executor sets cmd.Dir=workspace and loads .claude/settings.json naturally (internal/executor/claude:165), so ON writes the workspace settings there (no --settings needed on the active path); --settings ALSO wired into both legacy runners (agent_runner.go, agent_runner_streaming.go) for completeness. Resolved arm banked as RunMetrics.fmt_hook_state; per-turn hook reality banked as fmt_hook_events (captured via a composed EventHandler on the active path + stream-line scan on the legacy path, keyed off the LANDED hook's own status markers). make test (targeted) + boundaries green; lint clean on all touched files (1 pre-existing warning in untouched gemini_evaluator_bridge.go). NOTE: exact stream schema for hook additionalContext could not be verified against a live haiku run (no GPU / no API in this iteration) — capture is marker-based and correct-by-construction but its real-world hit rate is verified in M2b."
+    },
+    {
+      "id": "M2B_MATCHED_EXECUTION",
+      "description": "Run the matched A/B. Acquire tools/launchd/rig-lock.sh (rig_lock_acquire wait) around the eval step ONLY. Run claude-haiku-4-5 ON and OFF at frozen N on every frozen benchmark via ailang eval-suite --agent with -fmt-hook on/off, banking per run, everything else fixed. Release lock before analysis. OPTIONAL local Ollama replication arm under same protocol (also GPU, same lock, separated from primary).",
+      "estimated_loc": 20,
+      "gpu": true,
+      "dependencies": ["M2A_FMT_HOOK_TOGGLE_BUILD"],
+      "acceptance_criteria": [
+        "ON/OFF haiku runs complete under identical conditions except the LANDED PostToolUse hook",
+        "N>=5 per arm per benchmark banked",
+        "rig.lock acquire/release recorded for the eval-execution step only",
+        "Optional local replication arm (if run) clearly separated from primary haiku result",
+        "Lock released before M3"
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": "GPU YES (rig.lock). Execute ONLY in a GPU-available iteration. Config-only once M2a merged."
+    },
+    {
+      "id": "M3_ANALYSIS",
+      "description": "Aggregate all N runs via existing tools/eval_best_of_n.py-class N-run tooling + native rotation summary path (REUSE, do not fork). Report pass-rate delta (ON-OFF) w/ variance/CIs, convergence traces (edits-to-first-green, green-stability, compile-stuck incidence), per-turn fmt exit-code coverage (exit-0 vs refusal, vs ~8% baseline). Include null result if observed. NO GPU (lock released).",
+      "estimated_loc": 20,
+      "gpu": false,
+      "dependencies": ["M2B_MATCHED_EXECUTION"],
+      "acceptance_criteria": [
+        "Aggregate deltas + variance/CIs published",
+        "Convergence traces + compile-stuck/green-stability reported",
+        "Per-turn fmt exit-code coverage reported vs ~8% baseline",
+        "Reuses existing eval banking + N-run aggregate tooling (no separate aggregator)",
+        "Null result included if observed"
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": "NO GPU. Headless-safe once M2b banks results."
+    },
+    {
+      "id": "M4_VERDICT",
+      "description": "State whether the hook helps / is neutral / harms / is unevaluable (last if formatter refusal/no-op prevented treatment delivery — distinguish benefit from delivery failure). Publish positive/negative/null evidence; feed verdict back to mission bookkeeping issue; do NOT change adoption policy off a single benchmark/run. NO GPU.",
+      "estimated_loc": 0,
+      "gpu": false,
+      "dependencies": ["M3_ANALYSIS"],
+      "acceptance_criteria": [
+        "Verdict published: helps / neutral / harms / unevaluable",
+        "Distinguishes formatter benefit from treatment-delivery failure caused by refusals/no-ops",
+        "Positive, negative, or null evidence recorded",
+        "No adoption-policy change made off a single benchmark or run"
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": "NO GPU. Write-up only, headless-safe."
+    }
+  ]
+}

--- a/.ailang/state/sprints/sprint_M-EVAL-FMT-WEAKMODEL-AB.json
+++ b/.ailang/state/sprints/sprint_M-EVAL-FMT-WEAKMODEL-AB.json
@@ -3,7 +3,7 @@
   "created": "2026-07-21",
   "design_doc": "design_docs/planned/v0_31_0/m-eval-fmt-weakmodel-ab.md",
   "sprint_plan": "design_docs/planned/v0_31_0/m-eval-fmt-weakmodel-ab-sprint-plan.md",
-  "status": "planned",
+  "status": "in_progress",
   "risk_level": "medium",
   "github_issues": [422],
   "language_surface_change": false,

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,33 @@
 
 ## [Unreleased]
 
+### Added — fmt-hook A/B toggle for weak-model eval (M-EVAL-FMT-WEAKMODEL-AB, M1+M2a)
+
+Engineering + preregistration for the "does the `ailang fmt` PostToolUse hook
+help a weak model author correct AILANG?" experiment. No language-surface
+change; no GPU (the scored haiku runs are a later, rig-gated milestone).
+
+- **New `-fmt-hook on|off` flag** on `eval-suite` (agent mode; default `off` =
+  byte-identical to today's path). `on` writes a workspace `.claude/settings.json`
+  registering the LANDED `scripts/hooks/format_ail.sh` as a `PostToolUse`
+  Edit|Write hook so `ailang fmt --write` canonically formats every edited
+  `.ail` file. Modeled on the `-microrag` A/B precedent: a `FmtHookMode` type
+  (`ParseFmtHookMode` / `ResolvedState` / `Apply`) in
+  `internal/eval_harness/fmt_hook_mode.go`, one `AgentBenchmarkConfig.FmtHook`
+  field, wired through the active executor path (`RunAgentBenchmarkWithExecutor`)
+  and both legacy runners. A missing LANDED hook in `on` mode fails loudly
+  (no silent degrade to an untreated arm).
+- **Resolved arm banked** as `fmt_hook_state` in the per-run result, so the
+  required ON-vs-OFF config diff is reviewable from the banked JSON.
+- **Hook-reality capture**: per-turn `format_ail.sh` status
+  (`formatted`/`error`) captured from the executor tool-result stream into
+  `fmt_hook_events`, for the treatment-delivery metric (was the ON arm actually
+  treated, vs the ~8% fail-closed refusal baseline).
+- **Preregistration** (`design_docs/planned/v0_31_0/m-eval-fmt-weakmodel-ab-prereg.md`)
+  freezing the 6-benchmark matched set, N=5/arm/bench, `claude-haiku-4-5`,
+  budgets/timeouts/tools, metric definitions (pass-rate delta with Wilson CIs,
+  convergence, hook-reality), and the refutation threshold — before any scored run.
+
 ### Added — eval harness memory watchdog: generated code can no longer OOM the host (M-EVAL-MEM-GUARD)
 
 The 2026-07-20 rig kernel panic: the eval harness executed model-generated

--- a/cmd/ailang/eval_benchmark.go
+++ b/cmd/ailang/eval_benchmark.go
@@ -282,6 +282,10 @@ func runSingleBenchmark(ctx context.Context, model, benchmarkID, lang, condition
 			AgentTranscript: result.SessionLog,
 			EvalMode:        eval_harness.EvalModeAgent,                    // Mark as agent evaluation
 			MicroragState:   eval_harness.MicroragModeAuto.ResolvedState(), // M-BRAIN-MICRORAG
+			// Fmt-hook A/B (M-EVAL-FMT-WEAKMODEL-AB): resolved arm + hook reality,
+			// banked for the config-diff review and M3's treatment-delivery metric.
+			FmtHookState:  result.FmtHook,
+			FmtHookEvents: result.FmtHookEvents,
 
 			// Cost-and-speed budget metrics (M-EVAL-COST-AND-SPEED-BUDGETS, v0.15.1)
 			CostKilledAt:   result.CostKilledAt,

--- a/cmd/ailang/eval_helpers.go
+++ b/cmd/ailang/eval_helpers.go
@@ -27,6 +27,11 @@ var evalDevtoolsPromptFlag bool
 // Default auto: respect inherited environment. on/off force the value.
 var evalMicroragMode = eval_harness.MicroragModeAuto
 
+// evalFmtHookMode controls whether the LANDED format_ail.sh PostToolUse fmt hook
+// is wired into agent workspaces (M-EVAL-FMT-WEAKMODEL-AB). Default off preserves
+// today's behaviour; on is the treatment arm of the fmt A/B.
+var evalFmtHookMode = eval_harness.FmtHookModeOff
+
 // discoverBenchmarks finds all .yml files in the benchmark directory
 func discoverBenchmarks() []string {
 	entries, err := os.ReadDir(evalBenchmarkDir)

--- a/cmd/ailang/eval_suite.go
+++ b/cmd/ailang/eval_suite.go
@@ -143,6 +143,13 @@ func runEvalSuite() {
 	// off:  force AILANG_MICRORAG_ENABLED=0 (use for the baseline arm of an A/B run).
 	microragMode := fs.String("microrag", "auto", "μRAG knowledge injection: on | off | auto (default: auto). For A/B comparison, run twice with on/off.")
 
+	// fmt-hook toggle (M-EVAL-FMT-WEAKMODEL-AB)
+	// off: no fmt PostToolUse hook — byte-identical to today's path (DEFAULT).
+	// on:  wire the LANDED scripts/hooks/format_ail.sh PostToolUse hook into the
+	//      agent workspace so `ailang fmt --write` formats every edited .ail file.
+	// For the weak-model fmt A/B, run twice (agent mode) with on/off.
+	fmtHookMode := fs.String("fmt-hook", "off", "fmt PostToolUse hook: on | off (default: off). Agent mode only. For A/B, run twice with on/off.")
+
 	// Message-based coordination flags (M-UNIFIED-AI-CONTROL-PLANE)
 	queueMode := fs.Bool("queue", false, "Run benchmarks via message queue (coordinator processes, crash recovery)")
 	queueInbox := fs.String("queue-inbox", "eval-runner", "Inbox for queue mode benchmark jobs")
@@ -175,6 +182,7 @@ func runEvalSuite() {
 	evalVerifyTimeout = *verifyTimeout
 	evalDevtoolsPromptFlag = *devtoolsPrompt
 	evalMicroragMode = eval_harness.ParseMicroragMode(*microragMode)
+	evalFmtHookMode = eval_harness.ParseFmtHookMode(*fmtHookMode)
 
 	// Parse --conditions flag into a list
 	var conditionList []string
@@ -673,6 +681,7 @@ func runEvalSuite() {
 			DevtoolsPrompt:     devtoolsContent,    // M-CONTRACT-EVAL: devtools prompt for "full" condition
 			AgentPromptContent: agentPromptContent, // Agent coding prompt for "agent_prompt" condition
 			MicroragMode:       evalMicroragMode,   // M-BRAIN-MICRORAG: subprocess env mode
+			FmtHook:            evalFmtHookMode,    // M-EVAL-FMT-WEAKMODEL-AB: fmt PostToolUse hook A/B toggle
 		}
 	}
 

--- a/design_docs/planned/v0_31_0/m-eval-fmt-weakmodel-ab-prereg.md
+++ b/design_docs/planned/v0_31_0/m-eval-fmt-weakmodel-ab-prereg.md
@@ -1,0 +1,182 @@
+# PREREGISTRATION — M-EVAL-FMT-WEAKMODEL-AB
+
+**Status**: FROZEN 2026-07-21 (M1, before any scored run).
+**Design doc**: [`m-eval-fmt-weakmodel-ab.md`](m-eval-fmt-weakmodel-ab.md)
+**Sprint plan**: [`m-eval-fmt-weakmodel-ab-sprint-plan.md`](m-eval-fmt-weakmodel-ab-sprint-plan.md)
+**Frozen against repo SHA**: `2bb1820d65b4e8aee3077ece6b46c5535ef2dcee` (worktree base at M1 time).
+
+This document freezes the experiment BEFORE any scored A/B run so a null result is
+publishable rather than buried (design doc "Hypothesis" section). Nothing below may be
+changed after the first scored run banks. If a change is unavoidable, it must be recorded
+as a dated amendment at the bottom, and the prior-frozen runs re-labelled.
+
+---
+
+## 1. Hypothesis (restated, frozen)
+
+**H1 (directional):** With `claude-haiku-4-5` as the weak model, wiring the LANDED
+`scripts/hooks/format_ail.sh` PostToolUse fmt hook (ON) — which runs `ailang fmt --write`
+after every Edit/Write on a `.ail` file — reduces syntax drift, which reduces compile-stuck
+spirals, which raises pass rate and speeds convergence versus the identical harness with the
+hook absent (OFF).
+
+**H0 (null):** ON and OFF have no meaningful difference on the matched benchmark set.
+
+**Refutation of H1** (any one suffices):
+- The pass-rate delta (ON − OFF) is not a positive delta beyond the threshold in §6, OR
+- convergence (edits-to-first-green / green-stability) does not improve, OR
+- the hook did not actually run / did not exit 0 on most edited `.ail` files (treatment
+  never delivered → **unevaluable**, distinct from a true null; see §5.3 and the M4 verdict).
+
+---
+
+## 2. Frozen matched benchmark set
+
+Both arms run the SAME set, same versions, pinned to the repo SHA above (benchmark YAMLs
+carry no independent `version` field; the repo SHA IS the benchmark version). All six are
+`ailang`-supporting, agent-mode benchmarks where the agent authors/edits a `.ail` file in
+its workspace — so the PostToolUse Edit|Write hook on `*.ail` can actually fire. The set
+deliberately spans easy→hard so a weak model has room to spiral (the regime where canonical
+formatting could plausibly help), while staying cheap enough for N≥5 × 2 arms on haiku.
+
+| Benchmark ID              | File                                  | difficulty | tier  | Why chosen |
+|---------------------------|---------------------------------------|------------|-------|------------|
+| `fizzbuzz`                | `benchmarks/fizzbuzz.yml`             | easy       | smoke | Floor/control: near-ceiling for most models; ON should not REGRESS an easy task (guards against the hook harming). |
+| `gcd_lcm`                 | `benchmarks/gcd_lcm.yml`              | medium     | smoke | Recursion + multiple small functions; realistic multi-edit surface for a weak model. |
+| `adt_option`             | `benchmarks/adt_option.yml`           | medium     | smoke | ADTs + pattern matching — a known weak-model syntax-drift hotspot (`=>`/`->` confusion per docx dialect notes); canonical fmt most plausibly helps here. |
+| `higher_order_functions` | `benchmarks/higher_order_functions.yml` | medium     | core  | Lambdas (`\x. ...`) — another documented drift point; multi-turn editing likely. |
+| `json_parse`             | `benchmarks/json_parse.yml`           | medium     | smoke | Larger program, more edits, more chances for the hook to fire per run. |
+| `cli_args`               | `benchmarks/cli_args.yml`             | hard       | core  | Hard enough to induce compile-stuck spirals in a weak model — the exact regime H1 targets; seeds input files, exercises effect rows. |
+
+**Exclusions (frozen):**
+- No Python/JS/Go arms — the hook only touches `.ail` files; other languages would dilute.
+- No frontier/`stretch` benchmarks (e.g. `float_eq`) — saturated for stronger models and off-scope; this experiment is weak-model-specific.
+- No `docx_reimplement` / multi-file reimplement benchmarks — too expensive for N≥5 × 2 arms on the cheap-model budget and dominated by non-fmt failure modes.
+- Any benchmark that does NOT get the agent to write a `.ail` file (pure-Python-only specs) is excluded by construction.
+
+---
+
+## 3. Frozen model, N, and settings
+
+| Parameter | Frozen value | Source |
+|---|---|---|
+| Model | `claude-haiku-4-5` (`agent_model_name: haiku`, `agent_cli: claude`) | `internal/eval_harness/models.yml` |
+| API model id | `claude-haiku-4-5-20251001` | `models.yml` |
+| N (runs per arm per benchmark) | **N = 5** (≥5 required) | design doc §Experiment design |
+| Arms | 2: **ON** (`-fmt-hook on`) and **OFF** (`-fmt-hook off`) | this sprint (M2a) |
+| Total scored runs | 6 benchmarks × 2 arms × 5 = **60** | — |
+| Cost budget | `max_cost_usd: 0.30` per benchmark run | `models.yml` haiku `budgets` |
+| Hard timeout | `hard_timeout_secs: 600` (10 min) per run | `models.yml` haiku `budgets` |
+| Allowed tools | `Bash, Read, Write, Edit, Grep` (harness default `DefaultAgentConfig`) | `internal/eval_harness/agent_runner.go` |
+| Permission mode | `bypassPermissions` (streaming runner default) | `agent_runner_streaming.go` |
+| System prompt | The versioned AILANG teaching prompt selected by `GenerateAgentPromptsWithSystemPrompt` at the frozen SHA (record `prompt_version` from each banked result; MUST be identical across both arms) | harness |
+| Trials flag | `--trials 5` (native N-trial banking) | `cmd/ailang/eval_suite.go` |
+| Seed | fixed `--seed` value recorded at execution; identical for both arms | harness |
+
+**The ONLY difference between ON and OFF is the `-fmt-hook` flag.** All other flags,
+prompts, model settings, timeouts, tools, budgets, seed, and benchmark versions are held
+byte-identical. This is verified at execution time by diffing the two arms' resolved config
+(the banked `fmt_hook` field + logged resolved `.claude/settings.json`), per acceptance
+criterion "config diff between arms shows ONLY the hook".
+
+---
+
+## 4. Treatment definition (frozen)
+
+- **ON arm:** the harness writes a `.claude/settings.json` into each agent workspace that
+  registers `scripts/hooks/format_ail.sh` as a `PostToolUse` hook matching `Edit|Write`, and
+  passes `--settings <workspace>/.claude/settings.json` to the `claude` CLI. After every
+  Edit/Write on a `*.ail` file, `ailang fmt --write` canonically formats it.
+- **OFF arm:** no `.claude/settings.json` is written and no `--settings` flag is passed —
+  byte-identical to today's harness path (the hook is *absent*, exactly as it is in every
+  agent run today).
+- Banked per run: `fmt_hook: "on" | "off"` so the arm is unambiguous in analysis.
+
+---
+
+## 5. Metric definitions (frozen)
+
+### 5.1 Pass-rate delta (primary)
+
+- **Per-benchmark pass rate** for an arm = (# of the 5 runs that fully pass) / 5, where a
+  run "passes" iff `compile_ok && runtime_ok && stdout_ok` (the harness `Success`
+  definition, already banked in `RunMetrics`).
+- **Overall pass rate** for an arm = pooled passes / pooled runs across all 6 benchmarks
+  (30 runs/arm).
+- **Delta = pass_rate(ON) − pass_rate(OFF)**, reported per-benchmark AND overall, each with
+  N, variance, and a confidence interval (§6).
+
+### 5.2 Convergence (secondary)
+
+Using the DOCX compile-stuck / green-stability definitions already in the codebase and docs
+(`project_docx_compile_stuck_green_stability` memory; `analyze_stuck` per-edit `typecheck`
+field):
+- **Edits-to-first-green:** number of `.ail` Edit/Write operations before the first
+  compile-clean (type-checking) state of the solution file. Lower is better.
+- **Green-stability rate:** fraction of post-first-green edits that PRESERVE the green
+  (compile-clean) state (i.e. do not re-break it). Higher is better. This is the
+  green-stability metric from the DOCX convergence work (compile-preserving incremental
+  edits converge; big-bang rewrites spiral).
+- **Compile-stuck incidence:** fraction of runs that never reach first-green (stuck the
+  whole run). Lower is better.
+- Reported as ON vs OFF with variance/CIs; source is the per-turn edit + typecheck stream
+  banked in M2a's hook-reality capture plus existing transcript/`typecheck` data.
+
+### 5.3 Hook reality / treatment integrity (gate)
+
+Per turn, for the ON arm, record whether `fmt` ran on the edited `.ail` file and its exit
+status, classified as:
+- **exit 0** — canonical formatting applied (`✓ Formatted` on hook stderr), OR
+- **exit 3** — file did not parse yet (expected mid-edit; the hook defers silently), OR
+- **refusal/error** — any other exit (surfaced via `hookSpecificOutput.additionalContext`),
+  including the ~8% fail-closed refusal baseline observed in `m-ailang-fmt-phase2` /
+  inline-interior work.
+- **Treatment-delivery rate** = fraction of ON-arm `.ail` edits where `fmt` exited 0.
+- If the treatment-delivery rate is low (hook mostly refused/no-op'd), the ON arm was NOT
+  actually treated → the result is **unevaluable**, not a null. The M4 verdict MUST
+  distinguish "formatter is neutral/harmful" from "treatment never delivered". Compare the
+  observed refusal rate against the ~8% baseline.
+
+---
+
+## 6. Confidence method and refutation threshold (frozen)
+
+- **Unit of evidence:** the N-run aggregate, NEVER a single run (mission noisy-agentic-metrics
+  discipline). All deltas are aggregate over the 5 runs/arm/benchmark.
+- **Confidence method:** for each pass rate (a binomial proportion over the pooled runs),
+  report the **Wilson score 95% confidence interval**. For the ON−OFF pass-rate delta,
+  report the **95% CI of the difference of two independent binomial proportions**
+  (Newcombe/Wilson-based method). Convergence metrics (continuous/count) report
+  mean ± 95% CI (normal/bootstrap over the run-level values). This reuses the existing
+  N-run aggregate tooling (`tools/eval_best_of_n.py`-class); no separate aggregator.
+- **Refutation / "no meaningful difference" threshold (frozen):**
+  H1 is considered **supported** only if the overall ON−OFF pass-rate delta is **≥ +0.10
+  (10 percentage points)** AND the 95% CI of that delta **excludes 0** (lower bound > 0).
+  - If the delta's 95% CI **includes 0**, or the point delta is **< +0.10**, the result is
+    declared **NULL** (no meaningful positive difference) — and this null is published.
+  - If the point delta is **≤ −0.10** with a 95% CI excluding 0, the hook is declared to
+    **HARM** weak-model authoring.
+  - Convergence acts as corroboration, not an independent pass: even a positive pass-rate
+    delta is reported as "weak/unconfirmed" if edits-to-first-green does not also improve.
+  - Any headline verdict is **void** (→ **unevaluable**) if the ON-arm treatment-delivery
+    rate (§5.3) is low enough that fmt did not actually run on most edited files.
+
+---
+
+## 7. Reporting commitments (frozen)
+
+- Aggregate all 60 runs; preserve every per-run trace/bank; report variance and CIs, never
+  point estimates or selected anecdotes.
+- Publish the sign of the result — positive, negative, or NULL — and explicitly separate a
+  true formatter effect from a treatment-delivery failure.
+- Record `rig.lock` acquire/release around the M2b eval step only; any optional local
+  (Ollama) replication arm is reported separately and is NOT part of this frozen primary
+  result.
+
+---
+
+**Frozen by**: sprint-executor (M1), 2026-07-21. No scored runs have executed as of freezing.
+
+## Amendments
+
+(none)

--- a/design_docs/planned/v0_31_0/m-eval-fmt-weakmodel-ab-sprint-plan.md
+++ b/design_docs/planned/v0_31_0/m-eval-fmt-weakmodel-ab-sprint-plan.md
@@ -1,0 +1,213 @@
+# Sprint Plan: M-EVAL-FMT-WEAKMODEL-AB
+
+**Design doc**: [`design_docs/planned/v0_31_0/m-eval-fmt-weakmodel-ab.md`](m-eval-fmt-weakmodel-ab.md)
+**Sprint ID**: M-EVAL-FMT-WEAKMODEL-AB
+**Created**: 2026-07-21 (mission iter-72, sprint-planner)
+**Status**: PLAN READY (human green-lit; NOT re-quorumed)
+**Risk level**: medium (integration point does not yet exist; GPU-gated execution)
+**Estimated effort**: ~1.5d engineering (M1 + hook-toggle build in M2) + eval rig time
+
+---
+
+## Summary
+
+Green-lit A/B experiment: does the LANDED `format_ail.sh` PostToolUse fmt hook help a **weak
+model** (`claude-haiku-4-5`) author correct AILANG? Pure eval-infrastructure sprint — **NO
+language-surface change**. Both arms run the byte-identical agent-mode harness; the only
+difference is whether the `ailang fmt --write` PostToolUse hook is wired in.
+
+### KEY INTEGRATION FINDING (grounding the plan)
+
+**A hook ON/OFF toggle does NOT exist in the harness today — it must be built.**
+
+Verified against the tree (HEAD dev, 2026-07-21):
+
+- The active agent-mode path is `internal/eval_harness/agent_runner_streaming.go`
+  (`runHeadlessSessionStreaming`). It builds the `claude` command with `cmd.Dir = workspace`
+  but passes **no** `--settings` flag and writes **no** `.claude/settings.json` into the
+  workspace. Therefore `scripts/hooks/format_ail.sh` is **never wired into an agent-mode run
+  today** — not "off by default", but *absent entirely*.
+- `AgentBenchmarkConfig` (`agent_runner.go:19`) has no hook/settings field. It is constructed
+  in one place for the suite: `cmd/ailang/eval_suite.go:664`.
+- **The exact precedent to copy is `MicroragMode`** (`internal/eval_harness/microrag_mode.go`):
+  a `type FooMode string` with `Parse*`, `ApplyToEnv`/apply, and `ResolvedState()` methods,
+  plumbed as one `AgentBenchmarkConfig` field, set from one CLI flag, applied in BOTH runner
+  paths. The fmt-hook toggle should follow this structure exactly (an `on/off` `FmtHookMode`),
+  applied by writing/omitting a workspace `.claude/settings.json` that registers the LANDED
+  hook and passing `--settings <path>` to the claude command.
+- **Treatment-integrity ("hook reality") metric** needs per-turn `fmt` exit codes. The
+  stream-json parser already inspects `tool_use` blocks (`agent_runner_streaming.go:170`) but
+  does not currently surface PostToolUse hook `additionalContext` / exit codes. The hook script
+  emits its status via stderr (`✓ Formatted`) and `hookSpecificOutput.additionalContext` on
+  failure — capturing those per turn is a real (small) parsing task, not free.
+
+Conclusion: this is **~1 day of real harness engineering** (a new `FmtHookMode` toggle + workspace
+settings emission + hook-reality capture), plus M1 preregistration (cheap), plus GPU-gated
+execution and no-GPU analysis/verdict.
+
+---
+
+## GPU-touch map (per milestone)
+
+| Milestone | GPU / rig.lock? | Headless-schedulable when? |
+|---|---|---|
+| **M1 preregistration** | **NO** | Immediately — cheap, no eval, no GPU. Safe in any headless iteration. |
+| **M2 matched execution** | **YES** — acquires `tools/launchd/rig-lock.sh` (`rig_lock_acquire wait`) around the eval step ONLY; releases before M3. Optional local/Ollama replication arm also GPU. | GPU-available iteration only. |
+| **M3 analysis** | **NO** — consumes banked results; lock released. | Any headless iteration after M2 banks results. |
+| **M4 verdict** | **NO** — write-up only. | Any headless iteration after M3. |
+
+The **hook-toggle build itself (M2a below)** is pure Go/shell engineering and touches **NO
+GPU** — it can and should be built + unit-tested in a no-GPU iteration, so that when a GPU slot
+opens, M2b execution is a config-only run.
+
+---
+
+## Milestones
+
+### M1 — Preregistration (NO GPU, do first, headless-safe)
+
+Freeze the experiment before any scored run so a null result is publishable.
+
+**Tasks**
+- Select and freeze the matched benchmark set (draw from the curated weak-model set; prefer
+  benchmarks known to exercise `.ail` edits so the hook actually fires). Record exact IDs +
+  versions.
+- Fix N ≥ 5 runs per arm per benchmark; fix model = `claude-haiku-4-5`; fix timeouts, budgets
+  (haiku `max_cost_usd: 0.30`, `hard_timeout_secs: 600` from models.yml), allowed tools, and
+  prompt/system-prompt version.
+- Define metrics precisely: pass-rate delta (ON − OFF) with N/variance/CI; convergence (edits
+  to first green, green-stability rate) using the DOCX compile-stuck/green-stability
+  definitions; hook-reality (per-turn `fmt` exit-0 vs refusal/error; compare to the ~8%
+  fail-closed refusal baseline).
+- Fix the confidence method and the refutation threshold (what delta counts as "no meaningful
+  difference").
+- Write the preregistration into the design doc (or a sibling `prereg` section) and commit.
+
+**Acceptance**: preregistration committed, fixing benchmark set, N≥5/arm/bench, metrics,
+exclusions, statistical method, and refutation threshold BEFORE any scored run.
+**Effort**: ~0.25d. **GPU**: no.
+
+### M2 — Matched execution
+
+Two sub-parts, deliberately separated so the build is GPU-free and only execution is gated.
+
+#### M2a — Build the fmt-hook toggle (NO GPU, headless-safe)
+
+**Tasks**
+- Add `FmtHookMode` (`on`/`off`) modeled on `internal/eval_harness/microrag_mode.go`
+  (type + `ParseFmtHookMode` + apply + `ResolvedState()`), with a unit test mirroring
+  `microrag_mode_test.go`.
+- Add a `FmtHook FmtHookMode` field to `AgentBenchmarkConfig`; wire it in
+  `cmd/ailang/eval_suite.go:664` from a new CLI flag (e.g. `-fmt-hook on|off`, default `off`
+  to preserve current behaviour). Follow the `-microrag` flag precedent.
+- In workspace prep, when `FmtHook == on`, emit a `.claude/settings.json` into the agent
+  workspace registering the LANDED `scripts/hooks/format_ail.sh` as a PostToolUse hook for
+  Edit/Write, and pass `--settings <workspace>/.claude/settings.json` to the claude command in
+  BOTH `agent_runner_streaming.go` (active) and `agent_runner.go` (legacy). When `off`, emit
+  nothing / pass no settings. This is the ONLY per-arm difference.
+- Record the resolved config into the banked result (a `fmt_hook: on|off` field) and log the
+  resolved settings so the required **config diff** can be reviewed.
+- Capture per-turn hook reality: extend the stream-json handling to record `fmt` invocation +
+  exit status (from hook stderr / `additionalContext`) per turn, banked for M3's hook-reality
+  metric.
+
+**Acceptance**: `-fmt-hook on` writes the workspace settings + `--settings` flag and the hook
+fires on `.ail` edits; `-fmt-hook off` is byte-identical to today's path; config diff between
+arms shows ONLY the hook; unit tests green; `make test` + `make lint` + `make check-boundaries`
+pass.
+**Effort**: ~0.75d–1d. **GPU**: no.
+
+#### M2b — Run the matched A/B (GPU — rig.lock gated)
+
+**Tasks**
+- Acquire `tools/launchd/rig-lock.sh` (`rig_lock_acquire wait`) around the eval step ONLY.
+- Run `claude-haiku-4-5` ON and OFF at the frozen N on every frozen benchmark, via the existing
+  `ailang eval-suite` agent path (`--agent`, `-fmt-hook on` / `-fmt-hook off`), banking per
+  run. Keep everything else fixed.
+- OPTIONAL replication arm (local Ollama small model, e.g. Qwen) under the SAME protocol — also
+  GPU, also under the same lock; explicitly separated from the primary haiku result. Not
+  required for acceptance.
+- Release the lock BEFORE analysis.
+
+**Acceptance**: ON/OFF haiku runs complete under identical conditions except the hook; N≥5/arm
+per bench banked; `rig.lock` acquire/release recorded for the eval step; any local arm clearly
+separated.
+**Effort**: rig time (~hours, model/bench-count dependent), minimal engineering. **GPU**: YES.
+
+### M3 — Analysis (NO GPU, headless-safe after M2 banks)
+
+**Tasks**
+- Aggregate all N runs via the existing `tools/eval_best_of_n.py`-class N-run tooling and the
+  native rotation summary path — REUSE, do not fork.
+- Report pass-rate delta (ON − OFF) with variance/CIs; convergence (edits-to-first-green,
+  green-stability, compile-stuck incidence); per-turn `fmt` exit-code coverage (exit-0 vs
+  refusal/error), compared to the ~8% baseline.
+- Include the null result if observed.
+
+**Acceptance**: aggregate deltas + variance/CIs + convergence traces + per-turn formatter
+exit-code coverage published; reuses existing banking + aggregate tooling (no separate
+aggregator).
+**Effort**: ~0.25d. **GPU**: no.
+
+### M4 — Verdict (NO GPU, headless-safe)
+
+**Tasks**
+- State whether the hook **helps / is neutral / harms / is unevaluable** (the last if formatter
+  refusal/no-op prevented treatment delivery — distinguish benefit from delivery failure).
+- Publish positive, negative, or null evidence. Feed the verdict back to the mission bookkeeping
+  issue and route follow-up (do NOT change adoption policy off a single benchmark/run).
+
+**Acceptance**: verdict published distinguishing formatter benefit from treatment-delivery
+failure; evidence (whatever sign) recorded.
+**Effort**: ~0.25d. **GPU**: no.
+
+---
+
+## Execution sequencing for headless mission iterations
+
+1. **Iteration A (any slot, no GPU)**: execute **M1** (preregistration) + **M2a** (build the
+   `FmtHookMode` toggle, settings emission, hook-reality capture; unit-tested, lint/boundaries
+   green). Both are cheap and GPU-free.
+2. **Iteration B (GPU-available slot)**: execute **M2b** under `rig.lock` — config-only run once
+   M2a is merged.
+3. **Iteration C (any slot, no GPU)**: execute **M3** analysis + **M4** verdict on banked
+   results.
+
+This keeps every GPU-touching step (M2b, optional local arm) isolated to a single
+GPU-available iteration; all engineering, prereg, analysis, and verdict are safely headless.
+
+---
+
+## Success metrics
+
+- Preregistration committed before any scored run.
+- `-fmt-hook on|off` toggle exists, unit-tested; config diff between arms shows ONLY the hook.
+- Both arms share the identical harness code path (verified by config diff).
+- Results report pass-rate delta, compile-stuck/green-stability convergence, and per-turn `fmt`
+  exit codes with variance/CIs.
+- Verdict distinguishes formatter benefit from treatment-delivery failure.
+- `rig.lock` acquire/release recorded for M2b; optional local arm separated from primary result.
+
+## Risks & guardrails
+
+- **Integration surface is NEW** (biggest risk): the hook toggle does not exist; M2a is real
+  engineering, not config. Estimated honestly at ~0.75–1d.
+- **No single-run claims**: N-run aggregates are the unit of evidence.
+- **Treatment integrity**: do not classify the ON arm as treated when `fmt` did not run / did
+  not exit 0 — the hook-reality capture in M2a is what enforces this.
+- **GPU mutex**: hold `rig.lock` around M2b execution only; release before M3.
+- **Boundaries**: changes live in `internal/eval_harness/` + `cmd/ailang/` (dashboard/apps
+  layer for the CLI) — run `make check-boundaries`.
+- **Language surface: NONE.**
+
+## Out of scope
+
+- Formatter implementation/polish (dependency pair already LANDED).
+- Any parser/type/codegen/runtime/syntax change.
+- A separate A/B runner or aggregator (extend/reuse only).
+- Frontier-model comparison or metered spend; making the hook mandatory off one run.
+
+---
+
+**SPRINT_PLAN_PATH**: `design_docs/planned/v0_31_0/m-eval-fmt-weakmodel-ab-sprint-plan.md`
+**SPRINT_JSON_PATH**: `.ailang/state/sprints/sprint_M-EVAL-FMT-WEAKMODEL-AB.json`

--- a/internal/eval_harness/agent_runner.go
+++ b/internal/eval_harness/agent_runner.go
@@ -33,6 +33,11 @@ type AgentBenchmarkConfig struct {
 	AgentPromptContent string        // Agent coding prompt content (replaces teaching prompt when UseAgentPrompt condition is active)
 	Condition          EvalCondition // Experimental condition (overrides Verify/DevtoolsPrompt when set)
 	MicroragMode       MicroragMode  // μRAG subprocess env mode (M-BRAIN-MICRORAG): on/off/auto
+	// FmtHook (M-EVAL-FMT-WEAKMODEL-AB): on/off toggle for the LANDED
+	// scripts/hooks/format_ail.sh PostToolUse fmt hook. ON wires it into the
+	// agent workspace via .claude/settings.json + --settings; OFF is
+	// byte-identical to today's path. The ONLY per-arm difference in the fmt A/B.
+	FmtHook FmtHookMode
 
 	// MaxTokensPerBench (M-EVAL-OS-LONGITUDINAL Phase 1, v0.23.0): hard
 	// token-budget ceiling per benchmark for thrash detection on $0 local
@@ -115,6 +120,27 @@ type AgentBenchmarkResult struct {
 	CompactionCount     int `json:"compaction_count,omitempty"`
 	CompactionFirstStep int `json:"first_compaction_step,omitempty"`
 	CompactionMaxLevel  int `json:"compaction_level_max,omitempty"`
+
+	// Fmt-hook A/B fields (M-EVAL-FMT-WEAKMODEL-AB).
+	// FmtHook is the resolved arm ("on"|"off") for config-diff review.
+	FmtHook string `json:"fmt_hook,omitempty"`
+	// FmtHookEvents is the per-turn hook-reality capture: each PostToolUse fmt
+	// invocation observed in the stream, classified exit-0 / defer(3) / error.
+	// Powers M3's treatment-integrity metric (was the ON arm actually treated?).
+	FmtHookEvents []FmtHookEvent `json:"fmt_hook_events,omitempty"`
+}
+
+// FmtHookEvent is one observed run of the format_ail.sh PostToolUse hook
+// (M-EVAL-FMT-WEAKMODEL-AB hook-reality metric). The hook is non-blocking and
+// always exits 0 to the CLI, surfacing its real status via stderr
+// ("✓ Formatted <file>") or hookSpecificOutput.additionalContext (failure). We
+// classify each observed event so M3 can compute the treatment-delivery rate and
+// compare it to the ~8% fail-closed refusal baseline.
+type FmtHookEvent struct {
+	Turn   int    `json:"turn"`             // Agent turn the hook fired on
+	Status string `json:"status"`           // "formatted" (exit 0) | "deferred" (unparseable, exit 3) | "error" (fmt failed / refusal)
+	File   string `json:"file,omitempty"`   // .ail file the hook targeted, if identifiable
+	Detail string `json:"detail,omitempty"` // additionalContext / stderr excerpt for error/deferred cases
 }
 
 // TokenUsage captures detailed token metrics
@@ -152,6 +178,9 @@ type ClaudeHeadlessResult struct {
 	PermissionDenials []interface{}         `json:"permission_denials"`
 	UUID              string                `json:"uuid"`
 	Transcript        string                `json:"-"` // Full conversation transcript (not in JSON, set by streaming)
+	// FmtHookEvents (M-EVAL-FMT-WEAKMODEL-AB): per-turn fmt PostToolUse hook
+	// reality captured from the stream-json (not part of Claude's JSON).
+	FmtHookEvents []FmtHookEvent `json:"-"`
 }
 
 // RunAgentBenchmark runs a single benchmark using Claude Code headless mode
@@ -307,6 +336,9 @@ func RunAgentBenchmark(spec *BenchmarkSpec, config AgentBenchmarkConfig, languag
 		StdoutOk:  validation.StdoutOk,
 		Stdout:    validation.Stdout,
 		Stderr:    validation.Stderr,
+		// Fmt-hook A/B (M-EVAL-FMT-WEAKMODEL-AB): resolved arm + hook-reality.
+		FmtHook:       config.FmtHook.ResolvedState(),
+		FmtHookEvents: result.FmtHookEvents,
 	}
 
 	// M-CONTRACT-EVAL: Populate verify fields if verification was run
@@ -355,15 +387,27 @@ func runHeadlessSession(prompt, workspace string, config AgentBenchmarkConfig) (
 	// Generate UUID for session ID (Claude CLI requires valid UUID)
 	sessionID := uuid.New().String()
 
+	// Fmt-hook A/B (M-EVAL-FMT-WEAKMODEL-AB): when ON, emit a workspace
+	// .claude/settings.json registering the LANDED format_ail.sh PostToolUse
+	// hook and pass --settings. When OFF, nothing changes (byte-identical path).
+	fmtSettingsPath, _, fmtErr := config.FmtHook.Apply(workspace)
+	if fmtErr != nil {
+		return nil, fmt.Errorf("fmt-hook setup failed: %w", fmtErr)
+	}
+
 	// Build command: claude -p <prompt> --output-format json --model <model> --session-id <id>
 	// Note: --add-dir grants tool access to workspace directory
-	cmd := exec.Command(config.ClaudePath, "-p", prompt,
+	args := []string{"-p", prompt,
 		"--output-format", "json",
 		"--model", config.ClaudeModel,
 		"--session-id", sessionID,
 		"--add-dir", workspace,
 		"--allowedTools", strings.Join(config.AllowedTools, ","),
-	)
+	}
+	if fmtSettingsPath != "" {
+		args = append(args, "--settings", fmtSettingsPath)
+	}
+	cmd := exec.Command(config.ClaudePath, args...)
 
 	// Set working directory to workspace so relative paths work
 	cmd.Dir = workspace

--- a/internal/eval_harness/agent_runner_multi.go
+++ b/internal/eval_harness/agent_runner_multi.go
@@ -458,6 +458,18 @@ func (h *fmtHookEventHandler) OnToolResult(_ string, output string) {
 func (h *fmtHookEventHandler) OnTurnEnd(int) {}
 func (h *fmtHookEventHandler) OnError(error) {}
 
+// OnRawStreamLine implements executor.RawStreamLineHandler. The active claude
+// path (claude.go) never dispatches OnToolResult for the tool_result/PostToolUse
+// lines that carry format_ail.sh's status markers, so we key hook-reality off
+// the raw stream line instead — the same strategy the legacy streaming runner
+// uses. Fail-closed: detectFmtHookEvent returns ok=false for any line without a
+// real marker, so a line with no hook output is never recorded as treated.
+func (h *fmtHookEventHandler) OnRawStreamLine(line string) {
+	if ev, ok := detectFmtHookEvent(line, h.turn); ok {
+		h.events = append(h.events, ev)
+	}
+}
+
 // fmtTrackerEvents safely extracts events from a possibly-nil tracker (OFF arm).
 func fmtTrackerEvents(t *fmtHookEventHandler) []FmtHookEvent {
 	if t == nil {
@@ -537,6 +549,19 @@ func (c *compositeEventHandler) OnTurnEnd(turnNum int) {
 func (c *compositeEventHandler) OnError(err error) {
 	c.primary.OnError(err)
 	c.secondary.OnError(err)
+}
+
+// OnRawStreamLine implements executor.RawStreamLineHandler by forwarding the raw
+// stream line to whichever wrapped handler(s) opt into it. Composites can nest
+// (the ON arm wraps a base composite as primary and the fmt tracker as
+// secondary), so we recurse through the interface rather than assuming a leaf.
+func (c *compositeEventHandler) OnRawStreamLine(line string) {
+	if rh, ok := c.primary.(executor.RawStreamLineHandler); ok {
+		rh.OnRawStreamLine(line)
+	}
+	if rh, ok := c.secondary.(executor.RawStreamLineHandler); ok {
+		rh.OnRawStreamLine(line)
+	}
 }
 
 // ttftEventHandler records the elapsed time until the first output event (text or tool use).

--- a/internal/eval_harness/agent_runner_multi.go
+++ b/internal/eval_harness/agent_runner_multi.go
@@ -135,6 +135,21 @@ func RunAgentBenchmarkWithExecutor(spec *BenchmarkSpec, config MultiExecutorConf
 		return nil, err
 	}
 
+	// Fmt-hook A/B (M-EVAL-FMT-WEAKMODEL-AB): this is the ACTIVE executor path.
+	// When ON, write a workspace .claude/settings.json registering the LANDED
+	// format_ail.sh PostToolUse hook. The claude executor sets cmd.Dir = workspace
+	// and loads .claude/settings.json naturally (see internal/executor/claude:165),
+	// so no --settings flag is needed here — writing the file IS the wiring. When
+	// OFF, nothing is written: byte-identical to today's path. This is the ONLY
+	// per-arm difference in the experiment.
+	fmtSettingsPath, fmtSettingsJSON, fmtErr := config.FmtHook.Apply(workspace)
+	if fmtErr != nil {
+		return nil, fmt.Errorf("fmt-hook setup failed: %w", fmtErr)
+	}
+	if fmtSettingsPath != "" {
+		fmt.Fprintf(os.Stderr, "[FMT-HOOK] on (executor path): %s\n%s\n", fmtSettingsPath, string(fmtSettingsJSON))
+	}
+
 	// Create solution file placeholder
 	var solutionPath string
 	var placeholder string
@@ -297,6 +312,15 @@ func RunAgentBenchmarkWithExecutor(spec *BenchmarkSpec, config MultiExecutorConf
 			secondary: config.ExtraHandler,
 		}
 	}
+	// Hook-reality capture (M-EVAL-FMT-WEAKMODEL-AB): only for the ON arm. The
+	// LANDED format_ail.sh surfaces its status via stderr / additionalContext,
+	// which Claude Code echoes into the PostToolUse tool-result stream — captured
+	// here per turn via OnToolResult. Powers M3's treatment-delivery metric.
+	var fmtTracker *fmtHookEventHandler
+	if config.FmtHook == FmtHookModeOn {
+		fmtTracker = &fmtHookEventHandler{}
+		handler = &compositeEventHandler{primary: handler, secondary: fmtTracker}
+	}
 
 	// Execute with streaming
 	result, err := exec.ExecuteStreaming(ctx, task, handler)
@@ -407,7 +431,39 @@ func RunAgentBenchmarkWithExecutor(spec *BenchmarkSpec, config MultiExecutorConf
 		CompactionCount:     result.CompactionCount,
 		CompactionFirstStep: result.CompactionFirstStep,
 		CompactionMaxLevel:  result.CompactionMaxLevel,
+
+		// Fmt-hook A/B (M-EVAL-FMT-WEAKMODEL-AB): resolved arm + per-turn hook reality.
+		FmtHook:       config.FmtHook.ResolvedState(),
+		FmtHookEvents: fmtTrackerEvents(fmtTracker),
 	}, nil
+}
+
+// fmtHookEventHandler captures format_ail.sh PostToolUse status markers from the
+// executor tool-result stream (M-EVAL-FMT-WEAKMODEL-AB hook-reality metric). Only
+// installed for the ON arm. It records only what the hook actually emitted — it
+// never fabricates a "treated" event.
+type fmtHookEventHandler struct {
+	turn   int
+	events []FmtHookEvent
+}
+
+func (h *fmtHookEventHandler) OnTurnStart(turnNum int)  { h.turn = turnNum }
+func (h *fmtHookEventHandler) OnText(string)            {}
+func (h *fmtHookEventHandler) OnToolUse(string, string) {}
+func (h *fmtHookEventHandler) OnToolResult(_ string, output string) {
+	if ev, ok := detectFmtHookEvent(output, h.turn); ok {
+		h.events = append(h.events, ev)
+	}
+}
+func (h *fmtHookEventHandler) OnTurnEnd(int) {}
+func (h *fmtHookEventHandler) OnError(error) {}
+
+// fmtTrackerEvents safely extracts events from a possibly-nil tracker (OFF arm).
+func fmtTrackerEvents(t *fmtHookEventHandler) []FmtHookEvent {
+	if t == nil {
+		return nil
+	}
+	return t.events
 }
 
 // debugEventHandler prints streaming events when DEBUG_AGENT is set

--- a/internal/eval_harness/agent_runner_streaming.go
+++ b/internal/eval_harness/agent_runner_streaming.go
@@ -33,9 +33,21 @@ func RunHeadlessSessionStreaming(spec *BenchmarkSpec, systemPrompt, taskPrompt, 
 	// -p: Task prompt (benchmark description and expected output)
 	// --output-format stream-json: Get structured JSON events as they happen
 	// --include-partial-messages: Show thinking process token by token
+	// Fmt-hook A/B (M-EVAL-FMT-WEAKMODEL-AB): when ON, emit a workspace
+	// .claude/settings.json registering the LANDED format_ail.sh PostToolUse hook
+	// and pass --settings <path>. When OFF, nothing is emitted and no flag is
+	// added — byte-identical to today's path. This is the ONLY per-arm difference.
+	fmtSettingsPath, fmtSettingsJSON, fmtErr := config.FmtHook.Apply(workspace)
+	if fmtErr != nil {
+		return nil, fmt.Errorf("fmt-hook setup failed: %w", fmtErr)
+	}
+	if fmtSettingsPath != "" {
+		fmt.Fprintf(os.Stderr, "[FMT-HOOK] on: %s\n%s\n", fmtSettingsPath, string(fmtSettingsJSON))
+	}
+
 	// --permission-mode bypassPermissions: Skip approval prompts for automated execution
 	// --verbose: Show detailed execution information
-	cmd := exec.Command(config.ClaudePath,
+	streamArgs := []string{
 		"--system-prompt", systemPrompt,
 		"-p", taskPrompt,
 		"--output-format", "stream-json",
@@ -46,7 +58,11 @@ func RunHeadlessSessionStreaming(spec *BenchmarkSpec, systemPrompt, taskPrompt, 
 		"--session-id", sessionID,
 		"--add-dir", workspace,
 		"--allowedTools", strings.Join(config.AllowedTools, ","),
-	)
+	}
+	if fmtSettingsPath != "" {
+		streamArgs = append(streamArgs, "--settings", fmtSettingsPath)
+	}
+	cmd := exec.Command(config.ClaudePath, streamArgs...)
 
 	cmd.Dir = workspace
 
@@ -113,6 +129,10 @@ func RunHeadlessSessionStreaming(spec *BenchmarkSpec, systemPrompt, taskPrompt, 
 	var currentMessage strings.Builder
 	var transcriptBuf strings.Builder // Accumulate full conversation for session log
 	var turnNum int
+	// Hook-reality capture (M-EVAL-FMT-WEAKMODEL-AB): per-turn fmt PostToolUse
+	// events. Only populated when the ON arm wired the hook in.
+	var fmtHookEvents []FmtHookEvent
+	captureFmt := config.FmtHook == FmtHookModeOn
 
 	go func() {
 		stdoutScanner := bufio.NewScanner(stdout)
@@ -141,6 +161,19 @@ func RunHeadlessSessionStreaming(spec *BenchmarkSpec, systemPrompt, taskPrompt, 
 			}
 
 			eventType, _ := event["type"].(string)
+
+			// Hook-reality capture (M-EVAL-FMT-WEAKMODEL-AB): scan every event for
+			// the LANDED format_ail.sh hook's own status markers. The hook always
+			// exits 0 to the CLI but surfaces its real status via stderr
+			// ("✓ Formatted <file>") and hookSpecificOutput.additionalContext
+			// ("ailang fmt failed"/"timed out") on failure — both of which Claude
+			// Code echoes into the stream (system/user events). We only record what
+			// the hook actually emitted; a run with no markers records no events.
+			if captureFmt {
+				if ev, ok := detectFmtHookEvent(line, turnNum); ok {
+					fmtHookEvents = append(fmtHookEvents, ev)
+				}
+			}
 
 			switch eventType {
 			case "system":
@@ -264,19 +297,22 @@ func RunHeadlessSessionStreaming(spec *BenchmarkSpec, systemPrompt, taskPrompt, 
 		transcript := fmt.Sprintf("=== Claude Session Log ===\n\nTask Prompt:\n%s\n\nTranscript:\n%s\n",
 			taskPrompt, transcriptBuf.String())
 
+		// Goroutine has finished (done was signalled), so fmtHookEvents is safe to
+		// read here without a data race (M-EVAL-FMT-WEAKMODEL-AB).
 		if err != nil {
 			telemetry.Error() // Report error to collaboration hub
 			fmt.Fprintf(os.Stderr, "\n[ERROR] Claude failed: %v\n", err)
 			// Return partial result even on error, so we can capture transcript
 			result := &ClaudeHeadlessResult{
-				Type:       "result",
-				Subtype:    "error",
-				IsError:    true,
-				Result:     fmt.Sprintf("Claude execution error: %v", err),
-				NumTurns:   turnNum,
-				DurationMS: int(time.Since(time.Now().Add(-time.Duration(timeoutSeconds) * time.Second)).Milliseconds()),
-				SessionID:  sessionID,
-				Transcript: transcript,
+				Type:          "result",
+				Subtype:       "error",
+				IsError:       true,
+				Result:        fmt.Sprintf("Claude execution error: %v", err),
+				NumTurns:      turnNum,
+				DurationMS:    int(time.Since(time.Now().Add(-time.Duration(timeoutSeconds) * time.Second)).Milliseconds()),
+				SessionID:     sessionID,
+				Transcript:    transcript,
+				FmtHookEvents: fmtHookEvents,
 			}
 			return result, nil // Return result, not error, so caller can still log partial data
 		}
@@ -284,16 +320,18 @@ func RunHeadlessSessionStreaming(spec *BenchmarkSpec, systemPrompt, taskPrompt, 
 		if finalResult == nil {
 			// No structured result, but session completed
 			return &ClaudeHeadlessResult{
-				Type:       "result",
-				IsError:    false,
-				Result:     "Session completed (see workspace for solution.ail)",
-				NumTurns:   turnNum,
-				Transcript: transcript,
+				Type:          "result",
+				IsError:       false,
+				Result:        "Session completed (see workspace for solution.ail)",
+				NumTurns:      turnNum,
+				Transcript:    transcript,
+				FmtHookEvents: fmtHookEvents,
 			}, nil
 		}
 
-		// Attach transcript to finalResult
+		// Attach transcript + hook-reality to finalResult
 		finalResult.Transcript = transcript
+		finalResult.FmtHookEvents = fmtHookEvents
 		return finalResult, nil
 	}
 }

--- a/internal/eval_harness/fmt_hook_mode.go
+++ b/internal/eval_harness/fmt_hook_mode.go
@@ -1,0 +1,186 @@
+package eval_harness
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// FmtHookMode is the eval-suite -fmt-hook flag value (M-EVAL-FMT-WEAKMODEL-AB).
+//
+// It is the ONLY per-arm difference in the fmt-hook A/B experiment: whether the
+// LANDED scripts/hooks/format_ail.sh PostToolUse hook is wired into the agent
+// workspace so `ailang fmt --write` canonically formats every edited .ail file.
+//
+// Modeled on MicroragMode (type + Parse* + apply + ResolvedState), but the
+// treatment is a workspace .claude/settings.json + --settings flag rather than
+// a subprocess env var.
+type FmtHookMode string
+
+const (
+	// FmtHookModeOff omits the fmt PostToolUse hook entirely — byte-identical to
+	// the harness path that ships today (no .claude/settings.json, no --settings
+	// flag). This is the DEFAULT so existing eval runs are unchanged, and it is
+	// the baseline arm of the A/B.
+	FmtHookModeOff FmtHookMode = "off"
+	// FmtHookModeOn writes a workspace .claude/settings.json registering
+	// scripts/hooks/format_ail.sh as a PostToolUse hook for Edit|Write, and
+	// passes --settings <path> to the claude command. This is the treatment arm.
+	FmtHookModeOn FmtHookMode = "on"
+)
+
+// ParseFmtHookMode normalises CLI input. Empty / unknown → off (default,
+// preserves today's behaviour). Mirrors ParseMicroragMode.
+func ParseFmtHookMode(s string) FmtHookMode {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "on", "1", "true", "enabled":
+		return FmtHookModeOn
+	default:
+		return FmtHookModeOff
+	}
+}
+
+// ResolvedState returns what should be recorded in RunMetrics.FmtHookState /
+// AgentBenchmarkResult.FmtHook so the A/B arm is unambiguous in analysis.
+func (m FmtHookMode) ResolvedState() string {
+	if m == FmtHookModeOn {
+		return "on"
+	}
+	return "off"
+}
+
+// SettingsJSON is the exact bytes written to the workspace .claude/settings.json
+// for the ON arm. It registers the LANDED format_ail.sh as a PostToolUse hook
+// matching Edit|Write. hookScriptPath must be an ABSOLUTE path (the agent's CWD
+// is the isolated workspace, not the repo root). Returns the marshalled JSON so
+// callers can log the resolved settings for config-diff review.
+func (m FmtHookMode) SettingsJSON(hookScriptPath string) ([]byte, error) {
+	settings := map[string]interface{}{
+		"hooks": map[string]interface{}{
+			"PostToolUse": []interface{}{
+				map[string]interface{}{
+					"matcher": "Edit|Write",
+					"hooks": []interface{}{
+						map[string]interface{}{
+							"type":    "command",
+							"command": hookScriptPath,
+						},
+					},
+				},
+			},
+		},
+	}
+	return json.MarshalIndent(settings, "", "  ")
+}
+
+// Apply wires the fmt hook into the given agent workspace when the mode is ON.
+//
+// For ON: it locates scripts/hooks/format_ail.sh (relative to the repo root =
+// the process CWD during eval), writes workspace/.claude/settings.json
+// registering it as a PostToolUse Edit|Write hook, and returns the absolute path
+// to that settings file so the caller can pass `--settings <path>` to claude.
+// It also returns the resolved settings bytes for config-diff logging.
+//
+// For OFF: it writes nothing and returns ("", nil, nil) — byte-identical to the
+// path that ships today. This is the ONLY per-arm difference in the experiment.
+//
+// A missing hook script in ON mode is a HARD error (fail loudly, per the repo's
+// no-silent-fallback rule): silently degrading to OFF would corrupt the A/B by
+// classifying an untreated run as treated.
+func (m FmtHookMode) Apply(workspace string) (settingsPath string, settingsJSON []byte, err error) {
+	if m != FmtHookModeOn {
+		return "", nil, nil
+	}
+
+	hookScript, err := resolveFmtHookScript()
+	if err != nil {
+		return "", nil, err
+	}
+
+	jsonBytes, err := m.SettingsJSON(hookScript)
+	if err != nil {
+		return "", nil, fmt.Errorf("fmt-hook: marshal settings: %w", err)
+	}
+
+	claudeDir := filepath.Join(workspace, ".claude")
+	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+		return "", nil, fmt.Errorf("fmt-hook: create %s: %w", claudeDir, err)
+	}
+	settingsPath = filepath.Join(claudeDir, "settings.json")
+	if err := os.WriteFile(settingsPath, jsonBytes, 0644); err != nil {
+		return "", nil, fmt.Errorf("fmt-hook: write %s: %w", settingsPath, err)
+	}
+	return settingsPath, jsonBytes, nil
+}
+
+// Marker strings emitted by the LANDED scripts/hooks/format_ail.sh. These are
+// the ground-truth signals of what the hook actually did; we key hook-reality
+// classification off them so we never fabricate a "treated" event.
+const (
+	fmtHookMarkerFormatted = "✓ Formatted "            // exit 0: canonical format applied
+	fmtHookMarkerFailed    = "ailang fmt failed"       // non-0/non-3 exit surfaced via additionalContext
+	fmtHookMarkerTimedOut  = "ailang fmt timed out"    // synthetic timeout branch
+	fmtHookMarkerSkippedJq = "format_ail hook: jq not" // jq missing → skipped
+)
+
+// detectFmtHookEvent inspects one stream-json line for a format_ail.sh status
+// marker and, if present, returns a classified FmtHookEvent tagged with the
+// current turn. Returns ok=false when the line carries no hook marker.
+//
+// Classification (M-EVAL-FMT-WEAKMODEL-AB hook-reality metric):
+//   - "formatted" — the hook ran ailang fmt and it exited 0 (treatment delivered)
+//   - "error"     — the hook surfaced a failure/timeout/skip via additionalContext
+//     or stderr (refusal/no-op class; counts against the treatment-delivery rate)
+//
+// The exit-3 "deferred" (unparseable-mid-edit) case is intentionally SILENT in
+// the LANDED hook (contract clause 5), so it emits no marker and is not counted
+// as either treated or refused — which is the correct treatment-integrity
+// accounting.
+func detectFmtHookEvent(line string, turn int) (FmtHookEvent, bool) {
+	switch {
+	case strings.Contains(line, fmtHookMarkerFormatted):
+		return FmtHookEvent{Turn: turn, Status: "formatted", File: extractFmtFile(line, fmtHookMarkerFormatted)}, true
+	case strings.Contains(line, fmtHookMarkerTimedOut):
+		return FmtHookEvent{Turn: turn, Status: "error", Detail: "fmt timed out"}, true
+	case strings.Contains(line, fmtHookMarkerFailed):
+		return FmtHookEvent{Turn: turn, Status: "error", Detail: "ailang fmt failed"}, true
+	case strings.Contains(line, fmtHookMarkerSkippedJq):
+		return FmtHookEvent{Turn: turn, Status: "error", Detail: "jq missing — fmt skipped"}, true
+	default:
+		return FmtHookEvent{}, false
+	}
+}
+
+// extractFmtFile pulls the .ail filename out of a "✓ Formatted <file>" marker.
+// Best-effort: the marker may be embedded in a JSON string, so we take the token
+// after the marker up to the next quote/whitespace/escape.
+func extractFmtFile(line, marker string) string {
+	i := strings.Index(line, marker)
+	if i < 0 {
+		return ""
+	}
+	rest := line[i+len(marker):]
+	end := strings.IndexAny(rest, "\"\\ \t\n")
+	if end < 0 {
+		return strings.TrimSpace(rest)
+	}
+	return rest[:end]
+}
+
+// resolveFmtHookScript returns the absolute path to the LANDED fmt PostToolUse
+// hook. Eval runs execute from the repo root, so scripts/hooks/format_ail.sh is
+// CWD-relative. Fails loudly if the LANDED hook is absent (do not silently ship
+// an untreated ON arm).
+func resolveFmtHookScript() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("fmt-hook: getwd: %w", err)
+	}
+	script := filepath.Join(cwd, "scripts", "hooks", "format_ail.sh")
+	if _, statErr := os.Stat(script); statErr != nil {
+		return "", fmt.Errorf("fmt-hook: LANDED hook not found at %s (run eval from repo root): %w", script, statErr)
+	}
+	return script, nil
+}

--- a/internal/eval_harness/fmt_hook_mode_test.go
+++ b/internal/eval_harness/fmt_hook_mode_test.go
@@ -146,6 +146,83 @@ func TestApply_OnMissingHookFailsLoud(t *testing.T) {
 	}
 }
 
+// TestDetectFmtHookEvent covers the classifier that maps format_ail.sh's own
+// status markers to a FmtHookEvent (M-EVAL-FMT-WEAKMODEL-AB hook-reality metric).
+// It must classify each of the 4 landed markers and, critically, emit NO event
+// for an unrelated line (fail-closed: an absent hook marker is never counted as
+// a successful format).
+func TestDetectFmtHookEvent(t *testing.T) {
+	const turn = 7
+	cases := []struct {
+		name       string
+		line       string
+		wantOK     bool
+		wantStatus string
+		wantDetail string // "" = don't assert detail
+		wantFile   string // "" = don't assert file
+	}{
+		{
+			name:       "formatted marker → formatted",
+			line:       `{"type":"user","message":"✓ Formatted src/main.ail"}`,
+			wantOK:     true,
+			wantStatus: "formatted",
+			wantFile:   "src/main.ail",
+		},
+		{
+			name:       "fmt failed marker → error",
+			line:       `hookSpecificOutput: ailang fmt failed on foo.ail`,
+			wantOK:     true,
+			wantStatus: "error",
+			wantDetail: "ailang fmt failed",
+		},
+		{
+			name:       "fmt timed out marker → error/timeout",
+			line:       `additionalContext: ailang fmt timed out after 10s`,
+			wantOK:     true,
+			wantStatus: "error",
+			wantDetail: "fmt timed out",
+		},
+		{
+			name:       "jq missing marker → error",
+			line:       `format_ail hook: jq not found, skipping`,
+			wantOK:     true,
+			wantStatus: "error",
+			wantDetail: "jq missing — fmt skipped",
+		},
+		{
+			name:   "unrelated line → no event (fail-closed)",
+			line:   `{"type":"assistant","text":"Let me edit the file"}`,
+			wantOK: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ev, ok := detectFmtHookEvent(tc.line, turn)
+			if ok != tc.wantOK {
+				t.Fatalf("detectFmtHookEvent(%q) ok = %v, want %v", tc.line, ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				if ev != (FmtHookEvent{}) {
+					t.Errorf("no-match must return zero FmtHookEvent, got %+v", ev)
+				}
+				return
+			}
+			if ev.Turn != turn {
+				t.Errorf("Turn = %d, want %d", ev.Turn, turn)
+			}
+			if ev.Status != tc.wantStatus {
+				t.Errorf("Status = %q, want %q", ev.Status, tc.wantStatus)
+			}
+			if tc.wantDetail != "" && ev.Detail != tc.wantDetail {
+				t.Errorf("Detail = %q, want %q", ev.Detail, tc.wantDetail)
+			}
+			if tc.wantFile != "" && ev.File != tc.wantFile {
+				t.Errorf("File = %q, want %q", ev.File, tc.wantFile)
+			}
+		})
+	}
+}
+
 func jsonContains(t *testing.T, raw []byte, want string) bool {
 	t.Helper()
 	var m map[string]interface{}

--- a/internal/eval_harness/fmt_hook_mode_test.go
+++ b/internal/eval_harness/fmt_hook_mode_test.go
@@ -1,0 +1,156 @@
+package eval_harness
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseFmtHookMode(t *testing.T) {
+	cases := map[string]FmtHookMode{
+		"":         FmtHookModeOff,
+		"off":      FmtHookModeOff,
+		"OFF":      FmtHookModeOff,
+		"disabled": FmtHookModeOff,
+		"0":        FmtHookModeOff,
+		"unknown":  FmtHookModeOff, // unknown → off (default preserves today's behaviour)
+		"on":       FmtHookModeOn,
+		"ON":       FmtHookModeOn,
+		"true":     FmtHookModeOn,
+		"enabled":  FmtHookModeOn,
+		"1":        FmtHookModeOn,
+	}
+	for in, want := range cases {
+		if got := ParseFmtHookMode(in); got != want {
+			t.Errorf("ParseFmtHookMode(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestFmtHookResolvedState(t *testing.T) {
+	if got := FmtHookModeOn.ResolvedState(); got != "on" {
+		t.Errorf("on.ResolvedState() = %q, want on", got)
+	}
+	if got := FmtHookModeOff.ResolvedState(); got != "off" {
+		t.Errorf("off.ResolvedState() = %q, want off", got)
+	}
+}
+
+func TestSettingsJSON_RegistersHook(t *testing.T) {
+	raw, err := FmtHookModeOn.SettingsJSON("/abs/path/format_ail.sh")
+	if err != nil {
+		t.Fatalf("SettingsJSON: %v", err)
+	}
+	var parsed struct {
+		Hooks struct {
+			PostToolUse []struct {
+				Matcher string `json:"matcher"`
+				Hooks   []struct {
+					Type    string `json:"type"`
+					Command string `json:"command"`
+				} `json:"hooks"`
+			} `json:"PostToolUse"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("settings JSON did not parse: %v\n%s", err, raw)
+	}
+	if len(parsed.Hooks.PostToolUse) != 1 {
+		t.Fatalf("expected 1 PostToolUse matcher, got %d", len(parsed.Hooks.PostToolUse))
+	}
+	pt := parsed.Hooks.PostToolUse[0]
+	if pt.Matcher != "Edit|Write" {
+		t.Errorf("matcher = %q, want Edit|Write", pt.Matcher)
+	}
+	if len(pt.Hooks) != 1 || pt.Hooks[0].Type != "command" || pt.Hooks[0].Command != "/abs/path/format_ail.sh" {
+		t.Errorf("hook entry wrong: %+v", pt.Hooks)
+	}
+}
+
+// Off is byte-identical to today's path: no settings file, no path.
+func TestApply_OffWritesNothing(t *testing.T) {
+	ws := t.TempDir()
+	path, jsonBytes, err := FmtHookModeOff.Apply(ws)
+	if err != nil {
+		t.Fatalf("off Apply errored: %v", err)
+	}
+	if path != "" || jsonBytes != nil {
+		t.Fatalf("off must return empty path/json; got path=%q json=%v", path, jsonBytes)
+	}
+	if _, statErr := os.Stat(filepath.Join(ws, ".claude", "settings.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("off must not create .claude/settings.json (stat err=%v)", statErr)
+	}
+}
+
+// On writes .claude/settings.json referencing the LANDED hook and returns its path.
+func TestApply_OnWritesSettings(t *testing.T) {
+	// Apply resolves scripts/hooks/format_ail.sh relative to CWD. Build a fake
+	// repo root with that script present, and run from there.
+	repoRoot := t.TempDir()
+	hookDir := filepath.Join(repoRoot, "scripts", "hooks")
+	if err := os.MkdirAll(hookDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	hookPath := filepath.Join(hookDir, "format_ail.sh")
+	if err := os.WriteFile(hookPath, []byte("#!/bin/bash\nexit 0\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	origWd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+	if err := os.Chdir(repoRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	ws := filepath.Join(repoRoot, "workspace")
+	if err := os.MkdirAll(ws, 0755); err != nil {
+		t.Fatal(err)
+	}
+	path, jsonBytes, err := FmtHookModeOn.Apply(ws)
+	if err != nil {
+		t.Fatalf("on Apply errored: %v", err)
+	}
+	wantPath := filepath.Join(ws, ".claude", "settings.json")
+	if path != wantPath {
+		t.Errorf("settings path = %q, want %q", path, wantPath)
+	}
+	onDisk, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("settings not written: %v", err)
+	}
+	if string(onDisk) != string(jsonBytes) {
+		t.Errorf("returned json != on-disk json")
+	}
+	// The resolved (absolute) hook path must appear in the settings.
+	if !jsonContains(t, onDisk, hookPath) {
+		t.Errorf("settings do not reference the hook script %q:\n%s", hookPath, onDisk)
+	}
+}
+
+// On with a missing LANDED hook must FAIL LOUDLY, not silently degrade to off
+// (silently shipping an untreated ON arm would corrupt the A/B).
+func TestApply_OnMissingHookFailsLoud(t *testing.T) {
+	repoRoot := t.TempDir() // no scripts/hooks/format_ail.sh
+	origWd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+	if err := os.Chdir(repoRoot); err != nil {
+		t.Fatal(err)
+	}
+	ws := filepath.Join(repoRoot, "workspace")
+	if err := os.MkdirAll(ws, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := FmtHookModeOn.Apply(ws); err == nil {
+		t.Fatal("expected Apply to error when the LANDED hook is absent")
+	}
+}
+
+func jsonContains(t *testing.T, raw []byte, want string) bool {
+	t.Helper()
+	var m map[string]interface{}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("bad json: %v", err)
+	}
+	return strings.Contains(string(raw), want)
+}

--- a/internal/eval_harness/fmt_hook_mode_test.go
+++ b/internal/eval_harness/fmt_hook_mode_test.go
@@ -229,5 +229,14 @@ func jsonContains(t *testing.T, raw []byte, want string) bool {
 	if err := json.Unmarshal(raw, &m); err != nil {
 		t.Fatalf("bad json: %v", err)
 	}
-	return strings.Contains(string(raw), want)
+	// Search for the JSON-encoded form of want, not the raw string: json.Marshal
+	// escapes backslashes, so a Windows path (C:\...\format_ail.sh) appears in the
+	// settings as C:\\...\\format_ail.sh. Encoding want the same way keeps this
+	// assertion correct on every OS (no-op on Unix forward-slash paths).
+	enc, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal want: %v", err)
+	}
+	needle := string(enc[1 : len(enc)-1]) // strip the surrounding quotes
+	return strings.Contains(string(raw), needle)
 }

--- a/internal/eval_harness/metrics.go
+++ b/internal/eval_harness/metrics.go
@@ -83,6 +83,17 @@ type RunMetrics struct {
 	// Lets eval-report break results down with vs. without JIT knowledge injection.
 	MicroragState string `json:"microrag_state,omitempty"`
 
+	// fmt-hook A/B state for this run (M-EVAL-FMT-WEAKMODEL-AB).
+	// Values: "on" | "off" | "" (non-agent / not set). The resolved arm — the
+	// ONLY per-arm difference in the fmt weak-model experiment — banked so the
+	// required config diff between ON and OFF arms is reviewable from the results.
+	FmtHookState string `json:"fmt_hook_state,omitempty"`
+	// Per-turn fmt PostToolUse hook reality (M-EVAL-FMT-WEAKMODEL-AB). Each entry
+	// is one observed format_ail.sh run classified formatted / deferred / error.
+	// Empty on the OFF arm (and on ON runs where the hook never fired). Powers
+	// M3's treatment-delivery-rate metric vs the ~8% fail-closed refusal baseline.
+	FmtHookEvents []FmtHookEvent `json:"fmt_hook_events,omitempty"`
+
 	// Cross-harness grouping (M-EVAL-CROSS-HARNESS)
 	// Populated from models.yml model_family field. Enables --group-by=model-family
 	// in eval-matrix to compare same model across different harnesses (e.g. claude vs opencode).

--- a/internal/executor/claude/claude.go
+++ b/internal/executor/claude/claude.go
@@ -352,6 +352,36 @@ func (e *ClaudeExecutor) ExecuteStreaming(ctx context.Context, task *executor.Ta
 				continue
 			}
 
+			// Hook-reality capture (M-EVAL-FMT-WEAKMODEL-AB): the LANDED
+			// format_ail.sh PostToolUse hook always exits 0 to the CLI but
+			// surfaces its real status via stderr ("✓ Formatted <file>") and
+			// hookSpecificOutput.additionalContext ("ailang fmt failed"/"timed
+			// out"), which Claude Code echoes back into the stream-json (on a
+			// user/tool_result message or a PostToolUse event). claude.go's
+			// switch below only dispatches OnToolResult for stream_event
+			// sub-types — it never processes tool_result/PostToolUse lines — so
+			// the eval_harness fmtHookEventHandler.OnToolResult was dead on this
+			// (active) path. We forward the raw line to any handler that opts in
+			// via the RawStreamLineHandler interface (only the fmt-hook tracker
+			// does), so its detectFmtHookEvent classifier fires. This is
+			// fail-closed: detectFmtHookEvent returns ok=false for any line
+			// without a real hook marker, so a line with no hook output can
+			// never be recorded as a "formatted"/treated event. Dispatching only
+			// to opt-in handlers avoids polluting unrelated handlers (cloud
+			// metrics, debug) with raw JSON as if they were tool results.
+			//
+			// TODO(M2b): verify against a live haiku ON-arm run that the
+			// format_ail.sh markers ("✓ Formatted"/"ailang fmt failed") actually
+			// appear on a raw stdout stream-json line (i.e. Claude Code echoes
+			// the PostToolUse hook's stderr/additionalContext into the
+			// --output-format stream-json stdout, not only into the interactive
+			// TUI). If they do not surface in stdout, fmt_hook_events will stay
+			// empty and the capture point must move to wherever the hook output
+			// does land (e.g. a dedicated hook-event stream or a file sink).
+			if rh, ok := handler.(executor.RawStreamLineHandler); ok {
+				rh.OnRawStreamLine(line)
+			}
+
 			var event map[string]interface{}
 			if err := json.Unmarshal([]byte(line), &event); err != nil {
 				continue

--- a/internal/executor/claude/claude.go
+++ b/internal/executor/claude/claude.go
@@ -773,50 +773,6 @@ type claudeUsage struct {
 	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
 }
 
-func getErrorMessage(result *claudeHeadlessResult) string {
-	if result.IsError {
-		return result.Result
-	}
-	if result.Subtype == "error" || result.Subtype == "timeout" {
-		return result.Result
-	}
-	return ""
-}
-
-// isCloudWorkspace detects if a workspace path is in a cloud container.
-// Cloud paths typically start with /workspace/ (Cloud Run, Google Cloud Container).
-// This detection ensures we use appropriate permission handling for cloud environments.
-func isCloudWorkspace(workspace string) bool {
-	// Cloud container paths typically start with /workspace/
-	// This convention is used by Cloud Run, Pub/Sub-triggered containers, and GCP workspaces
-	return strings.HasPrefix(workspace, "/workspace/")
-}
-
-// isValidUUID checks if a string is a valid UUID format
-// Claude Code CLI requires session IDs to be valid UUIDs
-func isValidUUID(s string) bool {
-	_, err := uuid.Parse(s)
-	return err == nil
-}
-
-// intFromAny coerces a JSON-decoded number-ish value to int.
-// json.Unmarshal into map[string]interface{} yields float64 for numbers;
-// some payloads may also use json.Number or raw int. Returns 0 on miss.
-func intFromAny(v interface{}) int {
-	switch n := v.(type) {
-	case float64:
-		return int(n)
-	case int:
-		return n
-	case int64:
-		return int(n)
-	case json.Number:
-		i, _ := n.Int64()
-		return int(i)
-	}
-	return 0
-}
-
 // Register registers the Claude executor with the global factory
 func Register() {
 	executor.GlobalFactory().Register("claude", func(cfg *executor.Config) (executor.Executor, error) {

--- a/internal/executor/claude/helpers.go
+++ b/internal/executor/claude/helpers.go
@@ -1,0 +1,54 @@
+// Package claude helper utilities extracted from claude.go to keep that file
+// under the 800-line code-health gate. Pure, receiver-less helpers only.
+package claude
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+func getErrorMessage(result *claudeHeadlessResult) string {
+	if result.IsError {
+		return result.Result
+	}
+	if result.Subtype == "error" || result.Subtype == "timeout" {
+		return result.Result
+	}
+	return ""
+}
+
+// isCloudWorkspace detects if a workspace path is in a cloud container.
+// Cloud paths typically start with /workspace/ (Cloud Run, Google Cloud Container).
+// This detection ensures we use appropriate permission handling for cloud environments.
+func isCloudWorkspace(workspace string) bool {
+	// Cloud container paths typically start with /workspace/
+	// This convention is used by Cloud Run, Pub/Sub-triggered containers, and GCP workspaces
+	return strings.HasPrefix(workspace, "/workspace/")
+}
+
+// isValidUUID checks if a string is a valid UUID format
+// Claude Code CLI requires session IDs to be valid UUIDs
+func isValidUUID(s string) bool {
+	_, err := uuid.Parse(s)
+	return err == nil
+}
+
+// intFromAny coerces a JSON-decoded number-ish value to int.
+// json.Unmarshal into map[string]interface{} yields float64 for numbers;
+// some payloads may also use json.Number or raw int. Returns 0 on miss.
+func intFromAny(v interface{}) int {
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	case int64:
+		return int(n)
+	case json.Number:
+		i, _ := n.Int64()
+		return int(i)
+	}
+	return 0
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -285,6 +285,19 @@ type ContextAwareHandler interface {
 	SetContext(ctx context.Context)
 }
 
+// RawStreamLineHandler is an optional interface for handlers that need to inspect
+// the raw NDJSON stream lines an executor reads, not just the parsed high-level
+// events (turn/text/tool). It exists for out-of-band signals that ride along in
+// the stream but are not modeled as tool results — notably PostToolUse hook
+// output (M-EVAL-FMT-WEAKMODEL-AB), where a workspace hook surfaces its status
+// via stderr/additionalContext that the CLI echoes into the stream-json. When a
+// handler implements this, an executor forwards each raw stdout line to it. Not
+// every executor emits raw lines; handlers must not depend on it firing.
+type RawStreamLineHandler interface {
+	EventHandler
+	OnRawStreamLine(line string)
+}
+
 // MetricsHandler is an optional interface for handlers that want execution metrics.
 // When implemented, the executor calls OnMetrics after parsing the final result,
 // allowing the handler to broadcast cost/token data before the executor returns.


### PR DESCRIPTION
## Summary

Green-lit by Mark (#422 "Green light weakmodel ab"). Executes **M1 (preregistration) + M2a (build the fmt-hook toggle)** of the weak-model fmt A/B experiment — the no-GPU engineering. **M2b (GPU eval execution), M3 (analysis), M4 (verdict) are NOT in this PR** — GPU-rig-gated / depend on banked results, deferred to later iterations.

Design doc: `design_docs/planned/v0_31_0/m-eval-fmt-weakmodel-ab.md`

### M1 — Preregistration
`design_docs/planned/v0_31_0/m-eval-fmt-weakmodel-ab-prereg.md`: frozen matched set of 6 `.ail`-editing benchmarks (fizzbuzz, gcd_lcm, adt_option, higher_order_functions, json_parse, cli_args), N=5/arm/bench, model `claude-haiku-4-5`, metrics (pass-rate delta + Wilson CIs, convergence, hook-reality), refutation threshold (+0.10 delta AND 95% CI excludes 0).

### M2a — fmt-hook ON/OFF toggle (the integration point did not exist before)
- New `FmtHookMode` (on/off) in `internal/eval_harness/fmt_hook_mode.go` following the `microrag_mode.go` precedent; ON writes a workspace `.claude/settings.json` registering the LANDED `scripts/hooks/format_ail.sh` as a PostToolUse Edit|Write hook; OFF is byte-identical to today's path.
- New `-fmt-hook on|off` CLI flag (default `off`), wired through `cmd/ailang/eval_suite.go`.
- Resolved arm banked as `fmt_hook_state`; per-turn hook-reality events banked as `fmt_hook_events` (fail-closed — never fabricates a "formatted" event).
- Active-path capture wired via an opt-in `RawStreamLineHandler` (raw stream-line scan, mirroring the streaming runner) — the active executor never called `OnToolResult`. One `TODO(M2b)` marks the single unverifiable-without-a-live-run detail: that Claude Code echoes the hook stderr onto stdout stream-json.

### Validation
- `go test ./internal/eval_harness/... ./cmd/ailang/... ./internal/executor/...` → pass (incl. new `fmt_hook_mode_test.go`, race-clean)
- `make check-boundaries` → clean · `gofmt` clean · no new lint issues
- Language surface: **NONE**.

Sprint-evaluator (sonnet, generator≠judge vs opus executor): 80/100 PASS r1; the flagged must-fix (dead active-path capture) is resolved in commit `248bc2798`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)