### PR TITLE
fix(smt): declare reachable ADTs through record aliases; make ai-check exit honest (#477)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ For the latest version, see [changelogs/v0.18-current.md](changelogs/v0.18-curre
 
 ### Fixed
 
+- SMT verification now closes declarations through named record fields into
+  user ADTs, including `list[ADT]` and mutual record/ADT cycles.
+- `ai-check` now uses the same per-function type-demand filtering as `verify`,
+  so unrelated declarations no longer cascade otherwise verifiable functions
+  into skips. This changes the verification KPI population (the measured corpus
+  moved from 76→79 verified and 10→7 skipped) and must not be read as a model
+  quality improvement.
+
+### Changed
+
+- **Breaking for out-of-repo shell callers:** `ai-check` now exits 1 when its
+  emitted JSON reports `verify.errors > 0`; complete JSON is still written
+  before the exit decision. Skips remain exit 0.
+
 - Bounded both Z3 solver calls (`Solve` and the `Z3Version` header probe) by
   killing their process groups and reaping them after a hard deadline. `Solve`
   uses `max(configured timeout, effective -T seconds) + 2s grace` and preserves

--- a/cmd/ailang/ai_check.go
+++ b/cmd/ailang/ai_check.go
@@ -155,12 +155,33 @@ func aiCheckCommand() {
 		Verify: verifySection,
 	}
 
+	// The JSON is ALWAYS emitted before the exit decision: `ai-check` is an AI
+	// convergence signal, so a consumer must be able to read the full report even
+	// on the failing exit path.
 	outputAICheck(output)
 
-	// Exit code: 1 if check failed or contract violations found
-	if !checkSection.Passed || verifySection.Counterexample > 0 {
+	if aiCheckExitCode(checkSection, verifySection) != 0 {
 		os.Exit(1)
 	}
+}
+
+// aiCheckExitCode decides `ai-check`'s process exit status from its own JSON report.
+//
+// Extracted from aiCheckCommand so the exit lanes are unit-testable without a
+// subprocess (os.Exit is untestable in-process). The contract, which the eval
+// harness and every agent convergence loop depend on:
+//
+//	check failed        -> 1
+//	counterexample > 0  -> 1
+//	verifier errors > 0 -> 1   (added by M-Z3-ADT-RECORD-SORT; process status must
+//	                            never disagree with the JSON it just printed)
+//	skipped-only        -> 0   (a skip is "not proved", not "disproved")
+//	verified-only       -> 0
+func aiCheckExitCode(check aiCheckSection, verify aiVerifySection) int {
+	if !check.Passed || verify.Counterexample > 0 || verify.Errors > 0 {
+		return 1
+	}
+	return 0
 }
 
 // runVerification runs contract verification on compiled artifacts.
@@ -341,21 +362,15 @@ func runVerification(coreProg *core.Program, surfaceAST *ast.File, modules map[s
 		funcEncOpts.Contracts = meta.Contracts
 		funcEncOpts.RecursiveDepth = recursiveDepth
 
-		// Demand-driven ADT filtering (same as verify.go)
-		funcADTTypes := filterADTTypesForFunction(params, returnSort, innerBody, adtTypes)
+		funcADTTypes, funcAliases, funcExtraDecls :=
+			filterSMTInputsForFunction(params, returnSort, innerBody, adtTypes, recordAliases, adtRecordDecls)
+		funcEncOpts.RecordTypeAliases = funcAliases
+		funcEncOpts.ExtraDeclarations = funcExtraDecls
 
 		encResult, err := smt.EncodeFunction(funcName, params, innerBody, returnSort, meta, funcADTTypes, funcEncOpts)
 		if err != nil {
 			if errors.Is(err, smt.ErrUnresolvableTypes) {
-				section.Results = append(section.Results, verifyResult{
-					Function: funcName, Status: "skipped",
-					Reason: fmt.Sprintf("Uses cross-module types not yet supported in Z3 encoding (%v)", err),
-					Rejections: []smt.SMTRejectionReason{{
-						Code:    smt.RejectUnencodable,
-						Message: err.Error(),
-						Hint:    "Cross-module record type aliases and recursive ADTs are not yet supported in Z3 verification",
-					}},
-				})
+				section.Results = append(section.Results, unresolvedTypeVerifyResult(funcName, err))
 				section.Skipped++
 				continue
 			}

--- a/cmd/ailang/ai_check_exit_test.go
+++ b/cmd/ailang/ai_check_exit_test.go
@@ -1,0 +1,84 @@
+package main
+
+import "testing"
+
+// TestAICheckExitCode_Lanes is the AC3.2 guard.
+//
+// `ai-check` is documented to AI agents as THE convergence signal, so its process
+// exit status must never disagree with the JSON it just printed. Before
+// M-Z3-ADT-RECORD-SORT the verifier-errors lane was missing entirely: a file whose
+// report said `verify.errors: 1` still exited 0.
+//
+// Red mutation: delete `|| verify.Errors > 0` from aiCheckExitCode. It compiles,
+// and the "verifier errors" and "errors dominate a clean check" cases below fail.
+// (Measured end-to-end: with that clause removed, cross_module_functions.ail —
+// check.passed=true, verify.errors=3 — exits 0 instead of 1.)
+func TestAICheckExitCode_Lanes(t *testing.T) {
+	tests := []struct {
+		name  string
+		check aiCheckSection
+		verif aiVerifySection
+		want  int
+	}{
+		{
+			name:  "clean check, nothing verified",
+			check: aiCheckSection{Passed: true},
+			verif: aiVerifySection{Available: true},
+			want:  0,
+		},
+		{
+			name:  "verified only",
+			check: aiCheckSection{Passed: true},
+			verif: aiVerifySection{Available: true, Verified: 3},
+			want:  0,
+		},
+		{
+			// A skip is "not proved", NOT "disproved" — it must stay green, else
+			// every unencodable-but-correct program would fail the gate.
+			name:  "skipped only",
+			check: aiCheckSection{Passed: true},
+			verif: aiVerifySection{Available: true, Verified: 1, Skipped: 2},
+			want:  0,
+		},
+		{
+			name:  "counterexample",
+			check: aiCheckSection{Passed: true},
+			verif: aiVerifySection{Available: true, Counterexample: 1},
+			want:  1,
+		},
+		{
+			// THE regression this sprint closed.
+			name:  "verifier errors",
+			check: aiCheckSection{Passed: true},
+			verif: aiVerifySection{Available: true, Errors: 1},
+			want:  1,
+		},
+		{
+			name:  "errors dominate an otherwise clean run",
+			check: aiCheckSection{Passed: true},
+			verif: aiVerifySection{Available: true, Verified: 5, Skipped: 1, Errors: 3},
+			want:  1,
+		},
+		{
+			name:  "check failure",
+			check: aiCheckSection{Passed: false},
+			verif: aiVerifySection{Available: false},
+			want:  1,
+		},
+		{
+			name:  "check failure outranks a clean verify section",
+			check: aiCheckSection{Passed: false},
+			verif: aiVerifySection{Available: true, Verified: 2},
+			want:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := aiCheckExitCode(tt.check, tt.verif); got != tt.want {
+				t.Fatalf("aiCheckExitCode() = %d, want %d (check.Passed=%v verify=%+v)",
+					got, tt.want, tt.check.Passed, tt.verif)
+			}
+		})
+	}
+}

--- a/cmd/ailang/verify.go
+++ b/cmd/ailang/verify.go
@@ -374,26 +374,10 @@ func verifyCommand() {
 		// references via its params, return type, or body. This prevents cascade failures
 		// where unrelated cross-module types (e.g., Json) poison functions that only use
 		// primitive types (e.g., int → int).
-		funcADTTypes := filterADTTypesForFunction(params, returnSort, innerBody, adtTypes)
-
-		// Demand-driven record-alias and inline-record filtering: same principle.
-		// Without these, every function gets the union of all aliases and inline
-		// records from every imported module, causing cascade Z3 errors when an
-		// unused alias references a sort that the ADT filter correctly dropped.
-		// buildNeededSortSet must see the FULL alias map (not the filtered one)
-		// so that aliases referenced only via inline-record bodies (e.g., TableCell
-		// inside Record_headers_rows) are still detected and pulled into `needed`.
-		needed := buildNeededSortSet(params, returnSort, innerBody, funcADTTypes, recordAliases, adtRecordDecls)
-		funcEncOpts.ExtraDeclarations = filterExtraDeclarationsForFunction(adtRecordDecls, needed)
-		// Filter aliases against the widened needed-set: includes both directly-
-		// referenced aliases AND aliases pulled in by inline-record bodies.
-		widenedAliases := make(map[string]*types.TRecord)
-		for name, rec := range recordAliases {
-			if needed[name] {
-				widenedAliases[name] = rec
-			}
-		}
-		funcEncOpts.RecordTypeAliases = widenedAliases
+		funcADTTypes, funcAliases, funcExtraDecls :=
+			filterSMTInputsForFunction(params, returnSort, innerBody, adtTypes, recordAliases, adtRecordDecls)
+		funcEncOpts.RecordTypeAliases = funcAliases
+		funcEncOpts.ExtraDeclarations = funcExtraDecls
 
 		// Encode function to SMT-LIB (with cross-function call support)
 		encResult, err := smt.EncodeFunction(funcName, params, innerBody, returnSort, meta, funcADTTypes, funcEncOpts)
@@ -401,16 +385,7 @@ func verifyCommand() {
 			// If the error is due to unresolvable cross-module types,
 			// skip gracefully instead of reporting as error
 			if errors.Is(err, smt.ErrUnresolvableTypes) {
-				results = append(results, verifyResult{
-					Function: funcName,
-					Status:   "skipped",
-					Reason:   fmt.Sprintf("Uses cross-module types not yet supported in Z3 encoding (%v)", err),
-					Rejections: []smt.SMTRejectionReason{{
-						Code:    smt.RejectUnencodable,
-						Message: err.Error(),
-						Hint:    "Cross-module record type aliases and recursive ADTs are not yet supported in Z3 verification",
-					}},
-				})
+				results = append(results, unresolvedTypeVerifyResult(funcName, err))
 				skipped++
 				continue
 			}

--- a/cmd/ailang/verify_filter.go
+++ b/cmd/ailang/verify_filter.go
@@ -14,12 +14,26 @@ package main
 // follow-up (v0.14.3) to keep verify.go under the 800-line organisation budget.
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/sunholo-data/ailang/internal/core"
 	"github.com/sunholo-data/ailang/internal/smt"
 	"github.com/sunholo-data/ailang/internal/types"
 )
+
+func unresolvedTypeVerifyResult(funcName string, err error) verifyResult {
+	return verifyResult{
+		Function: funcName,
+		Status:   "skipped",
+		Reason:   fmt.Sprintf("SMT declaration closure could not resolve a required sort (%v)", err),
+		Rejections: []smt.SMTRejectionReason{{
+			Code:    smt.RejectUnencodable,
+			Message: err.Error(),
+			Hint:    "The function uses a type shape whose required SMT sorts cannot be declared",
+		}},
+	}
+}
 
 // buildNeededSortSet returns the set of sort names reachable from the function's
 // seeds (params, return, body) through ADT variant fields, record-alias field
@@ -127,8 +141,8 @@ func extractReferencedSorts(decl string, adtTypes map[string][]smt.ADTVariant, a
 //
 // The transitive closure walks alias field types to find further aliases that
 // must be retained. ADT types referenced from alias fields are NOT pulled in
-// here — those are handled separately by filterADTTypesForFunction. The seed
-// set should already include any ADT types reachable from the function body.
+// here — filterSMTInputsForFunction owns the combined alias+ADT closure and is
+// the single entry point that BOTH `verify` and `ai-check` call.
 func filterRecordAliasesForFunction(
 	params []smt.FunctionParam,
 	returnSort string,
@@ -223,62 +237,31 @@ func filterExtraDeclarationsForFunction(allDecls []string, needed map[string]boo
 	return out
 }
 
-// filterADTTypesForFunction returns only the ADT types that a function actually
-// references through its parameter types, return type, and body expressions.
-// This prevents cross-module type pollution where unrelated ADTs (e.g., Json)
-// cause cascade Z3 errors for functions that only use primitive types.
-func filterADTTypesForFunction(
+// filterSMTInputsForFunction applies the same demand closure for every CLI
+// verification driver. The full maps must remain visible while computing the
+// closure; filtering an input before the walk can hide a transitive dependency.
+func filterSMTInputsForFunction(
 	params []smt.FunctionParam,
 	returnSort string,
 	body core.CoreExpr,
 	allADTTypes map[string][]smt.ADTVariant,
-) map[string][]smt.ADTVariant {
-	if len(allADTTypes) == 0 {
-		return allADTTypes
-	}
-
-	// Collect sort names referenced by this function
-	seeds := collectSortSeeds(params, returnSort, body)
-
-	// If no non-primitive sorts referenced, return empty map
-	if len(seeds) == 0 {
-		return map[string][]smt.ADTVariant{}
-	}
-
-	// Compute transitive closure: ADT variants may reference other ADT types
-	needed := make(map[string]bool)
-	queue := make([]string, 0, len(seeds))
-	for s := range seeds {
-		queue = append(queue, s)
-	}
-	for len(queue) > 0 {
-		sort := queue[0]
-		queue = queue[1:]
-		if needed[sort] {
-			continue
-		}
-		needed[sort] = true
-		// Check if this sort is an ADT; if so, collect sorts from its variant fields
-		if variants, ok := allADTTypes[sort]; ok {
-			for _, v := range variants {
-				for _, f := range v.Fields {
-					dep := extractBaseSortName(f.Sort)
-					if !needed[dep] && !isPrimitiveSMTSort(dep) {
-						queue = append(queue, dep)
-					}
-				}
-			}
-		}
-	}
-
-	// Filter ADT types to only those needed
-	result := make(map[string][]smt.ADTVariant, len(needed))
+	allAliases map[string]*types.TRecord,
+	allExtraDecls []string,
+) (map[string][]smt.ADTVariant, map[string]*types.TRecord, []string) {
+	needed := buildNeededSortSet(params, returnSort, body, allADTTypes, allAliases, allExtraDecls)
+	adts := make(map[string][]smt.ADTVariant)
 	for name, variants := range allADTTypes {
 		if needed[name] {
-			result[name] = variants
+			adts[name] = variants
 		}
 	}
-	return result
+	aliases := make(map[string]*types.TRecord)
+	for name, rec := range allAliases {
+		if needed[name] {
+			aliases[name] = rec
+		}
+	}
+	return adts, aliases, filterExtraDeclarationsForFunction(allExtraDecls, needed)
 }
 
 // collectSortSeeds gathers non-primitive sort names from function params, return type, and body.

--- a/cmd/ailang/verify_filter_test.go
+++ b/cmd/ailang/verify_filter_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/sunholo-data/ailang/internal/smt"
@@ -67,7 +69,7 @@ func TestFilterRecordAliasesForFunction_OnlyDirectlyUsed(t *testing.T) {
 // TestFilterRecordAliasesForFunction_TransitiveClosure verifies that a function
 // using ParsedDocument transitively pulls in DocMetadata (which ParsedDocument
 // references via its metadata field). Block (an ADT) is OUT of scope for this
-// test — it's filtered separately via filterADTTypesForFunction.
+// test — the combined alias+ADT closure lives in filterSMTInputsForFunction.
 func TestFilterRecordAliasesForFunction_TransitiveClosure(t *testing.T) {
 	allAliases := map[string]*types.TRecord{
 		"DocMetadata": {
@@ -114,6 +116,30 @@ func TestFilterRecordAliasesForFunction_EmptyInput(t *testing.T) {
 	got := filterRecordAliasesForFunction(nil, "Int", nil, nil, nil)
 	if len(got) != 0 {
 		t.Errorf("expected empty result for nil aliases, got: %v", keysOf(got))
+	}
+}
+
+func TestFilterSMTInputs_WalksRecordAliasIntoADT(t *testing.T) {
+	params := []smt.FunctionParam{{Name: "p", Type: &types.TCon{Name: "Proposal"}}}
+	aliases := map[string]*types.TRecord{"Proposal": {Fields: map[string]types.Type{
+		"evidence": &types.TList{Element: &types.TCon{Name: "Evidence"}},
+	}}}
+	adts := map[string][]smt.ADTVariant{"Evidence": {{Name: "CompilerOutput"}}}
+
+	gotADTs, gotAliases, _ := filterSMTInputsForFunction(params, "", nil, adts, aliases, nil)
+	if _, ok := gotADTs["Evidence"]; !ok {
+		t.Fatalf("Evidence missing from ADT closure: %v", gotADTs)
+	}
+	if _, ok := gotAliases["Proposal"]; !ok {
+		t.Fatalf("Proposal missing from alias closure: %v", gotAliases)
+	}
+}
+
+func TestUnresolvedTypeVerifyResult_IsNeutral(t *testing.T) {
+	got := unresolvedTypeVerifyResult("f", fmt.Errorf("%w: sort Missing", smt.ErrUnresolvableTypes))
+	text := strings.ToLower(got.Reason + " " + got.Rejections[0].Message + " " + got.Rejections[0].Hint)
+	if strings.Contains(text, "cross-module") || !strings.Contains(text, "missing") {
+		t.Fatalf("non-neutral or non-contextual result: %+v", got)
 	}
 }
 

--- a/design_docs/implemented/v0_31_0/m-z3-adt-record-sort-sprint-plan.md
+++ b/design_docs/implemented/v0_31_0/m-z3-adt-record-sort-sprint-plan.md
@@ -1,0 +1,618 @@
+# Sprint Plan: M-Z3-ADT-RECORD-SORT — Declaration Closure Through Records + Honest `ai-check` Exit
+
+**Design doc**: [m-z3-adt-record-sort.md](m-z3-adt-record-sort.md)
+**Sprint ID**: `M-Z3-ADT-RECORD-SORT`
+**Worktree**: `/Users/voightkampff/dev/sunholo-data/.wt-iter117` (branch `sprint/m-z3-adt-record-sort`, base `origin/dev @ 7e75fa511`)
+**Mission iteration**: 117
+**Planned**: 2026-07-29
+**Duration**: **2.0 working days (16h)** — *reduced from the doc's 3–4 days; justification below*
+**Risk Level**: **Low-Medium** (mechanism proven by a live planning spike; residual risk is test surface, not design)
+
+---
+
+## Summary
+
+Close the SMT declaration-closure defect so a contracted function whose parameter is a named
+record containing a user ADT is **verified** rather than handed malformed SMT-LIB, and make
+`ai-check`'s process exit agree with its own JSON. The planner ran a **throwaway production spike
+at HEAD** that reproduces the defect, implements the mechanism, and proves the outcome end-to-end;
+the spike was fully reverted before this plan was written. This sprint is therefore an
+**implementation-and-hardening** sprint, not a discovery sprint.
+
+**Headline measured result of the spike** (see "Planning Spike" below):
+`ai-check` on the doc's own repro goes `errors=1, exit 0` → `verified=1, exit 0`; the examples
+corpus goes **verified 76 → 79, skipped 10 → 7**, counterexamples and errors unchanged;
+`go test ./internal/smt ./cmd/ailang ./internal/eval_harness` stays **green with zero changes to
+existing tests**.
+
+---
+
+## PLANNER REFUTATIONS — read before implementing
+
+The design doc was routed unchanged by Mark's decision (option B, `53d3ac727`). The **direction**
+is correct and is not re-litigated. But five load-bearing premises about *where the defect lives*
+are wrong, and one is wrong in a way that would have made M1 **not fix the doc's own repro**.
+
+### R-1 (BLOCKING) — The defect is TWO layers, not one. M1 as written cannot fix the repro.
+
+The doc localises the bug entirely inside `internal/smt/codegen.go` Step 0. That is **half** of it.
+
+There is a **second, independent** drop in the CLI driver. `filterADTTypesForFunction`
+(`cmd/ailang/verify_filter.go:230`) seeds from params/return/body and walks the transitive closure
+**only through ADT variant fields — never through record-alias fields**. For
+`hasName(p: Proposal, n: string)` the seed set is `{Proposal}`; `Proposal` is an alias, not an ADT,
+so the closure terminates and `funcADTTypes` is **empty**. `Evidence`'s variant list is never handed
+to `EncodeFunction`. **No encoder-side graph can emit a datatype whose body it was never given.**
+
+Measured proof (worktree HEAD, `./bin/ailang`): adding `e: Evidence` as an extra parameter — which
+makes the driver seed `Evidence` — changes the emitted SMT from *no declarations at all* to
+`(declare-datatype Evidence ...)` while `Proposal` is **still** missing. That isolates the two
+layers cleanly:
+
+| Fixture | Driver supplies `Evidence`? | HEAD result |
+|---|---|---|
+| `/tmp/i117/adtsort.ail` (doc's repro) | no | **no declarations at all**; Z3 `unknown sort 'Proposal'` |
+| `/tmp/i117/layer.ail` (`+ e: Evidence` param) | yes | `Evidence` declared, `Proposal` **still** missing |
+
+**Consequence for the plan:** M1 must change `cmd/ailang/verify_filter.go` / `verify.go` as well
+as `internal/smt/codegen.go`. The doc's "Files Expected to Change" table does **not list
+`verify_filter.go` at all** and allots `verify.go` only `+5/−5` "neutral skip reason". That table
+is wrong and is superseded by this plan.
+
+### R-2 (BLOCKING) — `ai-check` and `verify` are NOT the same driver. `ai-check` has **no** demand filtering, and it is measurably worse today.
+
+`cmd/ailang/verify.go:383-396` computes `buildNeededSortSet` → `filterExtraDeclarationsForFunction`
+→ `widenedAliases`. `cmd/ailang/ai_check.go`'s `runVerification` does **only**
+`filterADTTypesForFunction` and passes the **full, unfiltered** `recordAliases` and the **full**
+`adtRecordDecls` (`encOpts.ExtraDeclarations = adtRecordDecls`, set once at line 238 and never
+narrowed per function). `rg "buildNeededSortSet" cmd/ailang/ai_check.go` → **zero hits**.
+
+This is not theoretical. Measured at HEAD on one file (`/tmp/i117/casc.ail`, a `Doc` alias plus a
+`Block ↔ Record_blocks_kind` cyclic ADT plus a trivial `inc(x: int) -> int`):
+
+```
+verify   : inc VERIFIED, titleOf ERROR (Z3 unknown sort 'Doc')
+ai-check : BOTH skipped/UNENCODABLE_TYPE  — including inc(x:int)->int
+```
+
+`ai-check` poisons an unrelated primitive-only function. This is precisely the cascade
+`verify_filter.go`'s own header comment says the filters exist to prevent — the fix was never
+ported to `ai-check`.
+
+**This also refutes the doc's Impact framing.** The doc says the v1.0 KPI is "not inflated". True,
+but it misses that the KPI is **deflated**: `internal/observatory/cost_per_verified_success.go:99-104`
+requires `VerifySkipped == 0`, so every cascade skip that `verify` would have verified turns a run
+into a non-verified-success. The eval harness calls `RunAICheck` — i.e. **the broken driver** — so
+this gap sits directly under the headline v1.0 metric.
+
+**Consequence for the plan:** driver parity is **mandatory and in M1**, not a nice-to-have. Without
+it the sprint's headline AC ("`ai-check` verifies the repro") is **unreachable** — proven: with the
+encoder fix and the `verify.go` fix in place but `ai_check.go` untouched, `ai-check` still reported
+`skipped=1` on all three record fixtures.
+
+### R-3 — There is a THIRD ordering bug: `buildNeededSortSet` is fed the already-narrowed ADT map.
+
+`verify.go:386` passes `funcADTTypes` (the output of `filterADTTypesForFunction`) into
+`buildNeededSortSet`. The comment two lines above explicitly says *"buildNeededSortSet must see the
+FULL alias map (not the filtered one)"* — they fixed that for **aliases** and not for **ADTs**.
+Result: an inline record reachable only through an ADT variant field (the canonical
+`Block → Record_blocks_kind`) is never added to `needed`, so
+`filterExtraDeclarationsForFunction` drops it. Measured with an instrumented build:
+
+```
+DBG titleOf needed=map[Block:true Doc:true] extra=[]      <- Record_blocks_kind missing
+```
+
+Passing the full `adtTypes` fixes it, and the cycle then emits **one plural
+`declare-datatypes` group that Z3 accepts** (measured, see spike).
+
+### R-4 — The doc's V6 conclusion is wrong, and the code comment it dismisses is NOT cargo-cult.
+
+V6 reports the canonical `ParsedDocument → Block → Record_blocks_kind → Block` cycle was *"not
+found in the `.ail` corpus"* and concludes the Step-0 comment's circular-dependency justification is
+"unverified and must not justify exclusion". **The cycle is trivially expressible in ordinary
+AILANG and the planner constructed one in 4 lines:**
+
+```ailang
+export type Block = Para(string) | Container({ blocks: list[Block], kind: string })
+export type Doc   = { title: string, blocks: list[Block] }
+```
+
+`Container`'s inline record becomes `Record_blocks_kind`, which references `Block` → genuine
+2-node SCC. Absence from `examples/` is a coverage gap in the corpus, not evidence about the
+language. **M1 AC4 (plural-group emission for a real cycle) is therefore mandatory, and the cyclic
+fixture must be a first-class `.ail` example, not a hand-built decl list.**
+
+### R-5 — `go build ./...` is ALREADY RED at HEAD. The doc's Sprint Exit criterion is unusable as written.
+
+```
+$ go build ./...
+# github.com/sunholo-data/ailang/cmd/wasm
+runtime.main_main·f: function main is undeclared in the main package
+```
+
+`cmd/wasm` is `//go:build js && wasm`-gated; on darwin the package has no `main`. This is
+pre-existing and unrelated. **Sprint Exit must say `go build ./cmd/ailang ./internal/...` or
+`go vet` on the touched packages**, otherwise the executor will chase a phantom.
+
+### R-6 — The doc's own A5 / "Quorum round 2 — PARKED" section is STALE and must be corrected in this sprint.
+
+`#510` landed as `9253ec8a8` (in this worktree's history). `internal/smt/solver.go` now uses
+`exec.CommandContext` + `cmd.WaitDelay` + a `hardTimeout = max(config.Timeout, effectiveTimeout) +
+solverKillGrace` deadline, on **both** `Solve` and `Z3Version()`. The doc's A5 justification, its
+last Risks row ("Residual risk: production uses `exec.Command`/`CombinedOutput`"), and the entire
+"Quorum round 2 — PARKED" block describe code that no longer exists. Doc closeout is a milestone
+deliverable (M4), not optional.
+
+### Premises the planner CONFIRMED first-party (do not re-verify)
+
+| ID | Claim | Status |
+|---|---|---|
+| V1 | repro checks clean, `ai-check` reports `errors=1` and exits 0 | **confirmed** (`rc=0`, `errors:1`) |
+| V4 | Step-0 `if !allFieldsPrimitiveOrDeclared { continue }` + `if !progress { break }` silently abandons | **confirmed**, `codegen.go:240,259` |
+| V9-second-drop | `if err != nil { delete(remaining, aliasName); continue }` is a second silent drop | **confirmed**, `codegen.go:233-236` |
+| V5 | second fixpoint is NOT a silent give-up; routes to `findSCCs`/`DeclareDatatypesMutual` | **confirmed**, `codegen.go:317-355` |
+| V8 | Tarjan SCC + plural emitter exist and work | **confirmed** by code read **and by live spike** (Z3 accepted the emitted plural group) |
+| V11 | `RejectUnencodable = "UNENCODABLE_TYPE"`, `ErrUnresolvableTypes` → skip | **confirmed**, `encodable.go:22` |
+| V12 | `validateDeclarations` waves `declare-const` through | **confirmed**, `codegen.go:705` verbatim comment |
+| V13 | `ai-check` exit ignores `Errors`; JSON written first | **confirmed**, `ai_check.go:161-163` |
+| V14 | no in-repo Makefile/CI/shell consumer of `ai-check` | **confirmed** — only `cmd/ailang/*`, `internal/eval_harness/*`, and `prompts/agent/convergence-workflow.md:72` |
+| V15/V16 | `RunAICheck` parses JSON from a nonzero child (`rawOutput == "" && g.waitErr != nil`); comment at `verify.go:80` is inverted | **confirmed**, `internal/eval_harness/verify.go:79-84` |
+| V17 | `verify` has `-strict` (3 hits), `ai-check` has none (0 hits) | **confirmed** |
+| V19/A5 | solver bounded — **now by a hard wall-clock deadline**, not only `-T:` | **confirmed, upgraded** (see R-6) |
+| V20 | `(Seq X)` is the only parameterized sort `MapType` emits | **confirmed**, `types.go:35-70`; `TTuple` falls to the error default |
+
+### Premises the planner found IRRELEVANT (drop them from the risk register)
+
+- **No SMT golden files exist.** The only `.golden` files near this diff are
+  `cmd/ailang/testdata/debug_ast_simple.golden` and
+  `cmd/ailang/testdata/ext_registry_gen/two_packages.ail.golden`; neither contains SMT-LIB. The
+  "stale golden broke `make test`" hazard from iteration 13 **does not apply to this diff**.
+- **`examples/manifest.json` does not record verify counts.** Entries carry `path`/`status`/`tags`
+  only. Flipping a contract example from `skipped` to `verified` cannot break
+  `validate_manifest --ci`.
+
+---
+
+## Planning Spike — the mechanism is proven, not hypothesised
+
+A throwaway spike was applied at HEAD, measured, and **fully reverted** (`git status` clean,
+`go build ./cmd/ailang` green after revert). It is reproduced here because it converts most of M1
+from design work into transcription work.
+
+**Spike diff: `+65 / −42` across 3 files** (`internal/smt/codegen.go`, `cmd/ailang/verify.go`,
+`cmd/ailang/ai_check.go`).
+
+Three changes:
+
+1. **`internal/smt/codegen.go` Step 0** — replace the silent fixpoint with: iterate aliases in
+   **sorted name order**, register `activeRecordTypes` / `activeFieldSetToSort` **eagerly for every
+   mappable alias**, and stage `DeclareRecordDatatype(...)` output into a slice that is appended to
+   the **existing** Step-0.5/1 `pending` list. No new graph, no new SCC code, no new emitter.
+2. **`cmd/ailang/verify.go`** — pass the **full** `adtTypes` to `buildNeededSortSet` (R-3), then
+   widen `funcADTTypes` with every ADT in `needed` (R-1).
+3. **`cmd/ailang/ai_check.go`** — port verify.go's demand-filter block verbatim (R-2).
+
+Measured outcomes:
+
+| Fixture | HEAD `verify` | HEAD `ai-check` | Spike `verify` | Spike `ai-check` |
+|---|---|---|---|---|
+| `adtsort.ail` (doc repro) | Z3 error | `errors=1` | **verified** | **verified=1** |
+| `multi.ail` (4 aliases/ADTs) | Z3 error | `errors=1` | **verified** | **verified=1** |
+| `casc.ail` (real `Block ↔ Record_blocks_kind` cycle + unrelated `inc`) | 1 verified, 1 error | **2 skipped** | 2 verified | **verified=2** |
+| `layer.ail` | Z3 error | `errors=1` | **verified** | **verified=1** |
+
+Emitted SMT for the repro (dependency-first, exactly as the doc's Solution Design predicts):
+
+```smt2
+(declare-datatype Evidence ((CompilerOutput (CompilerOutput_0 String)) (TestReport (TestReport_0 String) (TestReport_1 Bool))))
+(declare-datatype Proposal ((mk_Proposal (evidence (Seq Evidence)) (name String))))
+(declare-const $p_p Proposal)
+```
+
+Emitted SMT for the genuine cycle — **one plural group, Z3 `unsat`, function VERIFIED**:
+
+```smt2
+(declare-datatypes ((Record_blocks_kind 0) (Block 0)) (((mk_Record_blocks_kind (blocks (Seq Block)) (kind String))) ((Para (Para_0 String)) (Container (Container_0 Record_blocks_kind)))))
+(declare-datatype Doc ((mk_Doc (blocks (Seq Block)) (title String))))
+```
+
+Regression evidence under the spike:
+
+- `go test ./internal/smt ./cmd/ailang ./internal/eval_harness` → **all ok**, **no existing test edited**.
+- Examples-corpus sweep (`ai-check` over all 40 contract-bearing `.ail` under `examples/` + `stdlib/`),
+  HEAD vs spike: **verified 76 → 79, counterexamples 23 → 23, skipped 10 → 7, errors 3 → 3**.
+  The single file that moved is `examples/runnable/contracts/cross_module_types.ail`
+  (`v=1 s=4` → `v=4 s=1`). Nothing regressed.
+
+**The spike is a sizing artefact, not a deliverable.** The executor must re-derive it with tests
+first (TDD), name the helpers properly, and add the failure paths the spike skipped (M2).
+
+---
+
+## Velocity
+
+- Last 7 days: **146 commits**, 583 files, +86,225/−5,546 (dominated by generated/eval data — not a
+  usable LOC/day signal).
+- Comparable compiler-surface sprints (`m-smt-callee-sort-gate`, `m-z3-hard-timeout` in iteration
+  116) landed in **~1 day each**.
+- **Basis for this estimate:** production change is *measured* at ~65 insertions. The cost is
+  **tests, fixtures and the doc closeout**, not implementation.
+
+**Estimate: 2.0 days (16h)** — M1 6h, M2 4h, M3 3h, M4 2h, +1h buffer.
+
+### Scope cut vs the doc's 3–4 days — what was cut and why
+
+| Doc item | Decision | Why |
+|---|---|---|
+| "Build a **new** declaration graph with node structs, sort-reference collector, SCC dispatch" (D3/M1) | **CUT — reuse the existing Step-0.5/1 pending list + `declReferencesUndeclaredSort` + `findSCCs`** | The spike proves the existing machinery already does dependency-ordering and plural-group emission correctly once aliases are fed into it. Building a parallel graph is ~200 LOC of duplicate mechanism for zero measured benefit. |
+| M1 AC6 "sort-reference collector rejects `(Future X)`" | **KEPT but retargeted** to the two extraction points that actually exist (`isSortPrimitiveOrDeclared`, and the new `declare-const` sort parser in M2) | There is no new collector to write. The fail-closed obligation is real; the new component is not. |
+| M1 AC7 "adversarial recursive-datatype timeout regression" | **CUT from this sprint** | `#510` (`9253ec8a8`) landed a hard wall-clock deadline **with its own tests** in iteration 116. Re-testing it here is duplicate coverage of another sprint's ACs. Recorded as R-6; the doc text is corrected in M4 instead. |
+| D4 option C "full SMT-LIB parser" | **stays deferred** (doc already defers it) | — |
+| **ADDED (not in the doc): driver parity + ADT-closure widening** | **ADDED to M1** | R-1/R-2/R-3. Without it the sprint's headline AC is unreachable. |
+| **ADDED: doc closeout of the stale A5 / PARKED section** | **ADDED as M4** | R-6. |
+
+Net: the doc's 3–4 days assumed writing a new graph engine. It isn't needed. The added driver work
+is smaller than the graph work removed.
+
+---
+
+## Milestones
+
+> **Sandbox note applies to M1 (partly), M2 (partly), M3 (wholly), M4 (no).**
+> Every milestone below that touches `cmd/ailang` is **UNINFORMATIVE UNDER THE EXECUTOR'S
+> `workspace-write` SANDBOX** if its verification spawns a subprocess or binds a socket. Those ACs
+> are tagged **[CONTROLLER-RERUN]** and the controller must re-run them outside the sandbox before
+> Gate 3b. The executor must still write them and must record `UNINFORMATIVE UNDER SANDBOX`
+> verbatim rather than reporting a pass or a failure.
+
+---
+
+### M1 — Declaration closure: encoder graph unification + driver demand parity (6h)
+
+**Goal.** A contracted function whose parameter is a named record reaching a user ADT (directly,
+under `list`, through another record, or through a genuine record↔ADT cycle) is **verified** by
+**both** `verify` and `ai-check`.
+
+**Production changes (fixed; helper names are implementer discretion):**
+
+1. `internal/smt/codegen.go` — Step 0 becomes *eager metadata registration + deferred emission*:
+   - iterate `opts[0].RecordTypeAliases` in **sorted name order** (`sort.Strings`), never by map range;
+   - for every alias whose `MapRecordFields` succeeds, register `activeRecordTypes` and
+     `activeFieldSetToSort` **before** `collectAndDeclareRecordTypes` runs;
+   - stage `DeclareRecordDatatype(...)` into the Step-0.5/1 `pending` list instead of appending to
+     `result.Declarations`;
+   - a `MapRecordFields` **error** must no longer be a bare `continue` — it must be recorded so M2
+     can turn a *needed* unmappable alias into `ErrUnresolvableTypes` (V9 second silent drop).
+2. `cmd/ailang/verify.go` — pass the **full** `adtTypes` (not `funcADTTypes`) to
+   `buildNeededSortSet`; widen `funcADTTypes` with every ADT in `needed`.
+3. `cmd/ailang/ai_check.go` — port the demand-filter block so `ai-check` and `verify` compute
+   identical `ExtraDeclarations`, `RecordTypeAliases` and ADT sets. **Preferred: extract the shared
+   block into one function in `cmd/ailang/verify_filter.go` and call it from both drivers**, so the
+   two can never drift again (CLAUDE.md Principle 3: one unified fix).
+
+**File-size constraint (HARD, CI gate).** `internal/smt/codegen.go` is **759 lines**;
+`make check-file-sizes` fails at **>800** and runs in `.github/workflows/ci.yml:97`. That is **41
+lines of headroom**. The doc's `+100/−60` estimate lands at 799 — one line from red. **Any new
+helper longer than a few lines goes in a new file** (suggested `internal/smt/codegen_decl_graph.go`).
+`cmd/ailang/verify.go` is 672 (headroom 128); `ai_check.go` is 420.
+
+#### Acceptance Criteria
+
+**AC1.1 — the doc's repro verifies under BOTH drivers.**
+A committed fixture equal to the doc's `adtsort.ail` yields `verified=1, counterexample=0,
+skipped=0, errors=0` from `ai-check`, and `1 verified` from `verify`.
+**Red mutation:** in production `codegen.go`, restore `if !allFieldsPrimitiveOrDeclared(fieldSorts, ctx) { continue }`
+before staging. Builds; the assertion must fail with a non-verified result.
+**[CONTROLLER-RERUN]** if asserted through the CLI subprocess; the `EncodeFunction`-level half is
+sandbox-safe.
+
+**AC1.2 — the driver widens the ADT closure through record-alias fields.**
+A unit test on `filterADTTypesForFunction` (or its replacement) proves that for
+`params=[p: Proposal]` with `aliases={Proposal:{evidence: list[Evidence]}}` and
+`adtTypes={Evidence:...}`, the returned map **contains `Evidence`**.
+**Red mutation:** remove the alias-field walk from the production closure. Builds; the unit test
+must fail. *(This is the R-1 guard and it is the single most important test in the sprint —
+without it a future refactor silently re-breaks the repro at the driver.)*
+**Sandbox-safe.**
+
+**AC1.3 — `ai-check` and `verify` agree, function for function.**
+A table-driven test runs both code paths over ≥4 committed fixtures (repro, list-of-ADT,
+nested record→record→ADT, and the cascade file with an unrelated `inc(x:int)->int`) and asserts
+**identical per-function status**. The cascade file must show `inc` **verified** under `ai-check`.
+**Red mutation:** in production `ai_check.go`, restore `funcEncOpts.ExtraDeclarations = adtRecordDecls`
+(unfiltered). Builds; `inc` must flip to `skipped` and the parity assertion must fail.
+**[CONTROLLER-RERUN]** if driven through the CLI; prefer calling `runVerification` in-process to
+keep it sandbox-informative.
+
+**AC1.4 — a genuine record↔ADT cycle emits ONE plural group Z3 accepts.**
+A committed `.ail` fixture containing `type Block = Para(string) | Container({blocks: list[Block], kind: string})`
+plus an alias over `list[Block]` verifies, and the emitted SMT contains exactly one
+`(declare-datatypes ((` group naming both member sorts.
+**Red mutation:** in production SCC dispatch, emit each SCC member as a separate singular
+`declare-datatype`. Builds; Z3 must reject the forward reference and the AC must fail.
+**Sandbox-safe** at the `EncodeFunction` level.
+
+**AC1.5 — byte-identical SMT across repeated encodes.**
+Encode a fixture with ≥3 record aliases and ≥2 ADTs **N ≥ 50** times in one test and assert all
+outputs are byte-identical.
+**Red mutation:** replace the `sort.Strings(aliasNames)` iteration with a bare `range` over
+`opts[0].RecordTypeAliases`. Builds; with N=50 the test must fail. *(Note: this AC is **already
+red at HEAD** for the alias pass — the current Step-0 loop ranges a Go map. It is a bug fix, not
+only a guard. The executor must confirm it fails before the fix and passes after.)*
+**Sandbox-safe.**
+
+**AC1.6 — controls do not regress.**
+`examples/runnable/contracts/*.ail` sweep: `verified` must be **≥ 79**, `errors` **≤ 3**,
+`counterexample` **== 23**, `skipped` **≤ 7** (baseline HEAD: 76 / 3 / 23 / 10; spike: 79 / 3 / 23 / 7).
+The three controller control fixtures (`list[string]` record, direct ADT param, pattern-matched
+ADT param) must be **committed as `.ail` fixtures in-repo** and must stay verified — the doc's
+`/tmp/iter115repro/*` paths must not appear in any test.
+**Red mutation:** n/a (this is a corpus control, not a unit gate) — instead the executor must
+record the before/after numbers in the commit message.
+**[CONTROLLER-RERUN]** (runs the CLI binary over the corpus).
+
+---
+
+### M2 — Fail-loud declaration gate (4h)
+
+**Goal.** No constant with an unresolved nonprimitive sort can reach Z3. When closure cannot be
+formed, the driver reports a structured `skipped` / `UNENCODABLE_TYPE`, never a raw Z3 error.
+
+**Production changes:**
+
+1. `internal/smt/codegen.go` `validateDeclarations` — remove the `declare-const`/`define-const`
+   free pass at line ~705. Parse the sort of `(declare-const NAME SORT)` and typed
+   `(define-const NAME SORT ...)` and require it to be primitive, `(Seq <resolved>)` recursively, or
+   already declared **at that position in the list**.
+2. `validateDeclarations` must recognise the **plural** form. Today `strings.HasPrefix(decl, "(declare-datatype ")`
+   (trailing space) **does not match** `"(declare-datatypes ("`, so a plural group is invisible to the
+   validator **both as a declarer and as a consumer**. Plural members must be installed **atomically**.
+3. Unmappable-but-**needed** aliases (V9 second silent drop) return wrapped `ErrUnresolvableTypes`
+   naming the alias and the offending field, instead of `delete(...); continue`.
+4. Both drivers: replace the literal reason
+   `"Uses cross-module types not yet supported in Z3 encoding (%v)"` and the hint
+   `"Cross-module record type aliases and recursive ADTs are not yet supported..."` with neutral,
+   accurate wording that names the unresolved sort and does **not** assert a cross-module cause.
+   These strings are duplicated verbatim in `verify.go:403-412` and `ai_check.go:349-358` — **fix
+   both from one shared constant/helper**.
+
+#### Acceptance Criteria
+
+**AC2.1 — dangling `declare-const` sort is rejected before the solver.**
+A unit test passes a hand-built decl list containing `(declare-const $p_p Missing)` to
+`validateDeclarations`; it returns an error satisfying `errors.Is(err, ErrUnresolvableTypes)` whose
+message names both `$p_p` and `Missing`. A companion test asserts `smt.Solve` is never reached
+(assert on the `EncodeFunction` error return, not on a solver spy).
+**Red mutation:** restore `if !strings.HasPrefix(decl, "(declare-datatype ") { continue }` ahead of
+the const check. Builds; the test must fail. **Sandbox-safe.**
+
+**AC2.2 — `(Seq X)` is validated recursively and positionally.**
+`(declare-const xs (Seq Evidence))` passes **after** `Evidence` is declared and fails **before** it.
+**Red mutation:** in the production sort parser, accept any `(Seq ...)` without recursing.
+Builds; the before-declaration case must fail to be rejected. **Sandbox-safe.**
+
+**AC2.3 — plural groups declare all members atomically.**
+A decl list `[(declare-datatypes ((A 0) (B 0)) (...)), (declare-const x A), (declare-const y B)]`
+validates clean; the same list with `(declare-const z C)` appended is rejected naming `C`.
+**Red mutation:** in production plural handling, register only the first member sort. Builds; the
+`y B` case must be wrongly rejected and the test must fail. **Sandbox-safe.**
+*(Note: this AC is red at HEAD in a second way — plural decls currently bypass validation entirely.)*
+
+**AC2.4 — an unresolvable shape becomes a structured skip, never a Z3 error.**
+An integration fixture the encoder genuinely cannot close reports `status:"skipped"` with
+rejection code `UNENCODABLE_TYPE`, and its `reason` contains **no** Z3 text (`assert !strings.Contains(reason, "Z3")`).
+**Red mutation:** in production `EncodeFunction`, swallow the `ErrUnresolvableTypes` return and
+continue assembling. Builds; the fixture must surface `status:"error"` + Z3 text and fail.
+**[CONTROLLER-RERUN]** if driven through the CLI.
+
+**AC2.5 — neutral skip wording in BOTH drivers, from one source.**
+A table-driven test over `verify` and `ai-check` asserts the skip reason names the unresolved sort
+and does **not** contain the substring `cross-module`.
+**Red mutation:** restore the literal `Uses cross-module types not yet supported` in **either**
+driver. Builds; the corresponding table row must fail. **Sandbox-safe** if asserted on the
+reason-building helper rather than on process output.
+
+---
+
+### M3 — Honest `ai-check` exit (3h) — **WHOLLY [CONTROLLER-RERUN]**
+
+**Goal.** `ai-check`'s process status agrees with its own JSON, without breaking the eval harness.
+
+**Production changes:**
+
+1. `cmd/ailang/ai_check.go:161-163` → `if !checkSection.Passed || verifySection.Counterexample > 0 || verifySection.Errors > 0 { os.Exit(1) }`.
+   `outputAICheck(output)` **stays above** the exit. No new flag (design decision D1-C).
+2. `internal/eval_harness/verify.go:79` — correct the inverted comment. Behaviour unchanged.
+
+**Breaking-change assessment (the doc asks; here is the answer).**
+`ai-check` is listed **Experimental** in `docs/docs/reference/stability.md:163` ("JSON shape still
+stabilising"), so the exit-code correction is **permitted without a compatibility flag**. In-repo
+consumers (re-verified, R-14 above): `internal/eval_harness.RunAICheck` tolerates a nonzero exit by
+construction (`if rawOutput == "" && g.waitErr != nil`), and `prompts/agent/convergence-workflow.md:72`
+tells agents `ai-check` is the green signal — which is exactly the contract being *repaired*. There
+is **no Makefile, CI job, or shell script** that runs `ai-check`. **Verdict: no `-strict` flag, no
+migration shim; a CHANGELOG "Changed (breaking for out-of-repo shell callers)" entry is required.**
+
+#### Acceptance Criteria
+
+**AC3.1 — errors exit 1 with complete JSON.**
+A subprocess test builds the CLI, runs `ai-check` on a fixture producing `verify.errors > 0`,
+asserts exit status 1 **and** that stdout parses as complete JSON with `verify.errors > 0`.
+**Red mutation:** delete `|| verifySection.Errors > 0`. Builds; the test observes exit 0 and fails.
+**[CONTROLLER-RERUN].**
+
+> **Fixture hazard — read this.** After M1+M2 the record repro is **verified** and the previous
+> unresolvable shapes become **skips**, so `verify.errors > 0` is *hard to produce naturally*. The
+> executor must **not** reach for the repaired record shape. Use a genuine solver-error path (e.g.
+> a fixture whose `Solve` returns an error, or an injected `aiVerifySection` in an in-process test
+> plus one real subprocess test on any fixture that still errors — `examples/runnable/contracts/cross_module_functions.ail`
+> currently reports `errors=3` and is the natural candidate; **re-confirm it still errors after M1/M2**
+> before relying on it).
+
+**AC3.2 — the other four lanes are unchanged.**
+counterexample → exit 1; skip-only → exit 0; verified-only → exit 0; check-failure → exit 1.
+**Red mutation:** replace `Errors > 0` with `Skipped > 0`; the skip-only row must turn red.
+Separately remove `Counterexample > 0`; the counterexample row must turn red.
+**[CONTROLLER-RERUN].**
+
+**AC3.3 — JSON precedes the exit on every exit-1 path.**
+**Red mutation:** move `outputAICheck(output)` below the `os.Exit(1)` branch. Builds; the
+subprocess test receives empty stdout and fails. **[CONTROLLER-RERUN].**
+
+**AC3.4 — `RunAICheck` still parses a nonzero child (V15 re-verified empirically, permanently).**
+A test in `internal/eval_harness` drives the **real** `RunAICheck` against a child that writes valid
+`ai-check` JSON with `verify.errors: 1` and then exits 1; asserts `err == nil` and
+`result.Verify.Errors == 1`.
+**Red mutation:** change the guard to `if g.waitErr != nil`. Builds; the test must fail.
+**[CONTROLLER-RERUN]** (spawns a subprocess). *Prefer a `go test`-compiled helper binary or a
+`TestHelperProcess` pattern over a shell script, so it works on any PATH.*
+
+**AC3.5 — the inverted comment is corrected.**
+`internal/eval_harness/verify.go:79` states that counterexamples **and verifier errors** are
+nonzero, and that nonempty stdout is still parsed. Behavioural ACs above remain the gate; the
+comment is documentation, not a test.
+
+---
+
+### M4 — Doc closeout, CHANGELOG, corpus coverage (2h) — sandbox-safe
+
+- **Correct the design doc** (R-6): delete/replace the "Quorum round 2 — PARKED" block with a
+  one-paragraph resolution note pointing at `#510` / `9253ec8a8`; rewrite the A5 row to cite
+  `exec.CommandContext` + `WaitDelay` + `hardTimeout`; delete the stale last Risks row; correct the
+  V6 row per R-4; correct the "Files Expected to Change" table per R-1/R-2/R-3; correct the Sprint
+  Exit `go build ./...` criterion per R-5.
+- **Add the record→ADT and cyclic shapes to `examples/runnable/contracts/`** with manifest entries
+  (`status: working`, tags including `contracts`, `smt-verification`). This is the doc's
+  "Programs and tests that must remain valid" list turned into permanent in-repo controls, and it
+  closes the corpus gap R-4 exposed.
+- **CHANGELOG.md** — three entries: (a) *Fixed*: records reaching user ADTs now verify;
+  (b) *Fixed*: `ai-check` no longer cascades unrelated functions into skips (driver parity with
+  `verify`) — call out the KPI impact; (c) *Changed (breaking for out-of-repo shell callers)*:
+  `ai-check` exits 1 when `verify.errors > 0`.
+
+#### Acceptance Criteria
+
+**AC4.1** — `make check-file-sizes` green (`internal/smt/codegen.go` **≤ 800**).
+**AC4.2** — `make check-boundaries` green (no new cross-layer import; `cmd/ailang` → `internal/smt`
+is existing and allowed).
+**AC4.3** — `make verify-examples` green with the new examples in `examples/manifest.json`
+(regenerate/patch statistics — hand-maintained block, known CI trap).
+**AC4.4** — the design doc contains **no** occurrence of `CombinedOutput` and **no**
+`Quorum round 2 — PARKED` heading.
+**AC4.5** — `gofmt -l` clean and `make lint` green on touched packages.
+
+---
+
+## Conflict Surface (MANDATORY — compiler surface)
+
+### Direct blast radius
+
+| Surface | Who else uses it | Risk | Guard |
+|---|---|---|---|
+| `EncodeFunction` Step 0 | **only** `cmd/ailang/verify.go` + `cmd/ailang/ai_check.go` (`rg EncodeFunction` → 2 non-test callers) | Low | AC1.3 parity table |
+| `validateDeclarations` | called once at the end of `EncodeFunction`; **M-SMT-CALLEE-SORT-GATE**'s `define-fun` branch lives in the same function | **Medium — do not weaken the `define-fun` branch**; a careless rewrite reopens the callee-sort leak | AC2.1-2.3 must be **added to**, not replace, `codegen_test.go`'s existing callee-gate tests |
+| `findSCCs` / `DeclareDatatypesMutual` | `internal/smt/codegen.go` only; tested in `codegen_mutual_test.go` | Low — this sprint **adds inputs**, changes no algorithm | existing `codegen_mutual_test.go` must stay green untouched |
+| `buildNeededSortSet` / `filterADTTypesForFunction` / `filterExtraDeclarationsForFunction` | `verify.go` today, `ai_check.go` after M1 | **Medium — widening the needed-set is the exact thing M-SMT-CROSS-MODULE-TYPES narrowed** | AC1.3's cascade fixture (`inc(x:int)->int` in a module with a poisoned type) is the anti-regression; AC1.6 corpus sweep is the population check |
+| `activeRecordTypes` / `activeFieldSetToSort` (package-level mutable state) | `encodeRecord`, `encodeRecordUpdate`, `collectAndDeclareRecordTypes` | **Medium** — eager registration now happens for aliases that are *never emitted*; a record literal could resolve to a named sort with no declaration | AC2.1's `declare-const` gate catches it as a structured skip rather than a Z3 error; `codegen_record_discovery_test.go` + `codegen_nested_records_test.go` must stay green |
+| `RunAICheck` | `agent_runner.go`, `eval_suite.go --verify`, `agentAICheck` var | Low — proven tolerant of nonzero exit | AC3.4 |
+
+### What could break that is easy to miss
+
+1. **`internal/smt/codegen.go` at 759/800.** The CI gate is 41 lines away. This is the most likely
+   accidental red in the sprint.
+2. **Existing `internal/smt` tests that construct `EncodeFunctionOpts{RecordTypeAliases: ...}` and
+   assert a declaration appears at a fixed index** in `result.Declarations`. Deferring alias
+   emission from Step 0 into the Step-0.5/1 pass **changes declaration ORDER**. The spike happened
+   not to trip any (`go test ./internal/smt` green), but an added test could. Assert on *set
+   membership and relative order*, never absolute index.
+3. **`examples/runnable/contracts/cross_module_types.ail` changes behaviour** (`v=1 s=4` → `v=4 s=1`).
+   If any test or doc asserts its skip count, it must be updated. None found — re-check after M1.
+4. **Banked eval data.** `eval_results/` is gitignored; no committed baseline pins verify counts.
+   But `docs/static/benchmarks/*.json` are committed — **do not regenerate them in this sprint**;
+   the coverage change will shift future `cost_per_verified_success` numbers and that must be an
+   observed post-release effect, not a hand-edited one.
+5. **`ai-check` skip→verified is a KPI-affecting change.** `isVerifiedSuccess` requires
+   `VerifySkipped == 0`; M1 will move runs from "not a verified success" into "verified success".
+   That is the *intent*, but the next eval baseline will show a **discontinuity**. Flag it in the
+   CHANGELOG so the next benchmark comparison is not read as model improvement.
+6. **Duplicate `ExtraDeclarations`.** Observed during the spike: `adtRecordDecls` contained
+   `Record_blocks_kind` **twice** for one module. Harmless today (the pending loop skips already-
+   declared sorts) but it will produce a duplicate node if a real graph is built. Dedup by sort
+   name when staging.
+7. **NOT a risk (verified):** no SMT golden files; `examples/manifest.json` records no verify
+   counts; `make check-boundaries` unaffected (no new package edges).
+
+---
+
+## Files Expected to Change (supersedes the design doc's table)
+
+| File | Purpose | Est. |
+|---|---|---:|
+| `internal/smt/codegen.go` | Step-0 eager-register/defer-emit; `validateDeclarations` const + plural handling. **Keep ≤ 800 lines.** | +45/−45 |
+| `internal/smt/codegen_decl_graph.go` *(new, if needed)* | overflow home for any helper that would push `codegen.go` over the gate | +0-60 |
+| `cmd/ailang/verify_filter.go` | ADT closure through alias fields; **shared** demand-filter helper for both drivers | +30/−5 |
+| `cmd/ailang/verify.go` | call the shared helper; neutral skip reason from a shared constant | +10/−12 |
+| `cmd/ailang/ai_check.go` | call the shared helper (**new capability**); `Errors > 0` exit; neutral skip reason | +12/−8 |
+| `internal/smt/codegen_*_test.go` | closure, cycle, determinism (N≥50), leak-gate, plural-group tests | +300 |
+| `cmd/ailang/*_test.go` | driver parity table; exit-code subprocess tests | +180 |
+| `internal/eval_harness/verify.go` | inverted comment only | +2/−2 |
+| `internal/eval_harness/*_test.go` | nonzero-child JSON parse test | +60 |
+| `examples/runnable/contracts/*.ail` + `examples/manifest.json` | committed fixtures for the 3 controls + record→ADT + cycle | +80 |
+| `design_docs/planned/v0_31_0/m-z3-adt-record-sort.md` | R-6/R-4/R-1/R-5 closeout | +25/−45 |
+| `CHANGELOG.md` | 3 entries | +14 |
+
+**Total ≈ 820 LOC changed, of which ~110 is production.** (M1 340 · M2 200 · M3 160 · M4 120.)
+
+---
+
+## Sprint Exit
+
+Complete only when **all** hold:
+
+1. M1–M4 acceptance criteria pass, with every listed **red mutation** demonstrated to *build and
+   then fail* (a mutation that fails to compile is **not** a mutation proof).
+2. `go test ./internal/smt/... ./cmd/ailang/... ./internal/eval_harness/...` green.
+3. `go vet ./internal/smt/... ./cmd/ailang/...` and `go build ./cmd/ailang` green.
+   **Do NOT gate on `go build ./...` — it is red at HEAD for `cmd/wasm` (R-5).**
+4. `make check-file-sizes`, `make check-boundaries`, `make verify-examples`, `make lint` green.
+5. Corpus sweep recorded in the commit message: `verified ≥ 79`, `errors ≤ 3`, `counterexample == 23`,
+   `skipped ≤ 7`.
+6. CHANGELOG documents the coverage expansion, the `ai-check` driver-parity fix, and the exit-code
+   correction (marked breaking for out-of-repo shell callers).
+7. Any sandbox-blocked AC recorded verbatim as **UNINFORMATIVE UNDER SANDBOX** — never as a pass.
+
+---
+
+## Things the executor must NOT do
+
+- **Do NOT build a new declaration-graph engine.** D3-C is satisfied by feeding record aliases into
+  the *existing* Step-0.5/1 pending list. Measured: it already does dependency ordering and plural
+  SCC emission correctly.
+- **Do NOT fix `ai-check` only in the encoder.** Without the driver parity port (R-2) the headline
+  AC is unreachable. This was measured, not guessed.
+- **Do NOT reference `/tmp/iter115repro/*` or `/tmp/i117/*` from any test.** Commit fixtures.
+- **Do NOT weaken or restructure the `define-fun` branch of `validateDeclarations`** — it is
+  M-SMT-CALLEE-SORT-GATE's live defense.
+- **Do NOT add an `ai-check -strict` flag** or make skips nonzero (design decision D1-C / D-option-D
+  rejected).
+- **Do NOT touch `internal/smt/solver.go`.** `#510` landed in iteration 116; timeout work is out of
+  scope (R-6).
+- **Do NOT regenerate `docs/static/benchmarks/*.json`.**
+- **Do NOT let `internal/smt/codegen.go` exceed 800 lines.**
+- **Do NOT edit the main checkout** at `/Users/voightkampff/dev/sunholo-data/ailang` — it holds a
+  sibling agent's uncommitted work. All work stays in `/Users/voightkampff/dev/sunholo-data/.wt-iter117`.
+- **Do NOT commit or push.** The controller handles git.
+
+---
+
+## Open Questions (non-blocking; implementer discretion unless noted)
+
+1. Should the shared demand-filter helper live in `cmd/ailang/verify_filter.go` or move to
+   `internal/smt`? Recommendation: keep it in `cmd/ailang` — it consumes `ast`/`loader` shapes and
+   moving it risks a boundary violation.
+2. Should the eager alias registration also register aliases whose `MapRecordFields` **fails**?
+   Recommendation: **no** — register only mappable aliases; record the failure for M2's error path.
+3. If AC3.1's natural error fixture disappears after M1/M2 (see the fixture hazard), is an
+   in-process injected `aiVerifySection` acceptable as the primary proof with one subprocess smoke
+   test? Recommendation: yes; note it in the sprint log.

--- a/design_docs/implemented/v0_31_0/m-z3-adt-record-sort.md
+++ b/design_docs/implemented/v0_31_0/m-z3-adt-record-sort.md
@@ -1,6 +1,7 @@
 # M-Z3-ADT-RECORD-SORT: Declare Reachable ADTs Through Records and Make `ai-check` Honest
 
-**Status**: Planned — **DECIDED by Mark 2026-07-28 (attended): OPTION (B)** — sprint `#510` separately and FIRST (small, self-contained, closes the standing-rule violation affecting every `ai-check` caller incl. Ailang World); then THIS doc routes to sprint-planner unchanged with A5 honestly compliant. [Was: PARKED `needs-human-review` after quorum round 2 (see "Quorum round 2 — PARKED" below); the design direction was never contested.]
+**Status**: Planned — **DECIDED by Mark 2026-07-28 (attended): OPTION (B)**. Sprint #510
+landed first as `9253ec8a8`, so A5 is now honestly compliant and this sprint can proceed.
 **Target**: v0.31.0
 **Priority**: P0
 **Estimated**: 3–4 days
@@ -20,7 +21,7 @@
 | A2: Replayability | 0 | No trace behavior changes. |
 | A3: Effect Legibility | 0 | No effect semantics change. |
 | A4: Explicit Authority | 0 | No authority change. |
-| A5: Bounded Verification | +1 | Finite declaration construction is followed by a mandatory Z3 `-T:<seconds>` soft timeout; zero, unset, and sub-second configurations floor to 5 seconds. A 1-second adversarial probe returned structured timeout state in 1.159 s. There is no independent hard wall-clock kill, recorded as a bounded residual risk below. |
+| A5: Bounded Verification | +1 | Finite declaration construction is followed by Z3's timeout and an independent hard wall-clock deadline. Both solver probes use `exec.CommandContext`, `WaitDelay`, and `hardTimeout = max(configured timeout, effective timeout) + solverKillGrace` (#510, `9253ec8a8`). |
 | A6: Safe Concurrency | 0 | No concurrency change. |
 | A7: Machines First | +1 | `ai-check` no longer reports process success when its JSON reports a verifier error; unsupported shapes retain a structured rejection. |
 | A8: Minimal Syntax | 0 | No syntax change. |
@@ -117,7 +118,7 @@ below did.
 | V3 | Inherited A3 | Failing script omits `Proposal`; direct ADT and record→`list[string]` scripts contain their datatype declarations | Controller ran `ailang verify -verbose` on all three and supplied verbatim dumps | Relied on; author `ai-check` output independently confirms the omitted-sort consequence. |
 | V4 | Inherited A4; author code read | First alias fixpoint silently abandons unresolved records | Read `internal/smt/codegen.go:213-260`, especially `allFieldsPrimitiveOrDeclared` and `if !progress { break }` | **Confirmed.** Required aliases remain in `remaining` with no error/result. |
 | V5 | **Author contradiction to A4** | The second fixpoint is also a silent give-up | Read `internal/smt/codegen.go:267-363`; `git log -- internal/smt/codegen.go` | **CONTRADICTED at `f495885b1`:** unresolved pending ADT/inline-record declarations go through `findSCCs` and `DeclareDatatypesMutual`; they are not simply dropped. The first fixpoint is the live silent-drop site. |
-| V6 | Author recheck of B1 | A real current `.ail` corpus instance of `ParsedDocument → Block → Record_blocks_kind → Block` exists | `rg -n "ParsedDocument|Record_blocks_kind|type Block|blocks: list\\[Block\\]" --glob '*.ail' --glob '*.go' --glob '*.md'` | **Not found in the `.ail` corpus.** The canonical shape exists in comments and unit fixtures. The comment's “current corpus” implication is unverified and must not justify exclusion. |
+| V6 | Author recheck of B1 | A real `.ail` program can express `Block → Record_blocks_kind → Block` | Construct and verify `type Block = Para(string) \| Container({blocks: list[Block], kind: string})` plus a record alias over `list[Block]` | **Confirmed.** The shape is ordinary AILANG; its earlier absence from the corpus was a coverage gap, now closed by `examples/runnable/contracts/record_adt_cycle_verify.ail`. |
 | V7 | Author recheck of B1 | Z3 4.16.0 accepts the alleged record/ADT cycle as one plural datatype group | Pipe a `Block ↔ Record_blocks_kind` `(declare-datatypes ...)` script to `z3 -in`; `z3 --version` | **Confirmed:** Z3 4.16.0 returns `sat`. |
 | V8 | Author recheck of B1/B2 | Mutual-recursion graph/group machinery already exists and is tested | Read `internal/smt/codegen_mutual.go`; `go test ./internal/smt -run 'Test(DeclareDatatypesMutual\\|FindSCCs\\|SplitDeclareDatatype)' -count=1` | **Confirmed:** Tarjan SCC + plural emitter exist; focused tests pass. This extends A3 and makes reuse feasible. |
 | V9 | Author inventory of B3, corrected in revision 1 | Which record field sorts enter the first silent-drop path | Re-read `MapType`/`MapRecordFields` in `internal/smt/types.go:36-90` and the Step-0 predicate | **Confirmed, with prior wording corrected:** any successfully mapped nonprimitive sort not already declared defers the alias: a direct bare ADT/other `TCon` name, `(Seq ADT)`, or an unresolved named record. “Arbitrary `TCon`” meant an arbitrary **bare constructor name**, not an arbitrary parameterized SMT sort. Type variables/functions/unit fail mapping earlier and are deleted, also silently. Non-list `TApp` is separately flattened to its bare constructor name. |
@@ -146,54 +147,11 @@ below did.
   V9 is corrected to remove the misleading implication that “arbitrary `TCon`” meant arbitrary
   parameterized SMT syntax.
 
-### Quorum round 2 — PARKED `needs-human-review`
+### Quorum round 2 — resolved
 
-Round 2 returned **blocked** again, on two NEW objections. Neither disputes the design
-**direction**; both were reproduced first-party by the controller before being acted on, and they
-did **not** land in the same place.
-
-- **`gemini-3-1-pro` — CLOSED AT DESIGN TIME.** It objected that V15's cross-boundary claim was
-  self-admittedly "not yet empirical" and must not be deferred to implementation. It was right to
-  refuse it, and the controller simply **ran the probe it asked for**: see V15 above —
-  `err=<nil>`, `verify.errors=1` parsed correctly from a child that exited 1. The objection is
-  satisfied by measurement, not by argument.
-
-- **`gpt5-6-sol` — CONFIRMED, AND IT IS THE PARK.** It objected that the design scores axiom A5
-  compliant while knowingly leaving **production** solver execution unbounded. Verified
-  first-party at `internal/smt/solver.go:147-148`:
-
-  ```go
-  cmd := exec.Command(z3Path, args...)
-  output, err := cmd.CombinedOutput()
-  ```
-
-  No `CommandContext`, no deadline, no `Process.Kill`, no process group. The only bound is Z3's
-  **cooperative** `-T:` flag, so a wedged or non-conforming solver hangs `verify`/`ai-check`
-  indefinitely. The reviewer is correct that a cooperative flag plus a test-only watchdog does not
-  discharge a bounded-waits axiom. **Filed independently as `ailang#510`** — it is a real defect
-  in its own right, not merely a documentation gap, and it exists at HEAD regardless of what this
-  doc does.
-
-**Why this parks rather than taking the narrow-refinement carve-out.** The carve-out permits the
-controller to apply reviewers' verbatim fixes only when every remaining objection is free of
-design-direction disputes *and* of controller judgment. `gpt5-6-sol`'s fix is a **scope
-expansion** — adding process-lifecycle management (context deadline, process-group kill, reap,
-fake-solver tests) to a sprint already estimated at 3–4 days. Deciding whether that belongs here,
-or ships as its own item, is precisely the sizing judgment the carve-out excludes. Same reasoning
-as iteration 114.
-
-**Recommended to Mark — option (B):**
-
-- **(A)** Absorb `#510` into this sprint as a fourth milestone. Honest, but pushes the estimate
-  past the sprint-sized bar and couples an encoder fix to a process-lifecycle fix.
-- **(B) — recommended.** Ship this doc as-is, with **A5 scored NON-compliant** and pointing at
-  `#510`, and sprint `#510` **separately and first** (it is small, self-contained, and closes a
-  standing-rule violation that affects every `ai-check` caller — including the sibling Ailang
-  World mission, which gates on `ai-check`). Then this doc's A5 becomes honestly compliant and it
-  routes to sprint-planner unchanged.
-- **(C)** Ship this doc as-is and accept the unbounded wait as a documented residual risk. Cheapest,
-  but it leaves a standing-rule violation open and would be scoring an axiom compliant that
-  demonstrably is not.
+The bounded-wait objection was resolved before this sprint: #510 landed as `9253ec8a8`, adding
+hard wall-clock deadlines and process reaping to both solver probes. V15's nonzero-child JSON
+behavior was also measured and is retained as a permanent regression test in this sprint.
 
 ---
 
@@ -473,10 +431,11 @@ All three milestones are **in scope** for this 3–4 day sprint.
 | File | Purpose | Estimate |
 |---|---|---:|
 | `internal/smt/codegen.go` | unified pending declaration graph; fail-loud validation | +100/−60 |
-| `internal/smt/codegen_mutual.go` | deterministic SCC/member ordering or structured declaration helpers | +30/−10 |
+| `internal/smt/codegen_decl_graph.go` | small declaration staging helpers, keeping codegen.go below 800 lines | +20 |
 | `internal/smt/codegen_*_test.go` | dependency, cycle, determinism, leak-gate unit tests | +250 |
+| `cmd/ailang/verify_filter.go` | shared driver demand closure through record aliases and ADTs | +50/−5 |
 | `cmd/ailang/ai_check.go` | error exit condition; neutral skip reason | +15/−10 |
-| `cmd/ailang/verify.go` | neutral skip reason | +5/−5 |
+| `cmd/ailang/verify.go` | shared demand filter and neutral skip reason | +5/−20 |
 | `cmd/ailang/*_test.go` | end-to-end JSON/status/exit tests | +150 |
 | `internal/eval_harness/verify.go` | correct stale comment only; behavior should remain | +2/−2 |
 | `internal/eval_harness/*_test.go` | empirical nonzero-child JSON parsing test | +60 |
@@ -566,7 +525,6 @@ integration fixtures during implementation rather than referenced by `/tmp` in C
 | Fail-loud gate converts a supported case to skip | Low | Medium | Controls for primitive, sequence, direct ADT, nested record, and mutual groups. |
 | Exit-code change surprises an external caller | Medium | Low | JSON schema/output order unchanged; changelog explicitly documents the correction. |
 | Full test suite binds loopback under sandbox | Medium | Low | Label such failures **UNINFORMATIVE UNDER SANDBOX**; rely on focused non-network suites plus unsandboxed CI for socket tests. |
-| Z3 ignores or fails to honor its soft/per-query `-T:` timeout | Low | High | **Residual risk:** production uses `exec.Command`/`CombinedOutput` with no context deadline, timer, or hard wall-clock process kill. The mandatory `-T:` and timeout regression AC bound normal supported Z3 behavior, but a wedged/nonconforming child can still hang. Queue a hard-kill backstop separately rather than claiming one exists. |
 
 ---
 
@@ -577,8 +535,7 @@ integration fixtures during implementation rather than referenced by `/tmp` in C
   silently discards `ty.Args`, so `Box[int]` and `Box[string]` collapse to the same SMT sort
   `Box`. This distinct correctness issue requires its own backlog item and is not fixed here.
 - Recursive contract reasoning or bounded recursion changes.
-- Changes to Z3 version, solver logic, hard-kill policy, or model extraction; this sprint only
-  regression-tests the existing mandatory soft timeout.
+- Changes to Z3 version, solver logic, hard-kill policy, or model extraction; #510 already landed.
 - Making `ai-check` skips nonzero or adding an `ai-check -strict` flag.
 - A full SMT-LIB parser/typed intermediate representation.
 - Changing eval KPI definitions, benchmark scores, or historical results.
@@ -597,8 +554,6 @@ integration fixtures during implementation rather than referenced by `/tmp` in C
   declaration/sort and must not assert a cross-module-only cause.
 - Parametric non-list ADT encoding/monomorphization for
   `internal/smt/types.go:56-67` — queue separately because type arguments currently collapse.
-- Whether to add an OS-level hard wall-clock kill around Z3 — queue as a separate bounded-
-  verification hardening item; current production has only Z3's mandatory soft `-T:` timeout.
 
 ---
 
@@ -616,7 +571,8 @@ integration fixtures during implementation rather than referenced by `/tmp` in C
 ## Sprint Exit
 
 The sprint is complete only when M1, M2, and M3 acceptance criteria pass, focused
-`go test ./internal/smt ./cmd/ailang ./internal/eval_harness` is green, `go build ./...` is green,
+`go test ./internal/smt ./cmd/ailang ./internal/eval_harness` is green,
+`go build ./cmd/ailang ./internal/...` is green,
 and the changelog documents both the expanded record/ADT verification fragment and
 `ai-check`'s corrected error exit. Any loopback bind failure under this sandbox is recorded as
 **UNINFORMATIVE UNDER SANDBOX**, not as a pass or regression.

--- a/examples/manifest.json
+++ b/examples/manifest.json
@@ -1579,6 +1579,30 @@
       "description": "Record pattern matching in contracts \u2014 Z3 verifies match expressions that destructure records into field bindings"
     },
     {
+      "path": "runnable/contracts/record_adt_cycle_verify.ail",
+      "status": "working",
+      "tags": [
+        "contracts",
+        "smt-verification",
+        "records",
+        "adt",
+        "mutual-recursion"
+      ],
+      "description": "A genuine record/ADT cycle emitted as one mutual SMT datatype group"
+    },
+    {
+      "path": "runnable/contracts/record_adt_sort_verify.ail",
+      "status": "working",
+      "tags": [
+        "contracts",
+        "smt-verification",
+        "records",
+        "adt",
+        "lists"
+      ],
+      "description": "A named record containing list[ADT] verifies with dependency-ordered SMT declarations"
+    },
+    {
       "path": "runnable/contracts/record_verify.ail",
       "status": "working",
       "tags": [
@@ -2646,11 +2670,11 @@
     }
   ],
   "statistics": {
-    "total": 190,
-    "working": 182,
+    "total": 192,
+    "working": 184,
     "aspirational": 4,
     "broken": 4,
-    "coverage": 0.9578947368421052,
+    "coverage": 0.9583333333333334,
     "experimental": 0
   },
   "milestones": {

--- a/examples/runnable/contracts/record_adt_cycle_verify.ail
+++ b/examples/runnable/contracts/record_adt_cycle_verify.ail
@@ -1,0 +1,15 @@
+-- A genuine inline-record/user-ADT cycle must use one mutual SMT datatype group.
+-- Run: ailang verify examples/runnable/contracts/record_adt_cycle_verify.ail
+-- Expect: 1 verified
+
+module examples/runnable/contracts/record_adt_cycle_verify
+
+export type Block = Para(string) | Container({ blocks: list[Block], kind: string })
+export type Doc = { title: string, blocks: list[Block] }
+
+export func titleOf(d: Doc) -> string ! {}
+ensures { result == d.title } {
+  d.title
+}
+
+export func main() -> int ! {} { 0 }

--- a/examples/runnable/contracts/record_adt_sort_verify.ail
+++ b/examples/runnable/contracts/record_adt_sort_verify.ail
@@ -1,0 +1,15 @@
+-- Record aliases may reach user ADTs through sequence fields.
+-- Run: ailang verify examples/runnable/contracts/record_adt_sort_verify.ail
+-- Expect: 1 verified
+
+module examples/runnable/contracts/record_adt_sort_verify
+
+export type Evidence = CompilerOutput(string) | TestReport(string, bool)
+export type Proposal = { name: string, evidence: list[Evidence] }
+
+export func hasName(p: Proposal, n: string) -> bool ! {}
+ensures { result == (p.name == n) } {
+  p.name == n
+}
+
+export func main() -> int ! {} { 0 }

--- a/internal/eval_harness/verify.go
+++ b/internal/eval_harness/verify.go
@@ -77,7 +77,8 @@ func RunAICheck(ailangPath, filePath string, timeout time.Duration) (*AICheckRes
 		return nil, "", fmt.Errorf("ai-check killed: %s process group exceeded the %s memory cap", MemKillMarker, EnvEvalMaxRSS)
 	}
 
-	// ai-check exits 0 even with counterexamples, exits non-zero on errors
+	// Counterexamples and verifier errors make ai-check exit nonzero; complete
+	// nonempty stdout is still parsed so callers retain the structured result.
 	rawOutput := stdout.String()
 	if rawOutput == "" && g.waitErr != nil {
 		return nil, stderr.String(), fmt.Errorf("ai-check failed: %w\nstderr: %s", g.waitErr, stderr.String())

--- a/internal/eval_harness/verify_nonzero_test.go
+++ b/internal/eval_harness/verify_nonzero_test.go
@@ -1,0 +1,39 @@
+package eval_harness
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestRunAICheckParsesJSONFromNonzeroChild(t *testing.T) {
+	dir := t.TempDir()
+	source := `package main
+import ("fmt"; "os")
+func main() {
+	fmt.Print("{\"file\":\"fixture.ail\",\"check\":{\"passed\":true,\"error_count\":0},\"verify\":{\"available\":true,\"verified\":0,\"counterexample\":0,\"skipped\":0,\"errors\":1}}")
+	os.Exit(1)
+}`
+	src := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(src, []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(dir, "fake-ailang")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	build := exec.Command("go", "build", "-o", bin, src)
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build helper: %v\n%s", err, output)
+	}
+	result, _, err := RunAICheck(bin, "fixture.ail", time.Second)
+	if err != nil {
+		t.Fatalf("RunAICheck: %v", err)
+	}
+	if result.Verify.Errors != 1 {
+		t.Fatalf("verify.errors = %d, want 1", result.Verify.Errors)
+	}
+}

--- a/internal/smt/codegen.go
+++ b/internal/smt/codegen.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/sunholo-data/ailang/internal/core"
@@ -13,7 +14,7 @@ import (
 // ErrUnresolvableTypes indicates that the function references types
 // (ADTs, record aliases) that cannot be fully resolved in Z3.
 // Functions with this error should be SKIPPED, not reported as errors.
-var ErrUnresolvableTypes = errors.New("unresolvable cross-module types")
+var ErrUnresolvableTypes = errors.New("unresolvable SMT declaration types")
 
 // FunctionParam describes a function parameter for SMT encoding.
 type FunctionParam struct {
@@ -210,55 +211,24 @@ func EncodeFunction(
 	// record literals with the same fields are discovered in function bodies, the named
 	// sort takes priority (e.g., "TableCell" instead of "Record_colSpan_merged_rowSpan_text").
 	//
-	// Multi-pass: aliases may reference other aliases (e.g., ParsedDocument uses DocMetadata).
-	// Iterate until no more progress, declaring aliases only when all their field sorts
-	// are primitive (Int/Bool/String/Real), already declared, or other record aliases.
-	// Aliases that reference ADT sorts (like Block) are skipped to avoid circular
-	// dependencies — they'll be emitted only if needed by function params/return type.
+	var aliasDecls []pendingDecl
 	if len(opts) > 0 && opts[0].RecordTypeAliases != nil {
-		remaining := make(map[string]*types.TRecord)
-		for name, rec := range opts[0].RecordTypeAliases {
-			remaining[name] = rec
+		aliasNames := make([]string, 0, len(opts[0].RecordTypeAliases))
+		for name := range opts[0].RecordTypeAliases {
+			aliasNames = append(aliasNames, name)
 		}
-		for {
-			progress := false
-			for aliasName, rec := range remaining {
-				if ctx.DeclaredTypes[aliasName] {
-					delete(remaining, aliasName)
-					progress = true
-					continue
-				}
-				namedRec := &types.TRecord{Fields: rec.Fields, TypeName: aliasName}
-				fieldSorts, err := MapRecordFields(namedRec)
-				if err != nil {
-					delete(remaining, aliasName)
-					continue
-				}
-				// Only declare if all field sorts are primitives or already declared.
-				// Do NOT count ADT types as resolvable — they may create circular
-				// dependencies (e.g., ParsedDocument → Block → Record_blocks_kind → Block).
-				if !allFieldsPrimitiveOrDeclared(fieldSorts, ctx) {
-					continue // defer to next pass
-				}
-				fieldNames := SortedFieldNamesStr(fieldSorts)
-				info := &RecordTypeInfo{
-					SortName:   aliasName,
-					CtorName:   RecordConstructorName(aliasName),
-					FieldNames: fieldNames,
-					FieldSorts: fieldSorts,
-				}
-				activeRecordTypes[aliasName] = info
-				key := strings.Join(fieldNames, ",")
-				activeFieldSetToSort[key] = aliasName
-				decl := DeclareRecordDatatype(aliasName, fieldSorts)
-				result.Declarations = append(result.Declarations, decl)
-				ctx.DeclaredTypes[aliasName] = true
-				delete(remaining, aliasName)
-				progress = true
+		sort.Strings(aliasNames)
+		for _, aliasName := range aliasNames {
+			rec := opts[0].RecordTypeAliases[aliasName]
+			fieldSorts, err := MapRecordFields(&types.TRecord{Fields: rec.Fields, TypeName: aliasName})
+			if err != nil {
+				return nil, fmt.Errorf("%w: record alias %q: %v", ErrUnresolvableTypes, aliasName, err)
 			}
-			if !progress {
-				break // no more aliases can be resolved
-			}
+			registerRecordAlias(aliasName, fieldSorts)
+			aliasDecls = append(aliasDecls, pendingDecl{
+				sortName: aliasName,
+				decl:     DeclareRecordDatatype(aliasName, fieldSorts),
+			})
 		}
 	}
 
@@ -270,11 +240,7 @@ func EncodeFunction(
 	// This prevents cascading errors from recursive ADTs (e.g., Block → Record_blocks_kind → Block).
 	{
 		// Collect all pending declarations
-		type pendingDecl struct {
-			sortName string
-			decl     string
-		}
-		var pending []pendingDecl
+		pending := append([]pendingDecl(nil), aliasDecls...)
 
 		// Add extra declarations (inline record types from ADT constructor fields)
 		if len(opts) > 0 {
@@ -287,10 +253,19 @@ func EncodeFunction(
 			}
 		}
 
-		// Add ADT type declarations
-		for typeName, variants := range adtTypes {
+		// Add ADT type declarations.
+		// Iterate in sorted name order, NOT Go map order: mutually independent ADTs are
+		// emitted in `pending` order, so a bare `range` makes the generated SMT-LIB differ
+		// between runs on identical input — a direct A1 (Determinism) violation. Mirrors the
+		// alias pass above.
+		adtNames := make([]string, 0, len(adtTypes))
+		for typeName := range adtTypes {
+			adtNames = append(adtNames, typeName)
+		}
+		sort.Strings(adtNames)
+		for _, typeName := range adtNames {
 			if !ctx.DeclaredTypes[typeName] {
-				decl := DeclareDatatype(typeName, variants)
+				decl := DeclareDatatype(typeName, adtTypes[typeName])
 				pending = append(pending, pendingDecl{sortName: typeName, decl: decl})
 			}
 		}
@@ -673,6 +648,9 @@ func validateDeclarations(decls []string, ctx *SMTContext) error {
 	// in this batch — those must be checked positionally.
 	declaredInBatch := make(map[string]bool)
 	for _, decl := range decls {
+		for _, name := range pluralDatatypeSortNames(decl) {
+			declaredInBatch[name] = true
+		}
 		if name := ExtractSortNameFromDecl(decl); name != "" {
 			declaredInBatch[name] = true
 		}
@@ -701,8 +679,36 @@ func validateDeclarations(decls []string, ctx *SMTContext) error {
 			}
 			continue
 		}
+		if strings.HasPrefix(decl, "(declare-datatypes ") {
+			sortNames := pluralDatatypeSortNames(decl)
+			groupSorts := make(map[string]bool, len(sortNames))
+			for _, name := range sortNames {
+				groupSorts[name] = true
+			}
+			constructors := pluralConstructorNames(decl)
+			for _, ref := range sortRefPattern.FindAllString(decl, -1) {
+				if primitiveSorts[ref] || groupSorts[ref] || constructors[ref] || declared[ref] || strings.HasPrefix(ref, "mk_") {
+					continue
+				}
+				return fmt.Errorf("%w: sort %q referenced in mutual datatype declaration is not declared", ErrUnresolvableTypes, ref)
+			}
+			for _, name := range sortNames {
+				declared[name] = true
+			}
+			continue
+		}
+		if strings.HasPrefix(decl, "(declare-const ") || strings.HasPrefix(decl, "(define-const ") {
+			name, sortStr, ok := constantDeclarationHeader(decl)
+			if !ok {
+				return fmt.Errorf("%w: malformed constant declaration %q", ErrUnresolvableTypes, decl)
+			}
+			if ref := firstUnresolvedSort(sortStr, declared); ref != "" {
+				return fmt.Errorf("%w: constant %q references undeclared sort %q", ErrUnresolvableTypes, name, ref)
+			}
+			continue
+		}
 		if !strings.HasPrefix(decl, "(declare-datatype ") {
-			// Non-datatype declarations (declare-const, define-const, etc.) are fine
+			// Other declaration shapes have no typed constant header.
 			continue
 		}
 		sortName := ExtractSortNameFromDecl(decl)
@@ -726,34 +732,4 @@ func validateDeclarations(decls []string, ctx *SMTContext) error {
 		}
 	}
 	return nil
-}
-
-// allFieldsPrimitiveOrDeclared checks whether all field sorts are either
-// primitive (Int, Bool, String, Real), sequence types of primitives/declared sorts,
-// or already declared in the context. Does NOT count pending ADT types as declared
-// to avoid circular dependency chains.
-func allFieldsPrimitiveOrDeclared(fieldSorts map[string]string, ctx *SMTContext) bool {
-	for _, sort := range fieldSorts {
-		if !isSortPrimitiveOrDeclared(sort, ctx) {
-			return false
-		}
-	}
-	return true
-}
-
-// isSortPrimitiveOrDeclared checks if a sort is primitive or already declared.
-func isSortPrimitiveOrDeclared(sort string, ctx *SMTContext) bool {
-	switch sort {
-	case "Int", "Bool", "String", "Real":
-		return true
-	}
-	if ctx.DeclaredTypes[sort] {
-		return true
-	}
-	// Sequence type: (Seq X) — check inner sort
-	if strings.HasPrefix(sort, "(Seq ") && strings.HasSuffix(sort, ")") {
-		inner := sort[5 : len(sort)-1]
-		return isSortPrimitiveOrDeclared(inner, ctx)
-	}
-	return false
 }

--- a/internal/smt/codegen_decl_closure_test.go
+++ b/internal/smt/codegen_decl_closure_test.go
@@ -1,0 +1,144 @@
+package smt
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/core"
+	"github.com/sunholo-data/ailang/internal/types"
+)
+
+func TestEncodeFunction_RecordAliasReachesADT(t *testing.T) {
+	params := []FunctionParam{{Name: "p", Type: &types.TCon{Name: "Proposal"}}}
+	meta := &core.DeclMeta{Name: "hasName", IsPure: true}
+	opts := EncodeFunctionOpts{RecordTypeAliases: map[string]*types.TRecord{
+		"Proposal": {Fields: map[string]types.Type{
+			"name":     &types.TCon{Name: "string"},
+			"evidence": &types.TList{Element: &types.TCon{Name: "Evidence"}},
+		}},
+	}}
+	adts := map[string][]ADTVariant{
+		"Evidence": {{Name: "CompilerOutput", Fields: []ADTField{{Name: "CompilerOutput_0", Sort: "String"}}}},
+	}
+	result, err := EncodeFunction("hasName", params, &core.Lit{Kind: core.BoolLit, Value: true}, "Bool", meta, adts, opts)
+	if err != nil {
+		t.Fatalf("EncodeFunction: %v", err)
+	}
+	evidenceAt := strings.Index(result.SMTLib, "(declare-datatype Evidence ")
+	proposalAt := strings.Index(result.SMTLib, "(declare-datatype Proposal ")
+	if evidenceAt < 0 || proposalAt < 0 || evidenceAt > proposalAt {
+		t.Fatalf("expected Evidence before Proposal:\n%s", result.SMTLib)
+	}
+}
+
+func TestEncodeFunction_RecordADTCycleUsesPluralGroup(t *testing.T) {
+	params := []FunctionParam{{Name: "d", Type: &types.TCon{Name: "Doc"}}}
+	opts := EncodeFunctionOpts{
+		RecordTypeAliases: map[string]*types.TRecord{"Doc": {Fields: map[string]types.Type{
+			"blocks": &types.TList{Element: &types.TCon{Name: "Block"}},
+		}}},
+		ExtraDeclarations: []string{
+			`(declare-datatype Record_blocks_kind ((mk_Record_blocks_kind (blocks (Seq Block)) (kind String))))`,
+		},
+	}
+	adts := map[string][]ADTVariant{"Block": {
+		{Name: "Para", Fields: []ADTField{{Name: "Para_0", Sort: "String"}}},
+		{Name: "Container", Fields: []ADTField{{Name: "Container_0", Sort: "Record_blocks_kind"}}},
+	}}
+	result, err := EncodeFunction("titleOf", params, &core.Lit{Kind: core.StringLit, Value: ""}, "String",
+		&core.DeclMeta{Name: "titleOf", IsPure: true}, adts, opts)
+	if err != nil {
+		t.Fatalf("EncodeFunction: %v", err)
+	}
+	if got := strings.Count(result.SMTLib, "(declare-datatypes (("); got != 1 {
+		t.Fatalf("plural group count = %d, want 1:\n%s", got, result.SMTLib)
+	}
+	for _, name := range []string{"(Block 0)", "(Record_blocks_kind 0)"} {
+		if !strings.Contains(result.SMTLib, name) {
+			t.Fatalf("missing %s:\n%s", name, result.SMTLib)
+		}
+	}
+}
+
+func TestValidateDeclarations_ConstantsAndPluralGroups(t *testing.T) {
+	ctx := NewSMTContext()
+	if err := validateDeclarations([]string{`(declare-const $p_p Missing)`}, ctx); !errors.Is(err, ErrUnresolvableTypes) ||
+		!strings.Contains(err.Error(), "$p_p") || !strings.Contains(err.Error(), "Missing") {
+		t.Fatalf("dangling constant error = %v", err)
+	}
+	evidence := `(declare-datatype Evidence ((CompilerOutput (CompilerOutput_0 String))))`
+	if err := validateDeclarations([]string{evidence, `(declare-const xs (Seq Evidence))`}, ctx); err != nil {
+		t.Fatalf("declared Seq element rejected: %v", err)
+	}
+	if err := validateDeclarations([]string{`(declare-const xs (Seq Evidence))`, evidence}, ctx); !errors.Is(err, ErrUnresolvableTypes) {
+		t.Fatalf("forward Seq element error = %v", err)
+	}
+	plural := `(declare-datatypes ((A 0) (B 0)) (((MkA (b B))) ((MkB (a A)))))`
+	if err := validateDeclarations([]string{plural, `(declare-const x A)`, `(declare-const y B)`}, ctx); err != nil {
+		t.Fatalf("atomic plural declaration rejected: %v", err)
+	}
+	if err := validateDeclarations([]string{plural, `(declare-const z C)`}, ctx); !errors.Is(err, ErrUnresolvableTypes) ||
+		!strings.Contains(err.Error(), "C") {
+		t.Fatalf("unknown post-group sort error = %v", err)
+	}
+}
+
+func TestEncodeFunction_UnmappableNeededAliasFailsLoud(t *testing.T) {
+	opts := EncodeFunctionOpts{RecordTypeAliases: map[string]*types.TRecord{
+		"Broken": {Fields: map[string]types.Type{"value": &types.TVar{Name: "a"}}},
+	}}
+	_, err := EncodeFunction("f", []FunctionParam{{Name: "x", Type: &types.TCon{Name: "Broken"}}},
+		&core.Lit{Kind: core.IntLit, Value: int64(1)}, "Int", &core.DeclMeta{Name: "f", IsPure: true}, nil, opts)
+	if !errors.Is(err, ErrUnresolvableTypes) || !strings.Contains(err.Error(), "Broken") {
+		t.Fatalf("unmappable alias error = %v", err)
+	}
+}
+
+// TestEncodeFunction_DeclarationOrderIsDeterministic is the AC1.5 guard.
+//
+// Mutually INDEPENDENT ADTs (none references another) are emitted in `pending` order.
+// If either the record-alias pass or the ADT pass iterates its Go map directly, that order
+// is randomized per run and the generated SMT-LIB differs between invocations on identical
+// input — a direct violation of design axiom A1 (Determinism).
+//
+// Red mutation: in EncodeFunction, replace the sorted `adtNames` iteration with a bare
+// `for typeName, variants := range adtTypes`. It compiles, and this test fails.
+// (Measured before the fix: 40 CLI invocations produced 3 distinct declaration orders.)
+func TestEncodeFunction_DeclarationOrderIsDeterministic(t *testing.T) {
+	encode := func() string {
+		t.Helper()
+		params := []FunctionParam{{Name: "p", Type: &types.TCon{Name: "Proposal"}}}
+		opts := EncodeFunctionOpts{RecordTypeAliases: map[string]*types.TRecord{
+			"Proposal": {Fields: map[string]types.Type{
+				"name":      &types.TCon{Name: "string"},
+				"evidence":  &types.TList{Element: &types.TCon{Name: "Evidence"}},
+				"decisions": &types.TList{Element: &types.TCon{Name: "Decision"}},
+				"verdicts":  &types.TList{Element: &types.TCon{Name: "Verdict"}},
+			}},
+			"Unused":  {Fields: map[string]types.Type{"a": &types.TCon{Name: "string"}}},
+			"Another": {Fields: map[string]types.Type{"b": &types.TCon{Name: "int"}}},
+		}}
+		// Three ADTs, none referencing another: their relative order is unconstrained by
+		// dependency, so only an explicit sort can pin it.
+		adts := map[string][]ADTVariant{
+			"Evidence": {{Name: "CompilerOutput", Fields: []ADTField{{Name: "CompilerOutput_0", Sort: "String"}}}},
+			"Decision": {{Name: "Accept", Fields: []ADTField{{Name: "Accept_0", Sort: "String"}}}},
+			"Verdict":  {{Name: "Pending", Fields: []ADTField{{Name: "Pending_0", Sort: "String"}}}},
+		}
+		result, err := EncodeFunction("hasName", params, &core.Lit{Kind: core.BoolLit, Value: true}, "Bool",
+			&core.DeclMeta{Name: "hasName", IsPure: true}, adts, opts)
+		if err != nil {
+			t.Fatalf("EncodeFunction: %v", err)
+		}
+		return result.SMTLib
+	}
+
+	first := encode()
+	for i := 1; i < 50; i++ {
+		if got := encode(); got != first {
+			t.Fatalf("SMT-LIB not byte-identical on encode #%d (A1 determinism violation)\n--- first ---\n%s\n--- got ---\n%s",
+				i+1, first, got)
+		}
+	}
+}

--- a/internal/smt/codegen_decl_graph.go
+++ b/internal/smt/codegen_decl_graph.go
@@ -1,0 +1,19 @@
+package smt
+
+import "strings"
+
+type pendingDecl struct {
+	sortName string
+	decl     string
+}
+
+func registerRecordAlias(aliasName string, fieldSorts map[string]string) {
+	fieldNames := SortedFieldNamesStr(fieldSorts)
+	activeRecordTypes[aliasName] = &RecordTypeInfo{
+		SortName:   aliasName,
+		CtorName:   RecordConstructorName(aliasName),
+		FieldNames: fieldNames,
+		FieldSorts: fieldSorts,
+	}
+	activeFieldSetToSort[strings.Join(fieldNames, ",")] = aliasName
+}

--- a/internal/smt/codegen_decl_validation.go
+++ b/internal/smt/codegen_decl_validation.go
@@ -1,0 +1,81 @@
+package smt
+
+import (
+	"regexp"
+	"strings"
+)
+
+var pluralSortPattern = regexp.MustCompile(`\(([A-Za-z_][A-Za-z_0-9]*)\s+0\)`)
+var pluralConstructorPattern = regexp.MustCompile(`\(\(?([A-Z][A-Za-z_0-9]*)(?:\s|\))`)
+
+func pluralDatatypeSortNames(decl string) []string {
+	if !strings.HasPrefix(decl, "(declare-datatypes (") {
+		return nil
+	}
+	headerEnd := strings.Index(decl, "))")
+	if headerEnd < 0 {
+		return nil
+	}
+	matches := pluralSortPattern.FindAllStringSubmatch(decl[:headerEnd+2], -1)
+	names := make([]string, 0, len(matches))
+	for _, match := range matches {
+		names = append(names, match[1])
+	}
+	return names
+}
+
+func pluralConstructorNames(decl string) map[string]bool {
+	names := make(map[string]bool)
+	for _, match := range pluralConstructorPattern.FindAllStringSubmatch(decl, -1) {
+		names[match[1]] = true
+	}
+	return names
+}
+
+func constantDeclarationHeader(decl string) (name, sortStr string, ok bool) {
+	fieldsStart := strings.IndexByte(decl, ' ')
+	if fieldsStart < 0 {
+		return "", "", false
+	}
+	rest := strings.TrimSpace(decl[fieldsStart+1:])
+	nameEnd := strings.IndexAny(rest, " \t\r\n")
+	if nameEnd < 1 {
+		return "", "", false
+	}
+	name = rest[:nameEnd]
+	rest = strings.TrimSpace(rest[nameEnd:])
+	if rest == "" {
+		return "", "", false
+	}
+	if rest[0] != '(' {
+		sortEnd := strings.IndexAny(rest, " \t\r\n)")
+		if sortEnd < 0 {
+			return "", "", false
+		}
+		return name, rest[:sortEnd], true
+	}
+	depth := 0
+	for i, r := range rest {
+		switch r {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return name, rest[:i+1], true
+			}
+		}
+	}
+	return "", "", false
+}
+
+func firstUnresolvedSort(sortStr string, declared map[string]bool) string {
+	sortStr = strings.TrimSpace(sortStr)
+	if strings.HasPrefix(sortStr, "(Seq ") && strings.HasSuffix(sortStr, ")") {
+		return firstUnresolvedSort(sortStr[5:len(sortStr)-1], declared)
+	}
+	if primitiveSorts[sortStr] || declared[sortStr] {
+		return ""
+	}
+	return sortStr
+}

--- a/internal/smt/codegen_function_test.go
+++ b/internal/smt/codegen_function_test.go
@@ -343,7 +343,10 @@ func TestEncodeFunction_WithReturnSort(t *testing.T) {
 	}
 
 	// With explicit return sort
-	result, err := EncodeFunction("f", params, body, "AgeClass", meta, nil)
+	ageClasses := map[string][]ADTVariant{"AgeClass": {
+		{Name: "Child"}, {Name: "Adult"},
+	}}
+	result, err := EncodeFunction("f", params, body, "AgeClass", meta, ageClasses)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/smt/codegen_record_discovery_test.go
+++ b/internal/smt/codegen_record_discovery_test.go
@@ -260,7 +260,7 @@ func TestEncodeFunction_ReturnOnlyRecord(t *testing.T) {
 		Contracts:  meta.Contracts,
 	}
 
-	result, err := EncodeFunction("makePoint", params, body, "Rec_x_y", meta, nil, opts)
+	result, err := EncodeFunction("makePoint", params, body, "Record_x_y", meta, nil, opts)
 	if err != nil {
 		t.Fatalf("EncodeFunction with return-only record: unexpected error: %v", err)
 	}


### PR DESCRIPTION
Closes #477. Mission iteration 117 (`m-z3-adt-record-sort`), routed unchanged per Mark's option (B) after `#510` landed in iteration 116.

## The defect was TWO layers, not one

The design doc localised the bug entirely inside `internal/smt/codegen.go`. The planner's live spike found that is **half** of it:

- **encoder** — the Step-0 record-alias fixpoint admitted a field sort only when primitive or already declared, so `(Seq Evidence)` deferred `Proposal` forever and `if !progress { break }` dropped it **silently** (a CLAUDE.md Principle 2 violation), while the parameter constant `(declare-const $p_p Proposal)` was emitted regardless.
- **driver** — `filterADTTypesForFunction` (`cmd/ailang/verify_filter.go`) walked the closure only through **ADT variant fields, never record-alias fields**, so `Evidence`'s variant list never reached `EncodeFunction` at all. **No encoder-only change could have fixed the repro**, and the doc's file table did not list this file.

A third finding: `verify` and `ai-check` are **different drivers**, and `ai-check` lacked the demand filter entirely (`buildNeededSortSet`: 2 hits in `verify.go`, **0** in `ai_check.go`). That **deflates** the verified count — inverting the design doc's impact framing.

## What shipped

| M | Change |
|---|---|
| M1 | Sorted eager-register / defer-emit into the **existing** pending+SCC machinery; both drivers unified on one `filterSMTInputsForFunction`; closure walks alias fields |
| M2 | `validateDeclarations` now covers `declare-const`, typed `define-const`, recursive `(Seq X)` element sorts, and plural groups **atomically** |
| M3 | `ai-check` exits 1 when `verify.errors > 0`; JSON still emitted first; exit decision extracted to a testable `aiCheckExitCode` |
| M4 | Two runnable fixtures (incl. the record↔ADT cycle), manifest, design doc, CHANGELOG |

**M2 also closes a pre-existing hole**: both validation gates tested `HasPrefix(decl, "(declare-datatype ")` — with a trailing space, which **never matches** `(declare-datatypes (`. Every mutually-recursive datatype group bypassed the guard that `m-smt-callee-sort-gate` claimed covered "every drop path".

## Evidence

- **Headline**: the design doc's own program goes `{verified:0, errors:1}` exit 0 → `{verified:1, errors:0}`.
- **Exit honesty**: `cross_module_functions.ail` (check passes, `verify.errors=3`) now exits **1**.
- **Determinism (axiom A1)**: measured **40 invocations → 3 distinct declaration orders** before; **40/40 identical** after. An independent 200-encode adversarial probe (6 ADTs, mutual cycle, 4 aliases) is byte-identical.
- **Corpus**: verified **76 → 81**, skipped **10 → 7**, counterexample 23, errors 3.
- Gates re-run **outside** the executor sandbox: `make test` rc=0 (**105 pkgs, 0 FAIL, 0 bind-denials**), lint/boundaries/file-sizes/gofmt/verify-examples all clean. `codegen.go` 735/800.

⚠️ The skip→verified movement is a **coverage fix, not a model improvement** — flagged in CHANGELOG so the next eval baseline is not misread.

## Breaking change

`ai-check` now exits non-zero on verifier errors. `ai-check` is **Experimental** in the stability reference and has no in-repo Makefile/CI/shell consumer; `RunAICheck` parses JSON from a non-zero child by construction (measured). Out-of-repo shell callers that relied on exit 0 will now correctly fail.

## Review trail

Planner **opus** refuted **7** design-doc premises (2 blocking). Executor **`codex:gpt-5.6-sol`** correctly labelled its socket-touching suites `UNINFORMATIVE UNDER SANDBOX` and self-declared incomplete mutation coverage rather than overclaiming. Evaluator **sonnet** (generator≠judge): **round 1 FAIL 59/100** — it caught a **live nondeterminism bug** the executor's alias-only sort had missed, which the controller reproduced end-to-end before fixing; **round 2 PASS 83/100**.

## Residual gaps — reported, not papered over

- AC1.3: no table-driven `verify`-vs-`ai-check` parity integration test (mitigated: both drivers now share one function).
- AC3.3: no subprocess guard that JSON precedes exit.
- AC2.4 / AC2.5: named red mutations not recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)