### PR TITLE
fix(docs): escape MDX-special chars in generated package summaries

### DIFF
--- a/docs/scripts/sync-registry.sh
+++ b/docs/scripts/sync-registry.sh
@@ -101,6 +101,14 @@ VENDOREOF
     SHORT_NAME=$(echo "$FULL_NAME" | cut -d/ -f2)
     LATEST=$(echo "$PKG_JSON" | jq -r '.latest')
     AI_SUMMARY=$(echo "$PKG_JSON" | jq -r '.ai_summary // "No description"')
+    # Sanitize the free-text summary before injecting it into MDX. It is untrusted
+    # (comes from the published package), so a bare '<' or '{' is parsed by MDX as an
+    # opening JSX tag / expression and breaks the Docusaurus build for the WHOLE site —
+    # e.g. sunholo/motoko_ext_fmt's "(<workdir>/...)" reddened Docs-Deploy 2026-07-23.
+    #   - Body blockquote: escape '<' '>' '{' '}' to HTML entities (MDX renders them literally).
+    #   - YAML frontmatter description: escape embedded double-quotes so the scalar can't terminate early.
+    AI_SUMMARY_MDX=$(printf '%s' "$AI_SUMMARY" | sed -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/{/\&#123;/g' -e 's/}/\&#125;/g')
+    AI_SUMMARY_YAML=$(printf '%s' "$AI_SUMMARY" | sed -e 's/"/\&quot;/g')
     STABILITY=$(echo "$PKG_JSON" | jq -r '.stability // "experimental"')
     EFFECTS_RAW=$(echo "$PKG_JSON" | jq -r '.effects // [] | if length == 0 then "Pure" else join(", ") end')
     EXPORTS_COUNT=$(echo "$PKG_JSON" | jq -r '.exports | length')
@@ -115,7 +123,7 @@ VENDOREOF
     cat > "$VENDOR_DIR/$SHORT_NAME.mdx" <<PKGEOF
 ---
 title: "${FULL_NAME}"
-description: "${AI_SUMMARY}"
+description: "${AI_SUMMARY_YAML}"
 sidebar_label: "${SHORT_NAME}"
 ---
 
@@ -123,7 +131,7 @@ import PackageDetail from '@site/src/components/PackageExplorer/PackageDetail';
 
 # ${FULL_NAME}
 
-> ${AI_SUMMARY}
+> ${AI_SUMMARY_MDX}
 
 | Field | Value |
 |-------|-------|


### PR DESCRIPTION
## Gate-1 RED fix (mission-control iteration)

**Deploy Documentation to GitHub Pages** went red on `dev` at 584ef6148: the `motoko_ext_fmt` package publish added an `ai_summary` containing `(<workdir>/...)`. The docs generator (`docs/scripts/sync-registry.sh`) injects each summary **raw** into the MDX page body (`> ${AI_SUMMARY}`), so MDX parsed `<workdir>` as an unclosed JSX tag → `Expected a closing tag for <workdir>` → whole-site build failure.

### Root cause
Untrusted free-text (published package summaries) injected into MDX without escaping. This is **systemic** — any future package with `<`/`{` in its summary would red the docs build.

### Fix
Sanitize the summary before injection:
- MDX body blockquote: `<` `>` `{` `}` → HTML entities (rendered literally).
- YAML frontmatter `description:` → `"` → `&quot;`.

### Verification
Local `docusaurus build`: **client + server compiled successfully, zero MDX errors** (prior failure was `motoko_ext_fmt.mdx` line 11). The generated page now shows `&lt;workdir&gt;`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)