### PR TITLE
ci: gate the fmt-hook round-trip against silent skips (Linux + Windows)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,14 @@ jobs:
     - name: Install z3 (SMT solver for contract-verification tests)
       run: sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends z3
 
+    # jq drives scripts/hooks/format_ail.sh, which TestFormatAilHookSinkRoundTrip
+    # executes end-to-end. It ships on the ubuntu-latest image today, but the
+    # no-silent-skip gate below now turns a missing jq into a hard failure
+    # instead of an invisible skip — so pin it explicitly rather than rely on
+    # the image (docusaurus-deploy.yml already installs jq for the same reason).
+    - name: Install jq (drives the .ail format PostToolUse hook under test)
+      run: sudo apt-get install -y -qq --no-install-recommends jq && jq --version
+
     # -timeout is PER TEST BINARY (package). cmd/ailang legitimately runs
     # 35-50s (CLI subprocess tests), so 60s was boundary-flaky on loaded
     # runners (red dev 2026-07-10: package panicked at exactly 1m0s).
@@ -73,11 +81,11 @@ jobs:
     # verbosely and require an explicit PASS — a skip or rename fails here.
     - name: Assert binary-gated integration tests ran (no silent skips)
       run: |
-        go test -count=1 -v -run '^(TestRunSmokeInTempDir_Pass|TestPromptCommand_Piping|TestZ3VerifyEndToEnd)$' \
-          ./internal/pkg ./cmd/ailang ./internal/bestof 2>&1 | tee gated_integration.log
-        for t in TestRunSmokeInTempDir_Pass TestPromptCommand_Piping TestZ3VerifyEndToEnd; do
+        go test -count=1 -v -run '^(TestRunSmokeInTempDir_Pass|TestPromptCommand_Piping|TestZ3VerifyEndToEnd|TestFormatAilHookSinkRoundTrip)$' \
+          ./internal/pkg ./cmd/ailang ./internal/bestof ./internal/eval_harness 2>&1 | tee gated_integration.log
+        for t in TestRunSmokeInTempDir_Pass TestPromptCommand_Piping TestZ3VerifyEndToEnd TestFormatAilHookSinkRoundTrip; do
           grep -q -- "--- PASS: $t" gated_integration.log || {
-            echo "::error::$t did not PASS — a binary-gated integration test is being skipped (missing/stale ailang or z3?) or was renamed (then update this step)."
+            echo "::error::$t did not PASS — a binary-gated integration test is being skipped (missing/stale ailang, z3, jq or bash?) or was renamed (then update this step)."
             exit 1
           }
         done
@@ -296,10 +304,10 @@ jobs:
     - name: Assert binary-gated integration tests ran (no silent skips)
       shell: pwsh
       run: |
-        go test -count=1 -v -run '^(TestRunSmokeInTempDir_Pass|TestPromptCommand_Piping)$' ./internal/pkg ./cmd/ailang 2>&1 | Tee-Object -FilePath gated_integration.log
-        foreach ($t in 'TestRunSmokeInTempDir_Pass','TestPromptCommand_Piping') {
+        go test -count=1 -v -run '^(TestRunSmokeInTempDir_Pass|TestPromptCommand_Piping|TestFormatAilHookSinkRoundTrip)$' ./internal/pkg ./cmd/ailang ./internal/eval_harness 2>&1 | Tee-Object -FilePath gated_integration.log
+        foreach ($t in 'TestRunSmokeInTempDir_Pass','TestPromptCommand_Piping','TestFormatAilHookSinkRoundTrip') {
           if (-not (Select-String -Path gated_integration.log -SimpleMatch "--- PASS: $t" -Quiet)) {
-            Write-Error "$t did not PASS - a binary-gated integration test is being skipped (missing/stale ailang?) or was renamed (then update this step)."
+            Write-Error "$t did not PASS - a binary-gated integration test is being skipped (missing/stale ailang, jq or bash?) or was renamed (then update this step)."
             exit 1
           }
         }

--- a/internal/eval_harness/fmt_hook_mode_test.go
+++ b/internal/eval_harness/fmt_hook_mode_test.go
@@ -310,9 +310,23 @@ func TestFormatAilHookSinkRoundTrip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stdin := `{"cwd":"` + ws + `","tool_use_id":"tool_rt_1","tool_input":{"file_path":"` + ailFile + `"}}`
+	// Build the PostToolUse stdin with json.Marshal, NOT string concatenation:
+	// on Windows t.TempDir() is C:\Users\RUNNER~1\AppData\Local\Temp\..., and
+	// pasting that raw into a JSON string literal produces invalid escapes
+	// (\U, \A, \T) that jq rejects outright ("Invalid escape at line 1").
+	// ToSlash additionally hands the hook C:/... paths, which git-bash treats
+	// unambiguously in `[ -d ]` and in the `>>"$FMT_SINK"` redirect, where a
+	// backslash path is separator-vs-escape ambiguous.
+	payload, err := json.Marshal(map[string]any{
+		"cwd":         filepath.ToSlash(ws),
+		"tool_use_id": "tool_rt_1",
+		"tool_input":  map[string]any{"file_path": filepath.ToSlash(ailFile)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	cmd := exec.Command("bash", hook)
-	cmd.Stdin = strings.NewReader(stdin)
+	cmd.Stdin = strings.NewReader(string(payload))
 	var out, errb strings.Builder
 	cmd.Stdout = &out
 	cmd.Stderr = &errb


### PR DESCRIPTION
Follow-up to #442.

## Why

`TestFormatAilHookSinkRoundTrip` is binary-gated — it `t.Skip`s when `bash`, `jq`, or `ailang` is missing. Both test jobs run `go test ./...` **non-verbose**, where a skip and a pass are indistinguishable: the package just prints `ok`.

That's a real gap, not a hypothetical. #442 fixed the Windows breakage, but nothing in CI asserts the test actually *runs* — so if a future runner image dropped `jq`, the round-trip coverage would silently evaporate and `test-windows` would stay green. The repo already has a gate for precisely this class of failure; this test just wasn't in it.

## What

Add the test to the existing **"Assert binary-gated integration tests ran (no silent skips)"** step in **both** jobs, requiring an explicit `--- PASS`:

- Linux gate: `+ ./internal/eval_harness`
- Windows gate: `+ ./internal/eval_harness`
- both error messages now name `jq`/`bash` among the causes

Plus one consequence worth being deliberate about: under the gate, a **missing `jq` becomes a hard failure** rather than an invisible skip. So the Linux job now installs `jq` explicitly instead of trusting the runner image — matching what `docusaurus-deploy.yml` already does. Windows needs no equivalent step: the #442 failure was jq *itself* erroring, which proves it's present on `windows-latest`.

## Verification

- ✓ Gate command run locally emits `--- PASS: TestFormatAilHookSinkRoundTrip`
- ✓ `ci.yml` parses; both gate steps confirmed updated
- ✓ Incidental live demo — the other three gated tests `SKIP` in a bare worktree lacking `bin/ailang` and `z3`, which is exactly the skip-vs-pass distinction the gate catches

No test or hook behaviour changes, so the in-flight M-EVAL-FMT-WEAKMODEL-AB sprint is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)