### PR TITLE
feat(stdlib): std/json jint(int) convenience constructor (M-DX-PACKAGE-DOGFOODING M2)

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `std/json`: `jint(n: int) -> Json` convenience constructor for integer JSON numbers (M-DX-PACKAGE-DOGFOODING M2)
+
 ### Added — Cross-provider request-side reasoning control (M-AI-REASONING-EFFORT, v0.31.0) (2026-07-22)
 
 AI provider requests now accept validated `Request.ReasoningEffort` controls and

--- a/cmd/ailang/prompts/v0.16.3.md
+++ b/cmd/ailang/prompts/v0.16.3.md
@@ -1471,7 +1471,8 @@ import std/result (Result, Ok, Err)
 ```ailang
 import std/json (encode, jo, ja, kv, js, jnum, jb, jn)
 
--- JSON constructors: js(string), jnum(float), jb(bool), jn() for null
+-- JSON constructors: js(string), jnum(float), jint(int), jb(bool), jn() for null
+-- jint(n) is the integer convenience for jnum(intToFloat(n))
 -- jo([kv(k,v)...]) for objects, ja([...]) for arrays
 
 -- Build JSON object with all types

--- a/cmd/ailang/prompts/versions.json
+++ b/cmd/ailang/prompts/versions.json
@@ -623,7 +623,7 @@
     },
     "v0.16.3": {
       "file": "prompts/v0.16.3.md",
-      "hash": "39d93a7926f4fa23ef0db112e1a30d51c934e23ec317a4c37b45b16f984fb153",
+      "hash": "b60348c93dd21a8ec33934c841cec87d1c57270412af0619c3227fbd497c5215",
       "description": "v0.16.2 + Formatting section teaching `ailang fmt --write`/`--check` (command usage only, no AILANG code snippet). Makes the canonical formatter discoverable to agents; usage guidance says format after edits type-check. M-AILANG-FMT-ADOPTION (v0.30.0).",
       "created": "2026-07-20",
       "tags": [

--- a/examples/manifest.json
+++ b/examples/manifest.json
@@ -1651,6 +1651,25 @@
       "description": "Temperature conversion with verified physical constraints"
     },
     {
+      "path": "runnable/json_jint.ail",
+      "status": "working",
+      "tags": [
+        "json",
+        "stdlib",
+        "constructors",
+        "m-dx-package-dogfooding"
+      ],
+      "description": "std/json jint() convenience constructor for integer JSON numbers (M-DX-PACKAGE-DOGFOODING M2)",
+      "expected": {
+        "stdout": "encode(jint(42))                 = 42\nencode(jo([kv(\"count\", jint(42))])) = {\"count\":42}\n",
+        "exit_code": 0
+      },
+      "modules": [
+        "std/io",
+        "std/json"
+      ]
+    },
+    {
       "path": "runnable/effectful_list.ail",
       "status": "working",
       "tags": [
@@ -2606,11 +2625,11 @@
     }
   ],
   "statistics": {
-    "total": 188,
-    "working": 180,
+    "total": 189,
+    "working": 181,
     "aspirational": 4,
     "broken": 4,
-    "coverage": 0.9574468085106383,
+    "coverage": 0.9576719576719577,
     "experimental": 0
   },
   "milestones": {

--- a/examples/runnable/json_jint.ail
+++ b/examples/runnable/json_jint.ail
@@ -1,0 +1,14 @@
+-- json_jint.ail - Integer JSON numbers via the jint() convenience constructor (v1.1.0)
+--
+-- JSON numbers are floats internally (JNumber(float)). Building an integer-valued
+-- number with jnum() means writing jnum(intToFloat(count)); jint(count) is the
+-- one-call convenience that does exactly that: jint(n) == jnum(intToFloat(n)).
+module examples/runnable/json_jint
+
+import std/json (jint, jo, kv, encode)
+import std/io (println)
+
+export func main() -> () ! {IO} = {
+  println("encode(jint(42))                 = ${encode(jint(42))}");
+  println("encode(jo([kv(\"count\", jint(42))])) = ${encode(jo([kv("count", jint(42))]))}")
+}

--- a/prompts/v0.16.3.md
+++ b/prompts/v0.16.3.md
@@ -1471,7 +1471,8 @@ import std/result (Result, Ok, Err)
 ```ailang
 import std/json (encode, jo, ja, kv, js, jnum, jb, jn)
 
--- JSON constructors: js(string), jnum(float), jb(bool), jn() for null
+-- JSON constructors: js(string), jnum(float), jint(int), jb(bool), jn() for null
+-- jint(n) is the integer convenience for jnum(intToFloat(n))
 -- jo([kv(k,v)...]) for objects, ja([...]) for arrays
 
 -- Build JSON object with all types

--- a/prompts/versions.json
+++ b/prompts/versions.json
@@ -623,7 +623,7 @@
     },
     "v0.16.3": {
       "file": "prompts/v0.16.3.md",
-      "hash": "39d93a7926f4fa23ef0db112e1a30d51c934e23ec317a4c37b45b16f984fb153",
+      "hash": "b60348c93dd21a8ec33934c841cec87d1c57270412af0619c3227fbd497c5215",
       "description": "v0.16.2 + Formatting section teaching `ailang fmt --write`/`--check` (command usage only, no AILANG code snippet). Makes the canonical formatter discoverable to agents; usage guidance says format after edits type-check. M-AILANG-FMT-ADOPTION (v0.30.0).",
       "created": "2026-07-20",
       "tags": [

--- a/std/json.ail
+++ b/std/json.ail
@@ -5,7 +5,7 @@ module std/json
 import std/option (Option, Some, None)
 import std/result (Result)
 import std/list (foldl, foldr, map)
-import std/math (floatToInt)
+import std/math (floatToInt, intToFloat)
 
 -- JSON ADT with all JSON types
 export type Json =
@@ -46,6 +46,9 @@ export func jb(b: bool) -> Json {
 export func jnum(x: float) -> Json {
   JNumber(x)
 }
+
+-- jint: convenience constructor for integer JSON numbers (JSON numbers are floats internally)
+export pure func jint(n: int) -> Json = JNumber(intToFloat(n))
 
 export func js(s: string) -> Json {
   JString(s)


### PR DESCRIPTION
## Summary

Completes the **final remaining issue** of `m-dx-package-dogfooding` (Issue 3 / M2). Issues 1 (hyphen module paths) and 2 (`++` list-only) already shipped in prior releases (`7d1e4b82a`, `99f76ec7a`), so this **closes the doc**.

`jint(n: int) -> Json` removes the `jnum(intToFloat(...))` footgun AI agents hit when building JSON objects from integer fields — a real friction point found dogfooding `sunholo/registry_validator` in AILANG.

## Changes
- **`std/json.ail`** — `export pure func jint(n: int) -> Json = JNumber(intToFloat(n))` (adds `intToFloat` to the `std/math` import). Mirrors the existing `jnum` convention.
- **`examples/runnable/json_jint.ail`** + **`examples/manifest.json`** — CI-enforced regression guard via `make verify-examples` (0 drift; statistics bumped 188→189 total, 180→181 working).
- **`prompts/v0.16.3.md`** (active embedded prompt, confirmed via `ailang prompt --source=embedded`) + cmd copy — teaches `jint` in the JSON constructor list; `versions.json` integrity hash rebumped. Historical `v0.16.2` left immutable.
- **`changelogs/v0.18-current.md`** — `[Unreleased] Added` entry.

## Verification
- `make build` ✓
- `ailang run examples/runnable/json_jint.ail` → `encode(jint(42)) = 42` / `{"count":42}` ✓
- `make verify-examples` ✓ GREEN (0 drift, all pass)
- `make test` ✓ (one unrelated external-network flake: `TestNetHttpPost` httpbin.org 503; passes with it skipped)
- `internal/prompt` tests ✓ (hash gate green)

Routing: controller opus · executor opus (isolated worktree) · quorum N/A (design-complete leaf helper, exact spec, zero conflict surface — the two design-forked issues already shipped). Mission iteration 90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)