### PR TITLE
fix(eval): agent mode records reasoning tokens + finish_reason

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,56 @@
 
 ## [Unreleased]
 
+### Fixed — agent mode records reasoning tokens + finish_reason (cost was understated)
+
+Agent-mode eval rows banked `reason_tokens` as 0 and `finish_reason` as empty
+100% of the time (all 280 rows of the v0.30.0 agent baseline), so hidden
+thinking — billed upstream at the output rate — was invisible in token totals,
+and a run truncated mid-thought was indistinguishable from a capability gap.
+This is the agent-side counterpart to `43333e7a8`, which fixed the same class of
+loss on the standard path *after* the v0.30.0 standard baseline was banked.
+
+The providers were never at fault. `internal/ai/gemini/generate.go` has mapped
+`usageMetadata.thoughtsTokenCount` since v0.18.x, and opencode has parsed
+`tokens.reasoning` and the `step_finish` `reason` for just as long — the fields
+were simply never copied across the mapping boundary into the banked result.
+
+- **`executor.Result` gains `ReasonTokens`**, contractually DISJOINT from
+  `OutputTokens` so totals cannot double-count.
+- **opencode**: sums `tokens.reasoning` across `step_finish` deltas and records
+  the *last* step's finish reason (intermediate steps report `tool-calls`;
+  `length` is the truncation signal that matters).
+- **claude**: the headless result `subtype` now maps to `FinishReason`. It was
+  already parsed for the success boolean and the failure reason discarded, so
+  `error_max_turns` runs landed in the generic bucket — `max_turns` is already
+  aliased to `step_exhausted` by `CategorizeAgentError`.
+- **managed_agents**: thought tokens are no longer folded into `OutputTokens`.
+  Cost is unchanged (still billed at the output rate over `output + reason`).
+- **Banked totals**: `total_tokens` now includes reasoning. `cost_usd` is
+  deliberately NOT recomputed in agent mode — agent CLIs report their own billed
+  cost, which already includes thinking; deriving it would double-count.
+- **Guards**: the executor→banked mapping is now a named
+  `tokenUsageFromResult` function covered by a test, plus a reflection-based
+  invariant asserting every `*Tokens` field on `executor.Result` has a
+  `TokenUsage` counterpart — so the *next* token field cannot be silently
+  dropped the way this one was.
+
+Verified live end-to-end on both paths: standard (`gemini-3-flash`:
+`reason_tokens: 673`, `finish_reason: "stop"`, cost matching
+`input×rate + (output+reason)×rate` exactly) and agent (`opencode-or-glm-5-2`:
+`reason_tokens: 106`, `finish_reason: "tool_calls"`, totals balancing).
+
+Still uninstrumented: `codex` and `pi` never set `FinishReason` (pi parses
+`stopReason` but its struct omits the field), and no CLI executor except
+opencode/managed_agents reports a reasoning count. Cache tokens parsed by
+opencode/codex remain dropped — deliberately left out of this change to avoid
+shifting input-token accounting mid-experiment.
+
+The affected v0.30.0 baseline is annotated in
+`eval_results/baselines/v0.30.0/CAVEATS.md` and flagged machine-readably via
+`cost_data_valid: false` in its `baseline.json`; its cost figures must not be
+used for model ranking.
+
 ### Added — fmt-hook A/B toggle for weak-model eval (M-EVAL-FMT-WEAKMODEL-AB, M1+M2a)
 
 Engineering + preregistration for the "does the `ailang fmt` PostToolUse hook

--- a/cmd/ailang/eval_benchmark.go
+++ b/cmd/ailang/eval_benchmark.go
@@ -256,8 +256,14 @@ func runSingleBenchmark(ctx context.Context, model, benchmarkID, lang, condition
 			Seed:         seed,
 			InputTokens:  result.Usage.InputTokens + result.Usage.CacheCreationInputTokens + result.Usage.CacheReadInputTokens,
 			OutputTokens: result.Usage.OutputTokens,
-			TotalTokens:  result.Usage.InputTokens + result.Usage.OutputTokens + result.Usage.CacheCreationInputTokens + result.Usage.CacheReadInputTokens,
-			CostUSD:      result.Cost,
+			// Hidden reasoning tokens, kept disjoint from OutputTokens but counted
+			// in TotalTokens (upstream bills them at the output rate). 0 = the
+			// executor doesn't report a count, not "the model didn't think".
+			ReasonTokens: result.Usage.ReasonTokens,
+			TotalTokens:  result.Usage.InputTokens + result.Usage.OutputTokens + result.Usage.ReasonTokens + result.Usage.CacheCreationInputTokens + result.Usage.CacheReadInputTokens,
+			// NOT recomputed from tokens: agent CLIs report their own billed cost,
+			// which already includes reasoning. Deriving it here would double-count.
+			CostUSD: result.Cost,
 			// Use standard validation fields from agent runner
 			CompileOk:  result.CompileOk,
 			RuntimeOk:  result.RuntimeOk,

--- a/internal/eval_harness/agent_runner.go
+++ b/internal/eval_harness/agent_runner.go
@@ -149,6 +149,9 @@ type TokenUsage struct {
 	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
 	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
 	OutputTokens             int `json:"output_tokens"`
+	// ReasonTokens are hidden reasoning tokens, disjoint from OutputTokens.
+	// 0 means the executor does not report a count (see executor.Result).
+	ReasonTokens int `json:"reason_tokens,omitempty"`
 }
 
 // ModelStats captures per-model statistics

--- a/internal/eval_harness/agent_runner_multi.go
+++ b/internal/eval_harness/agent_runner_multi.go
@@ -397,7 +397,7 @@ func RunAgentBenchmarkWithExecutor(spec *BenchmarkSpec, config MultiExecutorConf
 		Error:         result.Error,
 		SessionID:     result.SessionID,
 		Result:        result.Output,
-		Usage:         TokenUsage{InputTokens: result.InputTokens, OutputTokens: result.OutputTokens},
+		Usage:         tokenUsageFromResult(result),
 		TTFTSeconds:   ttftTracker.seconds,
 		ModelFamily: func() string {
 			if GlobalModelsConfig != nil {
@@ -646,4 +646,30 @@ func modelMaxOutputTokens(modelName string) int {
 		return m.MaxOutputTokens
 	}
 	return 0
+}
+
+// tokenUsageFromResult maps executor token counts into the banked TokenUsage.
+//
+// This mapping is a proven silent-data-loss point. The standard path had the
+// same shape and dropped reasoning tokens + finish_reason for every provider
+// until 43333e7a8, which is why the whole v0.30.0 standard baseline banked
+// cost figures that understate real spend (see
+// eval_results/baselines/v0.30.0/CAVEATS.md). The agent path dropped them for
+// even longer.
+//
+// It is a named function, not an inline literal, so the boundary itself is
+// covered by a test rather than only the parsers feeding it — a field that is
+// parsed correctly but never copied here is indistinguishable, in the banked
+// data, from a field the provider never reported.
+func tokenUsageFromResult(result *executor.Result) TokenUsage {
+	if result == nil {
+		return TokenUsage{}
+	}
+	return TokenUsage{
+		InputTokens:              result.InputTokens,
+		OutputTokens:             result.OutputTokens,
+		ReasonTokens:             result.ReasonTokens,
+		CacheReadInputTokens:     result.CacheReadInputTokens,
+		CacheCreationInputTokens: result.CacheCreationInputTokens,
+	}
 }

--- a/internal/eval_harness/token_usage_mapping_test.go
+++ b/internal/eval_harness/token_usage_mapping_test.go
@@ -1,0 +1,99 @@
+package eval_harness
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/executor"
+)
+
+// TestTokenUsageFromResult_CarriesEveryCount guards the executor -> banked-result
+// boundary.
+//
+// Every field is set to a DISTINCT value so a copy-paste mixup (reading
+// OutputTokens into ReasonTokens, say) fails instead of silently passing the way
+// it would if they shared a value.
+func TestTokenUsageFromResult_CarriesEveryCount(t *testing.T) {
+	got := tokenUsageFromResult(&executor.Result{
+		InputTokens:              11,
+		OutputTokens:             22,
+		ReasonTokens:             33,
+		CacheReadInputTokens:     44,
+		CacheCreationInputTokens: 55,
+	})
+
+	want := TokenUsage{
+		InputTokens:              11,
+		OutputTokens:             22,
+		ReasonTokens:             33,
+		CacheReadInputTokens:     44,
+		CacheCreationInputTokens: 55,
+	}
+
+	if got != want {
+		t.Errorf("tokenUsageFromResult() = %+v, want %+v", got, want)
+	}
+}
+
+func TestTokenUsageFromResult_NilResult(t *testing.T) {
+	if got := tokenUsageFromResult(nil); got != (TokenUsage{}) {
+		t.Errorf("tokenUsageFromResult(nil) = %+v, want zero value", got)
+	}
+}
+
+// TestTokenUsageCoversEveryExecutorTokenField is the systemic guard.
+//
+// The recurring failure mode in this codebase is not a wrong mapping, it is an
+// ABSENT one: a token field gets added to executor.Result and parsed correctly by
+// an executor, but nobody copies it across this boundary, so it banks as 0
+// forever and is indistinguishable from "the provider didn't report it". That is
+// exactly how the entire v0.30.0 baseline came to understate cost
+// (eval_results/baselines/v0.30.0/CAVEATS.md).
+//
+// Testing tokenUsageFromResult's current fields would not catch the NEXT one, so
+// this asserts the structural invariant instead: every *Tokens field on
+// executor.Result has a counterpart on TokenUsage. If you add a token field and
+// this fails, map it in tokenUsageFromResult — do not just add it to the skip
+// list.
+func TestTokenUsageCoversEveryExecutorTokenField(t *testing.T) {
+	resultType := reflect.TypeOf(executor.Result{})
+	usageType := reflect.TypeOf(TokenUsage{})
+
+	for i := 0; i < resultType.NumField(); i++ {
+		name := resultType.Field(i).Name
+		if !strings.HasSuffix(name, "Tokens") {
+			continue
+		}
+		if _, ok := usageType.FieldByName(name); !ok {
+			t.Errorf("executor.Result.%s has no counterpart on TokenUsage — it will bank as 0 "+
+				"and be indistinguishable from 'not reported'. Map it in tokenUsageFromResult.", name)
+		}
+	}
+}
+
+// TestTokenUsage_ReasonTokensDisjointFromOutput pins the arithmetic contract the
+// banking site in cmd/ailang/eval_benchmark.go relies on: reasoning is counted in
+// the total but NOT already inside OutputTokens. If an executor ever folds
+// thinking into its output count (managed_agents used to), the total
+// double-counts it and agent-mode token figures inflate silently.
+func TestTokenUsage_ReasonTokensDisjointFromOutput(t *testing.T) {
+	u := tokenUsageFromResult(&executor.Result{
+		InputTokens:  100,
+		OutputTokens: 20,
+		ReasonTokens: 500,
+	})
+
+	total := u.InputTokens + u.OutputTokens + u.ReasonTokens +
+		u.CacheCreationInputTokens + u.CacheReadInputTokens
+	if total != 620 {
+		t.Errorf("total = %d, want 620 (100 input + 20 output + 500 reasoning)", total)
+	}
+
+	// A model that thought far more than it emitted is the normal case for
+	// reasoning models, not a bug: in the v0.30.0 baseline the one correctly
+	// measured model reasoned 8.45x its output.
+	if u.OutputTokens >= u.ReasonTokens {
+		t.Fatal("fixture no longer exercises reasoning-heavy case")
+	}
+}

--- a/internal/executor/claude/claude.go
+++ b/internal/executor/claude/claude.go
@@ -703,7 +703,31 @@ func (e *ClaudeExecutor) ExecuteStreaming(ctx context.Context, task *executor.Ta
 			FirstAttemptMs:           firstAttemptMs,
 			SuccessAtMs:              -1,
 			TokensPerSec:             tokensPerSec,
+			FinishReason:             normalizeClaudeFinishReason(finalResult.Subtype),
 		}, nil
+	}
+}
+
+// normalizeClaudeFinishReason maps the Claude Code headless result subtype onto
+// the executor.Result.FinishReason vocabulary.
+//
+// The subtype was already parsed and used for the success boolean, but the
+// reason for a failure was discarded — so a run that burned through its turn
+// budget banked identically to one that failed on the task itself.
+// "error_max_turns" maps to "max_turns", which CategorizeAgentError already
+// aliases to step_exhausted.
+func normalizeClaudeFinishReason(subtype string) string {
+	switch subtype {
+	case "":
+		return ""
+	case "success":
+		return "stop"
+	case "error_max_turns":
+		return "max_turns"
+	case "error_during_execution":
+		return "error"
+	default:
+		return strings.ToLower(subtype)
 	}
 }
 

--- a/internal/executor/claude/claude_test.go
+++ b/internal/executor/claude/claude_test.go
@@ -624,3 +624,25 @@ func BenchmarkClaudeNew(b *testing.B) {
 		_, _ = New(cfg)
 	}
 }
+
+// TestNormalizeClaudeFinishReason guards the subtype -> FinishReason mapping.
+//
+// The subtype was already parsed and used to compute the success boolean, but
+// the failure reason was discarded, so claude-executor rows banked an empty
+// finish_reason 100% of the time. "error_max_turns" is the valuable case:
+// CategorizeAgentError already aliases "max_turns" to step_exhausted, so a run
+// that merely ran out of turns had been landing in the generic bucket instead.
+func TestNormalizeClaudeFinishReason(t *testing.T) {
+	cases := map[string]string{
+		"":                       "",
+		"success":                "stop",
+		"error_max_turns":        "max_turns",
+		"error_during_execution": "error",
+		"SOMETHING_NEW":          "something_new",
+	}
+	for in, want := range cases {
+		if got := normalizeClaudeFinishReason(in); got != want {
+			t.Errorf("normalizeClaudeFinishReason(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -150,6 +150,17 @@ type Result struct {
 	CacheReadInputTokens     int
 	CacheCreationInputTokens int
 
+	// ReasonTokens are hidden reasoning/thinking tokens, billed upstream at the
+	// output rate but reported separately (or not at all) by each agent CLI.
+	// 0 means "not reported by this executor", NOT "the model did not think" —
+	// only opencode and managed_agents surface a count today.
+	//
+	// Must stay DISJOINT from OutputTokens: executors that receive a merged
+	// figure have to subtract it out, or agent-mode totals double-count.
+	// Recorded because a run truncated mid-thought and a run that genuinely
+	// failed are indistinguishable without it (v0.30.0 baseline CAVEATS.md).
+	ReasonTokens int
+
 	// Session info
 	SessionID  string // Provider's session identifier
 	Transcript string // Full conversation log

--- a/internal/executor/managed_agents/managed_agents.go
+++ b/internal/executor/managed_agents/managed_agents.go
@@ -257,23 +257,28 @@ func (e *Executor) ExecuteStreaming(
 		turns = 1
 	}
 	res := &executor.Result{
-		Output:                   state.Text.String(),
-		DurationMS:               int(duration.Milliseconds()),
-		NumTurns:                 turns,
-		SessionID:                state.InteractionID,
-		InputTokens:              state.Usage.TotalInputTokens,
-		OutputTokens:             state.Usage.TotalOutputTokens + state.Usage.TotalThoughtTokens,
+		Output:      state.Text.String(),
+		DurationMS:  int(duration.Milliseconds()),
+		NumTurns:    turns,
+		SessionID:   state.InteractionID,
+		InputTokens: state.Usage.TotalInputTokens,
+		// Kept DISJOINT: thought tokens live in ReasonTokens, not folded into
+		// OutputTokens. Merging them made thinking invisible downstream and, now
+		// that TotalTokens counts reasoning, would double-count it.
+		OutputTokens:             state.Usage.TotalOutputTokens,
+		ReasonTokens:             state.Usage.TotalThoughtTokens,
 		CacheReadInputTokens:     0, // Not reported by Managed Agents API
 		CacheCreationInputTokens: 0,
 	}
 
 	// Cost from the API-reported usage. We bill thought tokens at the output
 	// rate because Vertex's gemini-3-5-flash pricing model doesn't separate
-	// them.
+	// them — so they must be added back here even though the fields are now
+	// stored separately.
 	cm := e.CostModel()
 	res.CostUSD = cm.CalculateCost(executor.TokenUsage{
 		InputTokens:  res.InputTokens,
-		OutputTokens: res.OutputTokens,
+		OutputTokens: res.OutputTokens + res.ReasonTokens,
 	})
 
 	// Stash multi-turn handles + unknown events into ProviderData for the

--- a/internal/executor/managed_agents/managed_agents_test.go
+++ b/internal/executor/managed_agents/managed_agents_test.go
@@ -107,9 +107,25 @@ func TestExecuteWithFixture(t *testing.T) {
 	if res.InputTokens != 6560 {
 		t.Errorf("InputTokens=%d, want 6560", res.InputTokens)
 	}
-	// OutputTokens = candidates (35) + thoughts (748)
-	if res.OutputTokens != 35+748 {
-		t.Errorf("OutputTokens=%d, want %d", res.OutputTokens, 35+748)
+	// OutputTokens and ReasonTokens are DISJOINT: candidates (35) stay in
+	// OutputTokens, thoughts (748) go to ReasonTokens. Folding thoughts into
+	// OutputTokens made thinking invisible downstream, and would now
+	// double-count once TotalTokens includes reasoning.
+	if res.OutputTokens != 35 {
+		t.Errorf("OutputTokens=%d, want 35 (candidates only, thoughts excluded)", res.OutputTokens)
+	}
+	if res.ReasonTokens != 748 {
+		t.Errorf("ReasonTokens=%d, want 748 (thought tokens)", res.ReasonTokens)
+	}
+
+	// Splitting the fields must NOT change billing: thought tokens are still
+	// billed at the output rate, so cost is computed over output+reason.
+	wantCost := exec.CostModel().CalculateCost(executor.TokenUsage{
+		InputTokens:  6560,
+		OutputTokens: 35 + 748,
+	})
+	if res.CostUSD != wantCost {
+		t.Errorf("CostUSD=%v, want %v (thoughts still billed at output rate)", res.CostUSD, wantCost)
 	}
 
 	// 4. Session/interaction ID extracted

--- a/internal/executor/opencode/opencode.go
+++ b/internal/executor/opencode/opencode.go
@@ -212,7 +212,11 @@ func (e *OpenCodeExecutor) ExecuteStreaming(ctx context.Context, task *executor.
 	var numSteps int
 	var toolCallCount int
 	// opencode emits per-step deltas; sum across step_finish events.
-	var inputTokens, outputTokens int
+	var inputTokens, outputTokens, reasonTokens int
+	// Finish reason of the LAST step_finish: intermediate steps report
+	// "tool-calls" as they hand off to a tool, so only the final one describes
+	// how the run actually ended (notably "length" = truncated at the cap).
+	var lastFinishReason string
 	var totalCostUSD float64
 	var stepSpan trace.Span
 	var stderrBuf strings.Builder
@@ -326,7 +330,11 @@ func (e *OpenCodeExecutor) ExecuteStreaming(ctx context.Context, task *executor.
 				// Per-step delta: sum across all step_finish events.
 				inputTokens += ev.Part.Tokens.Input
 				outputTokens += ev.Part.Tokens.Output
+				reasonTokens += ev.Part.Tokens.Reasoning
 				totalCostUSD += ev.Part.Cost
+				if ev.Part.Reason != "" {
+					lastFinishReason = ev.Part.Reason
+				}
 
 				// M-EVAL-COST-AND-SPEED-BUDGETS: incremental cost tally on per-step deltas.
 				if task.Budget != nil && (ev.Part.Tokens.Input > 0 || ev.Part.Tokens.Output > 0) {
@@ -398,6 +406,7 @@ func (e *OpenCodeExecutor) ExecuteStreaming(ctx context.Context, task *executor.
 					DurationMS:     int(duration.Milliseconds()),
 					InputTokens:    inputTokens,
 					OutputTokens:   outputTokens,
+					ReasonTokens:   reasonTokens,
 					CostUSD:        totalCostUSD,
 					NumTurns:       numSteps,
 					ToolCallCount:  toolCallCount,
@@ -408,6 +417,7 @@ func (e *OpenCodeExecutor) ExecuteStreaming(ctx context.Context, task *executor.
 					FirstAttemptMs: firstAttemptMs,
 					SuccessAtMs:    -1,
 					TokensPerSec:   tokensPerSec,
+					FinishReason:   normalizeOpencodeFinishReason(lastFinishReason),
 				}, nil
 			}
 
@@ -424,6 +434,7 @@ func (e *OpenCodeExecutor) ExecuteStreaming(ctx context.Context, task *executor.
 				DurationMS:     int(duration.Milliseconds()),
 				InputTokens:    inputTokens,
 				OutputTokens:   outputTokens,
+				ReasonTokens:   reasonTokens,
 				CostUSD:        totalCostUSD,
 				NumTurns:       numSteps,
 				ToolCallCount:  toolCallCount,
@@ -434,6 +445,7 @@ func (e *OpenCodeExecutor) ExecuteStreaming(ctx context.Context, task *executor.
 				FirstAttemptMs: firstAttemptMs,
 				SuccessAtMs:    -1,
 				TokensPerSec:   tokensPerSec,
+				FinishReason:   normalizeOpencodeFinishReason(lastFinishReason),
 			}, nil
 
 		case <-hardTimer.C:
@@ -444,6 +456,7 @@ func (e *OpenCodeExecutor) ExecuteStreaming(ctx context.Context, task *executor.
 				Error:          fmt.Sprintf("opencode exceeded hard timeout (%v)", timeout),
 				InputTokens:    inputTokens,
 				OutputTokens:   outputTokens,
+				ReasonTokens:   reasonTokens,
 				CostKilledAt:   task.Budget.KilledAt(),
 				FirstAttemptMs: firstAttemptMs,
 				SuccessAtMs:    -1,
@@ -469,6 +482,7 @@ func (e *OpenCodeExecutor) ExecuteStreaming(ctx context.Context, task *executor.
 					Error:          fmt.Sprintf("opencode idle for %v mid-generation (no output)", since),
 					InputTokens:    inputTokens,
 					OutputTokens:   outputTokens,
+					ReasonTokens:   reasonTokens,
 					CostKilledAt:   task.Budget.KilledAt(),
 					FirstAttemptMs: firstAttemptMs,
 					SuccessAtMs:    -1,
@@ -484,6 +498,7 @@ func (e *OpenCodeExecutor) ExecuteStreaming(ctx context.Context, task *executor.
 				Error:          fmt.Sprintf("opencode cancelled: %v", ctx.Err()),
 				InputTokens:    inputTokens,
 				OutputTokens:   outputTokens,
+				ReasonTokens:   reasonTokens,
 				CostKilledAt:   task.Budget.KilledAt(),
 				FirstAttemptMs: firstAttemptMs,
 				SuccessAtMs:    -1,
@@ -622,6 +637,31 @@ func computeTokensPerSec(outputTokens int, firstStreamEventAt time.Time) float64
 		return 0
 	}
 	return float64(outputTokens) / gen
+}
+
+// normalizeOpencodeFinishReason maps the opencode/AI-SDK step_finish vocabulary
+// ("stop", "length", "tool-calls", "content-filter", "error", "other") onto the
+// executor.Result.FinishReason vocabulary.
+//
+// "length" is the one that matters: it means the model hit the output cap, and a
+// reasoning model that burns its budget thinking returns "length" with a
+// truncated body. Without it a truncated run is indistinguishable from a model
+// that simply could not solve the task.
+//
+// Unrecognised values pass through underscored rather than being dropped —
+// CategorizeAgentError ignores reasons it does not know, so an unmapped value is
+// inert for classification but still visible in the banked row.
+func normalizeOpencodeFinishReason(r string) string {
+	switch r {
+	case "":
+		return ""
+	case "stop":
+		return "stop"
+	case "length":
+		return "length"
+	default:
+		return strings.ReplaceAll(strings.ToLower(r), "-", "_")
+	}
 }
 
 // opencodeProviderData wraps raw events as Result.ProviderData.

--- a/internal/executor/opencode/opencode_test.go
+++ b/internal/executor/opencode/opencode_test.go
@@ -462,6 +462,93 @@ func TestExecuteStreaming_ParsesFixture(t *testing.T) {
 	if _, ok := result.ProviderData["opencode_events"]; !ok {
 		t.Error("expected 'opencode_events' key in ProviderData")
 	}
+
+	// FinishReason comes from the LAST step_finish. The fixture's first step
+	// reports "tool-calls" (mid-run handoff) and the second "stop" — if an
+	// intermediate step won, every tool-using run would look like it ended on a
+	// tool call.
+	if result.FinishReason != "stop" {
+		t.Errorf("FinishReason = %q, want \"stop\" (last step_finish, not the intermediate \"tool-calls\")", result.FinishReason)
+	}
+
+	// Fixture reports reasoning:0 on both steps.
+	if result.ReasonTokens != 0 {
+		t.Errorf("ReasonTokens = %d, want 0 (fixture reports reasoning:0)", result.ReasonTokens)
+	}
+}
+
+// TestExecuteStreaming_CapturesReasoningAndTruncation guards the call site that
+// silently dropped this data: opencode parsed tokens.reasoning and the
+// step_finish reason for a long time, but neither was ever copied into
+// executor.Result, so agent-mode rows banked reasoning as 0 and finish_reason as
+// empty 100% of the time (see eval_results/baselines/v0.30.0/CAVEATS.md).
+//
+// "length" is the case that matters: it is how a reasoning model that exhausts
+// its budget mid-thought reports itself. Without it, truncation is
+// indistinguishable from a capability gap.
+func TestExecuteStreaming_CapturesReasoningAndTruncation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip(skipWindows)
+	}
+	dir := t.TempDir()
+	events := []string{
+		`{"type":"step_start","timestamp":1,"sessionID":"ses_r","part":{"id":"p1","messageID":"m1","sessionID":"ses_r","type":"step-start"}}`,
+		`{"type":"step_finish","timestamp":2,"sessionID":"ses_r","part":{"id":"p2","reason":"tool-calls","messageID":"m1","sessionID":"ses_r","type":"step-finish","tokens":{"total":900,"input":10,"output":40,"reasoning":850,"cache":{"write":0,"read":0}},"cost":0.001}}`,
+		`{"type":"step_start","timestamp":3,"sessionID":"ses_r","part":{"id":"p3","messageID":"m2","sessionID":"ses_r","type":"step-start"}}`,
+		`{"type":"step_finish","timestamp":4,"sessionID":"ses_r","part":{"id":"p4","reason":"length","messageID":"m2","sessionID":"ses_r","type":"step-finish","tokens":{"total":700,"input":5,"output":15,"reasoning":680,"cache":{"write":0,"read":0}},"cost":0.002}}`,
+	}
+	_ = writeFakeOpenCode(t, dir, events)
+
+	e, err := New(&executor.Config{
+		OpenCodePath:   filepath.Join(dir, "opencode"),
+		OpenCodeModel:  "anthropic/claude-haiku-4-5",
+		TimeoutSeconds: 10,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	result, err := e.ExecuteStreaming(context.Background(), &executor.Task{
+		ID:        "test-reasoning",
+		Directive: "think hard",
+		Workspace: dir,
+		Timeout:   10 * time.Second,
+	}, &collectingHandler{})
+	if err != nil {
+		t.Fatalf("ExecuteStreaming error: %v", err)
+	}
+
+	// Summed across step_finish deltas: 850 + 680.
+	if result.ReasonTokens != 1530 {
+		t.Errorf("ReasonTokens = %d, want 1530 (850+680 summed across steps)", result.ReasonTokens)
+	}
+
+	// Reasoning must stay DISJOINT from OutputTokens — the harness adds both
+	// into TotalTokens, so folding them together would double-count.
+	if result.OutputTokens != 55 {
+		t.Errorf("OutputTokens = %d, want 55 (40+15, reasoning excluded)", result.OutputTokens)
+	}
+
+	if result.FinishReason != "length" {
+		t.Errorf("FinishReason = %q, want \"length\" (truncated at the output cap)", result.FinishReason)
+	}
+}
+
+func TestNormalizeOpencodeFinishReason(t *testing.T) {
+	cases := map[string]string{
+		"":               "",
+		"stop":           "stop",
+		"length":         "length",
+		"tool-calls":     "tool_calls",
+		"content-filter": "content_filter",
+		"error":          "error",
+		"OTHER":          "other",
+	}
+	for in, want := range cases {
+		if got := normalizeOpencodeFinishReason(in); got != want {
+			t.Errorf("normalizeOpencodeFinishReason(%q) = %q, want %q", in, got, want)
+		}
+	}
 }
 
 func TestExecuteStreaming_NonJSONPreambleTolerated(t *testing.T) {


### PR DESCRIPTION
## Why

Agent-mode eval rows banked `reason_tokens` as 0 and `finish_reason` as empty **100% of the time** (all 280 rows of the v0.30.0 agent baseline). Hidden thinking — billed upstream at the output rate — was invisible in token totals, and a run truncated mid-thought was indistinguishable from a capability gap.

This is the agent-side counterpart to `43333e7a8`, which fixed the same class of loss on the **standard** path *after* the v0.30.0 standard baseline was banked.

**The providers were never at fault.** `internal/ai/gemini/generate.go` has mapped `usageMetadata.thoughtsTokenCount` since v0.18.x, and opencode has parsed `tokens.reasoning` and the `step_finish` `reason` for just as long. The fields were fetched, held, and dropped at a mapping boundary.

## What changed

- **`executor.Result` gains `ReasonTokens`**, contractually DISJOINT from `OutputTokens` so totals cannot double-count.
- **opencode**: sums `tokens.reasoning` across `step_finish` deltas; records the *last* step's finish reason (intermediate steps report `tool-calls`; `length` is the truncation signal that matters).
- **claude**: headless result `subtype` now maps to `FinishReason`. It was already parsed for the success boolean with the failure reason discarded — so `error_max_turns` runs landed in the generic bucket. `max_turns` is already aliased to `step_exhausted` by `CategorizeAgentError`, so this also fixes a miscategorization.
- **managed_agents**: thought tokens no longer folded into `OutputTokens`. Cost unchanged (still billed at the output rate over `output + reason`).
- **Banked totals**: `total_tokens` now includes reasoning. Agent `cost_usd` is deliberately **NOT** recomputed — agent CLIs report their own billed cost, which already includes thinking; deriving it would double-count.

## Guards against recurrence

This bug class (parsed-then-dropped at a boundary) has recurred repeatedly, and testing the helper rather than its call site is why. So:

- the executor→banked mapping is now a named `tokenUsageFromResult`, covered by a test;
- a reflection invariant asserts **every** `*Tokens` field on `executor.Result` has a `TokenUsage` counterpart, so the *next* token field cannot be silently dropped.

The reflection guard was verified non-vacuous: temporarily adding an unmapped `ProbeOnlyTokens` field made it fail, then reverted.

## Verification — live runs, both paths

**Standard** (`gemini-3-flash`, live Vertex call):
```
reason_tokens: 673        finish_reason: "stop"
total_tokens: 29492  = 28788 + 31 + 673                              OK
cost_usd: 0.016506   = 28788x$0.0005/1k + (31+673)x$0.003/1k         OK exact
```

**Agent** (`opencode-or-glm-5-2`, live opencode run):
```
reason_tokens: 106        finish_reason: "tool_calls"
total_tokens: 38658  = 38337 + 215 + 106                             OK
```

Both fields were absent in 100% of banked rows before this change.

Gates: `make check-boundaries` clean, lint clean on changed files, `./internal/executor/... ./internal/eval_harness/... ./cmd/ailang/` all pass. One stale test asserting the old merged-token semantics was updated to the disjoint contract, with a cost-unchanged assertion added.

## Deliberately out of scope

- `codex` and `pi` never set `FinishReason` (pi parses `stopReason` but its struct omits the field).
- Cache tokens parsed by opencode/codex remain dropped. Excluded on purpose: agent `InputTokens` is computed as `input + cache_creation + cache_read`, so populating it shifts banked input-token figures, and **M-EVAL-FMT-WEAKMODEL-AB is mid-flight running matched A/B comparisons**. Filed as a follow-up gated on that sprint.

## Related

The affected v0.30.0 baseline is annotated in `eval_results/baselines/v0.30.0/CAVEATS.md` (gitignored, local + GCS-synced) and flagged machine-readably via `cost_data_valid: false` in its `baseline.json`. **Its cost figures must not be used for model ranking** — 16 of 17 standard models are affected, and `or-glm-5-2` is the only correctly-measured row, which makes it look artificially expensive. A re-bank needs the Claude quota back on 2026-08-01.

One observation from the live agent run: `finish_reason` came back `tool_calls` on a *successful* run — opencode's final `step_finish` genuinely reported that. It's honest data and inert for categorization (unrecognized reasons fall through; the call site only consults it on failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)