### PR TITLE
feat(serve-api): exact MCP tool surface — --no-feedback-tool + A2A dispatch gate (Lane A of #498, #528)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,17 @@ For the latest version, see [changelogs/v0.18-current.md](changelogs/v0.18-curre
 
 ## [Unreleased]
 
+### Added
+
+- `serve-api --no-feedback-tool` can suppress the built-in
+  `submit_feedback` MCP tool for an exact caller-selected surface. Existing
+  invocations keep the tool by default (refs #498).
+
 ### Fixed
 
+- A2A `tasks/send` now applies the same `--routes-only` / `@noexpose`
+  projection as the agent card, so hidden functions are not callable and
+  remain indistinguishable from absent functions (refs #528).
 - SMT verification now closes declarations through named record fields into
   user ADTs, including `list[ADT]` and mutual record/ADT cycles.
 - `ai-check` now uses the same per-function type-demand filtering as `verify`,

--- a/cmd/ailang/serve_api.go
+++ b/cmd/ailang/serve_api.go
@@ -31,6 +31,7 @@ func serveAPICommand(args []string) error {
 	apiKeyHeaderFlag := fs.String("api-key-header", "", "HTTP header name for API key authentication")
 	apiKeyEnvFlag := fs.String("api-key-env", "", "Environment variable containing the expected API key")
 	routesOnlyFlag := fs.Bool("routes-only", false, "Only expose @route-annotated functions as HTTP endpoints")
+	noFeedbackToolFlag := fs.Bool("no-feedback-tool", false, "Suppress the built-in submit_feedback MCP tool (exact tool surface)")
 	helpFlag := fs.Bool("help", false, "Show help for serve-api command")
 	maxMemoryFlag := fs.String("max-memory", "", "Memory limit (e.g., 256MB, 1GB). Triggers aggressive GC near limit.")
 	logLevelFlag := fs.String("log-level", "", "Minimum log level for Debug output (debug, info, warn, error, none)")
@@ -124,20 +125,21 @@ func serveAPICommand(args []string) error {
 	}
 
 	cfg := apiserver.Config{
-		Port:          *portFlag,
-		CORS:          *corsFlag,
-		FrontendPath:  *frontendFlag,
-		StaticPath:    *staticFlag,
-		Watch:         *watchFlag,
-		EffCtx:        effCtx,
-		MCP:           *mcpHTTPFlag,
-		MCPOnly:       *mcpFlag,
-		A2A:           *a2aFlag,
-		MaxUploadSize: *maxUploadFlag,
-		APIKeyHeader:  *apiKeyHeaderFlag,
-		APIKeyEnv:     *apiKeyEnvFlag,
-		LogLevel:      debugLogLevel,
-		RoutesOnly:    *routesOnlyFlag,
+		Port:           *portFlag,
+		CORS:           *corsFlag,
+		FrontendPath:   *frontendFlag,
+		StaticPath:     *staticFlag,
+		Watch:          *watchFlag,
+		EffCtx:         effCtx,
+		MCP:            *mcpHTTPFlag,
+		MCPOnly:        *mcpFlag,
+		A2A:            *a2aFlag,
+		MaxUploadSize:  *maxUploadFlag,
+		APIKeyHeader:   *apiKeyHeaderFlag,
+		APIKeyEnv:      *apiKeyEnvFlag,
+		LogLevel:       debugLogLevel,
+		RoutesOnly:     *routesOnlyFlag,
+		NoFeedbackTool: *noFeedbackToolFlag,
 	}
 
 	srv := apiserver.New(basePath, cfg)
@@ -256,6 +258,7 @@ func printServeAPIHelp() {
 	fmt.Println("  --api-key-header H   HTTP header name for API key authentication")
 	fmt.Println("  --api-key-env VAR    Environment variable containing the expected API key")
 	fmt.Println("  --routes-only        Only expose @route-annotated functions (skip auto-generated endpoints)")
+	fmt.Println("  --no-feedback-tool   Suppress the built-in submit_feedback MCP tool (exact tool surface)")
 	fmt.Println("  --help               Show this help message")
 	fmt.Println()
 	fmt.Println("Route annotations:")

--- a/cmd/ailang/serve_api_mcp_surface_test.go
+++ b/cmd/ailang/serve_api_mcp_surface_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestServeAPI_MCPToolSurface(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds and drives the serve-api stdio MCP binary")
+	}
+	binary := filepath.Join(t.TempDir(), "ailang")
+	build := exec.Command("go", "build", "-o", binary, ".")
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build: %v\n%s", err, output)
+	}
+
+	moduleRoot := t.TempDir()
+	modulePath := filepath.Join(moduleRoot, "api", "surface.ail")
+	if err := os.MkdirAll(filepath.Dir(modulePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := `module api/surface
+
+@route("GET", "/status")
+export pure func status() -> string = "ok"
+
+export pure func helper() -> string = "helper"
+`
+	if err := os.WriteFile(modulePath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name       string
+		suppress   bool
+		wantSubmit bool
+	}{
+		{"default", false, true},
+		{"suppressed", true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			names := probeServeAPIMCPTools(t, binary, modulePath, tc.suppress)
+			if len(names) == 0 {
+				t.Fatal("instrument failure - positive control missing: empty tools/list")
+			}
+			if !names["status"] {
+				t.Fatalf("instrument failure - positive control status missing; tools: %v", names)
+			}
+			if names["submit_feedback"] != tc.wantSubmit {
+				t.Errorf("submit_feedback present = %v, want %v; tools: %v", names["submit_feedback"], tc.wantSubmit, names)
+			}
+		})
+	}
+}
+
+func probeServeAPIMCPTools(t *testing.T, binary, modulePath string, suppress bool) map[string]bool {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	args := []string{"serve-api", "--mcp"}
+	if suppress {
+		args = append(args, "--no-feedback-tool")
+	}
+	args = append(args, modulePath)
+	cmd := exec.CommandContext(ctx, binary, args...)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = stdin.Close()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	send := func(value any) {
+		t.Helper()
+		data, err := json.Marshal(value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := fmt.Fprintf(stdin, "%s\n", data); err != nil {
+			t.Fatalf("write request: %v; stderr:\n%s", err, stderr.String())
+		}
+	}
+	send(map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "surface-test", "version": "1"},
+		},
+	})
+
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		var response struct {
+			ID     json.RawMessage `json:"id"`
+			Result struct {
+				Tools []struct {
+					Name string `json:"name"`
+				} `json:"tools"`
+			} `json:"result"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &response); err != nil {
+			continue
+		}
+		var id int
+		if err := json.Unmarshal(response.ID, &id); err != nil {
+			continue
+		}
+		switch id {
+		case 1:
+			send(map[string]any{"jsonrpc": "2.0", "method": "notifications/initialized"})
+			send(map[string]any{"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": map[string]any{}})
+		case 2:
+			names := make(map[string]bool, len(response.Result.Tools))
+			for _, tool := range response.Result.Tools {
+				names[tool.Name] = true
+			}
+			return names
+		}
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("MCP probe timeout: %v; stderr:\n%s", ctx.Err(), stderr.String())
+	}
+	t.Fatalf("MCP stdout closed before tools/list response: %v; stderr:\n%s", scanner.Err(), stderr.String())
+	return nil
+}

--- a/cmd/ailang/serve_api_mcp_surface_test.go
+++ b/cmd/ailang/serve_api_mcp_surface_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -17,7 +18,14 @@ func TestServeAPI_MCPToolSurface(t *testing.T) {
 	if testing.Short() {
 		t.Skip("builds and drives the serve-api stdio MCP binary")
 	}
-	binary := filepath.Join(t.TempDir(), "ailang")
+	// Windows refuses to exec a file without the .exe suffix, failing with
+	// "executable file not found in %PATH%" — which reads like a missing
+	// toolchain rather than the naming bug it actually is.
+	binaryName := "ailang"
+	if runtime.GOOS == "windows" {
+		binaryName += ".exe"
+	}
+	binary := filepath.Join(t.TempDir(), binaryName)
 	build := exec.Command("go", "build", "-o", binary, ".")
 	if output, err := build.CombinedOutput(); err != nil {
 		t.Fatalf("go build: %v\n%s", err, output)

--- a/design_docs/planned/v0_31_0/m-mcp-exact-tool-surface-lane-a-sprint-plan.md
+++ b/design_docs/planned/v0_31_0/m-mcp-exact-tool-surface-lane-a-sprint-plan.md
@@ -505,18 +505,18 @@ one PR inside a day. This is in family.
 
 ## 9. Acceptance criteria
 
-- [ ] `serve-api --mcp --no-feedback-tool DIR` → `tools/list` has **no** `submit_feedback` and **does** have the user's exports.
-- [ ] `serve-api --mcp --routes-only --no-feedback-tool DIR` → `tools/list` is **exactly** the `@route` set.
-- [ ] `serve-api --mcp DIR` (no flag) → `submit_feedback` still present. **Default is unchanged.**
-- [ ] `--mcp-http` behaves identically to `--mcp` (same `NewMCPServer` path; asserted in M1, no separate transport test needed).
-- [ ] `tools/call submit_feedback` errors when suppressed.
-- [ ] Every new test carries a positive control; no absence assertion can pass on an empty list.
-- [ ] All named mutations (MUT-1a/1b/1c, M2, M3) observed **red**, then reverted — with the failing test names quoted in the sprint report.
-- [ ] `--routes-only` semantics unchanged; `filtering_test.go` and `mcp_schema_test.go` pass unmodified.
-- [ ] Docs state: `--caps` gates execution not discovery; `--routes-only` filters exports not built-ins; `--no-feedback-tool` exists.
-- [ ] `go test ./internal/apiserver/` green; `make lint`, `gofmt -l`, `make check-file-sizes` clean.
-- [ ] CHANGELOG `[Unreleased]` updated; `refs #498` on every commit; **no** `Fixes #498`.
-- [ ] Sprint report states explicitly which milestones were cut, if any, and what was filed instead.
+- [x] `serve-api --mcp --no-feedback-tool DIR` → `tools/list` has **no** `submit_feedback` and **does** have the user's exports.
+- [x] `serve-api --mcp --routes-only --no-feedback-tool DIR` → `tools/list` is **exactly** the `@route` set.
+- [x] `serve-api --mcp DIR` (no flag) → `submit_feedback` still present. **Default is unchanged.**
+- [x] `--mcp-http` behaves identically to `--mcp` (same `NewMCPServer` path; asserted in M1, no separate transport test needed).
+- [x] `tools/call submit_feedback` errors when suppressed.
+- [x] Every new test carries a positive control; no absence assertion can pass on an empty list.
+- [x] All named mutations (MUT-1a/1b/1c, M2, M3) observed **red**, then reverted — with the failing test names quoted in the sprint report.
+- [x] `--routes-only` semantics unchanged; `filtering_test.go` and `mcp_schema_test.go` pass unmodified.
+- [x] Docs state: `--caps` gates execution not discovery; `--routes-only` filters exports not built-ins; `--no-feedback-tool` exists.
+- [x] `go test ./internal/apiserver/` green; `make lint`, `gofmt -l`, `make check-file-sizes` clean.
+- [x] CHANGELOG `[Unreleased]` updated; `refs #498` on every commit; **no** `Fixes #498`.
+- [x] Sprint report states explicitly which milestones were cut, if any, and what was filed instead.
 
 ---
 

--- a/design_docs/planned/v0_31_0/m-mcp-exact-tool-surface-lane-a-sprint-plan.md
+++ b/design_docs/planned/v0_31_0/m-mcp-exact-tool-surface-lane-a-sprint-plan.md
@@ -1,0 +1,534 @@
+# Sprint Plan: M-MCP-EXACT-TOOL-SURFACE — Lane A
+
+**GitHub issue**: [sunholo-data/ailang#498](https://github.com/sunholo-data/ailang/issues/498)
+**Design doc**: none — mission-classified as a small settled bug fix, same shape as
+[m-nightly-run-validity-gate](../v1_0_0/m-nightly-run-validity-gate-sprint-plan.md) (iteration 119),
+which also ran doc-less. Lane B (callback-driven embedder API) is design-doc-sized and OUT of scope.
+**Sprint ID**: `M-MCP-EXACT-TOOL-SURFACE-A`
+**Branch**: `sprint/m-mcp-exact-tool-surface`
+**Worktree**: `/Users/voightkampff/dev/sunholo-data/ailang/.claude/worktrees/iter120-mcp-surface`
+**Base**: `origin/dev` @ `0f0896c70`
+**Planner model**: `claude-opus-4-8`
+**Planned**: 2026-07-29 (mission-control iteration 120)
+**Executor**: `codex:gpt-5.6-sol`, `workspace-write` sandbox, **loopback socket binds denied**
+**Estimate**: **~1.0 working day (6.5h bottom-up + 20% = ~7.8h)** — the top of the mission's 0.5–1.0d box, not the bottom. Justified in §6.
+**Risk**: medium-low. Small production diff (~43 LOC). The real risk is a **default-behaviour choice
+that would break the live public MCP server** — see §3 D1, which is why this sprint does NOT touch
+`--routes-only` semantics.
+
+---
+
+## 0. Premise re-verification (first-party, this worktree, at `0f0896c70`)
+
+The controller labelled every handed-down fact and asked me to re-check. I did. **One is refuted**
+(the `--a2a` leg), **one is materially narrower than stated** (which changes nothing about the fix
+but everything about what to test), and **while refuting it I found a second, independent defect
+in the same "exact surface" family that nobody had filed** (§0.3, M3).
+
+### CONFIRMED
+
+| # | Premise | How I verified it |
+|---|---|---|
+| C1 | `ms.registerFeedbackTool()` is called unconditionally at `internal/apiserver/mcp.go:43`, after `registerTools()` | Read `mcp.go:29-45`. The call sits outside every predicate. |
+| C2 | Defined at `internal/apiserver/feedback_tool.go:52`; `mcp.go:43` is its only call site | `grep -n 'registerFeedbackTool' internal/apiserver/*.go` → exactly 2 hits: the definition and the call. |
+| C3 | The live matrix (`--routes-only` filters the user's own function while the built-in survives) | **Reproduced in-process, socket-free, with a positive control.** Scratch test using `mcp.NewInMemoryTransports()` + a real `initialize`/`tools/list` client session against a module with one `@route` export (`status`) and one plain export (`addOne`): unfiltered → `[addOne status submit_feedback]`; `RoutesOnly:true` → `[status submit_feedback]`. `status` is the positive control — it proves the instrument sees tools; `addOne` correctly disappears; `submit_feedback` does not. Scratch files deleted; the worktree is clean. |
+| C4 | No off-switch exists | `grep -rn 'AILANG_FEEDBACK\|DISABLE_FEEDBACK\|no-feedback\|nofeedback' internal/ cmd/` → only `internal/feedbackgate/*` + `internal/coordinator/feedback_gate_wiring.go`, which is the coordinator triage gate, a different subsystem. Positive control present (those hits came back), so the negative is credible. |
+| C5 | Egress is gated on `AILANG_STORAGE=gcp` **and** `AILANG_CLOUD_PROJECT` | `internal/feedback/publisher.go:121-129` in `newPublisher`. Both are hard errors; `Get` memoises the failure via `sync.Once`. The controller's "advertises an egress tool it cannot perform" framing is exactly right — **not** a default-config exfiltration. |
+| C6 | `@nomcp` (`ee04f13d0`) is the naming/test precedent | `internal/apiserver/routes.go:246` (`isExposed`), `mcp.go:85-90` (`IsNoMCP` skip), `internal/apiserver/nomcp_test.go:206-263`. Confirmed it **cannot** be reused directly: `@nomcp` is a per-export annotation extracted from user `.ail` source (`extractNoMCPAnnotations`), and `submit_feedback` has no `.ail` export — the `.ail` mirror `mcp_tools/feedback.ail` is `@noexpose`'d and is documentation only (`feedback_tool.go:40-50`). The reusable part is the **test harness and the vocabulary**, not the mechanism. |
+
+### REFUTED
+
+> **R-A. `--a2a` does NOT advertise `submit_feedback`. The `--a2a` leg of the defect, as stated in
+> the issue title, is false.** This is a success of the loop: a milestone that "fixed A2A discovery"
+> would have been a **no-op that shipped green**.
+
+`buildAgentCard` (`internal/apiserver/a2a.go:30-57`) builds `skills[]` by iterating `s.modules` and
+applying `s.isExposed(export)`. It never touches `ms.mcpServer` and has no access to Go-side tools.
+I probed the real endpoint in-process (`httptest.NewRequest` + `mux.ServeHTTP` — no socket, `srv.a2aEnabled = true`, `RoutesOnly: true`):
+
+```
+A2A card contains submit_feedback: false
+A2A card contains status:          true    <- positive control
+A2A card contains addOne:          false   <- routes-only filter working
+```
+
+The issue reporter independently saw the same thing without realising it — #498 says the card had
+"the same 26 **non-feedback** entries". So the title over-reaches. **Consequence for scope**: there
+is no A2A discovery work in this sprint, and the executor must not invent any.
+
+**This does not make the sprint vacuous for the sibling.** The sibling consumes MCP-HTTP, and
+MCP-HTTP *is* covered: `server.go:509` (`StartMCP` → stdio) and `server.go:588` (`buildRoutes` →
+`/mcp/`) **both** call `NewMCPServer(s)`. One fix at `mcp.go:43` closes `--mcp` and `--mcp-http`
+together. Verified by reading both call sites.
+
+### MATERIALLY NARROWED
+
+**R-B. The `std/io` tool leak reported in #498 did NOT reproduce here.** #498 reports that
+unfiltered `tools/list` on a 5-module directory returned 27 tools including 8 embedded
+`std/io` exports (`exit`, `writeBytes`, ...) and that the A2A card carried
+`<embedded>.std.io.writeBytes`. I built a module that imports `std/io (println)` and served it
+unfiltered: `tools: [shout submit_feedback]` — **no `std/io` entries**. Either it is
+configuration-dependent (directory-vs-file serving, package load path) or it was fixed after
+v0.30.0. I am **not** scoping it: it is a separate, larger, and genuinely security-relevant leak
+(`std.io.exit` as an agent-callable tool) that needs its own first-party repro before anyone prices
+it. **Recommend the controller file it separately.** Do not let the executor chase it.
+
+### NEW DEFECT FOUND WHILE VERIFYING (this is M3)
+
+**R-C. A2A `tasks/send` dispatch has no `isExposed` gate: `--routes-only` and `@noexpose` are
+card-only on A2A — functions are hidden from discovery but remain fully callable.**
+
+Every other surface gates invocation: HTTP `handler.go:142`, MCP `mcp.go:85`, OpenAPI
+`openapi.go:187`, A2A **card** `a2a.go:57`. `handleA2ATaskSend` (`a2a.go:161-193`) checks only that
+the module is loaded and `e.Name == funcName`; it then calls `s.engine.CallPreserveFloats(...)`.
+I probed it under `RoutesOnly:true` with `skill_id=test.api.keys.addOne` (a non-`@route` export
+that is **absent from the card**):
+
+```
+POST /a2a/ -> 200 {"result":{"status":{"message":"expected float arguments","state":"failed"}}}
+```
+
+That message comes from the *engine argument coercion path*, i.e. dispatch was **allowed through**.
+Had the gate existed the response would have been `-32602 function %q not found in module %q`.
+
+This is the exact mirror image of the `--caps` discovery/execution split the sprint is chartered to
+document, on the same protocol family, and CLAUDE.md §3 ("systemic fixes — audit before patching")
+says fix the pattern rather than the reported instance. It is 4 lines of production code. **M3 is
+CUTTABLE** (§7) if the budget bites — but if cut it must be filed, not forgotten.
+
+---
+
+## 1. Goal
+
+Give an embedding host an **exact** MCP tool surface from the CLI, and stop lying to models about a
+capability the server usually cannot perform.
+
+After this sprint:
+
+| invocation | `tools/list` |
+|---|---|
+| `serve-api --mcp DIR` | user exports **+ `submit_feedback`** (unchanged — see D1) |
+| `serve-api --mcp --no-feedback-tool DIR` | user exports, **exactly** |
+| `serve-api --mcp --routes-only --no-feedback-tool DIR` | `@route` exports, **exactly** |
+| `serve-api --mcp-http --no-feedback-tool DIR` | same, over `/mcp/` |
+
+Plus: `--caps` is documented as gating **execution, not discovery**; `--routes-only` is documented
+as filtering **user exports**, with the built-in controlled separately; and (M3) A2A can no longer
+invoke what it refuses to advertise.
+
+**Non-goals** (Lane B, do not drift): caller-supplied tool descriptors, per-session/per-principal
+capability resolution, mountable `http.Handler` export, callback-driven invocation. Also non-goals:
+the `std/io` leak (R-B), any change to the feedback publisher, any change to the coordinator's
+`internal/feedbackgate`.
+
+---
+
+## 2. Impact statement (use this wording; do not inflate it)
+
+> The **discovery** defect is unconditional and real: every model that connects to any
+> `ailang serve-api --mcp`/`--mcp-http` process is told a public-feedback egress tool exists, and
+> there is no way to withdraw that claim. **Egress itself is not open by default** —
+> `internal/feedback/publisher.go:121-129` requires *both* `AILANG_STORAGE=gcp` and
+> `AILANG_CLOUD_PROJECT`; without them the publisher fails to construct and no client is opened. So
+> a default local server **advertises an egress tool it cannot perform** — a false capability claim
+> to every connected model, plus a live egress path in any environment that does carry those two
+> vars. This is **not** a default-config exfiltration, and must not be described as one.
+
+---
+
+## 3. Design decisions (settled with evidence)
+
+### D1 — Mechanism: a new opt-out CLI flag `--no-feedback-tool`. Default behaviour UNCHANGED.
+
+**Options weighed:**
+
+| option | verdict |
+|---|---|
+| Make `--routes-only` suppress the built-in | **REJECTED — it breaks production.** |
+| Suppress by default, add `--feedback-tool` to opt in | **REJECTED** — same breakage, worse skew. |
+| Per-export annotation (`@nomcp`-style) | **IMPOSSIBLE** — see C6; the built-in has no `.ail` export. |
+| Env var only (`AILANG_MCP_NO_FEEDBACK_TOOL`) | **REJECTED** — see below. |
+| **New flag `--no-feedback-tool`, default off** | **CHOSEN.** |
+
+**The evidence that kills the `--routes-only` option** — and it is concrete, not hypothetical.
+`docs/docs/guides/agent-mcp.md:127-129` documents the *live* public AILANG MCP server:
+
+```
+- Cloud Run service runs `ailang serve-api --mcp-http --routes-only --caps FS,Env`
+- `--routes-only` means only `@mcp_name`/`@route` exports register as tools — no helper leakage
+```
+
+and lines 22/100/106 of the same file document `submit_feedback` as that server's **one write tool**
+and the intended public triage channel. So the flagship deployment runs `--routes-only` **and
+depends on the built-in surviving it**. Changing `--routes-only` semantics would:
+
+1. silently delete the public feedback channel the moment a new binary rolls out;
+2. require a matching config change in the **separate Terraform deploy project** (per project
+   memory: ailang-multivac deploy is Terraform-only, in a different repo) — a cross-repo change this
+   sprint cannot make atomically, guaranteeing a version-skew window.
+
+The controller's framing — "`--routes-only` arguably already promises suppression" — is *right about
+the words* and wrong about the cost. The honest resolution is: keep the behaviour, **fix the
+promise in the docs** (M4), and give callers an explicit lever.
+
+**Why not env-var-only**: `AllowDropsEnvVar` (`server.go:~228`) sets this repo's precedent — and its
+own comment says env-var-only exists to force operators to make a **bypass** explicit in a
+manifest. `--no-feedback-tool` is a *tightening*, not a bypass; the CLI is the discoverable place
+for it, and adding both a flag and an env var would create two sources of truth (CLAUDE.md §2).
+Recorded as a deliberate non-goal so nobody re-derives it.
+
+**Back-compat cost of the chosen option, stated plainly**: none for existing users, and the
+downstream (#498) must add one flag to its invocation. The residual is that an operator who passes
+`--routes-only` alone still gets a tool they did not ask for. **CLAUDE.md §2 forbids that being
+*silent***, so M1.4 emits a one-line stderr notice naming the flag whenever the built-in is
+registered under `--routes-only`. `log` writes to stderr by default and nothing in the serve path
+calls `log.SetOutput` (verified: the only hits are a test helper and an unrelated `cmd/`), so this
+is safe in stdio MCP mode where stdout is the protocol channel.
+
+### D2 — Coverage: one fix covers `--mcp` and `--mcp-http`. `--a2a` needs no discovery fix.
+
+Both transports construct through `NewMCPServer(s)` (`server.go:509`, `server.go:588`); the
+suppression predicate therefore lives on the `Server`, flows `Config → New() → Server` exactly like
+`routesOnly` (`server.go:165,218`), and is read once inside `NewMCPServer`. A2A is refuted (R-A).
+The A2A work in this sprint (M3) is about **invocation**, not discovery, and is a different bug.
+
+### D3 — Test shape: in-memory MCP transport, positive control inside every assertion.
+
+`internal/apiserver/nomcp_test.go:206-263` already establishes the pattern: `mcp.NewInMemoryTransports()`
++ `ms.mcpServer.Connect` + `client.Connect` + `ListTools`. **No sockets.** I ran the whole package:
+`ok github.com/sunholo-data/ailang/internal/apiserver 0.711s`, and
+`grep -rn 'httptest.NewServer|net.Listen|ListenAndServe' internal/apiserver/*_test.go` returns
+**nothing** — the package is entirely socket-free and safe under the executor's sandbox.
+(`httptest.NewRequest` + `httptest.NewRecorder` + `mux.ServeHTTP` do **not** bind; only
+`httptest.NewServer` would.)
+
+Every new assertion must name a real user tool that IS present in the **same** `tools/list`
+response that asserts the built-in is absent. Rationale is on the record: the controller's first
+probe returned an empty list for every row with `rc=1`/`server is closing: EOF` — a broken
+instrument indistinguishable from "no tools found". An assertion of the form "`submit_feedback` not
+in tools" passes trivially against an empty list.
+
+---
+
+## 4. Milestones
+
+Each is independently committable with its own verification command and its own named mutation.
+
+Run every command from the worktree root:
+`/Users/voightkampff/dev/sunholo-data/ailang/.claude/worktrees/iter120-mcp-surface`.
+
+---
+
+### M1 — Suppress the built-in inside `NewMCPServer` (~2.0h, ~25 prod + ~120 test LOC)
+
+**Files**: `internal/apiserver/server.go`, `internal/apiserver/mcp.go`,
+`internal/apiserver/feedback_tool_surface_test.go` (new).
+
+**M1.1** Add `NoFeedbackTool bool` to `Config` (`server.go:150-166`, next to `RoutesOnly`, with a
+comment: *"suppress the built-in submit_feedback MCP tool; user exports unaffected"*). Add
+`noFeedbackTool bool` to the `Server` struct and wire `noFeedbackTool: cfg.NoFeedbackTool` in `New()`
+(`server.go:~218`, next to `routesOnly:`).
+
+**M1.2** Guard the call at `mcp.go:43`:
+
+```go
+if !srv.noFeedbackTool {
+    ms.registerFeedbackTool()
+}
+```
+
+Update the `NewMCPServer` doc comment (`mcp.go:23-28`) to say the built-in is registered *unless*
+suppressed. Do **not** touch `registerFeedbackTool` itself, and do **not** delete
+`feedback_tool_test.go` — those tests build `&MCPServer{feedbackRL: ...}` by hand and call
+`handleSubmitFeedback` directly, so they are unaffected by registration and must keep passing.
+
+**M1.3** New test file with three tests, all on the in-memory transport:
+
+- `TestFeedbackTool_PresentByDefault` — default `Config`: `submit_feedback` present **and** the
+  `@route` export `status` present. (This is the over-suppression guard: it fails if someone just
+  deletes the call.)
+- `TestFeedbackTool_SuppressedWhenConfigured` — `Config{NoFeedbackTool: true}`: `submit_feedback`
+  **absent** and `status` **present in the same response** (positive control). Assert on the same
+  `res.Tools` slice; on failure print the full `toolNames(res.Tools)`.
+- `TestFeedbackTool_SuppressedIsAlsoUncallable` — with suppression on, `CallTool{Name:"submit_feedback"}`
+  returns a non-nil error (unregistered), mirroring `nomcp_test.go:255-262`.
+- Add a `RoutesOnly:true, NoFeedbackTool:true` sub-case asserting the surface is **exactly**
+  `["status"]` (a set equality, not a subset check) — this is the sibling's actual ask.
+
+Reuse `toolNames` (already in `nomcp_test.go:268`). Write a local server builder modelled on
+`nomcpTestServer` (`nomcp_test.go:122-166`) — including its `AILANG_STDLIB_PATH` walk-up, which is
+required or `LoadModules` fails.
+
+**M1.4 (cuttable, ~20min)** In `registerFeedbackTool`'s call site, when the built-in **is** registered
+and `srv.routesOnly` is true, `log.Printf` one line to stderr: name the tool and name
+`--no-feedback-tool`. Capture-and-assert it with the `log.SetOutput(&buf)` pattern from
+`cold_start_test.go:121-129`. This is the CLAUDE.md §2 "not silent" mitigation for keeping the
+default.
+
+**Verify**:
+```bash
+go test ./internal/apiserver/ -run 'TestFeedbackTool|TestNoMCP|TestHandleSubmitFeedback' -v
+go test ./internal/apiserver/
+```
+
+**Mutation proofs (all three required; each must be applied, observed red, and reverted):**
+
+| # | Mutation | Must fail |
+|---|---|---|
+| MUT-1a | Revert `mcp.go` to the unconditional `ms.registerFeedbackTool()` | `TestFeedbackTool_SuppressedWhenConfigured` |
+| MUT-1b | Delete the `ms.registerFeedbackTool()` call entirely | `TestFeedbackTool_PresentByDefault` |
+| MUT-1c | Drop `noFeedbackTool: cfg.NoFeedbackTool` from `New()` (leave the field zero) | `TestFeedbackTool_SuppressedWhenConfigured` — this proves the `Config`→`Server` wiring, which MUT-1a does not |
+
+---
+
+### M2 — CLI flag `--no-feedback-tool` + end-to-end stdio proof (~2.0h, ~10 prod + ~130 test LOC)
+
+**Files**: `cmd/ailang/serve_api.go`, `cmd/ailang/serve_api_mcp_surface_test.go` (new).
+
+**M2.1** Add the flag next to `routesOnlyFlag` (`serve_api.go:33`):
+
+```go
+noFeedbackToolFlag := fs.Bool("no-feedback-tool", false,
+    "Suppress the built-in submit_feedback MCP tool (exact tool surface)")
+```
+
+and `NoFeedbackTool: *noFeedbackToolFlag` in the `apiserver.Config` literal (`serve_api.go:~128-141`).
+
+**M2.2** Add a line to `printServeAPIHelp()` (`serve_api.go:~258`, after `--routes-only`).
+
+**M2.3 — the end-to-end proof.** `--mcp` is **pure stdio: it binds no socket**, so it is fully
+runnable under the executor's sandbox. Build the binary into `t.TempDir()` with `exec.Command("go","build",...)`,
+then drive two probes with a real `initialize` → `notifications/initialized` → `tools/list` handshake
+against a one-`@route`-plus-one-plain-export module:
+
+- default → asserts `submit_feedback` present, user tool present;
+- `--no-feedback-tool` → asserts `submit_feedback` absent, user tool present **in the same response**.
+
+**Framing requirements — these are the difference between a test and a broken instrument.** The
+controller's first probe of this exact handshake returned empty lists with `rc=1` /
+`server is closing: EOF`. Therefore:
+
+- **Do not** close stdin and then read. Keep stdin open; read stdout line-by-line with
+  `bufio.Scanner` until the JSON-RPC object with `"id":2` arrives; only then close.
+- **Do not** use fixed `sleep`s for sequencing. Wait for the `initialize` **response** (`id:1`)
+  before sending `notifications/initialized`.
+- Wrap the whole probe in a 30s `context.WithTimeout`; on timeout, fail with the captured **stderr**
+  attached (that is where module-load errors go).
+- Guard with `if testing.Short() { t.Skip(...) }` so `go test -short` stays fast.
+- If a probe returns an **empty** tool list, the test must `t.Fatal` with "instrument failure —
+  positive control missing", never pass.
+
+**Verify**:
+```bash
+go test ./cmd/ailang/ -run TestServeAPI_MCPToolSurface -v
+go build ./... && go vet ./internal/apiserver/ ./cmd/ailang/
+```
+
+> **Sandbox note for the executor**: do **not** run the whole `cmd/ailang` package. Six test files
+> there (`configdriven_*`, `messages_send_test.go`) call `httptest.NewServer` / `net.Listen` and will
+> fail with `bind: operation not permitted` — a sandbox artefact, **not** a regression. Always use
+> `-run`. If you ever do run the package, label any bind failure
+> **UNINFORMATIVE UNDER SANDBOX** in your report so the controller re-runs it outside.
+
+**Mutation proof**: delete `NoFeedbackTool: *noFeedbackToolFlag` from the `Config` literal →
+`TestServeAPI_MCPToolSurface` must fail on the suppressed row. (This is the *only* guard that covers
+the CLI wiring line; M1's tests cannot see it.)
+
+**Cut-down if M2.3 exceeds 2h** (see §7): keep M2.1/M2.2, drop the in-test `go build`, and instead
+record the manual command + its output verbatim in the milestone commit message, clearly labelled
+`MANUALLY VERIFIED, NOT CI-GUARDED`. Do not silently ship an unguarded flag.
+
+---
+
+### M3 — CUTTABLE: gate A2A `tasks/send` on `isExposed` (~1.25h, ~8 prod + ~90 test LOC)
+
+**Files**: `internal/apiserver/a2a.go`, `internal/apiserver/a2a_dispatch_gate_test.go` (new).
+
+**M3.1** In `handleA2ATaskSend` (`a2a.go:~183-193`), the existence loop currently sets `found` on a
+name match alone. Require exposure too:
+
+```go
+for _, e := range modInfo.Exports {
+    if e.Name == funcName {
+        found = s.isExposed(e)   // hidden exports are indistinguishable from absent
+        break
+    }
+}
+```
+
+**Error shape is a deliberate design point, not an oversight**: reuse the existing
+`-32602 function %q not found in module %q` message unchanged. `docs/docs/guides/serve-api.md:1312`
+states the project convention explicitly — `FUNCTION_NOT_FOUND` is *"intentionally indistinguishable
+so `@noexpose` reveals nothing to external callers."* Do **not** invent a "function is hidden" error.
+
+**M3.2** Test with positive control in the same test:
+
+- `RoutesOnly:true` + `tasks/send` on the non-`@route` export → JSON-RPC error `-32602`
+  (**not** a 200 task result, and not an engine-level failure message);
+- same server, `tasks/send` on the `@route` export → a completed task result (positive control:
+  proves dispatch still works and the test is not just erroring on everything);
+- `@noexpose` export with `RoutesOnly:false` → `-32602`.
+
+Socket-free: `srv.a2aEnabled = true; mux := srv.buildRoutes()` + `httptest.NewRequest`/`NewRecorder`.
+(Confirmed working — this is exactly how I found the bug.)
+
+**Verify**: `go test ./internal/apiserver/ -run 'TestA2A' -v`
+
+**Mutation proof**: revert `found = s.isExposed(e)` to `found = true` →
+`TestA2ADispatch_RespectsRoutesOnly` must fail with the hidden export reaching the engine.
+
+**If cut**: file a GitHub issue titled *"A2A tasks/send bypasses --routes-only / @noexpose (card-only
+filtering)"* with the probe output from §0 R-C, and say so in the sprint report. Do not drop it silently.
+
+---
+
+### M4 — Docs: the `--caps` split, the `--routes-only` promise, the new flag (~1.25h, ~60 doc lines)
+
+**Files**: `docs/docs/guides/serve-api.md`, `docs/docs/guides/agent-mcp.md`, `CHANGELOG.md`.
+
+**M4.1 `serve-api.md`, flag list (~line 525)** — add `--no-feedback-tool` after `--routes-only`.
+(Note: this block has already drifted from the CLI — it is missing `--a2a`, `--log-level`,
+`--max-memory`. Adding those is **optional**; if it takes more than 5 minutes, skip it and say so.)
+
+**M4.2 `serve-api.md`, MCP "Filtering" bullet (~line 399)** — it currently reads
+*"`--routes-only` and `@noexpose` are respected in MCP `tools/list`, consistent with HTTP and
+OpenAPI."* That is now the misleading sentence. Amend it to state that these filters apply to
+**module exports**, that the server registers one built-in Go-side tool (`submit_feedback`) which is
+**not** an export and is therefore not affected by them, and that `--no-feedback-tool` removes it.
+
+**M4.3 `serve-api.md`, new subsection after `--routes-only` (~line 1090)** —
+`### --no-feedback-tool — Exact MCP tool surface`: what it does, the `--routes-only --no-feedback-tool`
+recipe for an exact `@route` surface, that it covers `--mcp` and `--mcp-http` identically, and that
+A2A skills never included the built-in in the first place.
+
+**M4.4 `serve-api.md`, the `--caps` discovery/execution note** — near the `--caps` docs (~line 716)
+and in the MCP section: **`--caps` gates effect *execution*, not tool *discovery*.** A tool whose
+effects are not granted is still advertised in `tools/list`; the failure surfaces at call time. Give
+the measured example: `--caps ''` leaves the tool list unchanged. State plainly that `--caps` is
+**not** a discovery filter and that `--routes-only` / `@noexpose` / `@nomcp` / `--no-feedback-tool`
+are the discovery controls.
+
+**M4.5 `agent-mcp.md` (~line 127)** — one clarifying sentence: the public server's
+`--mcp-http --routes-only` invocation **intentionally** keeps `submit_feedback` (it is that server's
+purpose), and self-hosted operators who want an exact surface add `--no-feedback-tool`. This is the
+line that stops a future reader from "fixing" `--routes-only` and breaking production.
+
+**M4.6 `CHANGELOG.md`** — under `## [Unreleased] / ### Added`, one entry for the flag naming
+`refs #498`; under `### Fixed`, M3 if it shipped. Say explicitly that the default is unchanged.
+
+**Verify**:
+```bash
+make check-file-sizes
+gofmt -l ./internal/apiserver ./cmd/ailang   # must print nothing
+make lint
+go test ./internal/apiserver/
+```
+Plus a manual grep that the three claims added to the docs are true of the code as committed.
+
+---
+
+## 5. Sequencing and commits
+
+| order | commit | depends on |
+|---|---|---|
+| 1 | `fix(apiserver): --no-feedback-tool suppresses the built-in MCP tool (refs #498)` (M1) | — |
+| 2 | `feat(cli): serve-api --no-feedback-tool + stdio tool-surface E2E (refs #498)` (M2) | M1 |
+| 3 | `fix(apiserver): A2A tasks/send now honours --routes-only/@noexpose` (M3) | independent of 1–2 |
+| 4 | `docs(serve-api): --caps gates execution not discovery; document --no-feedback-tool (refs #498)` (M4) | 1–3 |
+
+Use `refs #498` throughout. **Do not use `Fixes #498`** — #498's stated resolution is the Lane B
+embedder API; Lane A is explicitly the *interim* unblock and must not auto-close the issue. Post a
+comment on #498 instead, saying which of the seven requested behaviours (only #6) Lane A delivers.
+
+---
+
+## 6. Estimate, bottom-up (not top-down)
+
+| item | h |
+|---|---|
+| M1.1 Config/Server/New wiring | 0.2 |
+| M1.2 guard + doc comment | 0.1 |
+| M1.3 four tests + server builder | 1.0 |
+| M1.4 stderr notice + log-capture test | 0.35 |
+| M1 mutation proofs (3 × build/run/revert) | 0.35 |
+| M2.1/M2.2 flag + help | 0.25 |
+| M2.3 stdio E2E (build-in-test, framing, timeout, 2 probes) | 1.5 |
+| M2 mutation proof | 0.25 |
+| M3.1 gate | 0.3 |
+| M3.2 tests (3 cases) | 0.75 |
+| M3 mutation proof | 0.2 |
+| M4 docs (5 edits) + CHANGELOG | 1.0 |
+| M4 lint/fmt/file-size/full-package run | 0.25 |
+| **subtotal** | **6.5** |
+| +20% unknowns | 1.3 |
+| **total** | **~7.8h ≈ 1.0 day** |
+
+**This is the top of the 0.5–1.0d box, not the bottom, and I am saying so rather than absorbing it.**
+The production diff really is ~43 lines; the cost is entirely in *proving* it — three mutation
+proofs, a hand-rolled JSON-RPC stdio handshake that has already broken once for the controller, and
+five doc edits that each make a factual claim about behaviour. Without M2.3 and M3 the sprint is
+~4.5h; both are defensible cuts (§7) and both have a named consequence.
+
+**Velocity check**: comparable recent single-concern fixes in this repo — `a089a6fe7` (nightly
+validity gate), `9253ec8a8` (Z3 hard timeout), `5998f4039` (SMT ADT declarations) — each landed as
+one PR inside a day. This is in family.
+
+---
+
+## 7. Cut order (if the budget bites, cut in this order and SAY SO)
+
+1. **M1.4** (stderr notice) — costs the §2 "not silent" mitigation. Cheapest cut.
+2. **M2.3** (stdio E2E) → M2-lite with a recorded manual verification. Costs CI coverage of the CLI
+   wiring line; the mutation becomes undetectable in CI. Must be labelled in the commit.
+3. **M3** (A2A gate) → file the issue with the §0 R-C probe output. Costs a real security-relevant
+   fix, but it is genuinely a different bug from #498.
+
+**Never cut**: M1 (the fix), M2.1/M2.2 (the flag is useless without a CLI surface), M4.4 (the
+`--caps` note is half of the chartered Lane A deliverable).
+
+---
+
+## 8. Risks the executor must actively guard
+
+| # | risk | guard |
+|---|---|---|
+| R1 | **Changing `--routes-only` semantics.** The tempting "honest" fix silently kills the live public MCP server (D1). | `--routes-only` behaviour must be **byte-identical** after this sprint. `TestIsExposed_RoutesOnly*` (`filtering_test.go:78-113`) and `mcp_schema_test.go:107-265` must pass **unmodified**. If you find yourself editing either, stop. |
+| R2 | **Empty-list false pass.** "`submit_feedback` not in tools" passes against a broken instrument. | Every absence assertion carries a presence assertion on the **same** response object. Any empty tool list is a `t.Fatal`, never a pass. |
+| R3 | **Sandbox socket denial misread as a regression.** | `internal/apiserver` is socket-free (verified: no `httptest.NewServer`/`net.Listen`; package runs in 0.71s). `cmd/ailang` is **not** — always use `-run`. Label any `bind: operation not permitted` as **UNINFORMATIVE UNDER SANDBOX**. |
+| R4 | **Lane B drift.** #498's headline ask is a callback-driven embedder API. | No new exported types on `apiserver` beyond one `Config` field. No `http.Handler` export. No per-request/per-principal anything. If a change needs a new public interface, it is Lane B — stop and report. |
+| R5 | **Chasing the `std/io` leak** (R-B) — it did not reproduce and is a much bigger fix. | Out of scope. Report it; do not scope it. |
+| R6 | **Deleting `feedback_tool_test.go`.** Those tests hand-build `&MCPServer{}` and look "orphaned" once registration is conditional. CLAUDE.md coding-standards: never delete on a linter's say-so. | All 5 tests in `feedback_tool_test.go` must still pass, untouched. |
+| R7 | **Negative-boolean confusion.** `NoFeedbackTool` inverts twice (`if !srv.noFeedbackTool`). An inverted wiring bug passes a "flag exists" test. | MUT-1c exists precisely for this; the default-present test (M1.3 #1) catches the other polarity. |
+| R8 | **M3 leaking information via a new error message.** | Reuse the existing `-32602` text verbatim (serve-api.md:1312 convention). |
+
+---
+
+## 9. Acceptance criteria
+
+- [ ] `serve-api --mcp --no-feedback-tool DIR` → `tools/list` has **no** `submit_feedback` and **does** have the user's exports.
+- [ ] `serve-api --mcp --routes-only --no-feedback-tool DIR` → `tools/list` is **exactly** the `@route` set.
+- [ ] `serve-api --mcp DIR` (no flag) → `submit_feedback` still present. **Default is unchanged.**
+- [ ] `--mcp-http` behaves identically to `--mcp` (same `NewMCPServer` path; asserted in M1, no separate transport test needed).
+- [ ] `tools/call submit_feedback` errors when suppressed.
+- [ ] Every new test carries a positive control; no absence assertion can pass on an empty list.
+- [ ] All named mutations (MUT-1a/1b/1c, M2, M3) observed **red**, then reverted — with the failing test names quoted in the sprint report.
+- [ ] `--routes-only` semantics unchanged; `filtering_test.go` and `mcp_schema_test.go` pass unmodified.
+- [ ] Docs state: `--caps` gates execution not discovery; `--routes-only` filters exports not built-ins; `--no-feedback-tool` exists.
+- [ ] `go test ./internal/apiserver/` green; `make lint`, `gofmt -l`, `make check-file-sizes` clean.
+- [ ] CHANGELOG `[Unreleased]` updated; `refs #498` on every commit; **no** `Fixes #498`.
+- [ ] Sprint report states explicitly which milestones were cut, if any, and what was filed instead.
+
+---
+
+## 10. Handoff notes for the executor
+
+- Work **only** in the worktree. The main checkout is dirty with a sibling agent's work — do not
+  touch it, do not `git checkout`, do not `git stash`.
+- The controller's `--a2a` premise is **refuted** (§0 R-A). If you find yourself writing a test that
+  asserts `submit_feedback` is gone from the A2A card, you are writing a test that already passes.
+  Stop and re-read §0.
+- The reproduction is cheap and socket-free; reproduce it yourself before you fix anything, and
+  paste the before/after tool lists into your report.
+- If you refute anything in **this** plan, say so loudly. Two of the last three iterations shipped a
+  false "verified" fact to the next role; both were caught by the next role re-checking. That is the
+  loop working.

--- a/docs/docs/guides/agent-mcp.md
+++ b/docs/docs/guides/agent-mcp.md
@@ -126,6 +126,7 @@ If you ask for a version that isn't in the snapshot, you get `{error: "unknown_v
 
 - Cloud Run service runs `ailang serve-api --mcp-http --routes-only --caps FS,Env`
 - `--routes-only` means only `@mcp_name`/`@route` exports register as tools — no helper leakage
+- The public service intentionally keeps the Go-side `submit_feedback` built-in despite `--routes-only`; self-hosted operators who need an exact export-only surface add `--no-feedback-tool`
 - `--caps FS,Env` is the only ambient authority (filesystem reads from the baked snapshot, env reads for snapshot dir config). `Net` is added in v0.15+ when `submit_feedback` publishes to the existing `ailang-messages` Pub/Sub topic
 - Tool replies are deterministic for a given image SHA — replays are byte-identical
 

--- a/docs/docs/guides/serve-api.md
+++ b/docs/docs/guides/serve-api.md
@@ -396,7 +396,8 @@ Each exported AILANG function becomes an MCP tool. Module metadata is available 
 - **Named parameter schemas** — `inputSchema` uses named parameters with JSON Schema types (e.g., `{"filepath": {"type": "string"}}`) instead of generic positional arrays. Types are mapped from AILANG: `string`→`"string"`, `int`→`"integer"`, `float`→`"number"`, `bool`→`"boolean"`, `Json`/records→`"object"`, lists→`"array"`.
 - **Doc comment descriptions** — `--` comment lines immediately above a function are used as the MCP tool description. Functions without doc comments fall back to the type signature.
 - **MCP-compliant tool names** — All names match the strict regex `^[a-zA-Z0-9_-]{1,64}$` required by Claude Desktop and most current MCP clients. Resolution order: (1) `@mcp_name("name")` author override, (2) bare function name when globally unique (e.g. `mcpParse`), (3) `<lastModuleSegment>_<funcName>` fallback for collisions (e.g. `services_parseCsv`), (4) deterministic hash suffix when truncated to 64 chars. Use `@mcp_name("parse")` to control the exact tool name surfaced to MCP clients.
-- **Filtering** — `--routes-only` and `@noexpose` are respected in MCP `tools/list`, consistent with HTTP and OpenAPI. `@nomcp` additionally hides a handler from `tools/list`/`tools/call` while keeping it served over HTTP/OpenAPI/A2A (MCP-only exclusion). With `--routes-only`, undocumented non-route helpers are also auto-excluded from MCP.
+- **Filtering** — `--routes-only` and `@noexpose` filter module exports in MCP `tools/list`, consistent with HTTP and OpenAPI. `@nomcp` additionally hides an export from `tools/list`/`tools/call` while keeping it served over HTTP/OpenAPI/A2A (MCP-only exclusion). The Go-side built-in `submit_feedback` is not a module export, so these filters do not affect it; use `--no-feedback-tool` to remove it. With `--routes-only`, undocumented non-route helpers are auto-excluded from MCP.
+- **Capabilities versus discovery** — `--caps` gates effect execution, not tool discovery. Exports remain advertised in `tools/list` when their effects are not granted and fail only when called. Even `--caps ''` leaves the tool list unchanged. Use `--routes-only`, `@noexpose`, `@nomcp`, and `--no-feedback-tool` to control discovery.
 - **Backward compatible** — Tool handlers accept both named parameters (`{"filepath": "doc.pdf"}`) and legacy positional format (`{"args": ["doc.pdf"]}`).
 - **Missing-parameter rejection** — A `tools/call` that omits a declared parameter (absent key) or sends it as JSON `null` is rejected with a structured `missing required parameter(s): <names>` error (`isError: true`) **before** the function runs. The names are listed in declaration order. This is type-agnostic — an omitted `int` param is rejected the same way as a `string`. Without this guard the omitted value bound to `nil`→Unit and crashed deep in stdlib (e.g. `_str_len: expected String, got Unit`) with no actionable message. The legacy positional `{"args": [...]}` form is unaffected (it opts out of named binding entirely).
 
@@ -523,6 +524,7 @@ Flags:
   --api-key-header H   HTTP header name for API key authentication
   --api-key-env VAR    Environment variable containing the expected API key
   --routes-only        Only expose @route-annotated functions (skip auto-generated endpoints)
+  --no-feedback-tool   Suppress the built-in submit_feedback MCP tool (exact tool surface)
 
 Arguments:
   <path...>            One or more .ail files or directories
@@ -724,6 +726,12 @@ ailang serve-api --caps IO,AI --ai gemini-2-5-flash ./api/
 # Use stub AI handler for testing (returns fixed responses)
 ailang serve-api --caps IO,AI --ai-stub ./api/
 ```
+
+`--caps` controls which effects may execute; it does not filter HTTP endpoints or
+MCP discovery. A function whose effects are not granted is still advertised in
+`tools/list` and fails at call time. In particular, `--caps ''` leaves the tool
+list unchanged. For discovery filtering, use `--routes-only`, `@noexpose`,
+`@nomcp`, and `--no-feedback-tool`.
 
 #### Capability Reference
 
@@ -1086,6 +1094,21 @@ This is useful when your project has many exported functions for cross-module us
 - `--routes-only` hides **all** non-`@route` exports
 - `@noexpose` hides **specific** exports regardless of `--routes-only`
 - `@route` functions are always exposed
+
+### `--no-feedback-tool` — Exact MCP Tool Surface
+
+AILANG normally registers the Go-side `submit_feedback` built-in in addition to
+module exports. Pass `--no-feedback-tool` to suppress that built-in without
+changing which user exports are exposed:
+
+```bash
+ailang serve-api --mcp --routes-only --no-feedback-tool ./api/
+```
+
+This combination produces exactly the `@route` export set. The flag behaves
+identically for stdio `--mcp` and HTTP `--mcp-http`, because both use the same
+MCP server construction path. A2A agent-card skills never include the
+MCP-only built-in.
 
 ---
 

--- a/internal/apiserver/a2a.go
+++ b/internal/apiserver/a2a.go
@@ -182,7 +182,7 @@ func (s *Server) handleA2ATaskSend(w http.ResponseWriter, req *a2aRequest) {
 	var found bool
 	for _, e := range modInfo.Exports {
 		if e.Name == funcName {
-			found = true
+			found = s.isExposed(e)
 			break
 		}
 	}

--- a/internal/apiserver/a2a_dispatch_gate_test.go
+++ b/internal/apiserver/a2a_dispatch_gate_test.go
@@ -37,8 +37,18 @@ func requireA2ANotFound(t *testing.T, resp map[string]any) {
 	if got := errObj["code"]; got != float64(-32602) {
 		t.Fatalf("error code = %v, want -32602; response: %#v", got, resp)
 	}
-	if msg, _ := errObj["message"].(string); !strings.Contains(msg, "not found in module") {
+	msg, _ := errObj["message"].(string)
+	if !strings.Contains(msg, "not found in module") {
 		t.Errorf("error message = %q, want existing indistinguishable not-found shape", msg)
+	}
+	// The point of reusing -32602 is that a hidden function is
+	// indistinguishable from an absent one. The HTTP not-found path appends
+	// an "(available: [...])" list; if that ever gets copied onto the A2A
+	// path it would enumerate the visible surface to a caller who was
+	// explicitly denied it, turning the gate into a disclosure channel.
+	// Assert the leak is absent, not merely that the prefix is right.
+	if strings.Contains(msg, "available:") {
+		t.Errorf("error message = %q leaks the visible function list; hidden must stay indistinguishable from absent", msg)
 	}
 }
 

--- a/internal/apiserver/a2a_dispatch_gate_test.go
+++ b/internal/apiserver/a2a_dispatch_gate_test.go
@@ -1,0 +1,80 @@
+package apiserver
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func sendA2ATestTask(t *testing.T, srv *Server, skillID string) map[string]any {
+	t.Helper()
+	body := `{
+		"jsonrpc":"2.0",
+		"id":1,
+		"method":"tasks/send",
+		"params":{
+			"metadata":{"skill_id":"` + skillID + `"},
+			"message":{"role":"user","parts":[{"type":"data","data":{"args":[]}}]}
+		}
+	}`
+	req := httptest.NewRequest("POST", "/a2a/", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.buildRoutes().ServeHTTP(w, req)
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response %q: %v", w.Body.String(), err)
+	}
+	return resp
+}
+
+func requireA2ANotFound(t *testing.T, resp map[string]any) {
+	t.Helper()
+	errObj, ok := resp["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("hidden function reached dispatch; response: %#v", resp)
+	}
+	if got := errObj["code"]; got != float64(-32602) {
+		t.Fatalf("error code = %v, want -32602; response: %#v", got, resp)
+	}
+	if msg, _ := errObj["message"].(string); !strings.Contains(msg, "not found in module") {
+		t.Errorf("error message = %q, want existing indistinguishable not-found shape", msg)
+	}
+}
+
+func TestA2ADispatch_RespectsRoutesOnly(t *testing.T) {
+	srv := feedbackSurfaceServer(t, Config{RoutesOnly: true, A2A: true})
+	defer srv.Close()
+
+	hidden := sendA2ATestTask(t, srv, "test.api.surface.helper")
+	requireA2ANotFound(t, hidden)
+
+	visible := sendA2ATestTask(t, srv, "test.api.surface.status")
+	result, ok := visible["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("positive control route did not dispatch: %#v", visible)
+	}
+	status, ok := result["status"].(map[string]any)
+	if !ok || status["state"] != "completed" {
+		t.Fatalf("positive control route did not complete: %#v", visible)
+	}
+}
+
+func TestA2ADispatch_RespectsNoExpose(t *testing.T) {
+	srv := nomcpTestServer(t)
+	defer srv.Close()
+	srv.a2aEnabled = true
+
+	hidden := sendA2ATestTask(t, srv, "test.api.keys.internalSecret")
+	requireA2ANotFound(t, hidden)
+
+	visible := sendA2ATestTask(t, srv, "test.api.keys.status")
+	result, ok := visible["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("positive control route did not dispatch: %#v", visible)
+	}
+	status, ok := result["status"].(map[string]any)
+	if !ok || status["state"] != "completed" {
+		t.Fatalf("positive control route did not complete: %#v", visible)
+	}
+}

--- a/internal/apiserver/feedback_tool_surface_test.go
+++ b/internal/apiserver/feedback_tool_surface_test.go
@@ -1,0 +1,158 @@
+package apiserver
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func feedbackSurfaceServer(t *testing.T, cfg Config) *Server {
+	t.Helper()
+
+	apiDir := filepath.Join(t.TempDir(), "test", "api")
+	if err := os.MkdirAll(apiDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	modPath := filepath.Join(apiDir, "surface.ail")
+	content := `module test/api/surface
+
+@route("GET", "/status")
+export pure func status() -> string = "ok"
+
+export pure func helper() -> string = "helper"
+`
+	if err := os.WriteFile(modPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if os.Getenv("AILANG_STDLIB_PATH") == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		for dir := cwd; dir != filepath.Dir(dir); dir = filepath.Dir(dir) {
+			if _, err := os.Stat(filepath.Join(dir, "stdlib")); err == nil {
+				t.Setenv("AILANG_STDLIB_PATH", dir)
+				break
+			}
+		}
+	}
+	srv := New(filepath.Dir(filepath.Dir(apiDir)), cfg)
+	if err := srv.LoadModules([]string{modPath}); err != nil {
+		srv.Close()
+		t.Fatalf("LoadModules: %v", err)
+	}
+	return srv
+}
+
+func listFeedbackSurfaceTools(t *testing.T, srv *Server) (*mcp.ListToolsResult, *mcp.ClientSession) {
+	t.Helper()
+	ms := NewMCPServer(srv)
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	serverSession, err := ms.mcpServer.Connect(context.Background(), serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = serverSession.Close() })
+	client := mcp.NewClient(&mcp.Implementation{Name: "surface-test", Version: "1"}, nil)
+	clientSession, err := client.Connect(context.Background(), clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = clientSession.Close() })
+	res, err := clientSession.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if len(res.Tools) == 0 {
+		t.Fatal("instrument failure - positive control missing: empty tools/list")
+	}
+	return res, clientSession
+}
+
+func feedbackToolSet(tools []*mcp.Tool) map[string]bool {
+	names := make(map[string]bool, len(tools))
+	for _, tool := range tools {
+		names[tool.Name] = true
+	}
+	return names
+}
+
+func TestFeedbackTool_PresentByDefault(t *testing.T) {
+	srv := feedbackSurfaceServer(t, Config{})
+	defer srv.Close()
+	res, _ := listFeedbackSurfaceTools(t, srv)
+	names := feedbackToolSet(res.Tools)
+	if !names["status"] {
+		t.Fatalf("positive control status missing; tools: %v", toolNames(res.Tools))
+	}
+	if !names["submit_feedback"] {
+		t.Errorf("submit_feedback missing by default; tools: %v", toolNames(res.Tools))
+	}
+}
+
+func TestFeedbackTool_SuppressedWhenConfigured(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+		want []string
+	}{
+		{"all user exports", Config{NoFeedbackTool: true}, []string{"helper", "status"}},
+		{"routes only exact surface", Config{RoutesOnly: true, NoFeedbackTool: true}, []string{"status"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := feedbackSurfaceServer(t, tc.cfg)
+			defer srv.Close()
+			res, _ := listFeedbackSurfaceTools(t, srv)
+			names := feedbackToolSet(res.Tools)
+			if !names["status"] {
+				t.Fatalf("instrument failure - positive control status missing; tools: %v", toolNames(res.Tools))
+			}
+			if names["submit_feedback"] {
+				t.Errorf("submit_feedback present when suppressed; tools: %v", toolNames(res.Tools))
+			}
+			got := toolNames(res.Tools)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("tools = %v, want exact surface %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFeedbackTool_SuppressedIsAlsoUncallable(t *testing.T) {
+	srv := feedbackSurfaceServer(t, Config{NoFeedbackTool: true})
+	defer srv.Close()
+	res, session := listFeedbackSurfaceTools(t, srv)
+	if !feedbackToolSet(res.Tools)["status"] {
+		t.Fatalf("instrument failure - positive control status missing; tools: %v", toolNames(res.Tools))
+	}
+	if _, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "submit_feedback", Arguments: map[string]any{},
+	}); err == nil {
+		t.Error("CallTool submit_feedback should error when suppressed")
+	}
+}
+
+func TestFeedbackTool_RoutesOnlyNotice(t *testing.T) {
+	var buf bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(previous) })
+
+	srv := feedbackSurfaceServer(t, Config{RoutesOnly: true})
+	defer srv.Close()
+	res, _ := listFeedbackSurfaceTools(t, srv)
+	names := feedbackToolSet(res.Tools)
+	if !names["status"] || !names["submit_feedback"] {
+		t.Fatalf("positive controls missing; tools: %v", toolNames(res.Tools))
+	}
+	if got := buf.String(); !strings.Contains(got, "submit_feedback") || !strings.Contains(got, "--no-feedback-tool") {
+		t.Errorf("notice = %q, want tool and suppression flag", got)
+	}
+}

--- a/internal/apiserver/mcp.go
+++ b/internal/apiserver/mcp.go
@@ -23,7 +23,8 @@ type MCPServer struct {
 // NewMCPServer creates an MCP server from an apiserver.Server.
 // All loaded modules' exported functions are registered as MCP tools.
 //
-// The submit_feedback tool is rate-limited per-client-IP via env vars
+// Unless suppressed by Config.NoFeedbackTool, the submit_feedback tool is
+// registered and rate-limited per-client-IP via env vars
 // (AILANG_RATELIMIT_RPM, AILANG_RATELIMIT_BURST). Read-only tools are not
 // throttled — they're idempotent and cacheable.
 func NewMCPServer(srv *Server) *MCPServer {
@@ -40,7 +41,12 @@ func NewMCPServer(srv *Server) *MCPServer {
 
 	ms.registerTools()
 	ms.registerResources()
-	ms.registerFeedbackTool()
+	if !srv.noFeedbackTool {
+		if srv.routesOnly {
+			log.Printf("MCP tool submit_feedback remains enabled with --routes-only; use --no-feedback-tool to suppress it")
+		}
+		ms.registerFeedbackTool()
+	}
 
 	return ms
 }

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -74,15 +74,16 @@ type Server struct {
 	watchPaths []string // absolute paths of loaded .ail files (for reload mapping)
 
 	// Protocol support
-	mcpEnabled    bool                // serve MCP at /mcp/
-	mcpOnly       bool                // stdio-only MCP mode (no HTTP)
-	a2aEnabled    bool                // serve A2A at /.well-known/agent.json and /a2a/
-	maxUploadSize int64               // maximum upload size in bytes (0 = use DefaultMaxUploadSize)
-	apiKeyHeader  string              // HTTP header name for API key auth
-	apiKeyEnv     string              // env var containing expected API key
-	effCtx        *effects.EffContext // for Debug output collection
-	logLevel      int                 // minimum severity for Debug output
-	routesOnly    bool                // only expose @route-annotated functions
+	mcpEnabled     bool                // serve MCP at /mcp/
+	mcpOnly        bool                // stdio-only MCP mode (no HTTP)
+	a2aEnabled     bool                // serve A2A at /.well-known/agent.json and /a2a/
+	maxUploadSize  int64               // maximum upload size in bytes (0 = use DefaultMaxUploadSize)
+	apiKeyHeader   string              // HTTP header name for API key auth
+	apiKeyEnv      string              // env var containing expected API key
+	effCtx         *effects.EffContext // for Debug output collection
+	logLevel       int                 // minimum severity for Debug output
+	routesOnly     bool                // only expose @route-annotated functions
+	noFeedbackTool bool                // suppress the built-in submit_feedback MCP tool
 }
 
 // ModuleInfo holds metadata about a loaded AILANG module.
@@ -149,20 +150,21 @@ type ExportInfo struct {
 
 // Config holds configuration for the API server.
 type Config struct {
-	Port          string
-	CORS          bool
-	FrontendPath  string      // optional: React project path for Vite proxy
-	StaticPath    string      // optional: built frontend files
-	Watch         bool        // enable file watching for hot reload
-	EffCtx        interface{} // optional: pre-configured effect context (*effects.EffContext)
-	MCP           bool        // enable MCP endpoint at /mcp/
-	MCPOnly       bool        // run as MCP stdio server only (no HTTP)
-	A2A           bool        // enable A2A endpoints (/.well-known/agent.json, /a2a/)
-	MaxUploadSize int64       // max upload size in bytes (0 = DefaultMaxUploadSize)
-	APIKeyHeader  string      // HTTP header for API key auth (empty = no auth)
-	APIKeyEnv     string      // env var containing expected API key
-	LogLevel      int         // minimum severity for Debug output (0=DEBUG, 1=INFO, 2=WARN, 3=ERROR, 4=NONE)
-	RoutesOnly    bool        // only expose @route-annotated functions as HTTP endpoints
+	Port           string
+	CORS           bool
+	FrontendPath   string      // optional: React project path for Vite proxy
+	StaticPath     string      // optional: built frontend files
+	Watch          bool        // enable file watching for hot reload
+	EffCtx         interface{} // optional: pre-configured effect context (*effects.EffContext)
+	MCP            bool        // enable MCP endpoint at /mcp/
+	MCPOnly        bool        // run as MCP stdio server only (no HTTP)
+	A2A            bool        // enable A2A endpoints (/.well-known/agent.json, /a2a/)
+	MaxUploadSize  int64       // max upload size in bytes (0 = DefaultMaxUploadSize)
+	APIKeyHeader   string      // HTTP header for API key auth (empty = no auth)
+	APIKeyEnv      string      // env var containing expected API key
+	LogLevel       int         // minimum severity for Debug output (0=DEBUG, 1=INFO, 2=WARN, 3=ERROR, 4=NONE)
+	RoutesOnly     bool        // only expose @route-annotated functions as HTTP endpoints
+	NoFeedbackTool bool        // suppress the built-in submit_feedback MCP tool; user exports unaffected
 }
 
 // New creates a new API server.
@@ -216,6 +218,7 @@ func New(basePath string, cfg Config) *Server {
 		effCtx:             storedEffCtx,
 		logLevel:           cfg.LogLevel,
 		routesOnly:         cfg.RoutesOnly,
+		noFeedbackTool:     cfg.NoFeedbackTool,
 	}
 }
 


### PR DESCRIPTION
Lane A of `#498` (filed by the sibling Ailang World mission, which records `w-mcp-projection` as BLOCKED on it), plus `#528` found while planning it. V1 mission iteration 120.

## What was wrong

`serve-api` could not project an exact caller-supplied tool surface. Measured first-party at `0f0896c70` over a real MCP stdio handshake:

| flags | `tools/list` |
|---|---|
| (unfiltered) | `[addOne, submit_feedback]` |
| `--routes-only` | `[submit_feedback]` |
| `--caps ''` | `[addOne, submit_feedback]` |
| `--caps IO` | `[addOne, submit_feedback]` |

The `--routes-only` row is the sharp one — the user's own function is filtered out while the Go-side built-in survives. `internal/apiserver/mcp.go:43` called `registerFeedbackTool()` unconditionally, *after* the surface `--routes-only` filters, and `--caps` gates effect execution rather than discovery.

## What changed

- **`--no-feedback-tool`** suppresses the built-in. **Default unchanged** — the live public Cloud Run service documented at `docs/docs/guides/agent-mcp.md:127` runs `--mcp-http --routes-only` with `submit_feedback` as its one write tool, and its config lives in a separate deploy project, so tightening `--routes-only` would open a version-skew window that silently kills the public feedback channel. Per CLAUDE.md §2 the permissive default is not silent: registering under `--routes-only` logs a notice naming the flag (verified to go to **stderr**, so the stdio JSON-RPC stream stays clean).
- **A2A `tasks/send` now gates on `isExposed`** (`#528`). It resolved targets by name alone, so `@noexpose` / `--routes-only` hid a function from the agent card while leaving it callable. HTTP, MCP and OpenAPI all gated; A2A dispatch was the only hole. Reuses the existing `-32602` response verbatim so hidden stays indistinguishable from absent.
- Docs for the `--caps` execution-vs-discovery split.

Verified end-to-end on a fresh binary:

```
default                          [addOne, submit_feedback]
--no-feedback-tool               [addOne]                    <- built-in gone, user tool intact
--routes-only                    [submit_feedback]  + stderr notice
--routes-only --no-feedback-tool []                          <- exact empty surface
```

## Impact bound (deliberately not overstated)

The *discovery* defect is real and unconditional — every connected model is told a public-feedback egress tool exists. But *egress* requires `AILANG_STORAGE=gcp` **and** `AILANG_CLOUD_PROJECT` (`internal/feedback/publisher.go:123-129`). So a default local server **advertises a tool it cannot perform** — a false capability claim, **not** a default-config exfiltration path. `#528` likewise requires `--a2a`, which is off by default.

## Corrections to the issue as filed

- **`--a2a` discovery is NOT affected.** `buildAgentCard` builds skills from `s.modules` + `isExposed` and never touches the MCP registry; `submit_feedback` is absent from `/.well-known/agent.json`. A milestone "fixing" it would have been a no-op shipping green. Both `--mcp` and `--mcp-http` go through `NewMCPServer`, so the transport the sibling consumes *is* covered.
- The `std/io` export leak did not reproduce at HEAD; out of scope, needs its own repro.

## Non-vacuity

Every absence assertion names a known-present tool in the same result set; an empty tool list fails as an instrument failure rather than passing. (The controller's own first probe of this bug returned an empty list because the *probe* was broken — it looked exactly like a clean result.)

Mutation-proved, each reverted byte-identical by `sha256`: unconditional registration → suppression test fails; registration removed → default-present test fails; Config→Server wiring removed → suppression test fails; A2A gate restored to `found = true` → both dispatch tests fail (re-run independently by the controller).

Gates re-run **outside** the executor's sandbox: `go test ./internal/apiserver/...` rc=0, `go test ./cmd/ailang/...` rc=0 (95s, the socket tests the sandbox denies), `gofmt -l` clean, `go vet` rc=0. `go build ./...` fails identically on clean `origin/dev` (`cmd/wasm` build-tag issue) — pre-existing, verified in a detached baseline worktree, not from this diff.

**Lane B** — exporting the serving machinery behind a narrow callback-driven Go API with caller-supplied descriptors — remains a separate design-doc-sized item requiring quorum. Hence `refs`, not `Fixes`, on `#498`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)