### PR TITLE
fix(eval-fmt-hook): make hook round-trip test Windows-safe (unbreak test-windows on dev)

### DIFF
--- a/internal/eval_harness/fmt_hook_mode_test.go
+++ b/internal/eval_harness/fmt_hook_mode_test.go
@@ -310,9 +310,23 @@ func TestFormatAilHookSinkRoundTrip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stdin := `{"cwd":"` + ws + `","tool_use_id":"tool_rt_1","tool_input":{"file_path":"` + ailFile + `"}}`
+	// Build the PostToolUse stdin with json.Marshal, NOT string concatenation:
+	// on Windows t.TempDir() is C:\Users\RUNNER~1\AppData\Local\Temp\..., and
+	// pasting that raw into a JSON string literal produces invalid escapes
+	// (\U, \A, \T) that jq rejects outright ("Invalid escape at line 1").
+	// ToSlash additionally hands the hook C:/... paths, which git-bash treats
+	// unambiguously in `[ -d ]` and in the `>>"$FMT_SINK"` redirect, where a
+	// backslash path is separator-vs-escape ambiguous.
+	payload, err := json.Marshal(map[string]any{
+		"cwd":         filepath.ToSlash(ws),
+		"tool_use_id": "tool_rt_1",
+		"tool_input":  map[string]any{"file_path": filepath.ToSlash(ailFile)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	cmd := exec.Command("bash", hook)
-	cmd.Stdin = strings.NewReader(stdin)
+	cmd.Stdin = strings.NewReader(string(payload))
 	var out, errb strings.Builder
 	cmd.Stdout = &out
 	cmd.Stderr = &errb


### PR DESCRIPTION
## Problem

`test-windows` (and therefore `Build windows-latest`) has been red on `dev` independently of any PR, making every PR show a red check and hiding real regressions.

```
--- FAIL: TestFormatAilHookSinkRoundTrip (0.45s)
    fmt_hook_mode_test.go:328: hook wrote no sink event (stderr: jq: parse error: Invalid escape at line 1, column 90
FAIL	github.com/sunholo-data/ailang/internal/eval_harness
```

## Root cause (reproduced, not inferred)

`TestFormatAilHookSinkRoundTrip` built the PostToolUse stdin by concatenating `t.TempDir()` into a JSON string literal:

```go
stdin := `{"cwd":"` + ws + `","tool_use_id":...`
```

On `windows-latest` that path is `C:\Users\RUNNER~1\AppData\Local\Temp\...`, so `\U`, `\A`, `\T` are invalid JSON escapes. jq rejects the document before the hook does any work, `emit_sink` never runs, and the sink is empty.

Reproduced locally by piping the equivalent Windows-path JSON to jq — identical error, the column differs only with temp-path length:

```
$ printf '%s' '{"cwd":"C:\Users\RUNNER~1\AppData\Local\Temp\Test...","tool_input":{...}}' | jq -r '.tool_input.file_path'
jq: parse error: Invalid escape at line 1, column 83
```

## Fix — test-only (option 1 from the two candidates)

The hook is **already Windows-clean**: it passes every value through `jq --arg` and never interpolates a path into the jq program. So no hook change was needed, and none was made — this keeps the in-flight **M-EVAL-FMT-WEAKMODEL-AB** A/B (milestone `M2B_MATCHED_EXECUTION`) unperturbed.

- Build the stdin payload with `json.Marshal` so any path escapes correctly.
- `filepath.ToSlash` the `cwd` / `file_path` so git-bash sees `C:/...`, which is unambiguous in `[ -d ]` and in the `>>"$FMT_SINK"` redirect (a backslash path is separator-vs-escape ambiguous there).

No `t.Skip` was added: the hook is expected to work on Windows, so skipping would have hidden the capability rather than restored it.

## Verification

- ✓ `go test ./internal/eval_harness/ -run TestFormatAilHookSinkRoundTrip` passes locally
- ✓ full `./internal/eval_harness` package green
- ✗ **Windows is not yet proven** — the jq parse error masked everything downstream, so a second Windows-specific failure could still be hiding behind it. `test-windows` on this PR is the real verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)