### PR TITLE
feat(serve-api): @nomcp — hide a handler from the MCP tool surface only (M-SERVEAPI-NOMCP M1)

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,26 @@
 
 ## [Unreleased]
 
+### Added — `@nomcp` annotation (hide a handler from the MCP tool surface only)
+
+`serve-api` gains a parameterless `@nomcp` annotation for handlers that should be
+reachable over HTTP — and present in the OpenAPI spec and the A2A agent card —
+but NOT advertised as an agent-callable MCP tool. It closes the
+docparse `getKeyUsage`/`requestHistory` MCP leak with a one-line annotation and
+no HTTP behavior change.
+
+- A `@route @nomcp` handler answers HTTP 200 and appears in `/api/_meta/openapi.json`,
+  but is **absent** from MCP `tools/list`, and `tools/call` on its name errors as
+  unregistered.
+- Unlike `@noexpose` (which hides from HTTP + MCP and is reset by `@route`),
+  `@nomcp` is an MCP-only exclusion carried on a new independent
+  `ExportInfo.IsNoMCP` flag that is set **unconditionally** — so it survives the
+  `@route` override in `routes.go`. `@noexpose` and `@nomcp` do not interact.
+- Parser: `@nomcp` joins the `@route`/`@raw`/`@nowrap`/`@noexpose`/`@mcp_name`
+  allowlist; unknown annotations still hard-error with `PAR_UNKNOWN_ATTRIBUTE`.
+- Docs, both devtools prompt copies (+ compact), and
+  `examples/runnable/serve_api_webhook.ail` (new `@nomcp` demo route) updated.
+
 ### Fixed — agent mode records reasoning tokens + finish_reason (cost was understated)
 
 Agent-mode eval rows banked `reason_tokens` as 0 and `finish_reason` as empty

--- a/cmd/ailang/prompts/devtools/v0.8.0-compact.md
+++ b/cmd/ailang/prompts/devtools/v0.8.0-compact.md
@@ -164,7 +164,7 @@ ailang serve-api --routes-only ./api/                  # Only @route endpoints
 ailang init web-app my-app                            # Scaffold new web app
 # Auto-serves: /api/_meta/docs (Swagger UI), /api/_meta/redoc (ReDoc)
 # Protocols:   /.well-known/agent.json (A2A), /a2a/ (JSON-RPC), /mcp/ (MCP)
-# Annotations: @route("METHOD","/path"), @raw, @nowrap, @noexpose, @mcp_name("name")
+# Annotations: @route("METHOD","/path"), @raw, @nowrap, @noexpose, @nomcp (MCP-only hide), @mcp_name("name")
 # Request headers: _headers: Json param on @route (no @raw needed)
 # MCP: -- doc comments = tool descriptions, named inputSchema, --routes-only filters
 # MCP names: ^[a-zA-Z0-9_-]{1,64}$ (Claude Desktop strict); use @mcp_name to override

--- a/cmd/ailang/prompts/devtools/v0.8.0.md
+++ b/cmd/ailang/prompts/devtools/v0.8.0.md
@@ -633,11 +633,12 @@ ailang init web-app my-app
 | `@raw` | Receive full HttpRequest record (body, headers, method, query) |
 | `@nowrap` | Return raw JSON without response envelope |
 | `@noexpose` | Hide from HTTP/MCP (still importable by other modules) |
+| `@nomcp` | Hide from the MCP tool surface ONLY — still served over HTTP/OpenAPI/A2A (not reset by `@route`) |
 | `@mcp_name("name")` | Override the MCP tool name (must match `^[a-zA-Z0-9_-]{1,64}$`) |
 
 **Request headers in `@route`**: Declare a `_headers: Json` parameter to receive HTTP request headers without switching to `@raw` (preserves multipart parsing).
 
-**MCP tool quality**: Doc comments (`--` above func) become tool descriptions. `inputSchema` uses named parameters with JSON Schema types. `--routes-only` and `@noexpose` filter MCP `tools/list`. MCP tool names match `^[a-zA-Z0-9_-]{1,64}$` (Claude Desktop compatible) — auto-generated as bare function names when unique, or `<lastSegment>_<funcName>` on collision. Override with `@mcp_name("name")`.
+**MCP tool quality**: Doc comments (`--` above func) become tool descriptions. `inputSchema` uses named parameters with JSON Schema types. `--routes-only`, `@noexpose`, and `@nomcp` filter MCP `tools/list` (`@nomcp` filters MCP only; HTTP/OpenAPI unaffected). MCP tool names match `^[a-zA-Z0-9_-]{1,64}$` (Claude Desktop compatible) — auto-generated as bare function names when unique, or `<lastSegment>_<funcName>` on collision. Override with `@mcp_name("name")`.
 
 ## 13. Unified AI Execution
 

--- a/docs/docs/guides/serve-api.md
+++ b/docs/docs/guides/serve-api.md
@@ -396,7 +396,7 @@ Each exported AILANG function becomes an MCP tool. Module metadata is available 
 - **Named parameter schemas** — `inputSchema` uses named parameters with JSON Schema types (e.g., `{"filepath": {"type": "string"}}`) instead of generic positional arrays. Types are mapped from AILANG: `string`→`"string"`, `int`→`"integer"`, `float`→`"number"`, `bool`→`"boolean"`, `Json`/records→`"object"`, lists→`"array"`.
 - **Doc comment descriptions** — `--` comment lines immediately above a function are used as the MCP tool description. Functions without doc comments fall back to the type signature.
 - **MCP-compliant tool names** — All names match the strict regex `^[a-zA-Z0-9_-]{1,64}$` required by Claude Desktop and most current MCP clients. Resolution order: (1) `@mcp_name("name")` author override, (2) bare function name when globally unique (e.g. `mcpParse`), (3) `<lastModuleSegment>_<funcName>` fallback for collisions (e.g. `services_parseCsv`), (4) deterministic hash suffix when truncated to 64 chars. Use `@mcp_name("parse")` to control the exact tool name surfaced to MCP clients.
-- **Filtering** — `--routes-only` and `@noexpose` are respected in MCP `tools/list`, consistent with HTTP and OpenAPI. With `--routes-only`, undocumented non-route helpers are also auto-excluded from MCP.
+- **Filtering** — `--routes-only` and `@noexpose` are respected in MCP `tools/list`, consistent with HTTP and OpenAPI. `@nomcp` additionally hides a handler from `tools/list`/`tools/call` while keeping it served over HTTP/OpenAPI/A2A (MCP-only exclusion). With `--routes-only`, undocumented non-route helpers are also auto-excluded from MCP.
 - **Backward compatible** — Tool handlers accept both named parameters (`{"filepath": "doc.pdf"}`) and legacy positional format (`{"args": ["doc.pdf"]}`).
 - **Missing-parameter rejection** — A `tools/call` that omits a declared parameter (absent key) or sends it as JSON `null` is rejected with a structured `missing required parameter(s): <names>` error (`isError: true`) **before** the function runs. The names are listed in declaration order. This is type-agnostic — an omitted `int` param is rejected the same way as a `string`. Without this guard the omitted value bound to `nil`→Unit and crashed deep in stdlib (e.g. `_str_len: expected String, got Unit`) with no actionable message. The legacy positional `{"args": [...]}` form is unaffected (it opts out of named binding entirely).
 
@@ -828,6 +828,7 @@ Custom routes are registered before the auto-generated catch-all routes, so they
 | `@raw` | Receive full `HttpRequest` record (headers, body, method, query) instead of parsed args |
 | `@nowrap` | Return raw JSON instead of the `FunctionCallResponse` envelope |
 | `@noexpose` | Hide exported function from HTTP endpoints (still importable by other modules) |
+| `@nomcp` | Hide from the MCP tool surface ONLY — still served over HTTP, OpenAPI, and A2A (not reset by `@route`) |
 | `@mcp_name("name")` | Override the auto-generated MCP tool name for this function |
 | `@verify(depth: N)` | Runtime contract validation |
 
@@ -1005,6 +1006,40 @@ export func validateApiKey(key: string) -> bool ! {IO}
 - Are **not** included in the OpenAPI spec or A2A Agent Card
 - Are still importable by other AILANG modules via `import`
 - If a function has both `@route` and `@noexpose`, the `@route` takes precedence (it remains exposed)
+
+---
+
+### `@nomcp` — Hide from the MCP Tool Surface Only
+
+Use `@nomcp` on a handler that should be reachable over HTTP (and appear in the OpenAPI spec and A2A card) but should NOT be advertised as an agent-callable MCP tool. This is the right choice for internal/observability endpoints — health probes, metrics, key-usage dumps — that you want a human or a `curl` to hit, but that you do not want an LLM to discover in `tools/list` and call:
+
+```ailang
+module billing/api
+
+-- Public agent tool: appears in MCP tools/list AND served over HTTP.
+@route("GET", "/api/v1/usage")
+export func getUsage(userId: string) -> string ! {IO}
+  lookupUsage(userId)
+
+-- Served over HTTP + OpenAPI + A2A, but ABSENT from the MCP tool surface.
+@nomcp
+@route("GET", "/internal/key-usage")
+export func getKeyUsage() -> string ! {IO}
+  dumpKeyUsage()
+```
+
+`@nomcp` functions:
+- Are **excluded** from MCP `tools/list` and `tools/call` (a call to the excluded tool name errors as unregistered)
+- Are **still** served over HTTP (`GET /internal/key-usage` answers 200)
+- Are **still** present in the OpenAPI spec and the A2A Agent Card
+- Keep `@nomcp` even when combined with `@route` — unlike `@noexpose`, `@route` does **not** reset it
+
+`@noexpose` and `@nomcp` are independent and can be combined. They differ in which surfaces they hide:
+
+| Annotation | HTTP endpoint | OpenAPI / A2A | MCP `tools/list` + `tools/call` | Reset by `@route`? |
+|------------|:-------------:|:-------------:|:-------------------------------:|:------------------:|
+| `@noexpose` | hidden | hidden | hidden | yes (`@route` re-exposes) |
+| `@nomcp` | **served** | **present** | hidden | no (survives `@route`) |
 
 ---
 

--- a/examples/runnable/serve_api_webhook.ail
+++ b/examples/runnable/serve_api_webhook.ail
@@ -36,6 +36,17 @@ export pure func health() -> string {
   "ok"
 }
 
+-- @nomcp hides this handler from the MCP tool surface (tools/list AND
+-- tools/call) while keeping it fully served over HTTP, OpenAPI, and the A2A
+-- card. Use it for internal/observability endpoints you want reachable by curl
+-- but NOT advertised as an agent-callable tool. Unlike @noexpose (which hides
+-- from HTTP too), @nomcp is MCP-only and is NOT reset by @route.
+@nomcp
+@route("GET", "/internal/metrics")
+export pure func metrics() -> string {
+  "requests=0"
+}
+
 -- Demo entrypoint for verify-examples: exercises handleWebhook with a
 -- synthetic request so the file both type-checks and runs cleanly.
 export func main() -> () ! {IO} {

--- a/internal/apiserver/mcp.go
+++ b/internal/apiserver/mcp.go
@@ -85,6 +85,9 @@ func (ms *MCPServer) registerTools() {
 			if !ms.server.isExposed(export) {
 				continue
 			}
+			if export.IsNoMCP {
+				continue // @nomcp: served over HTTP/OpenAPI/A2A but absent from MCP
+			}
 
 			dedupKey := export.Name + "|" + export.Type
 			candidate := toolCandidate{modPath, export}

--- a/internal/apiserver/module_entry.go
+++ b/internal/apiserver/module_entry.go
@@ -113,6 +113,7 @@ func (s *Server) registerModule(loaded *loader.LoadedModule) (string, bool, erro
 	extractRouteAnnotations(info, loaded.File)
 	extractNoExposeAnnotations(info, loaded.File)
 	extractMCPNameAnnotations(info, loaded.File)
+	extractNoMCPAnnotations(info, loaded.File)
 	extractDocComments(info, loaded.File, absFile)
 
 	// Write.

--- a/internal/apiserver/nomcp_test.go
+++ b/internal/apiserver/nomcp_test.go
@@ -1,0 +1,309 @@
+package apiserver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/sunholo-data/ailang/internal/ast"
+)
+
+// M-SERVEAPI-NOMCP M1
+//
+// @nomcp is a parameterless annotation that hides an export from the MCP tool
+// surface ONLY (tools/list and tools/call). HTTP, OpenAPI, and the A2A card are
+// unaffected. Unlike @noexpose, @nomcp is NOT reset by @route: a @route @nomcp
+// handler is served over HTTP (200) and appears in OpenAPI while being absent
+// from MCP. IsNoExpose and IsNoMCP are independent flags.
+
+// --- Extractor unit test (mirrors TestExtractNoExposeAnnotations) ---
+
+func TestExtractNoMCPAnnotations(t *testing.T) {
+	modInfo := &ModuleInfo{
+		Path: "test/billing",
+		Exports: []ExportInfo{
+			// @route @nomcp — the flag must survive @route (no RoutePath gate).
+			{Name: "getKeyUsage", Type: "string -> Json", Arity: 1, RoutePath: "/api/v1/keys", RouteMethod: "GET"},
+			// bare @nomcp — flag set unconditionally.
+			{Name: "requestHistory", Type: "string -> Json", Arity: 1},
+			// @noexpose only — must NOT get IsNoMCP (flags independent).
+			{Name: "internalHelper", Type: "int -> int", Arity: 1},
+			// plain export — neither flag.
+			{Name: "publicHelper", Type: "int -> int", Arity: 1},
+		},
+	}
+
+	file := &ast.File{
+		Funcs: []*ast.FuncDecl{
+			{Name: "getKeyUsage", IsExport: true, Annotations: []*ast.Annotation{
+				{Name: "route"}, {Name: "nomcp"},
+			}},
+			{Name: "requestHistory", IsExport: true, Annotations: []*ast.Annotation{{Name: "nomcp"}}},
+			{Name: "internalHelper", IsExport: true, Annotations: []*ast.Annotation{{Name: "noexpose"}}},
+			{Name: "publicHelper", IsExport: true},
+		},
+	}
+
+	// Emulate the load order: @route override runs first (resets IsNoExpose),
+	// then noexpose, then nomcp.
+	extractNoExposeAnnotations(modInfo, file)
+	extractNoMCPAnnotations(modInfo, file)
+
+	// getKeyUsage: @route @nomcp — IsNoMCP set UNCONDITIONALLY (survives @route).
+	if !modInfo.Exports[0].IsNoMCP {
+		t.Error("getKeyUsage (@route @nomcp) should keep IsNoMCP=true — @route must NOT reset it")
+	}
+
+	// requestHistory: bare @nomcp — flag set.
+	if !modInfo.Exports[1].IsNoMCP {
+		t.Error("requestHistory (@nomcp) should be marked IsNoMCP=true")
+	}
+
+	// internalHelper: @noexpose only — must NOT get IsNoMCP (flags independent).
+	if modInfo.Exports[2].IsNoMCP {
+		t.Error("internalHelper (@noexpose only) must NOT be marked IsNoMCP")
+	}
+	if !modInfo.Exports[2].IsNoExpose {
+		t.Error("internalHelper (@noexpose, no @route) should be IsNoExpose=true")
+	}
+
+	// publicHelper: neither flag.
+	if modInfo.Exports[3].IsNoMCP {
+		t.Error("publicHelper should NOT be marked IsNoMCP")
+	}
+}
+
+// TestNoMCPAndNoExposeIndependent asserts the two flags do not interact:
+// a @route @noexpose export gets IsNoExpose=false (existing @route override)
+// while a @route @nomcp export keeps IsNoMCP=true.
+func TestNoMCPAndNoExposeIndependent(t *testing.T) {
+	modInfo := &ModuleInfo{
+		Path: "test/x",
+		Exports: []ExportInfo{
+			{Name: "routeNoExpose", Type: "int -> int", Arity: 1, RoutePath: "/a", RouteMethod: "GET"},
+			{Name: "routeNoMCP", Type: "int -> int", Arity: 1, RoutePath: "/b", RouteMethod: "GET"},
+		},
+	}
+	file := &ast.File{
+		Funcs: []*ast.FuncDecl{
+			{Name: "routeNoExpose", IsExport: true, Annotations: []*ast.Annotation{{Name: "route"}, {Name: "noexpose"}}},
+			{Name: "routeNoMCP", IsExport: true, Annotations: []*ast.Annotation{{Name: "route"}, {Name: "nomcp"}}},
+		},
+	}
+
+	extractNoExposeAnnotations(modInfo, file)
+	extractNoMCPAnnotations(modInfo, file)
+
+	// @route @noexpose: @route wins → IsNoExpose stays false (visible over HTTP).
+	if modInfo.Exports[0].IsNoExpose {
+		t.Error("@route @noexpose: @route override should keep IsNoExpose=false")
+	}
+	if modInfo.Exports[0].IsNoMCP {
+		t.Error("@route @noexpose should not set IsNoMCP")
+	}
+
+	// @route @nomcp: IsNoMCP survives @route (MCP-only exclusion).
+	if !modInfo.Exports[1].IsNoMCP {
+		t.Error("@route @nomcp should keep IsNoMCP=true")
+	}
+	if modInfo.Exports[1].IsNoExpose {
+		t.Error("@route @nomcp should not set IsNoExpose")
+	}
+}
+
+// nomcpTestServer boots a real Server loaded with a module exercising three
+// annotation states: a plain @route (visible everywhere), a @route @nomcp
+// (HTTP/OpenAPI yes, MCP no), and a @noexpose (hidden everywhere).
+func nomcpTestServer(t *testing.T) *Server {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	apiDir := filepath.Join(tmpDir, "test", "api")
+	if err := os.MkdirAll(apiDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	modContent := `module test/api/keys
+
+@route("GET", "/api/v1/status")
+export pure func status() -> string = "ok"
+
+@route("GET", "/api/v1/keys")
+@nomcp
+export pure func getKeyUsage() -> string = "usage"
+
+@noexpose
+export pure func internalSecret() -> string = "secret"
+`
+	modPath := filepath.Join(apiDir, "keys.ail")
+	if err := os.WriteFile(modPath, []byte(modContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdlibPath := os.Getenv("AILANG_STDLIB_PATH")
+	if stdlibPath == "" {
+		cwd, _ := os.Getwd()
+		for dir := cwd; dir != filepath.Dir(dir); dir = filepath.Dir(dir) {
+			if _, err := os.Stat(filepath.Join(dir, "stdlib")); err == nil {
+				stdlibPath = dir
+				break
+			}
+		}
+	}
+	if stdlibPath != "" {
+		os.Setenv("AILANG_STDLIB_PATH", stdlibPath)
+	}
+
+	srv := New(tmpDir, Config{Port: "0", CORS: true})
+	if err := srv.LoadModules([]string{modPath}); err != nil {
+		t.Fatalf("LoadModules: %v", err)
+	}
+	return srv
+}
+
+// findExport locates an export by name across all loaded modules.
+func findExport(t *testing.T, srv *Server, name string) ExportInfo {
+	t.Helper()
+	for _, mod := range srv.GetModules() {
+		for _, exp := range mod.Exports {
+			if exp.Name == name {
+				return exp
+			}
+		}
+	}
+	t.Fatalf("export %q not found", name)
+	return ExportInfo{}
+}
+
+// TestNoMCP_FlagSetOnLoad verifies the annotation survives the real load path
+// (parser → extractNoMCPAnnotations) with the @route override in play.
+func TestNoMCP_FlagSetOnLoad(t *testing.T) {
+	srv := nomcpTestServer(t)
+	defer srv.Close()
+
+	getKeyUsage := findExport(t, srv, "getKeyUsage")
+	if !getKeyUsage.IsNoMCP {
+		t.Error("getKeyUsage (@route @nomcp) should have IsNoMCP=true after load")
+	}
+	if getKeyUsage.IsNoExpose {
+		t.Error("getKeyUsage should NOT be IsNoExpose (it has @route)")
+	}
+	if getKeyUsage.RoutePath != "/api/v1/keys" {
+		t.Errorf("getKeyUsage RoutePath = %q, want /api/v1/keys", getKeyUsage.RoutePath)
+	}
+
+	status := findExport(t, srv, "status")
+	if status.IsNoMCP {
+		t.Error("status (plain @route) should NOT have IsNoMCP")
+	}
+}
+
+// TestNoMCP_HiddenFromMCPToolSurface is the E2E MCP enumeration test. It wires
+// a go-sdk in-memory client session and asserts the @nomcp tool is absent from
+// tools/list and errors on tools/call, while the plain @route tool is present.
+func TestNoMCP_HiddenFromMCPToolSurface(t *testing.T) {
+	srv := nomcpTestServer(t)
+	defer srv.Close()
+
+	ms := NewMCPServer(srv)
+
+	ctx := context.Background()
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+
+	// Server must connect before the client (client initializes the session).
+	serverSession, err := ms.mcpServer.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server Connect: %v", err)
+	}
+	defer serverSession.Close()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client Connect: %v", err)
+	}
+	defer clientSession.Close()
+
+	res, err := clientSession.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+
+	names := map[string]bool{}
+	for _, tool := range res.Tools {
+		names[tool.Name] = true
+	}
+
+	// Plain @route export IS present in the MCP tool surface.
+	if !names["status"] {
+		t.Errorf("plain @route tool 'status' should be in tools/list; got tools: %v", toolNames(res.Tools))
+	}
+	// @route @nomcp export is ABSENT from the MCP tool surface.
+	if names["getKeyUsage"] {
+		t.Errorf("@nomcp tool 'getKeyUsage' must NOT be in tools/list; got tools: %v", toolNames(res.Tools))
+	}
+	// @noexpose export is hidden from MCP too (regression).
+	if names["internalSecret"] {
+		t.Errorf("@noexpose tool 'internalSecret' must NOT be in tools/list; got tools: %v", toolNames(res.Tools))
+	}
+
+	// tools/call on the @nomcp tool name errors (unregistered).
+	_, callErr := clientSession.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "getKeyUsage",
+		Arguments: map[string]any{},
+	})
+	if callErr == nil {
+		t.Error("CallTool on @nomcp tool 'getKeyUsage' should error (unregistered)")
+	}
+}
+
+func toolNames(tools []*mcp.Tool) []string {
+	out := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		out = append(out, tool.Name)
+	}
+	return out
+}
+
+// TestNoMCP_StillServedOverHTTPAndOpenAPI asserts the @route @nomcp handler is
+// unaffected on the HTTP surface: it answers 200 and appears in the OpenAPI
+// spec. @noexpose remains hidden from HTTP (regression).
+func TestNoMCP_StillServedOverHTTPAndOpenAPI(t *testing.T) {
+	srv := nomcpTestServer(t)
+	defer srv.Close()
+
+	mux := srv.buildRoutes()
+
+	// @route @nomcp handler still answers HTTP 200.
+	req := httptest.NewRequest("GET", "/api/v1/keys", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("@nomcp route /api/v1/keys should answer 200 over HTTP, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// @route @nomcp handler present in the OpenAPI spec.
+	oreq := httptest.NewRequest("GET", "/api/_meta/openapi.json", nil)
+	ow := httptest.NewRecorder()
+	mux.ServeHTTP(ow, oreq)
+	if ow.Code != http.StatusOK {
+		t.Fatalf("openapi.json should answer 200, got %d", ow.Code)
+	}
+	spec := ow.Body.String()
+	if !strings.Contains(spec, "/api/v1/keys") {
+		t.Errorf("@nomcp route /api/v1/keys should be present in OpenAPI spec")
+	}
+
+	// @noexpose export stays hidden from HTTP (regression): no route registered.
+	nreq := httptest.NewRequest("POST", "/test/api/keys/internalSecret", nil)
+	nw := httptest.NewRecorder()
+	mux.ServeHTTP(nw, nreq)
+	if nw.Code == http.StatusOK {
+		t.Error("@noexpose export 'internalSecret' must NOT be reachable over HTTP")
+	}
+}

--- a/internal/apiserver/routes.go
+++ b/internal/apiserver/routes.go
@@ -223,6 +223,24 @@ func extractNoExposeAnnotations(modInfo *ModuleInfo, file *ast.File) {
 	}
 }
 
+// extractNoMCPAnnotations marks exported functions with @nomcp as hidden from
+// the MCP tool surface (tools/list and tools/call). Unlike @noexpose, @nomcp is
+// NOT reset by @route — the flag is set UNCONDITIONALLY so a @route @nomcp
+// handler is still served over HTTP/OpenAPI/A2A while being absent from MCP.
+func extractNoMCPAnnotations(modInfo *ModuleInfo, file *ast.File) {
+	for _, fn := range file.Funcs {
+		if fn.GetAnnotation("nomcp") == nil {
+			continue
+		}
+		for i := range modInfo.Exports {
+			if modInfo.Exports[i].Name == fn.Name {
+				modInfo.Exports[i].IsNoMCP = true
+				break
+			}
+		}
+	}
+}
+
 // isExposed returns true if the export should be visible as an HTTP endpoint,
 // considering the server's routesOnly setting and the export's annotations.
 func (s *Server) isExposed(exp ExportInfo) bool {

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -142,6 +142,7 @@ type ExportInfo struct {
 	IsRaw       bool     `json:"is_raw,omitempty"`       // @raw annotation: pass full HttpRequest record
 	IsNowrap    bool     `json:"is_nowrap,omitempty"`    // @nowrap annotation: skip FunctionCallResponse envelope
 	IsNoExpose  bool     `json:"is_no_expose,omitempty"` // @noexpose annotation: hide from HTTP endpoints
+	IsNoMCP     bool     `json:"is_no_mcp,omitempty"`    // @nomcp annotation: hide from the MCP tool surface only (HTTP/OpenAPI/A2A unaffected)
 	MCPName     string   `json:"mcp_name,omitempty"`     // @mcp_name annotation: explicit MCP tool name override
 	DocComment  string   `json:"doc_comment,omitempty"`  // doc comment (-- lines) preceding the function
 }

--- a/internal/parser/parser_decl.go
+++ b/internal/parser/parser_decl.go
@@ -20,7 +20,7 @@ func (p *Parser) parseAnnotation() *ast.Annotation {
 	if !p.curTokenIs(lexer.IDENT) {
 		p.report("PAR_INVALID_ATTRIBUTE",
 			fmt.Sprintf("expected annotation name after '@', got '%s'", p.curToken.Literal),
-			"Use @verify(depth: N), @route(\"METHOD\", \"/path\"), @mcp_name(\"name\"), @raw, @nowrap, or @noexpose")
+			"Use @verify(depth: N), @route(\"METHOD\", \"/path\"), @mcp_name(\"name\"), @raw, @nowrap, @noexpose, or @nomcp")
 		return nil
 	}
 
@@ -42,10 +42,14 @@ func (p *Parser) parseAnnotation() *ast.Annotation {
 	case "noexpose":
 		// @noexpose is a parameterless annotation — hide from HTTP endpoints
 		return &ast.Annotation{Name: "noexpose", Pos: pos}
+	case "nomcp":
+		// @nomcp is a parameterless annotation — hide from the MCP tool surface
+		// only (HTTP, OpenAPI, and A2A remain unaffected).
+		return &ast.Annotation{Name: "nomcp", Pos: pos}
 	default:
 		p.report("PAR_UNKNOWN_ATTRIBUTE",
-			fmt.Sprintf("unknown attribute '@%s'; supported: @verify, @route, @mcp_name, @raw, @nowrap, @noexpose", name),
-			"Use @verify(depth: N), @route(\"METHOD\", \"/path\"), @mcp_name(\"name\"), @raw, @nowrap, or @noexpose")
+			fmt.Sprintf("unknown attribute '@%s'; supported: @verify, @route, @mcp_name, @raw, @nowrap, @noexpose, @nomcp", name),
+			"Use @verify(depth: N), @route(\"METHOD\", \"/path\"), @mcp_name(\"name\"), @raw, @nowrap, @noexpose, or @nomcp")
 		return nil
 	}
 }

--- a/internal/parser/route_attr_test.go
+++ b/internal/parser/route_attr_test.go
@@ -420,6 +420,92 @@ export func healthCheck(x: int) -> string ! {} { "ok" }`
 	}
 }
 
+// TestNomcpAnnotation_Basic tests @nomcp standalone parses as a
+// parameterless annotation.
+func TestNomcpAnnotation_Basic(t *testing.T) {
+	input := `
+@nomcp
+export func internalTool(x: int) -> int ! {} { x }`
+
+	l := lexer.New(input, "test.ail")
+	p := New(l)
+	file := p.ParseFile()
+
+	if len(p.Errors()) > 0 {
+		for _, err := range p.Errors() {
+			t.Errorf("parser error: %v", err)
+		}
+		t.FailNow()
+	}
+
+	if len(file.Funcs) != 1 {
+		t.Fatalf("expected 1 function, got %d", len(file.Funcs))
+	}
+
+	fn := file.Funcs[0]
+	ann := fn.GetAnnotation("nomcp")
+	if ann == nil {
+		t.Fatal("expected @nomcp annotation")
+	}
+	if len(ann.Args) != 0 {
+		t.Errorf("expected @nomcp to have no args, got %d", len(ann.Args))
+	}
+}
+
+// TestNomcpAnnotation_WithRoute tests @nomcp combined with @route parses
+// cleanly (both annotations present; the runtime keeps IsNoMCP even with @route).
+func TestNomcpAnnotation_WithRoute(t *testing.T) {
+	input := `
+@nomcp
+@route("GET", "/internal/keys")
+export func getKeyUsage(x: int) -> string ! {} { "ok" }`
+
+	l := lexer.New(input, "test.ail")
+	p := New(l)
+	file := p.ParseFile()
+
+	if len(p.Errors()) > 0 {
+		for _, err := range p.Errors() {
+			t.Errorf("parser error: %v", err)
+		}
+		t.FailNow()
+	}
+
+	fn := file.Funcs[0]
+	if fn.GetAnnotation("nomcp") == nil {
+		t.Error("expected @nomcp annotation")
+	}
+	if fn.GetAnnotation("route") == nil {
+		t.Error("expected @route annotation")
+	}
+}
+
+// TestUnknownAnnotation_HardErrors verifies that an unknown annotation (e.g.
+// @nope) still hard-errors with PAR_UNKNOWN_ATTRIBUTE — the @nomcp addition
+// did not loosen the allowlist.
+func TestUnknownAnnotation_HardErrors(t *testing.T) {
+	input := `
+@nope
+export func f(x: int) -> int ! {} { x }`
+
+	l := lexer.New(input, "test.ail")
+	p := New(l)
+	_ = p.ParseFile()
+
+	if len(p.Errors()) == 0 {
+		t.Fatal("expected parser error for unknown attribute @nope")
+	}
+	found := false
+	for _, err := range p.Errors() {
+		if strings.Contains(err.Error(), "unknown attribute '@nope'") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected PAR_UNKNOWN_ATTRIBUTE mentioning @nope, got: %v", p.Errors())
+	}
+}
+
 // TestNowrapAnnotation_Basic tests @nowrap standalone.
 func TestNowrapAnnotation_Basic(t *testing.T) {
 	input := `

--- a/prompts/devtools/v0.8.0-compact.md
+++ b/prompts/devtools/v0.8.0-compact.md
@@ -164,7 +164,7 @@ ailang serve-api --routes-only ./api/                  # Only @route endpoints
 ailang init web-app my-app                            # Scaffold new web app
 # Auto-serves: /api/_meta/docs (Swagger UI), /api/_meta/redoc (ReDoc)
 # Protocols:   /.well-known/agent.json (A2A), /a2a/ (JSON-RPC), /mcp/ (MCP)
-# Annotations: @route("METHOD","/path"), @raw, @nowrap, @noexpose, @mcp_name("name")
+# Annotations: @route("METHOD","/path"), @raw, @nowrap, @noexpose, @nomcp (MCP-only hide), @mcp_name("name")
 # Request headers: _headers: Json param on @route (no @raw needed)
 # MCP: -- doc comments = tool descriptions, named inputSchema, --routes-only filters
 # MCP names: ^[a-zA-Z0-9_-]{1,64}$ (Claude Desktop strict); use @mcp_name to override

--- a/prompts/devtools/v0.8.0.md
+++ b/prompts/devtools/v0.8.0.md
@@ -633,11 +633,12 @@ ailang init web-app my-app
 | `@raw` | Receive full HttpRequest record (body, headers, method, query) |
 | `@nowrap` | Return raw JSON without response envelope |
 | `@noexpose` | Hide from HTTP/MCP (still importable by other modules) |
+| `@nomcp` | Hide from the MCP tool surface ONLY — still served over HTTP/OpenAPI/A2A (not reset by `@route`) |
 | `@mcp_name("name")` | Override the MCP tool name (must match `^[a-zA-Z0-9_-]{1,64}$`) |
 
 **Request headers in `@route`**: Declare a `_headers: Json` parameter to receive HTTP request headers without switching to `@raw` (preserves multipart parsing).
 
-**MCP tool quality**: Doc comments (`--` above func) become tool descriptions. `inputSchema` uses named parameters with JSON Schema types. `--routes-only` and `@noexpose` filter MCP `tools/list`. MCP tool names match `^[a-zA-Z0-9_-]{1,64}$` (Claude Desktop compatible) — auto-generated as bare function names when unique, or `<lastSegment>_<funcName>` on collision. Override with `@mcp_name("name")`.
+**MCP tool quality**: Doc comments (`--` above func) become tool descriptions. `inputSchema` uses named parameters with JSON Schema types. `--routes-only`, `@noexpose`, and `@nomcp` filter MCP `tools/list` (`@nomcp` filters MCP only; HTTP/OpenAPI unaffected). MCP tool names match `^[a-zA-Z0-9_-]{1,64}$` (Claude Desktop compatible) — auto-generated as bare function names when unique, or `<lastSegment>_<funcName>` on collision. Override with `@mcp_name("name")`.
 
 ## 13. Unified AI Execution
 


### PR DESCRIPTION
## M-SERVEAPI-NOMCP M1 — `@nomcp` annotation

Mission-control iteration pick (v1-mission queue). Design doc: `design_docs/planned/v0_30_0/m-serveapi-raw-handler-mcp.md` (DECIDED-routable by Mark 2026-07-20; M1 standalone, M2 dropped; quorum satisfied, no re-quorum).

### What
New parameterless `@nomcp` annotation. A `@route @nomcp` handler is served over **HTTP (200)**, appears in **OpenAPI** + the **A2A agent card**, but is **absent** from the MCP tool surface (`tools/list` and `tools/call`). MCP-surface-only exclusion — closes the live docparse `getKeyUsage`/`requestHistory` MCP capability leak with a one-line annotation, no HTTP behavior change.

Unlike `@noexpose` (which `@route` overrides at `routes.go:106`, and which also hides from HTTP), `@nomcp` sets its flag **unconditionally** and is **independent** of `@noexpose` — a `@route @nomcp` keeps `IsNoMCP=true`.

### Scope discipline
No eval-core change (Minimal-Frozen-Core north star): diff confined to the parser annotation allowlist (`internal/parser/parser_decl.go`) + `internal/apiserver/` + docs/prompts/example/tests. `isExposed`/`makeToolHandler`/the `@route` override untouched.

### Tests (8 new, all pass)
- Parser: `@nomcp` parses; unknown `@nope` still hard-errors (allowlist not loosened).
- Extractor: `IsNoMCP` set on `@route @nomcp` and bare `@nomcp`; independent of `@noexpose`.
- E2E (go-sdk in-memory MCP client): real `tools/list` excludes `@nomcp`, includes plain `@route`; `tools/call` on `@nomcp` errors. HTTP 200 + OpenAPI presence for the same route; `@noexpose` regression stays hidden from both.

### Routing evidence
Planner opus → executor opus (commit `2d6596292`) → evaluator **sonnet** (generator≠judge) **PASS 96/100 round 1**, no defects. `metered=$0.00`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)