### PR TITLE
fix(eval-executors): cache tokens + finish_reason for pi/opencode/codex

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -39,6 +39,55 @@ Final Gemini suite state: `benchmark_suite` = `gemini-3-1-pro`; `extended_suite`
 made this session — "3.6 is 3 benchmarks worse" and "3.5 beats the flagship" —
 were retracted after N=3 / matched-run checks. Do not rank models on frontier
 gaps ≤2.
+### Fixed — cache tokens + finish_reason for the remaining CLI executors (pi/opencode/codex)
+
+Follow-on to "agent mode records reasoning tokens + finish_reason". That change
+fixed the `tokenUsageFromResult` mapping boundary (cache fields now carry
+through) and wired `FinishReason` for `claude`/`opencode`, but three executors
+were still leaving telemetry on the floor.
+
+> **⚠️ DATA BOUNDARY: banked agent-mode `input_tokens` shifts UP for opencode
+> and codex.** Runs banked before this change are not directly comparable with
+> runs after it. No cost figures change (opencode reports cost directly; codex's
+> split is total-preserving). Landed while `M-EVAL-FMT-WEAKMODEL-AB` M2b was
+> still **unstarted**, so both A/B arms run under the new accounting.
+
+- **opencode cache tokens**: the prior change wired opencode's `FinishReason`
+  and `ReasonTokens` but never its cache counters. Now sums
+  `step_finish.part.tokens.cache.write`/`.read` into `CacheCreation`/`CacheRead`.
+  These counters are **exclusive** of `input`, verified against fixture data
+  (`total 17240 == input 1 + output 26 + cache.write 17213 + cache.read 0`), so
+  the sum is additive. Impact is large: the fixture run banked `input_tokens: 5`
+  and now banks `51,811`.
+- **codex cache tokens**: reports `cached_input_tokens`, but **splits** rather
+  than adds — OpenAI's counter is a *subset* of `input_tokens` (the opposite of
+  opencode), so `InputTokens` becomes `input - cached` and `CacheReadInputTokens`
+  becomes `cached`. Total-preserving; also lets the long-dormant
+  `CostModel.CacheReadCost` apply. Unverified vs a real stream (the repo's codex
+  fixture is synthetic and has no usage block).
+- **pi `FinishReason`**: modeled `piMessage.stopReason` (was unmodeled in the
+  struct), normalized from the last *settled* value (`message_end`/`turn_end`
+  only — streaming `message_update` events carry cumulative partial state). A
+  tool-using run ends `toolUse` mid-run and `stop` at the end; a regression test
+  pins that the intermediate `toolUse` does not win.
+- **codex `FinishReason`**: the `--json` stream exposes **no** model-level stop
+  reason in either schema generation, so codex reports only what the executor
+  observes (`stop` = clean termination, plus `timeout`/`cost_exhausted`/`error`)
+  — a codex run that refused or truncated is indistinguishable from a clean
+  finish. Documented in the executor + README rather than left silently empty.
+
+**Terminal precedence (correctness).** `CategorizeAgentError` trusts
+`FinishReason` over the error string, so pi and codex apply a kill-outranks-stream
+ladder: a cost/timeout kill outranks the stream's last value, or a cost-killed
+run whose final event said `stop` would be misread as a clean finish. Unknown
+native stop reasons pass through verbatim. Canonical vocabulary added as
+`executor.Finish*` constants (used by pi/codex).
+
+`codex.go` schema/parsing moved to `events.go` to stay under the 800-line CI gate.
+
+**Not changed:** the `claude` executor still ignores `result.subtype`
+(`error_max_turns` → `step_exhausted`). Deferred — it changes `error_category`
+for the pending `M-EVAL-FMT-WEAKMODEL-AB` A/B.
 
 ### Added — `@nomcp` annotation (hide a handler from the MCP tool surface only)
 

--- a/internal/executor/codex/README.md
+++ b/internal/executor/codex/README.md
@@ -124,6 +124,49 @@ OpenAI API usage semantics), not per-turn deltas. The parser takes `max(…)`
 rather than summing, so the final totals reflect the cumulative state from the
 last event, not a double-counted sum.
 
+#### Cache counters are a SUBSET of input
+
+`turn.completed.usage.cached_input_tokens` is part of `input_tokens`, not in
+addition to it (OpenAI Responses API semantics) — the **opposite** of opencode,
+whose cache counters are exclusive. The executor therefore *splits* rather than
+adds (`splitCodexInputTokens`):
+
+```
+Result.InputTokens          = input_tokens - cached_input_tokens
+Result.CacheReadInputTokens = cached_input_tokens
+```
+
+This is total-preserving, which matters because the eval harness banks
+agent-mode input as `InputTokens + CacheCreationInputTokens +
+CacheReadInputTokens` — adding the cached count on top would inflate it.
+Codex reports no cache-*creation* counter, so `CacheCreationInputTokens`
+stays 0.
+
+> Not verified against a real codex stream: this repo's only codex fixture is
+> synthetic and carries no `usage` block. Re-check when a real capture lands.
+
+### Finish Reason
+
+**The codex CLI's `exec --json` stream exposes no model-level stop reason**, in
+either schema generation:
+
+- New format: `turn.completed` carries only a `usage` block.
+- Old flat format: `result` carries a `status` field observed only as
+  `"success"` — and only in the synthetic fixture, so the failure vocabulary is
+  unknown. It is not modeled as a typed field; it survives only in
+  `ProviderData["codex_events"]`.
+
+So `Result.FinishReason` from this executor reports what the **executor**
+observed (`stop` = terminal event arrived and the process exited cleanly,
+plus `timeout` / `cost_exhausted` / `error`), never what the **model** decided.
+A codex run that refused the task, tripped a content filter, or truncated at
+the token cap is indistinguishable from a clean finish at this layer — and,
+separately, `Success` is likewise just "a terminal event arrived".
+
+Closing that gap requires capturing a real `codex exec --json` stream including
+a deliberately failing run, not extending the parser against the synthetic
+fixture.
+
 ## Cost Model
 
 `gpt-5-codex`: `$1.25 / $10.00` per 1M tokens (input / output).

--- a/internal/executor/codex/cached_tokens_test.go
+++ b/internal/executor/codex/cached_tokens_test.go
@@ -1,0 +1,44 @@
+package codex
+
+import "testing"
+
+// TestSplitCodexInputTokens pins the property that matters downstream:
+// cmd/ailang/eval_benchmark.go banks agent-mode input as
+// InputTokens + CacheCreationInputTokens + CacheReadInputTokens, so the split
+// MUST be total-preserving. codex's cached_input_tokens is a subset of
+// input_tokens (OpenAI Responses API semantics), which is why it is split out
+// rather than added on top.
+func TestSplitCodexInputTokens(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      int
+		cached     int
+		wantFresh  int
+		wantCached int
+	}{
+		{"no cache reported", 1000, 0, 1000, 0},
+		{"partial cache", 1000, 400, 600, 400},
+		{"fully cached", 1000, 1000, 0, 1000},
+		{"zero usage", 0, 0, 0, 0},
+		// Defensive: a malformed stream must never yield negative InputTokens.
+		{"cached exceeds input", 500, 900, 0, 500},
+		{"negative cached ignored", 800, -5, 800, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fresh, cached := splitCodexInputTokens(tt.input, tt.cached)
+			if fresh != tt.wantFresh || cached != tt.wantCached {
+				t.Errorf("splitCodexInputTokens(%d, %d) = (%d, %d), want (%d, %d)",
+					tt.input, tt.cached, fresh, cached, tt.wantFresh, tt.wantCached)
+			}
+			if fresh < 0 {
+				t.Errorf("fresh = %d, must never be negative", fresh)
+			}
+			// The invariant the eval banking layer depends on.
+			if tt.input >= 0 && tt.cached >= 0 && fresh+cached != tt.input {
+				t.Errorf("fresh+cached = %d, want %d (split must preserve the input total)",
+					fresh+cached, tt.input)
+			}
+		})
+	}
+}

--- a/internal/executor/codex/codex.go
+++ b/internal/executor/codex/codex.go
@@ -9,7 +9,6 @@ package codex
 import (
 	"bufio"
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -205,7 +204,7 @@ func (e *CodexExecutor) ExecuteStreaming(ctx context.Context, task *executor.Tas
 	var rawEvents []map[string]any
 	var turnNum int
 	var toolCallCount int
-	var inputTokens, outputTokens int
+	var inputTokens, outputTokens, cachedInputTokens int
 	var turnSpan trace.Span
 	var stderrBuf strings.Builder
 	sawResult := false
@@ -314,6 +313,9 @@ func (e *CodexExecutor) ExecuteStreaming(ctx context.Context, task *executor.Tas
 					}
 					if ev.Usage.OutputTokens > outputTokens {
 						outputTokens = ev.Usage.OutputTokens
+					}
+					if ev.Usage.CachedInputTokens > cachedInputTokens {
+						cachedInputTokens = ev.Usage.CachedInputTokens
 					}
 					// M-EVAL-COST-AND-SPEED-BUDGETS: per-turn cumulative→delta.
 					if task.Budget != nil {
@@ -474,20 +476,23 @@ func (e *CodexExecutor) ExecuteStreaming(ctx context.Context, task *executor.Tas
 				attribute.Int("task.turns", turnNum),
 				attribute.Bool("task.success", false),
 			)
+			freshInput, cachedInput := splitCodexInputTokens(inputTokens, cachedInputTokens)
 			return &executor.Result{
-				Success:        false,
-				Error:          timeoutErr.Error(),
-				DurationMS:     int(time.Since(startTime).Milliseconds()),
-				NumTurns:       turnNum,
-				ToolCallCount:  toolCallCount,
-				SessionID:      sessionID,
-				Transcript:     transcriptBuf.String(),
-				ProviderData:   providerData(rawEvents),
-				InputTokens:    inputTokens,
-				OutputTokens:   outputTokens,
-				CostKilledAt:   task.Budget.KilledAt(),
-				FirstAttemptMs: firstAttemptMs,
-				SuccessAtMs:    -1,
+				Success:              false,
+				Error:                timeoutErr.Error(),
+				FinishReason:         executor.FinishTimeout,
+				DurationMS:           int(time.Since(startTime).Milliseconds()),
+				NumTurns:             turnNum,
+				ToolCallCount:        toolCallCount,
+				SessionID:            sessionID,
+				Transcript:           transcriptBuf.String(),
+				ProviderData:         providerData(rawEvents),
+				InputTokens:          freshInput,
+				OutputTokens:         outputTokens,
+				CacheReadInputTokens: cachedInput,
+				CostKilledAt:         task.Budget.KilledAt(),
+				FirstAttemptMs:       firstAttemptMs,
+				SuccessAtMs:          -1,
 			}, nil
 
 		case <-ttftTimer.C:
@@ -503,6 +508,7 @@ func (e *CodexExecutor) ExecuteStreaming(ctx context.Context, task *executor.Tas
 			return &executor.Result{
 				Success:        false,
 				Error:          ttftErr.Error(),
+				FinishReason:   executor.FinishTimeout,
 				DurationMS:     int(time.Since(startTime).Milliseconds()),
 				NumTurns:       turnNum,
 				ToolCallCount:  toolCallCount,
@@ -526,20 +532,23 @@ func (e *CodexExecutor) ExecuteStreaming(ctx context.Context, task *executor.Tas
 					attribute.Int("task.turns", turnNum),
 					attribute.Bool("task.success", false),
 				)
+				freshInput, cachedInput := splitCodexInputTokens(inputTokens, cachedInputTokens)
 				return &executor.Result{
-					Success:        false,
-					Error:          idleErr.Error(),
-					DurationMS:     int(time.Since(startTime).Milliseconds()),
-					NumTurns:       turnNum,
-					ToolCallCount:  toolCallCount,
-					SessionID:      sessionID,
-					Transcript:     transcriptBuf.String(),
-					ProviderData:   providerData(rawEvents),
-					InputTokens:    inputTokens,
-					OutputTokens:   outputTokens,
-					CostKilledAt:   task.Budget.KilledAt(),
-					FirstAttemptMs: firstAttemptMs,
-					SuccessAtMs:    -1,
+					Success:              false,
+					Error:                idleErr.Error(),
+					FinishReason:         executor.FinishTimeout,
+					DurationMS:           int(time.Since(startTime).Milliseconds()),
+					NumTurns:             turnNum,
+					ToolCallCount:        toolCallCount,
+					SessionID:            sessionID,
+					Transcript:           transcriptBuf.String(),
+					ProviderData:         providerData(rawEvents),
+					InputTokens:          freshInput,
+					OutputTokens:         outputTokens,
+					CacheReadInputTokens: cachedInput,
+					CostKilledAt:         task.Budget.KilledAt(),
+					FirstAttemptMs:       firstAttemptMs,
+					SuccessAtMs:          -1,
 				}, nil
 			}
 			idleCheck.Reset(idleTimeout - idle)
@@ -567,34 +576,55 @@ func (e *CodexExecutor) ExecuteStreaming(ctx context.Context, task *executor.Tas
 				if stderrContent := stderrBuf.String(); stderrContent != "" {
 					errMsg = fmt.Sprintf("%s\nstderr: %s", errMsg, stderrContent)
 				}
+				// Terminal precedence: a cost kill outranks the generic exit
+				// error, because CategorizeAgentError trusts FinishReason
+				// over the Error string.
+				finishReason := executor.FinishError
 				if costKilled {
 					errMsg = fmt.Sprintf("cost budget exceeded ($%.4f) — %s", task.Budget.KilledAt(), errMsg)
+					finishReason = executor.FinishCostExhausted
 				}
+				freshInput, cachedInput := splitCodexInputTokens(inputTokens, cachedInputTokens)
 				return &executor.Result{
-					Success:        false,
-					Error:          errMsg,
-					DurationMS:     int(duration.Milliseconds()),
-					NumTurns:       turnNum,
-					ToolCallCount:  toolCallCount,
-					SessionID:      sessionID,
-					Transcript:     transcriptBuf.String(),
-					ProviderData:   providerData(rawEvents),
-					InputTokens:    inputTokens,
-					OutputTokens:   outputTokens,
-					CostKilledAt:   task.Budget.KilledAt(),
-					FirstAttemptMs: firstAttemptMs,
-					SuccessAtMs:    -1,
-					TokensPerSec:   tokensPerSec,
+					Success:              false,
+					Error:                errMsg,
+					FinishReason:         finishReason,
+					DurationMS:           int(duration.Milliseconds()),
+					NumTurns:             turnNum,
+					ToolCallCount:        toolCallCount,
+					SessionID:            sessionID,
+					Transcript:           transcriptBuf.String(),
+					ProviderData:         providerData(rawEvents),
+					InputTokens:          freshInput,
+					OutputTokens:         outputTokens,
+					CacheReadInputTokens: cachedInput,
+					CostKilledAt:         task.Budget.KilledAt(),
+					FirstAttemptMs:       firstAttemptMs,
+					SuccessAtMs:          -1,
+					TokensPerSec:         tokensPerSec,
 				}, nil
 			}
 
+			freshInput, cachedInput := splitCodexInputTokens(inputTokens, cachedInputTokens)
 			cost := e.CostModel().CalculateCost(executor.TokenUsage{
-				InputTokens:  inputTokens,
-				OutputTokens: outputTokens,
+				InputTokens:          freshInput,
+				OutputTokens:         outputTokens,
+				CacheReadInputTokens: cachedInput,
 			})
 			success := sawResult
+			// The codex CLI's --json stream carries NO model-level stop reason
+			// (see the schema note on codexEvent), so "stop" here asserts only
+			// what this executor can actually observe: a terminal event
+			// arrived and the process exited cleanly. A codex run that refused
+			// the task, tripped a content filter, or truncated at the token cap
+			// is indistinguishable from a clean finish at this layer.
+			finishReason := executor.FinishStop
+			if !success {
+				finishReason = executor.FinishError
+			}
 			if costKilled {
 				success = false
+				finishReason = executor.FinishCostExhausted
 			}
 
 			span.SetAttributes(
@@ -612,21 +642,23 @@ func (e *CodexExecutor) ExecuteStreaming(ctx context.Context, task *executor.Tas
 			}
 
 			return &executor.Result{
-				Success:        success,
-				Output:         transcriptBuf.String(),
-				DurationMS:     int(duration.Milliseconds()),
-				NumTurns:       turnNum,
-				ToolCallCount:  toolCallCount,
-				CostUSD:        cost,
-				InputTokens:    inputTokens,
-				OutputTokens:   outputTokens,
-				SessionID:      sessionID,
-				Transcript:     transcriptBuf.String(),
-				ProviderData:   providerData(rawEvents),
-				CostKilledAt:   task.Budget.KilledAt(),
-				FirstAttemptMs: firstAttemptMs,
-				SuccessAtMs:    -1,
-				TokensPerSec:   tokensPerSec,
+				Success:              success,
+				FinishReason:         finishReason,
+				Output:               transcriptBuf.String(),
+				DurationMS:           int(duration.Milliseconds()),
+				NumTurns:             turnNum,
+				ToolCallCount:        toolCallCount,
+				CostUSD:              cost,
+				InputTokens:          freshInput,
+				OutputTokens:         outputTokens,
+				CacheReadInputTokens: cachedInput,
+				SessionID:            sessionID,
+				Transcript:           transcriptBuf.String(),
+				ProviderData:         providerData(rawEvents),
+				CostKilledAt:         task.Budget.KilledAt(),
+				FirstAttemptMs:       firstAttemptMs,
+				SuccessAtMs:          -1,
+				TokensPerSec:         tokensPerSec,
 			}, nil
 		}
 	}
@@ -683,94 +715,6 @@ func (e *CodexExecutor) getModel(task *executor.Task) string {
 		return task.Model
 	}
 	return e.model
-}
-
-// codexTokens captures the flat token structure Codex emits.
-type codexTokens struct {
-	Input  int `json:"input"`
-	Output int `json:"output"`
-}
-
-// codexEvent is the normalized Codex NDJSON event shape.
-//
-// Codex CLI v0.1+ emits a thread/item stream format:
-//
-//	{"type":"thread.started","thread_id":"..."}
-//	{"type":"turn.started"}
-//	{"type":"item.started","item":{"id":"...","type":"file_change"|"command_execution"|"agent_message",...}}
-//	{"type":"item.completed","item":{...}}
-//	{"type":"turn.completed","usage":{"input_tokens":N,"cached_input_tokens":N,"output_tokens":N}}
-//
-// Older format (pre-v0.1) used flat records:
-//
-//	{"type":"message","turn_number":N,"text":"...","tokens_used":{"input":N,"output":N}}
-//	{"type":"tool_use","tool_name":"...","parameters":{...}}
-//
-// Both formats are handled. Unknown fields are preserved in Raw for ProviderData.
-type codexEvent struct {
-	Type       string          `json:"type"`
-	TurnNumber int             `json:"turn_number,omitempty"`
-	Text       string          `json:"text,omitempty"`
-	Tokens     codexTokens     `json:"tokens_used,omitempty"`
-	SessionID  string          `json:"session_id,omitempty"`
-	ThreadID   string          `json:"thread_id,omitempty"`
-	ToolName   string          `json:"tool_name,omitempty"`
-	Parameters json.RawMessage `json:"parameters,omitempty"`
-	Output     string          `json:"output,omitempty"`
-	Role       string          `json:"role,omitempty"`
-	Usage      *codexUsage     `json:"usage,omitempty"`
-	Item       *codexItem      `json:"item,omitempty"`
-
-	// Raw preserves the full event map for ProviderData (tolerance to schema drift).
-	Raw map[string]any `json:"-"`
-}
-
-// codexUsage is the token usage block in turn.completed events.
-type codexUsage struct {
-	InputTokens       int `json:"input_tokens"`
-	CachedInputTokens int `json:"cached_input_tokens"`
-	OutputTokens      int `json:"output_tokens"`
-}
-
-// codexItem is the item payload in item.started / item.completed events.
-type codexItem struct {
-	ID      string `json:"id"`
-	Type    string `json:"type"` // "agent_message", "command_execution", "file_change"
-	Text    string `json:"text,omitempty"`
-	Command string `json:"command,omitempty"`
-}
-
-// parseCodexEvent parses a single NDJSON line into a codexEvent.
-// Non-JSON and unparseable lines return an error; callers should skip them
-// rather than fail hard (Codex CLI may emit non-JSON preamble on stdout).
-func parseCodexEvent(line []byte) (*codexEvent, error) {
-	trimmed := strings.TrimSpace(string(line))
-	if trimmed == "" {
-		return nil, fmt.Errorf("empty line")
-	}
-	if trimmed[0] != '{' {
-		return nil, fmt.Errorf("non-JSON line")
-	}
-	var ev codexEvent
-	if err := json.Unmarshal(line, &ev); err != nil {
-		return nil, fmt.Errorf("json: %w", err)
-	}
-	// Tolerate schema drift: always capture the raw map.
-	var raw map[string]any
-	if err := json.Unmarshal(line, &raw); err == nil {
-		ev.Raw = raw
-	}
-	return &ev, nil
-}
-
-// providerData wraps the list of raw events as the Result.ProviderData map.
-func providerData(events []map[string]any) map[string]any {
-	if len(events) == 0 {
-		return nil
-	}
-	return map[string]any{
-		"codex_events": events,
-	}
 }
 
 // Register registers the Codex executor with the global factory.

--- a/internal/executor/codex/events.go
+++ b/internal/executor/codex/events.go
@@ -1,0 +1,151 @@
+package codex
+
+// Codex CLI event schema, NDJSON parsing, and token accounting.
+//
+// Split out of codex.go to keep both files under the 800-line
+// check-file-sizes gate. See README.md for schema documentation.
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// codexTokens captures the flat token structure Codex emits.
+type codexTokens struct {
+	Input  int `json:"input"`
+	Output int `json:"output"`
+}
+
+// codexEvent is the normalized Codex NDJSON event shape.
+//
+// Codex CLI v0.1+ emits a thread/item stream format:
+//
+//	{"type":"thread.started","thread_id":"..."}
+//	{"type":"turn.started"}
+//	{"type":"item.started","item":{"id":"...","type":"file_change"|"command_execution"|"agent_message",...}}
+//	{"type":"item.completed","item":{...}}
+//	{"type":"turn.completed","usage":{"input_tokens":N,"cached_input_tokens":N,"output_tokens":N}}
+//
+// Older format (pre-v0.1) used flat records:
+//
+//	{"type":"message","turn_number":N,"text":"...","tokens_used":{"input":N,"output":N}}
+//	{"type":"tool_use","tool_name":"...","parameters":{...}}
+//
+// Both formats are handled. Unknown fields are preserved in Raw for ProviderData.
+type codexEvent struct {
+	Type       string          `json:"type"`
+	TurnNumber int             `json:"turn_number,omitempty"`
+	Text       string          `json:"text,omitempty"`
+	Tokens     codexTokens     `json:"tokens_used,omitempty"`
+	SessionID  string          `json:"session_id,omitempty"`
+	ThreadID   string          `json:"thread_id,omitempty"`
+	ToolName   string          `json:"tool_name,omitempty"`
+	Parameters json.RawMessage `json:"parameters,omitempty"`
+	Output     string          `json:"output,omitempty"`
+	Role       string          `json:"role,omitempty"`
+	Usage      *codexUsage     `json:"usage,omitempty"`
+	Item       *codexItem      `json:"item,omitempty"`
+
+	// Raw preserves the full event map for ProviderData (tolerance to schema drift).
+	Raw map[string]any `json:"-"`
+}
+
+// codexUsage is the token usage block in turn.completed events.
+//
+// CachedInputTokens is a SUBSET of InputTokens (OpenAI Responses API
+// semantics) — see splitCodexInputTokens before using it.
+type codexUsage struct {
+	InputTokens       int `json:"input_tokens"`
+	CachedInputTokens int `json:"cached_input_tokens"`
+	OutputTokens      int `json:"output_tokens"`
+}
+
+// NOTE (finish reason): the codex CLI's `exec --json` stream exposes NO
+// model-level stop reason, in either schema generation. The new format's
+// terminal event, turn.completed, carries only a usage block; the old flat
+// format's `result` event carries a `status` field that has only ever been
+// observed as "success" (and only in this repo's hand-authored fixture — no
+// real codex capture exists here, so the failure vocabulary is unknown).
+// Neither is modeled as a typed field; `status` survives only in
+// ProviderData["codex_events"].
+//
+// Consequently Result.FinishReason from this executor reflects what the
+// EXECUTOR observed (clean termination / timeout / cost kill / non-zero exit),
+// never what the MODEL decided. A codex run that refused the task, tripped a
+// content filter, or truncated at max tokens reports "stop" like any other
+// clean run. Closing that gap requires capturing a real `codex exec --json`
+// stream — including a deliberately failing run — not extending the parser
+// against the synthetic fixture.
+
+// codexItem is the item payload in item.started / item.completed events.
+type codexItem struct {
+	ID      string `json:"id"`
+	Type    string `json:"type"` // "agent_message", "command_execution", "file_change"
+	Text    string `json:"text,omitempty"`
+	Command string `json:"command,omitempty"`
+}
+
+// parseCodexEvent parses a single NDJSON line into a codexEvent.
+// Non-JSON and unparseable lines return an error; callers should skip them
+// rather than fail hard (Codex CLI may emit non-JSON preamble on stdout).
+func parseCodexEvent(line []byte) (*codexEvent, error) {
+	trimmed := strings.TrimSpace(string(line))
+	if trimmed == "" {
+		return nil, fmt.Errorf("empty line")
+	}
+	if trimmed[0] != '{' {
+		return nil, fmt.Errorf("non-JSON line")
+	}
+	var ev codexEvent
+	if err := json.Unmarshal(line, &ev); err != nil {
+		return nil, fmt.Errorf("json: %w", err)
+	}
+	// Tolerate schema drift: always capture the raw map.
+	var raw map[string]any
+	if err := json.Unmarshal(line, &raw); err == nil {
+		ev.Raw = raw
+	}
+	return &ev, nil
+}
+
+// providerData wraps the list of raw events as the Result.ProviderData map.
+// splitCodexInputTokens separates codex's cumulative input_tokens into the
+// (fresh, cached) pair that executor.Result models as InputTokens +
+// CacheReadInputTokens.
+//
+// codex is OpenAI's own CLI over the Responses API, where cached_input_tokens
+// is a SUBSET of input_tokens (unlike opencode, whose cache counters are
+// exclusive of input). Adding it to InputTokens would therefore double-count:
+// cmd/ailang/eval_benchmark.go banks agent-mode input as
+// InputTokens + CacheCreationInputTokens + CacheReadInputTokens.
+//
+// Splitting is total-preserving — (input-cached) + cached == input — so the
+// banked input total is correct under the documented subset semantics, and no
+// worse than today's (cache-blind) total even if a future codex release made
+// the counters exclusive. It also lets CostModel.CacheReadCost, declared since
+// the executor was written but never applicable, finally apply.
+//
+// codex reports no cache-CREATION counter, so CacheCreationInputTokens stays 0.
+// Not verified against a real codex stream: the repo's only codex fixture is
+// synthetic and carries no usage block (see README). Re-check when a real
+// capture lands.
+func splitCodexInputTokens(inputTokens, cachedInputTokens int) (fresh, cached int) {
+	if cachedInputTokens <= 0 {
+		return inputTokens, 0
+	}
+	// Defensive: never let a malformed cached > input yield negative fresh.
+	if cachedInputTokens > inputTokens {
+		return 0, inputTokens
+	}
+	return inputTokens - cachedInputTokens, cachedInputTokens
+}
+
+func providerData(events []map[string]any) map[string]any {
+	if len(events) == 0 {
+		return nil
+	}
+	return map[string]any{
+		"codex_events": events,
+	}
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -194,12 +194,47 @@ type Result struct {
 	CompactionMaxLevel  int // Highest structural compaction level/threshold seen (0 = none)
 
 	// FinishReason (M-EVAL-SWEET-SPOT, v0.19.0) is the structured executor
-	// stop signal: "stop" (normal completion), "cost_exhausted" (motoko cost
-	// cap), "step_exhausted" (agent ran out of turns), "timeout", "error",
-	// or "". The eval harness consumes this via CategorizeAgentError to
+	// stop signal — see the Finish* constants below for the canonical
+	// vocabulary. The eval harness consumes this via CategorizeAgentError to
 	// promote ambiguous api_error rows into typed buckets.
+	//
+	// IMPORTANT (precedence): CategorizeAgentError trusts FinishReason OVER
+	// the Error string. An executor must therefore report how the run ACTUALLY
+	// ended, not merely echo the last stop reason it saw on the wire. A run
+	// killed for cost/thrash/timeout whose final stream event happened to say
+	// "stop" must report the kill, or the kill is misclassified as a clean
+	// finish. See the terminal-precedence ladder in the pi/opencode/codex
+	// executors for the reference implementation.
 	FinishReason string
 }
+
+// Canonical Result.FinishReason vocabulary. Executors normalize their
+// harness-native stop reason into these values; an unrecognized native value
+// is passed through verbatim rather than dropped, so it stays visible in the
+// banked JSON (CategorizeAgentError falls through to its error-string path for
+// anything it doesn't recognize, so pass-through is safe).
+const (
+	// FinishStop is normal completion — the model finished its turn.
+	FinishStop = "stop"
+	// FinishLength means output was truncated at the token cap.
+	FinishLength = "length"
+	// FinishToolCalls means the model stopped to call tools. Normally an
+	// INTERMEDIATE stop; terminal only if the harness loop ended mid-tool.
+	FinishToolCalls = "tool_calls"
+	// FinishContentFilter means a provider content filter stopped generation.
+	FinishContentFilter = "content_filter"
+	// FinishCostExhausted means a cost budget killed the run.
+	FinishCostExhausted = "cost_exhausted"
+	// FinishStepExhausted means the agent ran out of turns/steps.
+	FinishStepExhausted = "step_exhausted"
+	// FinishThrashAborted means a cumulative-token thrash guard killed the run.
+	FinishThrashAborted = "thrash_aborted"
+	// FinishTimeout means a hard/idle/prefill timeout killed the run.
+	FinishTimeout = "timeout"
+	// FinishError means the run terminated abnormally (non-zero exit, crash,
+	// cancellation).
+	FinishError = "error"
+)
 
 // TokenUsage captures token metrics
 type TokenUsage struct {

--- a/internal/executor/opencode/README.md
+++ b/internal/executor/opencode/README.md
@@ -113,6 +113,23 @@ Cost is also per-step; sum `step_finish.part.cost` for total.
 The executor's `CostUSD` field reflects the summed per-step cost (reported by
 opencode directly, not estimated from token counts × pricing).
 
+### Cache counters are EXCLUSIVE of input
+
+`tokens.cache.write` and `tokens.cache.read` are **not** a subset of
+`tokens.input` — unlike OpenAI/codex, where `cached_input_tokens ⊆
+input_tokens`. The fixture proves it:
+
+```
+total 17240 == input 1 + output 26 + cache.write 17213 + cache.read 0
+```
+
+So the four counters sum to `total`, and the executor sums cache into
+`Result.CacheCreationInputTokens` (write) and `Result.CacheReadInputTokens`
+(read) **additively**. This matters because the eval harness banks agent-mode
+input as `InputTokens + CacheCreationInputTokens + CacheReadInputTokens`:
+before this was wired up, a run consuming ~52K tokens banked `input_tokens: 5` —
+the uncached remainder was all that survived.
+
 ## Session Resume
 
 The `sessionID` from any event can be used to resume:

--- a/internal/executor/opencode/cache_tokens_test.go
+++ b/internal/executor/opencode/cache_tokens_test.go
@@ -1,0 +1,101 @@
+package opencode
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/sunholo-data/ailang/internal/executor"
+)
+
+// TestExecuteStreaming_CacheTokens pins the cache-token accounting that dev's
+// fixture test does not cover. Before cache wiring, opencode summed only
+// input/output, so a run that consumed ~52K tokens banked InputTokens=5 —
+// opencode reports cache counters EXCLUSIVE of input, so the uncached
+// remainder was all that survived.
+func TestExecuteStreaming_CacheTokens(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip(skipWindows)
+	}
+	_, thisFile, _, _ := runtime.Caller(0)
+	fixture := filepath.Join(filepath.Dir(thisFile), "testdata", "opencode_response.jsonl")
+	f, err := os.Open(fixture)
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var lines []string
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	for sc.Scan() {
+		if line := sc.Text(); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan fixture: %v", err)
+	}
+
+	dir := t.TempDir()
+	_ = writeFakeOpenCode(t, dir, lines)
+
+	e, err := New(&executor.Config{
+		OpenCodePath:   filepath.Join(dir, "opencode"),
+		OpenCodeModel:  "anthropic/claude-haiku-4-5",
+		TimeoutSeconds: 10,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	result, err := e.ExecuteStreaming(context.Background(), &executor.Task{
+		ID:        "test-cache-tokens",
+		Directive: "create a file",
+		Workspace: dir,
+		Timeout:   10 * time.Second,
+	}, &executor.NoOpEventHandler{})
+	if err != nil {
+		t.Fatalf("ExecuteStreaming: %v", err)
+	}
+	if result == nil {
+		t.Fatal("nil result")
+	}
+
+	// Summed across the fixture's three step_finish events:
+	//   input   1 +   1 +     3 =     5
+	//   output 26 + 133 +    25 =   184
+	//   write  17213 + 17223 + 147 = 34583
+	//   read       0 +     0 + 17223 = 17223
+	const (
+		wantInput      = 5
+		wantOutput     = 184
+		wantCacheWrite = 34583
+		wantCacheRead  = 17223
+	)
+	if result.InputTokens != wantInput {
+		t.Errorf("InputTokens = %d, want %d", result.InputTokens, wantInput)
+	}
+	if result.OutputTokens != wantOutput {
+		t.Errorf("OutputTokens = %d, want %d", result.OutputTokens, wantOutput)
+	}
+	if result.CacheCreationInputTokens != wantCacheWrite {
+		t.Errorf("CacheCreationInputTokens = %d, want %d", result.CacheCreationInputTokens, wantCacheWrite)
+	}
+	if result.CacheReadInputTokens != wantCacheRead {
+		t.Errorf("CacheReadInputTokens = %d, want %d", result.CacheReadInputTokens, wantCacheRead)
+	}
+
+	// Cache counters are exclusive of input, so the four sum to the fixture's
+	// own reported per-step totals (17240 + 17357 + 17398). This is the
+	// invariant that makes summing them additive rather than double-counting.
+	const wantTotal = 17240 + 17357 + 17398
+	gotTotal := result.InputTokens + result.OutputTokens +
+		result.CacheCreationInputTokens + result.CacheReadInputTokens
+	if gotTotal != wantTotal {
+		t.Errorf("token total = %d, want %d (cache counters must be exclusive of input)", gotTotal, wantTotal)
+	}
+}

--- a/internal/executor/opencode/opencode.go
+++ b/internal/executor/opencode/opencode.go
@@ -212,7 +212,7 @@ func (e *OpenCodeExecutor) ExecuteStreaming(ctx context.Context, task *executor.
 	var numSteps int
 	var toolCallCount int
 	// opencode emits per-step deltas; sum across step_finish events.
-	var inputTokens, outputTokens, reasonTokens int
+	var inputTokens, outputTokens, reasonTokens, cacheReadTokens, cacheWriteTokens int
 	// Finish reason of the LAST step_finish: intermediate steps report
 	// "tool-calls" as they hand off to a tool, so only the final one describes
 	// how the run actually ended (notably "length" = truncated at the cap).
@@ -331,6 +331,13 @@ func (e *OpenCodeExecutor) ExecuteStreaming(ctx context.Context, task *executor.
 				inputTokens += ev.Part.Tokens.Input
 				outputTokens += ev.Part.Tokens.Output
 				reasonTokens += ev.Part.Tokens.Reasoning
+				// opencode reports cache tokens EXCLUSIVE of input (verified
+				// against testdata: total == input + output + cache.write +
+				// cache.read exactly, with input as small as 1 on a step that
+				// wrote 17213 cache tokens). Summing them here is therefore
+				// additive, not double-counting.
+				cacheWriteTokens += ev.Part.Tokens.Cache.Write
+				cacheReadTokens += ev.Part.Tokens.Cache.Read
 				totalCostUSD += ev.Part.Cost
 				if ev.Part.Reason != "" {
 					lastFinishReason = ev.Part.Reason
@@ -400,24 +407,26 @@ func (e *OpenCodeExecutor) ExecuteStreaming(ctx context.Context, task *executor.
 						thrashKilledAtTokens, task.MaxTokensPerBench, errMsg)
 				}
 				return &executor.Result{
-					Success:        success,
-					Output:         transcriptBuf.String(),
-					Error:          errMsg,
-					DurationMS:     int(duration.Milliseconds()),
-					InputTokens:    inputTokens,
-					OutputTokens:   outputTokens,
-					ReasonTokens:   reasonTokens,
-					CostUSD:        totalCostUSD,
-					NumTurns:       numSteps,
-					ToolCallCount:  toolCallCount,
-					SessionID:      lastSessionID,
-					ProviderData:   opencodeProviderData(rawEvents),
-					CostKilledAt:   task.Budget.KilledAt(),
-					ThrashKilledAt: thrashKilledAtTokens,
-					FirstAttemptMs: firstAttemptMs,
-					SuccessAtMs:    -1,
-					TokensPerSec:   tokensPerSec,
-					FinishReason:   normalizeOpencodeFinishReason(lastFinishReason),
+					Success:                  success,
+					Output:                   transcriptBuf.String(),
+					Error:                    errMsg,
+					DurationMS:               int(duration.Milliseconds()),
+					InputTokens:              inputTokens,
+					OutputTokens:             outputTokens,
+					ReasonTokens:             reasonTokens,
+					CacheReadInputTokens:     cacheReadTokens,
+					CacheCreationInputTokens: cacheWriteTokens,
+					CostUSD:                  totalCostUSD,
+					NumTurns:                 numSteps,
+					ToolCallCount:            toolCallCount,
+					SessionID:                lastSessionID,
+					ProviderData:             opencodeProviderData(rawEvents),
+					CostKilledAt:             task.Budget.KilledAt(),
+					ThrashKilledAt:           thrashKilledAtTokens,
+					FirstAttemptMs:           firstAttemptMs,
+					SuccessAtMs:              -1,
+					TokensPerSec:             tokensPerSec,
+					FinishReason:             normalizeOpencodeFinishReason(lastFinishReason),
 				}, nil
 			}
 
@@ -429,37 +438,41 @@ func (e *OpenCodeExecutor) ExecuteStreaming(ctx context.Context, task *executor.
 
 			span.SetStatus(codes.Ok, "")
 			return &executor.Result{
-				Success:        success,
-				Output:         output,
-				DurationMS:     int(duration.Milliseconds()),
-				InputTokens:    inputTokens,
-				OutputTokens:   outputTokens,
-				ReasonTokens:   reasonTokens,
-				CostUSD:        totalCostUSD,
-				NumTurns:       numSteps,
-				ToolCallCount:  toolCallCount,
-				SessionID:      lastSessionID,
-				ProviderData:   opencodeProviderData(rawEvents),
-				CostKilledAt:   task.Budget.KilledAt(),
-				ThrashKilledAt: thrashKilledAtTokens,
-				FirstAttemptMs: firstAttemptMs,
-				SuccessAtMs:    -1,
-				TokensPerSec:   tokensPerSec,
-				FinishReason:   normalizeOpencodeFinishReason(lastFinishReason),
+				Success:                  success,
+				Output:                   output,
+				DurationMS:               int(duration.Milliseconds()),
+				InputTokens:              inputTokens,
+				OutputTokens:             outputTokens,
+				ReasonTokens:             reasonTokens,
+				CacheReadInputTokens:     cacheReadTokens,
+				CacheCreationInputTokens: cacheWriteTokens,
+				CostUSD:                  totalCostUSD,
+				NumTurns:                 numSteps,
+				ToolCallCount:            toolCallCount,
+				SessionID:                lastSessionID,
+				ProviderData:             opencodeProviderData(rawEvents),
+				CostKilledAt:             task.Budget.KilledAt(),
+				ThrashKilledAt:           thrashKilledAtTokens,
+				FirstAttemptMs:           firstAttemptMs,
+				SuccessAtMs:              -1,
+				TokensPerSec:             tokensPerSec,
+				FinishReason:             normalizeOpencodeFinishReason(lastFinishReason),
 			}, nil
 
 		case <-hardTimer.C:
 			_ = cmd.Process.Kill()
 			span.SetStatus(codes.Error, "hard timeout")
 			return &executor.Result{
-				Success:        false,
-				Error:          fmt.Sprintf("opencode exceeded hard timeout (%v)", timeout),
-				InputTokens:    inputTokens,
-				OutputTokens:   outputTokens,
-				ReasonTokens:   reasonTokens,
-				CostKilledAt:   task.Budget.KilledAt(),
-				FirstAttemptMs: firstAttemptMs,
-				SuccessAtMs:    -1,
+				Success:                  false,
+				Error:                    fmt.Sprintf("opencode exceeded hard timeout (%v)", timeout),
+				InputTokens:              inputTokens,
+				OutputTokens:             outputTokens,
+				ReasonTokens:             reasonTokens,
+				CacheReadInputTokens:     cacheReadTokens,
+				CacheCreationInputTokens: cacheWriteTokens,
+				CostKilledAt:             task.Budget.KilledAt(),
+				FirstAttemptMs:           firstAttemptMs,
+				SuccessAtMs:              -1,
 			}, nil
 
 		case <-ttftTimer.C:
@@ -478,14 +491,16 @@ func (e *OpenCodeExecutor) ExecuteStreaming(ctx context.Context, task *executor.
 				_ = cmd.Process.Kill()
 				span.SetStatus(codes.Error, "generation idle timeout")
 				return &executor.Result{
-					Success:        false,
-					Error:          fmt.Sprintf("opencode idle for %v mid-generation (no output)", since),
-					InputTokens:    inputTokens,
-					OutputTokens:   outputTokens,
-					ReasonTokens:   reasonTokens,
-					CostKilledAt:   task.Budget.KilledAt(),
-					FirstAttemptMs: firstAttemptMs,
-					SuccessAtMs:    -1,
+					Success:                  false,
+					Error:                    fmt.Sprintf("opencode idle for %v mid-generation (no output)", since),
+					InputTokens:              inputTokens,
+					OutputTokens:             outputTokens,
+					ReasonTokens:             reasonTokens,
+					CacheReadInputTokens:     cacheReadTokens,
+					CacheCreationInputTokens: cacheWriteTokens,
+					CostKilledAt:             task.Budget.KilledAt(),
+					FirstAttemptMs:           firstAttemptMs,
+					SuccessAtMs:              -1,
 				}, nil
 			}
 			idleCheck.Reset(idleTimeout - since)
@@ -494,14 +509,16 @@ func (e *OpenCodeExecutor) ExecuteStreaming(ctx context.Context, task *executor.
 			_ = cmd.Process.Kill()
 			span.SetStatus(codes.Error, ctx.Err().Error())
 			return &executor.Result{
-				Success:        false,
-				Error:          fmt.Sprintf("opencode cancelled: %v", ctx.Err()),
-				InputTokens:    inputTokens,
-				OutputTokens:   outputTokens,
-				ReasonTokens:   reasonTokens,
-				CostKilledAt:   task.Budget.KilledAt(),
-				FirstAttemptMs: firstAttemptMs,
-				SuccessAtMs:    -1,
+				Success:                  false,
+				Error:                    fmt.Sprintf("opencode cancelled: %v", ctx.Err()),
+				InputTokens:              inputTokens,
+				OutputTokens:             outputTokens,
+				ReasonTokens:             reasonTokens,
+				CacheReadInputTokens:     cacheReadTokens,
+				CacheCreationInputTokens: cacheWriteTokens,
+				CostKilledAt:             task.Budget.KilledAt(),
+				FirstAttemptMs:           firstAttemptMs,
+				SuccessAtMs:              -1,
 			}, nil
 		}
 	}

--- a/internal/executor/pi/README.md
+++ b/internal/executor/pi/README.md
@@ -106,6 +106,30 @@ In `message_end` and `turn_end`:
 **Pi reports cost directly** — the executor uses `usage.cost.total` for
 `Result.CostUSD` rather than recomputing from token counts.
 
+### Stop Reason
+
+`message` carries a `stopReason` on `message_start` / `message_end` /
+`turn_end` (and mirrored on `assistantMessageEvent.partial` during
+`message_update`). Values observed in captured fixtures at 0.70.2:
+
+| Value | Meaning | Maps to |
+|---|---|---|
+| `stop` | Model finished its turn | `stop` |
+| `toolUse` | Model stopped to call a tool (**intermediate**) | `tool_calls` |
+
+The executor takes the **last settled** value (`message_end` / `turn_end`
+only — streaming `message_update` events carry cumulative partial state) and
+normalizes it into `Result.FinishReason` via `normalizePiFinishReason`. A
+tool-using run ends `toolUse` mid-run and `stop` at the end, so only the last
+value is meaningful at run level.
+
+The vocabulary is **not documented upstream** and only these two values have
+been observed; unrecognized values are passed through verbatim rather than
+coerced, so they surface in banked eval JSON. An explicit kill
+(cost budget, timeout, cancellation) overrides the stream value — the eval
+harness trusts `FinishReason` over the error string when categorizing.
+Re-check this mapping when bumping the pinned pi version.
+
 ### Parser Strategy
 
 - Use `message_end` (assistant role) as the source of truth for usage / cost.

--- a/internal/executor/pi/finish_reason_test.go
+++ b/internal/executor/pi/finish_reason_test.go
@@ -1,0 +1,95 @@
+package pi
+
+import (
+	"context"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/sunholo-data/ailang/internal/executor"
+)
+
+func TestNormalizePiFinishReason(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want string
+	}{
+		// Observed in captured fixtures (pi 0.70.2).
+		{"stop", executor.FinishStop},
+		{"toolUse", executor.FinishToolCalls},
+		// Plausible synonyms, mapped defensively.
+		{"endTurn", executor.FinishStop},
+		{"maxTokens", executor.FinishLength},
+		{"refusal", executor.FinishContentFilter},
+		{"aborted", executor.FinishError},
+		// Unknown values pass through verbatim rather than being coerced to
+		// "stop" — CategorizeAgentError ignores what it doesn't recognize, so
+		// pass-through stays visible in banked JSON without misclassifying.
+		{"someFuturePiReason", "someFuturePiReason"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := normalizePiFinishReason(tt.raw); got != tt.want {
+			t.Errorf("normalizePiFinishReason(%q) = %q, want %q", tt.raw, got, tt.want)
+		}
+	}
+}
+
+// runPiFixture executes a fixture through the fake-pi harness and returns the
+// Result, so finish-reason assertions read as one line each.
+func runPiFixture(t *testing.T, fixture string) *executor.Result {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip(skipWindows)
+	}
+	dir := t.TempDir()
+	_ = writeFakePi(t, dir, loadFixtureLines(t, fixture))
+
+	e, err := New(&executor.Config{
+		PiPath:         filepath.Join(dir, "pi"),
+		PiModel:        "anthropic/claude-haiku-4-5",
+		TimeoutSeconds: 10,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	result, err := e.ExecuteStreaming(context.Background(), &executor.Task{
+		ID:        "test-finish-reason",
+		Directive: "test",
+		Workspace: dir,
+		Timeout:   10 * time.Second,
+	}, &collectingHandler{})
+	if err != nil {
+		t.Fatalf("ExecuteStreaming: %v", err)
+	}
+	if result == nil {
+		t.Fatal("nil result")
+	}
+	return result
+}
+
+func TestExecuteStreaming_FinishReasonFromStopReason(t *testing.T) {
+	if got := runPiFixture(t, "fizzbuzz.ndjson").FinishReason; got != executor.FinishStop {
+		t.Errorf("FinishReason = %q, want %q", got, executor.FinishStop)
+	}
+}
+
+// The tool_use fixture has an INTERMEDIATE message_end/turn_end with
+// stopReason "toolUse" before the run's final "stop". Taking the last settled
+// value (not the first, and not any streaming message_update partial) is what
+// keeps a normal tool-using run from banking as "tool_calls".
+func TestExecuteStreaming_FinishReasonIgnoresIntermediateToolUse(t *testing.T) {
+	if got := runPiFixture(t, "tool_use.ndjson").FinishReason; got != executor.FinishStop {
+		t.Errorf("FinishReason = %q, want %q (intermediate toolUse must not win)", got, executor.FinishStop)
+	}
+}
+
+func TestPiCancelFinishReason(t *testing.T) {
+	if got := piCancelFinishReason(context.DeadlineExceeded); got != executor.FinishTimeout {
+		t.Errorf("DeadlineExceeded → %q, want %q", got, executor.FinishTimeout)
+	}
+	if got := piCancelFinishReason(context.Canceled); got != executor.FinishError {
+		t.Errorf("Canceled → %q, want %q", got, executor.FinishError)
+	}
+}

--- a/internal/executor/pi/pi.go
+++ b/internal/executor/pi/pi.go
@@ -25,6 +25,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -178,6 +179,10 @@ func (e *PiExecutor) ExecuteStreaming(ctx context.Context, task *executor.Task, 
 	var sessionID string
 	var turnSpan trace.Span
 	var stderrBuf strings.Builder
+	// Last settled stopReason seen on a message_end / turn_end. Streaming
+	// message_update events carry cumulative partial state, so they are
+	// deliberately excluded — only settled events are authoritative.
+	var lastStopReason string
 
 	// M-EVAL-COST-AND-SPEED-BUDGETS: speed + cost-kill instrumentation.
 	// pi emits per-turn token deltas in message_end (role=assistant), so the
@@ -278,6 +283,9 @@ func (e *PiExecutor) ExecuteStreaming(ctx context.Context, task *executor.Task, 
 				handler.OnToolResult(ev.ToolName, output)
 
 			case "message_end":
+				if ev.Message != nil && ev.Message.StopReason != "" {
+					lastStopReason = ev.Message.StopReason
+				}
 				// Per-turn deltas for assistant messages — sum into totals.
 				if ev.Message != nil && ev.Message.Role == "assistant" && ev.Message.Usage != nil {
 					u := ev.Message.Usage
@@ -296,6 +304,9 @@ func (e *PiExecutor) ExecuteStreaming(ctx context.Context, task *executor.Task, 
 				}
 
 			case "turn_end":
+				if ev.Message != nil && ev.Message.StopReason != "" {
+					lastStopReason = ev.Message.StopReason
+				}
 				if turnSpan != nil {
 					if ev.Message != nil && ev.Message.Usage != nil {
 						u := ev.Message.Usage
@@ -342,11 +353,17 @@ func (e *PiExecutor) ExecuteStreaming(ctx context.Context, task *executor.Task, 
 			if err != nil {
 				span.SetStatus(codes.Error, err.Error())
 				errMsg := fmt.Sprintf("pi exited with error: %v\nstderr: %s", err, stderrBuf.String())
+				// Terminal precedence: a cost kill outranks whatever the last
+				// stream event said, because CategorizeAgentError trusts
+				// FinishReason over the Error string.
+				finishReason := executor.FinishError
 				if costKilled {
 					errMsg = fmt.Sprintf("cost budget exceeded ($%.4f) — %s", task.Budget.KilledAt(), errMsg)
+					finishReason = executor.FinishCostExhausted
 				}
 				return &executor.Result{
 					Success:                  false,
+					FinishReason:             finishReason,
 					Output:                   transcriptBuf.String(),
 					Error:                    errMsg,
 					DurationMS:               int(duration.Milliseconds()),
@@ -368,13 +385,21 @@ func (e *PiExecutor) ExecuteStreaming(ctx context.Context, task *executor.Task, 
 
 			output := transcriptBuf.String()
 			success := output != "" || toolCallCount > 0
+			// Clean exit: the stream's own last stop reason is authoritative.
+			// Default to "stop" when pi reported none at all.
+			finishReason := executor.FinishStop
+			if lastStopReason != "" {
+				finishReason = normalizePiFinishReason(lastStopReason)
+			}
 			if costKilled {
 				success = false
+				finishReason = executor.FinishCostExhausted
 			}
 
 			span.SetStatus(codes.Ok, "")
 			return &executor.Result{
 				Success:                  success,
+				FinishReason:             finishReason,
 				Output:                   output,
 				DurationMS:               int(duration.Milliseconds()),
 				InputTokens:              inputTokens,
@@ -398,6 +423,7 @@ func (e *PiExecutor) ExecuteStreaming(ctx context.Context, task *executor.Task, 
 			return &executor.Result{
 				Success:        false,
 				Error:          fmt.Sprintf("pi exceeded hard timeout (%v)", timeout),
+				FinishReason:   executor.FinishTimeout,
 				InputTokens:    inputTokens,
 				OutputTokens:   outputTokens,
 				CostKilledAt:   task.Budget.KilledAt(),
@@ -411,6 +437,7 @@ func (e *PiExecutor) ExecuteStreaming(ctx context.Context, task *executor.Task, 
 			return &executor.Result{
 				Success:        false,
 				Error:          fmt.Sprintf("pi produced no output within %v (prefill timeout)", ttftTimeout),
+				FinishReason:   executor.FinishTimeout,
 				FirstAttemptMs: -1,
 				SuccessAtMs:    -1,
 			}, nil
@@ -423,6 +450,7 @@ func (e *PiExecutor) ExecuteStreaming(ctx context.Context, task *executor.Task, 
 				return &executor.Result{
 					Success:        false,
 					Error:          fmt.Sprintf("pi idle for %v mid-generation (no output)", since),
+					FinishReason:   executor.FinishTimeout,
 					InputTokens:    inputTokens,
 					OutputTokens:   outputTokens,
 					CostKilledAt:   task.Budget.KilledAt(),
@@ -438,6 +466,7 @@ func (e *PiExecutor) ExecuteStreaming(ctx context.Context, task *executor.Task, 
 			return &executor.Result{
 				Success:        false,
 				Error:          fmt.Sprintf("pi cancelled: %v", ctx.Err()),
+				FinishReason:   piCancelFinishReason(ctx.Err()),
 				InputTokens:    inputTokens,
 				OutputTokens:   outputTokens,
 				CostKilledAt:   task.Budget.KilledAt(),
@@ -549,8 +578,14 @@ type piUsage struct {
 
 // piMessage captures the per-message envelope.
 type piMessage struct {
-	Role  string   `json:"role"`
-	Usage *piUsage `json:"usage,omitempty"`
+	Role string `json:"role"`
+	// StopReason is pi's per-message stop signal, present on message_start /
+	// message_end / turn_end (and mirrored on assistantMessageEvent.partial).
+	// Observed values: "stop", "toolUse" (fixtures, pi 0.70.2). A tool-calling
+	// turn ends "toolUse" and the run's FINAL turn ends "stop", so only the
+	// last value seen is meaningful as a run-level finish reason.
+	StopReason string   `json:"stopReason,omitempty"`
+	Usage      *piUsage `json:"usage,omitempty"`
 }
 
 // piAssistantMessageEvent captures the inner discriminator for message_update.
@@ -629,6 +664,42 @@ func flattenPiToolResult(r *piToolResult) string {
 		b.WriteString(c.Text)
 	}
 	return b.String()
+}
+
+// piCancelFinishReason distinguishes a deadline-driven context cancellation
+// (a timeout by another name) from a caller-driven one (an abort).
+func piCancelFinishReason(err error) string {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return executor.FinishTimeout
+	}
+	return executor.FinishError
+}
+
+// normalizePiFinishReason maps pi's camelCase stopReason vocabulary onto the
+// canonical executor.Finish* values.
+//
+// Pi is pre-1.0 (0.70.x) and its stop-reason vocabulary is NOT documented
+// upstream; "stop" and "toolUse" are the only values observed in captured
+// fixtures. Rather than guess at the rest, unrecognized values are passed
+// through verbatim so they surface in the banked JSON instead of being
+// silently coerced to "stop" (CategorizeAgentError ignores values it doesn't
+// know, so pass-through cannot misclassify a run). Re-check this mapping when
+// bumping the pinned pi version.
+func normalizePiFinishReason(raw string) string {
+	switch raw {
+	case "stop", "endTurn", "end_turn":
+		return executor.FinishStop
+	case "toolUse", "tool_use", "toolCalls":
+		return executor.FinishToolCalls
+	case "maxTokens", "max_tokens", "length":
+		return executor.FinishLength
+	case "refusal", "safety", "contentFilter":
+		return executor.FinishContentFilter
+	case "aborted", "error":
+		return executor.FinishError
+	default:
+		return raw
+	}
 }
 
 // piProviderData wraps raw events as Result.ProviderData.


### PR DESCRIPTION
Follow-on to #441 (agent mode records reasoning tokens + finish_reason), which already fixed the `tokenUsageFromResult` mapping boundary and wired `FinishReason` for `claude`/`opencode`. This branch was originally cut *before* #441 landed, so it's been rebased onto current `dev` and trimmed to only the pieces #441 did **not** cover.

## Net-new (dev does not have these)
- **opencode cache tokens** — #441 wired opencode `FinishReason` + `ReasonTokens` but never its cache counters. Now sums `step_finish.part.tokens.cache.write`/`.read`. Counters are **exclusive** of input (verified against fixture: `total 17240 == input 1 + output 26 + cache.write 17213 + cache.read 0`), so additive. Fixture run: `input_tokens 5` → `51,811`.
- **codex cache tokens** — `cached_input_tokens` is a **subset** of input (OpenAI semantics), so **split** rather than add (total-preserving); also lets the dormant `CostModel.CacheReadCost` apply. Unverified vs a real stream (repo fixture is synthetic).
- **pi `FinishReason`** — modeled `piMessage.stopReason` (was unmodeled), last-settled value; regression test pins that an intermediate `toolUse` doesn't win.
- **codex `FinishReason`** — the `--json` stream exposes no model-level stop reason; documented in executor + README rather than left silently empty.
- `executor.Finish*` canonical constants (used by pi/codex).

## Correctness
`CategorizeAgentError` trusts `FinishReason` over the error string, so pi/codex apply a kill-outranks-stream ladder (a cost/timeout kill outranks the stream's last value). Unknown native reasons pass through verbatim.

## Notes
- `codex.go` schema/parsing moved to `events.go` to stay under the 800-line CI gate.
- Dropped from the original branch as **already landed in #441**: the `tokenUsageFromResult` extraction, its test, opencode `FinishReason`, `ReasonTokens`.
- **⚠️ DATA BOUNDARY**: banked agent-mode `input_tokens` shifts up for opencode/codex. Landed while `M-EVAL-FMT-WEAKMODEL-AB` M2b was still unstarted, so both A/B arms run under the new accounting. No cost figures change.
- **Not changed**: `claude` executor still ignores `result.subtype` — deferred (changes `error_category` for the pending A/B).

## Verification
`go test ./...` green (except a pre-existing httpbin.org network flake in `internal/effects`, untouched here) · lint / `check-boundaries` / `check-file-sizes` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)