### PR TITLE
Anthropic prompt-cache hit rate: make Generate cache-capable, cache the teaching prompt, bank the metric

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,50 @@
 
 ## [Unreleased]
 
+### Fixed — our Anthropic prompt-cache hit rate was structurally zero (M-ANTHROPIC-CACHE-HIT-RATE)
+
+Anthropic told us our organization's prompt-cache hit rate was very low. It was very low because
+the code path carrying essentially all of our Anthropic traffic **could not request a cache at
+all**: `internal/ai/anthropic/client.go` contained zero references to `CacheBreakpoint`.
+M-AI-PROMPT-CACHING (v0.18.4) wired `Step`; every 0-shot eval, classifier call, and `ai.generate`
+goes through `Generate`.
+
+Three things were wrong, and each hid the next:
+
+| | Problem |
+|---|---|
+| Capability | `Generate` had no `cache_control` support whatsoever |
+| Placement | The only implemented breakpoint was `system`, but our reusable content is a ~16K-token teaching prompt in the **user** turn, sat behind a ~70-token system prompt — below every model's minimum cacheable prefix |
+| Visibility | Cache tokens were modelled on `ai.Response` but never persisted; **zero of 28,139** banked result files carried them, so the miss was invisible in our own telemetry |
+
+What changed:
+
+- **`ai.Request.CachedPrefix`** — a provider-neutral carrier for the stable head of a user turn.
+  The model always sees `CachedPrefix + UserPrompt`; only the encoding differs. On Anthropic with a
+  `user_prefix` breakpoint it becomes a two-block content array with `cache_control` on block 0
+  only (a marker on the volatile block would write an entry per request and never read one).
+  Everywhere else it concatenates, byte-identical to v0.30.0.
+- **Caching is ON by default** for the eval harness on Anthropic. Opt-in is exactly why the rate
+  was near zero — the v0.18.4 mechanism shipped and no Go caller ever set it.
+- **Silent no-ops now warn.** Anthropic accepts a too-short `cache_control` marker, returns 200,
+  and quietly declines to cache. A model-tier minimum table (512/1024/2048/4096 — *not* monotonic
+  across generations) drives a one-shot warning naming the model and the shortfall.
+- **Cache tokens are persisted** into banked eval metrics, additive and `omitempty` so pre-v0.31.0
+  baselines still parse.
+
+Two decisions worth recording. The teaching prompt was **not** moved to the system role, though
+that would cache equally well: it changes model inputs and would invalidate every v0.30.0 baseline
+in the same commit as a cost change. Splitting in place keeps the bytes identical. And the
+feedback-gate classifier is measured and deliberately **not** cached — ~439 tokens against
+`claude-haiku-4-5`'s 4096-token minimum, so a breakpoint there would be the exact silent no-op
+this work removes; a test fails if the prompt ever outgrows the minimum.
+
+Not yet proven: that Anthropic actually creates and reads the entries. That needs a live billed
+call and no API key was available in this window. The check is written and gated as
+`TestLiveGeneratePromptCache` (`AILANG_LIVE_ANTHROPIC_CACHE=1`).
+
+Design doc: `design_docs/planned/v0_31_0/m-anthropic-cache-hit-rate.md`
+
 ### Added — the measurement contract: banked data must earn its place (M-EVAL-MEASUREMENT-CONTRACT)
 
 The eval pipeline could not distinguish **"the subject was measured and did badly"** from

--- a/cmd/ailang/eval_cache_warmup.go
+++ b/cmd/ailang/eval_cache_warmup.go
@@ -139,15 +139,24 @@ func warmOneCache(ctx context.Context, key cacheWarmupKey, sample Job, timeout t
 		return fmt.Errorf("no cacheable base prompt for language %q", key.language)
 	}
 
-	agent, err := eval_harness.NewAIAgent(key.model, 0)
-	if err != nil {
-		return fmt.Errorf("create agent: %w", err)
-	}
-
 	callCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	if _, err := agent.GenerateCodeWarmup(callCtx, base, warmupTask, warmupMaxTokens); err != nil {
+	return warmupCallFn(callCtx, key.model, base, warmupTask, warmupMaxTokens)
+}
+
+// warmupCallFn performs the actual prefill request. It is a package-level var so
+// tests can exercise the ORCHESTRATION around it — grouping, spec loading,
+// prefix derivation, error propagation, the warmed counter — without a provider,
+// an API key, or a network. The network call itself is covered by the live,
+// key-gated probe in internal/ai/anthropic (TestLiveGeneratePromptCache); there
+// is nothing this indirection hides that a unit test could have checked anyway.
+var warmupCallFn = func(ctx context.Context, model, cachedPrefix, task string, maxTokens int) error {
+	agent, err := eval_harness.NewAIAgent(model, 0)
+	if err != nil {
+		return fmt.Errorf("create agent: %w", err)
+	}
+	if _, err := agent.GenerateCodeWarmup(ctx, cachedPrefix, task, maxTokens); err != nil {
 		return fmt.Errorf("prefill call: %w", err)
 	}
 	return nil

--- a/cmd/ailang/eval_cache_warmup.go
+++ b/cmd/ailang/eval_cache_warmup.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/sunholo-data/ailang/internal/ai"
+	"github.com/sunholo-data/ailang/internal/eval_harness"
+)
+
+// Prompt-cache warm-up (M-ANTHROPIC-CACHE-HIT-RATE, design decision D4).
+//
+// Why this exists: a cache entry only becomes readable once the FIRST response
+// has begun streaming. The suite fans out `--parallel 10` by default, so without
+// a warm-up all ten concurrent calls miss and each pays a full ~1.25x cache
+// WRITE for the same prefix. On a 30-benchmark suite that is the difference
+// between a ~52% and a ~86% saving on the shared teaching prompt:
+//
+//	no warm-up : 10 writes x 1.25 + 20 reads x 0.10 = 14.50  (vs 30.00 uncached)
+//	warm-up    :  1 write  x 1.25 + 29 reads x 0.10 =  4.15
+//
+// One extra serial round-trip buys 34 percentage points.
+//
+// Design constraints this respects:
+//   - NEVER fatal. A warm-up is an optimisation; if it fails for any reason the
+//     suite must run exactly as it would have anyway. Every error path here
+//     warns and returns.
+//   - Only where it pays. Anthropic-only (the other providers cache
+//     automatically with no notion of a warm-up), and only when a (model,
+//     language) group has at least 2 jobs — with one job there is no second
+//     call to read the entry back.
+//   - Cheap. MaxTokens is 1: the point is to make the provider PREFILL and cache
+//     the prompt prefix, not to get an answer. The response is discarded.
+
+// warmupMaxTokens keeps the warm-up call's output to a single token. The prefill
+// (and therefore the cache write) happens regardless of the output budget, so
+// there is no reason to pay for more.
+//
+// Not 0: our Generate path treats MaxTokens <= 0 as "unset" and substitutes
+// 4096, which would make the warm-up more expensive than the calls it is meant
+// to accelerate.
+const warmupMaxTokens = 1
+
+// warmupTask is the volatile suffix for the warm-up request. It is deliberately
+// NOT a real benchmark task — the cached prefix is the teaching prompt, and what
+// follows it is never part of the cached span.
+const warmupTask = "\n\n## Task\n\nReply with the single word: ok."
+
+// cacheWarmupKey identifies a group of jobs that share a cacheable prefix.
+// Language matters because the teaching prompt is per-language.
+type cacheWarmupKey struct {
+	model    string
+	language string
+}
+
+// warmPromptCaches makes one cheap call per (model, language) group so the
+// shared teaching prompt is cached before the parallel fan-out begins.
+//
+// Returns the number of groups successfully warmed (for logging/tests).
+func warmPromptCaches(ctx context.Context, jobs []Job, timeout time.Duration) int {
+	groups := groupJobsForWarmup(jobs)
+	if len(groups) == 0 {
+		return 0
+	}
+
+	warmed := 0
+	for key, sample := range groups {
+		if err := warmOneCache(ctx, key, sample, timeout); err != nil {
+			// Non-fatal by design — see the file comment.
+			fmt.Fprintf(os.Stderr, "⚠ prompt-cache warm-up skipped for %s/%s: %v\n",
+				key.model, key.language, err)
+			continue
+		}
+		warmed++
+	}
+	if warmed > 0 {
+		fmt.Printf("🔥 Warmed prompt cache for %d model/language group(s)\n", warmed)
+	}
+	return warmed
+}
+
+// groupJobsForWarmup returns one representative job per (model, language) group
+// that is worth warming: Anthropic-backed and running at least 2 jobs.
+func groupJobsForWarmup(jobs []Job) map[cacheWarmupKey]Job {
+	counts := make(map[cacheWarmupKey]int)
+	sample := make(map[cacheWarmupKey]Job)
+	for _, j := range jobs {
+		k := cacheWarmupKey{model: j.Model, language: j.Language}
+		counts[k]++
+		if _, seen := sample[k]; !seen {
+			sample[k] = j
+		}
+	}
+
+	out := make(map[cacheWarmupKey]Job)
+	for k, n := range counts {
+		if n < 2 {
+			// A single call can never read back what it wrote; warming would be
+			// a pure ~1.25x cost.
+			continue
+		}
+		if !isAnthropicModel(k.model) {
+			// Other providers cache automatically on the server side with no
+			// client-visible write step, so there is nothing to pre-warm.
+			continue
+		}
+		out[k] = sample[k]
+	}
+	return out
+}
+
+// isAnthropicModel reports whether a models.yml model id resolves to the
+// Anthropic provider. Resolution failures are treated as "not Anthropic" so an
+// unknown model silently skips the warm-up rather than aborting the suite.
+func isAnthropicModel(model string) bool {
+	_, provider, err := eval_harness.ResolveModelName(model)
+	if err != nil {
+		return false
+	}
+	return ai.ProviderFromString(provider) == ai.ProviderAnthropic
+}
+
+// warmOneCache issues the single prefill call for one group.
+func warmOneCache(ctx context.Context, key cacheWarmupKey, sample Job, timeout time.Duration) error {
+	specPath := filepath.Join(evalBenchmarkDir, sample.Benchmark+".yml")
+	spec, err := eval_harness.LoadSpec(specPath)
+	if err != nil {
+		return fmt.Errorf("load spec: %w", err)
+	}
+
+	// The base is identical across every benchmark in a language (asserted by
+	// TestPromptParts_BaseIsStableAcrossBenchmarks), so any job in the group
+	// gives the prefix the whole group will share.
+	base, _ := spec.PromptPartsForLanguage(key.language)
+	if base == "" {
+		return fmt.Errorf("no cacheable base prompt for language %q", key.language)
+	}
+
+	agent, err := eval_harness.NewAIAgent(key.model, 0)
+	if err != nil {
+		return fmt.Errorf("create agent: %w", err)
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	if _, err := agent.GenerateCodeWarmup(callCtx, base, warmupTask, warmupMaxTokens); err != nil {
+		return fmt.Errorf("prefill call: %w", err)
+	}
+	return nil
+}

--- a/cmd/ailang/eval_cache_warmup_test.go
+++ b/cmd/ailang/eval_cache_warmup_test.go
@@ -1,0 +1,69 @@
+package main
+
+import "testing"
+
+// M-ANTHROPIC-CACHE-HIT-RATE D4: the warm-up must fire exactly where it pays and
+// nowhere else. Getting the grouping wrong is expensive in both directions —
+// warming a single-job group is a pure ~1.25x loss, and failing to warm a real
+// group forfeits ~34 percentage points of the saving.
+func TestGroupJobsForWarmup(t *testing.T) {
+	t.Run("skips single-job groups", func(t *testing.T) {
+		// One benchmark for this model: the write could never be read back.
+		jobs := []Job{{Model: "claude-sonnet-4-5", Benchmark: "b1", Language: "ailang"}}
+		if got := groupJobsForWarmup(jobs); len(got) != 0 {
+			t.Errorf("got %d groups, want 0 — a single call cannot read back its own cache write", len(got))
+		}
+	})
+
+	t.Run("skips non-anthropic models", func(t *testing.T) {
+		// Other providers cache automatically server-side; there is no
+		// client-visible write step to pre-warm.
+		jobs := []Job{
+			{Model: "gpt5", Benchmark: "b1", Language: "ailang"},
+			{Model: "gpt5", Benchmark: "b2", Language: "ailang"},
+		}
+		for k := range groupJobsForWarmup(jobs) {
+			if k.model == "gpt5" {
+				t.Error("non-Anthropic model should not be warmed")
+			}
+		}
+	})
+
+	t.Run("separates groups by language", func(t *testing.T) {
+		// The teaching prompt is per-language, so ailang and python do not share
+		// a cacheable prefix and must be warmed independently.
+		jobs := []Job{
+			{Model: "m", Benchmark: "b1", Language: "ailang"},
+			{Model: "m", Benchmark: "b2", Language: "ailang"},
+			{Model: "m", Benchmark: "b1", Language: "python"},
+			{Model: "m", Benchmark: "b2", Language: "python"},
+		}
+		counts := map[cacheWarmupKey]int{}
+		for _, j := range jobs {
+			counts[cacheWarmupKey{model: j.Model, language: j.Language}]++
+		}
+		if len(counts) != 2 {
+			t.Fatalf("expected 2 (model,language) groups, got %d", len(counts))
+		}
+		for k, n := range counts {
+			if n != 2 {
+				t.Errorf("group %v has %d jobs, want 2", k, n)
+			}
+		}
+	})
+
+	t.Run("picks one representative per group", func(t *testing.T) {
+		jobs := []Job{
+			{Model: "m", Benchmark: "b1", Language: "ailang"},
+			{Model: "m", Benchmark: "b2", Language: "ailang"},
+			{Model: "m", Benchmark: "b3", Language: "ailang"},
+		}
+		counts := map[cacheWarmupKey]int{}
+		for _, j := range jobs {
+			counts[cacheWarmupKey{model: j.Model, language: j.Language}]++
+		}
+		if len(counts) != 1 {
+			t.Errorf("3 jobs on one model+language should be ONE warm-up group, got %d", len(counts))
+		}
+	})
+}

--- a/cmd/ailang/eval_cache_warmup_test.go
+++ b/cmd/ailang/eval_cache_warmup_test.go
@@ -1,6 +1,13 @@
 package main
 
-import "testing"
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
 
 // M-ANTHROPIC-CACHE-HIT-RATE D4: the warm-up must fire exactly where it pays and
 // nowhere else. Getting the grouping wrong is expensive in both directions —
@@ -64,6 +71,99 @@ func TestGroupJobsForWarmup(t *testing.T) {
 		}
 		if len(counts) != 1 {
 			t.Errorf("3 jobs on one model+language should be ONE warm-up group, got %d", len(counts))
+		}
+	})
+}
+
+// The warm-up's failure paths all return BEFORE any network call, which makes
+// them testable without a provider — and they are the paths that matter most,
+// since the whole design promise is "a warm-up can never break a suite".
+
+func TestWarmPromptCaches_NoEligibleGroups(t *testing.T) {
+	// Single-job groups are ineligible, so no spec is loaded and no call made.
+	jobs := []Job{{Model: "claude-sonnet-4-5", Benchmark: "b1", Language: "ailang"}}
+	if got := warmPromptCaches(context.Background(), jobs, time.Second); got != 0 {
+		t.Errorf("warmed %d groups, want 0 — nothing here is eligible", got)
+	}
+}
+
+func TestWarmPromptCaches_EmptyJobs(t *testing.T) {
+	if got := warmPromptCaches(context.Background(), nil, time.Second); got != 0 {
+		t.Errorf("warmed %d groups from no jobs, want 0", got)
+	}
+}
+
+// A missing benchmark spec must degrade to a warning and zero warmed groups —
+// never a panic and never an abort. This is the guarantee the suite depends on.
+func TestWarmPromptCaches_MissingSpecIsNonFatal(t *testing.T) {
+	prev := evalBenchmarkDir
+	evalBenchmarkDir = t.TempDir() // no .yml files at all
+	defer func() { evalBenchmarkDir = prev }()
+
+	jobs := []Job{
+		{Model: "claude-sonnet-4-5", Benchmark: "does-not-exist", Language: "ailang"},
+		{Model: "claude-sonnet-4-5", Benchmark: "also-missing", Language: "ailang"},
+	}
+	got := warmPromptCaches(context.Background(), jobs, time.Second)
+	if got != 0 {
+		t.Errorf("warmed %d groups despite a missing spec, want 0", got)
+	}
+}
+
+func TestWarmOneCache_MissingSpecReturnsError(t *testing.T) {
+	prev := evalBenchmarkDir
+	evalBenchmarkDir = t.TempDir()
+	defer func() { evalBenchmarkDir = prev }()
+
+	key := cacheWarmupKey{model: "claude-sonnet-4-5", language: "ailang"}
+	sample := Job{Model: key.model, Benchmark: "nope", Language: key.language}
+
+	err := warmOneCache(context.Background(), key, sample, time.Second)
+	if err == nil {
+		t.Fatal("expected an error for a missing benchmark spec")
+	}
+	if !strings.Contains(err.Error(), "load spec") {
+		t.Errorf("error = %q, want it to name the load-spec step", err)
+	}
+}
+
+func TestIsAnthropicModel_UnknownModelIsNotAnthropic(t *testing.T) {
+	// Resolution failure must mean "skip the warm-up", not "abort the suite".
+	if isAnthropicModel("no-such-model-xyz") {
+		t.Error("an unresolvable model must not be treated as Anthropic")
+	}
+}
+
+// With a VALID spec the warm-up gets past loading and into prefix derivation
+// and agent construction. Both later failure modes must still be plain errors.
+func TestWarmOneCache_ValidSpecLaterFailuresAreErrors(t *testing.T) {
+	dir := t.TempDir()
+	spec := "id: wu1\nlanguages: [ailang]\ntask_prompt: \"print hello\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "wu1.yml"), []byte(spec), 0o644); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+	prev := evalBenchmarkDir
+	evalBenchmarkDir = dir
+	defer func() { evalBenchmarkDir = prev }()
+
+	t.Run("unknown language has no cacheable base", func(t *testing.T) {
+		key := cacheWarmupKey{model: "claude-sonnet-4-5", language: "no-such-lang"}
+		err := warmOneCache(context.Background(), key,
+			Job{Model: key.model, Benchmark: "wu1", Language: key.language}, time.Second)
+		if err == nil {
+			t.Fatal("expected an error when there is no base prompt to cache")
+		}
+	})
+
+	t.Run("unresolvable model fails at agent construction", func(t *testing.T) {
+		key := cacheWarmupKey{model: "no-such-model-xyz", language: "ailang"}
+		err := warmOneCache(context.Background(), key,
+			Job{Model: key.model, Benchmark: "wu1", Language: key.language}, time.Second)
+		if err == nil {
+			t.Fatal("expected an error for an unresolvable model")
+		}
+		if !strings.Contains(err.Error(), "create agent") {
+			t.Errorf("error = %q, want it to name the agent-construction step", err)
 		}
 	})
 }

--- a/cmd/ailang/eval_cache_warmup_test.go
+++ b/cmd/ailang/eval_cache_warmup_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -166,4 +167,84 @@ func TestWarmOneCache_ValidSpecLaterFailuresAreErrors(t *testing.T) {
 			t.Errorf("error = %q, want it to name the agent-construction step", err)
 		}
 	})
+}
+
+// withStubWarmupCall swaps the prefill for a stub and restores it afterwards.
+func withStubWarmupCall(t *testing.T, fn func(ctx context.Context, model, prefix, task string, maxTokens int) error) {
+	t.Helper()
+	prev := warmupCallFn
+	warmupCallFn = fn
+	t.Cleanup(func() { warmupCallFn = prev })
+}
+
+// writeWarmupSpec drops a minimal valid benchmark spec and points the harness at it.
+func writeWarmupSpec(t *testing.T, ids ...string) {
+	t.Helper()
+	dir := t.TempDir()
+	for _, id := range ids {
+		body := "id: " + id + "\nlanguages: [ailang]\ntask_prompt: \"print hello\"\n"
+		if err := os.WriteFile(filepath.Join(dir, id+".yml"), []byte(body), 0o644); err != nil {
+			t.Fatalf("write spec %s: %v", id, err)
+		}
+	}
+	prev := evalBenchmarkDir
+	evalBenchmarkDir = dir
+	t.Cleanup(func() { evalBenchmarkDir = prev })
+}
+
+// The success path: one warm-up per eligible group, carrying the cacheable base
+// (not the task) and the cheap token budget.
+func TestWarmPromptCaches_WarmsEligibleGroupOnce(t *testing.T) {
+	writeWarmupSpec(t, "b1", "b2")
+
+	var calls int
+	var gotModel, gotPrefix string
+	var gotMaxTokens int
+	withStubWarmupCall(t, func(_ context.Context, model, prefix, task string, maxTokens int) error {
+		calls++
+		gotModel, gotPrefix, gotMaxTokens = model, prefix, maxTokens
+		if task != warmupTask {
+			t.Errorf("task = %q, want the fixed warm-up task", task)
+		}
+		return nil
+	})
+
+	jobs := []Job{
+		{Model: "claude-sonnet-4-5", Benchmark: "b1", Language: "ailang"},
+		{Model: "claude-sonnet-4-5", Benchmark: "b2", Language: "ailang"},
+	}
+	if got := warmPromptCaches(context.Background(), jobs, time.Second); got != 1 {
+		t.Errorf("warmed %d groups, want 1", got)
+	}
+	if calls != 1 {
+		t.Errorf("made %d prefill calls for one group, want exactly 1 — a per-benchmark warm-up would cost more than it saves", calls)
+	}
+	if gotModel != "claude-sonnet-4-5" {
+		t.Errorf("warmed model %q, want claude-sonnet-4-5", gotModel)
+	}
+	if gotMaxTokens != warmupMaxTokens {
+		t.Errorf("warm-up used MaxTokens=%d, want %d", gotMaxTokens, warmupMaxTokens)
+	}
+	if gotPrefix == "" {
+		t.Error("warm-up sent an empty prefix — there would be nothing to cache")
+	}
+	if strings.Contains(gotPrefix, "print hello") {
+		t.Error("task text leaked into the warmed prefix; the cached span must be the stable base only")
+	}
+}
+
+// A failing prefill must be swallowed: the suite runs uncached rather than dying.
+func TestWarmPromptCaches_PrefillFailureIsNonFatal(t *testing.T) {
+	writeWarmupSpec(t, "b1", "b2")
+	withStubWarmupCall(t, func(_ context.Context, _, _, _ string, _ int) error {
+		return errors.New("provider exploded")
+	})
+
+	jobs := []Job{
+		{Model: "claude-sonnet-4-5", Benchmark: "b1", Language: "ailang"},
+		{Model: "claude-sonnet-4-5", Benchmark: "b2", Language: "ailang"},
+	}
+	if got := warmPromptCaches(context.Background(), jobs, time.Second); got != 0 {
+		t.Errorf("warmed %d groups despite a failing prefill, want 0", got)
+	}
 }

--- a/cmd/ailang/eval_parallel.go
+++ b/cmd/ailang/eval_parallel.go
@@ -32,6 +32,15 @@ func runBenchmarksParallel(ctx context.Context, jobs []Job, seed int64, outputDi
 		maxConcurrent = 1 // Sequential
 	}
 
+	// Warm the prompt cache BEFORE fanning out. A cache entry only becomes
+	// readable once the first response starts streaming, so without this every
+	// concurrent call in the first wave misses and pays a full cache WRITE for
+	// the same prefix. Non-fatal: failures warn and the suite runs uncached.
+	// (M-ANTHROPIC-CACHE-HIT-RATE D4 — see eval_cache_warmup.go.)
+	if maxConcurrent > 1 {
+		warmPromptCaches(ctx, jobs, timeout)
+	}
+
 	var (
 		wg           sync.WaitGroup
 		results      = make([]SuiteResult, len(jobs))

--- a/design_docs/planned/v0_31_0/m-anthropic-cache-hit-rate-sprint-plan.md
+++ b/design_docs/planned/v0_31_0/m-anthropic-cache-hit-rate-sprint-plan.md
@@ -1,0 +1,136 @@
+# Sprint Plan: M-ANTHROPIC-CACHE-HIT-RATE
+
+**Design doc**: [m-anthropic-cache-hit-rate.md](m-anthropic-cache-hit-rate.md)
+**Sprint ID**: `M-ANTHROPIC-CACHE-HIT-RATE`
+**Target**: v0.31.0
+**Duration**: 2 days (~8 hours)
+**Total LOC estimate**: ~470 (≈290 implementation + ≈180 tests)
+**Risk level**: Medium — the risk is concentrated entirely in M1's content-block branch ordering
+**Created**: 2026-07-29
+
+---
+
+## Goal
+
+Make our Anthropic API traffic cache-capable end to end. Today the `Generate` path — which
+carries essentially all of our Anthropic spend — contains **zero** references to `CacheBreakpoint`
+(design doc V1), so it cannot request a cache at all. Close that, put the breakpoint where the
+~16K-token teaching prompt actually is, turn it on by default, and make the resulting hit rate a
+banked metric instead of an invisible one.
+
+## Design Freeze — resolved, do not re-litigate
+
+| ID | Decision |
+|----|----------|
+| **D1** | Cache **in place**. Split the user message at the `\n\n## Task\n\n` boundary into two content blocks. Do **not** move the teaching prompt to the system role — that is behaviour-changing and would invalidate v0.30.0 baseline comparability |
+| **D2** | `Request.CachedPrefix` is the provider-neutral carrier. Anthropic stamps it; every other provider concatenates `CachedPrefix + UserPrompt` and stays byte-identical |
+| **D3** | Caching defaults **ON** for the eval harness and feedback gate on Anthropic, with a guard that skips the breakpoint when a run makes fewer than 2 calls per model |
+
+## Velocity basis
+
+Recent comparable milestones (`M-EVAL-MEASUREMENT-CONTRACT` M3/M4/M5, `M-Z3-HARD-TIMEOUT`) each
+landed as a discrete commit at roughly half-day granularity with tests included. Three milestones
+at ~2.5h each is consistent with that pace; the design doc's ~8h estimate stands.
+
+---
+
+## Milestones
+
+### M1 — `Generate` becomes cache-capable (~3h, ~230 LOC)
+
+The only milestone with real risk. Everything else is wiring.
+
+**Tasks:**
+- [ ] Add `CachedPrefix string` to `ai.Request` (`internal/ai/provider.go`), documented alongside
+      `CacheBreakpoints`. Empty = today's behaviour exactly
+- [ ] Add `"user_prefix"` to the `CacheBreakpoint.Position` vocabulary
+- [ ] `internal/ai/anthropic/cache.go`: add `userContentFromPrompt(cachedPrefix, userPrompt, breakpoints)`
+      returning `json.RawMessage` — bare string when not caching, two-block array when caching
+- [ ] `internal/ai/anthropic/client.go`: call `systemFieldFromPrompt` + the new user-content
+      builder from `Generate` (this is the V1 gap)
+- [ ] Below-minimum-prefix one-shot warning (model-aware: 512 / 1024 / 4096 by tier)
+- [ ] Non-Anthropic providers (`openai`, `gemini`, `ollama`, `openrouter`): concatenate
+      `CachedPrefix + UserPrompt`
+- [ ] New `internal/ai/anthropic/cache_generate_test.go`
+
+**Acceptance criteria:**
+- A `Generate` request declaring a `user_prefix` breakpoint emits the two-block user content array
+  with `cache_control` on block 0
+- A request declaring **no** breakpoints is byte-identical to v0.30.0 (golden-JSON test)
+- Existing `step_vision_test.go` and `step_edge_test.go` pass **unmodified** — if either needs
+  editing, the branch ordering is wrong and the milestone is not done
+- Non-Anthropic providers produce byte-identical output with `CachedPrefix` set vs. pre-concatenated
+- Below-minimum prefix warns once, naming model and shortfall
+
+**Risk:** The user `content` field already has two array-producing branches — tool results
+(`step.go:266-278`) and vision (`step.go:281-300`). The new branch must be **last**. Getting this
+wrong silently breaks vision or tool calling. The unmodified-existing-tests criterion is the guard.
+
+---
+
+### M2 — Turn it on for our own callers (~2h, ~130 LOC)
+
+**Tasks:**
+- [ ] `internal/eval_harness/spec.go`: return `basePrompt` and `taskDescription` separately instead
+      of pre-concatenating at line 274-276
+- [ ] `internal/eval_harness/ai_provider.go`: set `CachedPrefix = basePrompt`,
+      `UserPrompt = taskDescription`, declare the breakpoint when the provider is Anthropic (D3)
+- [ ] Fewer-than-2-calls-per-model guard (D3)
+- [ ] `internal/feedbackgate/classifier.go`: declare a `system` breakpoint; **measure first** — if
+      the classifier prompt is under the model's minimum, skip it rather than ship a silent no-op
+- [ ] `cmd/ailang/eval_parallel.go`: warm-up call before the fan-out (`max_tokens: 0` prefill)
+
+**Acceptance criteria:**
+- The prompt string reaching the model is unchanged from v0.30.0 (`CachedPrefix + UserPrompt`
+  equals the old `fullPrompt` byte-for-byte) — asserted by test
+- A 2-benchmark stub run shows call 1 writing cache and call 2 reading it
+- Warm-up fires exactly once per (model, suite), before any fan-out
+- Runs with <2 calls per model declare no breakpoint
+
+**Risk:** Low. The byte-equality assertion is what protects baseline comparability.
+
+---
+
+### M3 — Make the hit rate visible (~2.5h, ~110 LOC)
+
+Without this we cannot verify M1/M2 worked, and the next hit-rate collapse is again invisible.
+
+**Tasks:**
+- [ ] Thread `CacheReadInputTokens` / `CacheCreationInputTokens` from `ai.Response` through
+      `GenerateResult` (`internal/eval_harness/ai_agent.go`) into the banked summary
+- [ ] Add a cache hit-rate column to the `eval-report` renderer (`cmd/ailang/eval_tools.go:272`)
+- [ ] Backward compatibility: pre-v0.31.0 baselines with absent fields read as 0, not error
+
+**Acceptance criteria:**
+- Banked summaries carry non-zero `cache_read_input_tokens` after a warm Anthropic run
+- `ailang eval-report` against a **pre-v0.31.0** baseline directory still succeeds
+- Hit rate appears in the report output
+
+**Risk:** Low. Additive schema only.
+
+---
+
+## Success Metrics
+
+- [ ] `cache_read_input_tokens > 0` in banked summaries (today: 0 across 28,139 files — V5)
+- [ ] ≥70% cache-read share of shared-prefix input tokens on a repeat 30-benchmark suite
+- [ ] Zero wire-shape change when no breakpoints are declared
+- [ ] `make ci` green, `make check-boundaries` green
+- [ ] CHANGELOG.md updated
+
+## Out of scope (from the design doc's Non-Goals)
+
+System-role prompt move · agent-mode/`claude` CLI caching · `tool_result` multi-turn breakpoints ·
+Gemini Context Caching · auto-cache heuristics · retrofitting metrics onto old baselines
+
+## Open questions for execution
+
+- **Warm-up shape** — `max_tokens: 0` prefill vs. a real minimal call. Agent may choose;
+  `max_tokens: 0` avoids billing output tokens
+- **TTL tier** — `ephemeral` (5m) for dense suites. 1h deferred until telemetry justifies the 2×
+  write premium
+- **Classifier breakpoint** — ship only if the prompt clears the model minimum; measure in M2
+
+---
+
+**Sprint plan created**: 2026-07-29

--- a/design_docs/planned/v0_31_0/m-anthropic-cache-hit-rate-sprint-plan.md
+++ b/design_docs/planned/v0_31_0/m-anthropic-cache-hit-rate-sprint-plan.md
@@ -10,6 +10,40 @@
 
 ---
 
+## Status (updated 2026-07-29)
+
+**All three milestones implemented and committed** — `b9dcdf796` (M1), `9f99ad6be` (M2),
+`449839532` (M3). ~920 LOC including 17 new tests. `make lint` / `fmt-check` /
+`check-boundaries` / `check-file-sizes` all green.
+
+**The sprint is NOT closed out**, because its headline claim is unverified:
+
+| Item | State |
+|---|---|
+| Generate emits `cache_control` | ✅ done, wire-shape tested |
+| Teaching prompt cached in place, bytes unchanged | ✅ done, byte-equality asserted |
+| Cache tokens banked | ✅ done, round-trip + back-compat tested |
+| **A real cache hit against the live API** | ❌ **unverified** — no `ANTHROPIC_API_KEY` this window (quota returns ~2026-08-01). `TestLiveGeneratePromptCache` is written and gated on `AILANG_LIVE_ANTHROPIC_CACHE=1` |
+| Pre-fan-out warm-up (D4) | ⏸ deferred — worth ~34pp of the saving; needs suite orchestration + a `max_tokens:0` prefill path `Generate` does not yet express |
+| `eval-report` hit-rate column | ⏸ deferred — presentation only; the data is banked and queryable |
+
+**To close this out** when the API key returns:
+1. `AILANG_LIVE_ANTHROPIC_CACHE=1 go test ./internal/ai/anthropic/ -run TestLiveGeneratePromptCache -v`
+2. Run one 2-benchmark Anthropic suite; confirm banked `cache_read_input_tokens > 0`
+3. Cross-check the Anthropic Console hit rate moved
+
+**Correction made during execution** (recorded so the reasoning is not lost): the planned
+"only cache when this adapter will see ≥2 calls" guard was wrong and would have shipped the
+feature dead — the harness builds a fresh `AIAgent` per benchmark, so every adapter sees exactly
+one call, while Anthropic's cache is server-side and keyed by prefix. The guard is inverted:
+cache unless a caller declares itself one-shot.
+
+**M1's HIGH risk rating did not materialise** — it assumed the new content-block branch would join
+`step.go`'s tool_result/vision chain. `Generate` builds its own single user message, so no ordering
+hazard existed. Both guard tests verified unmodified and passing.
+
+---
+
 ## Goal
 
 Make our Anthropic API traffic cache-capable end to end. Today the `Generate` path — which

--- a/design_docs/planned/v0_31_0/m-anthropic-cache-hit-rate.md
+++ b/design_docs/planned/v0_31_0/m-anthropic-cache-hit-rate.md
@@ -1,0 +1,492 @@
+# M-ANTHROPIC-CACHE-HIT-RATE: Close the prompt-cache gap on the `Generate` path
+
+**Status**: Planned
+**Target**: v0.31.0
+**Priority**: P1 (Medium — a standing ~2-6× input-cost multiplier on every 0-shot eval and classifier call; not a correctness bug, but Anthropic has flagged our org cache rate as very low)
+**Estimated**: ~8 hours (~320 LOC across `internal/ai/`, `internal/eval_harness/`, `cmd/ailang/`)
+**Dependencies**: None blocking. The [M-EVAL-TOKEN-HEADROOM](m-eval-token-headroom.md) sequencing constraint is **already satisfied** — its `FinishReason: mapStopReason(result.StopReason)` line has landed in `Generate` (verified at `internal/ai/anthropic/client.go:399`, 2026-07-29), so this work builds on top of it rather than racing it. Directly extends [M-AI-PROMPT-CACHING (v0.18.4)](../../implemented/v0_18_4/m-ai-prompt-caching.md) — this is that doc's deferred "Phase 2 — Wider Anthropic placement", plus the `Generate`-path gap it never covered.
+**Author**: Claude Opus 5 + Mark
+**Created**: 2026-07-29
+
+---
+
+## Honest framing — what this fixes vs what it doesn't
+
+Anthropic reported that our organization's prompt-cache hit rate is very low. Investigation
+found the cause is **structural, not configuration**: the code path that carries essentially all
+of our Anthropic API traffic cannot emit `cache_control` at all.
+
+Three distinct things need separating:
+
+**(A) In scope — the `Generate` path has no cache support whatsoever.**
+[`internal/ai/anthropic/client.go:221`](../../../internal/ai/anthropic/client.go#L221) assigns
+`apiReq.System = req.SystemPrompt` as a bare JSON string, and the file contains **zero**
+references to `CacheBreakpoint` (V1 below). M-AI-PROMPT-CACHING wired caching into `Step` only.
+Everything that actually spends money goes through `Generate`: standard-mode evals, the
+feedback-gate classifier, and AILANG's `ai.generate`. All of it is uncached by construction.
+
+**(B) In scope — the largest reusable block sits where no breakpoint can reach it.**
+Standard-mode evals concatenate a ~16K-token teaching prompt with the per-benchmark task into a
+single user string ([`spec.go:274-276`](../../../internal/eval_harness/spec.go#L274)), behind a
+**70-token** system prompt (V8). Anthropic's minimum cacheable prefix is 1024 tokens on Sonnet
+4.6/5 and Opus 4.8 (512 on Opus 5, 4096 on Haiku 4.5), so even a working system breakpoint would
+cache nothing and report `cache_creation_input_tokens: 0` — silently, with no error.
+
+**(C) NOT in scope — agent-mode evals.** Those shell out to the `claude` CLI, which manages its
+own caching internally. Our only lever there is session reuse, which is a separate concern and
+is deliberately excluded (see Non-Goals). This doc is about API-key traffic.
+
+**What this does not claim:** we could not measure our current hit rate locally — every file
+under `eval_results/` carries zero cache-token fields (V5) and the local observatory has 0 spans.
+The Anthropic Console usage breakdown is the authority on the size of the prize; this doc fixes
+a gap that is real regardless of that number, and Phase 3 makes it measurable going forward.
+
+---
+
+## Verification Log
+
+Every claim below was checked against the code at `588ffcb67`. Negative-existence claims
+(the load-bearing ones) each carry their own row.
+
+| # | Claim | Verification | Result |
+|---|-------|--------------|--------|
+| V1 | `Generate` never emits `cache_control`; `CacheBreakpoints` is silently dropped on that path | `grep -c "CacheBreakpoint" internal/ai/anthropic/client.go` | **0** — confirmed. `System` set as bare string at `client.go:221` |
+| V2 | No Go-native caller ever populates `Request.CacheBreakpoints` | `grep -rn "CacheBreakpoints:" --include="*.go" internal/ cmd/ \| grep -v _test` | Only `handler.go:385,406` — pure pass-through. Sole origin is `internal/effects/ai_step.go:296` (the AILANG `stepWithCache` builtin) and the WASM JS handler. Confirmed: no Go caller |
+| V3 | Only the 5-minute `ephemeral` tier is emitted; no 1h tier | `grep -n '"ephemeral"\|"1h"\|ttl' internal/ai/anthropic/cache.go` | Only `"ephemeral"` literal at `cache.go:80`. Confirmed |
+| V4 | `last_user` and `tool_result` breakpoint positions are unimplemented | `grep -rn "last_user" --include="*.go" internal/ai/anthropic/` | No hits. `tool_result` appears only as a *message content block type* (`step.go:272,322`), never as a cache position. Confirmed |
+| V5 | No banked eval result carries cache-token fields | `grep -rl "cache_read_input_tokens\|cacheReadInputTokens" eval_results/ \| wc -l` | **0** of 28,139 JSON files. Structs exist (`agent_runner.go:176`, `provider.go:302`) but nothing serializes them into summaries. Confirmed |
+| V6 | Eval teaching prompt is concatenated into the user message, not the system prompt | Read `internal/eval_harness/spec.go:274-276` | `fullPrompt = basePrompt + "\n\n## Task\n\n" + taskDescription`, passed as the single `prompt` arg to `GenerateCode` → `Request.UserPrompt` (`ai_provider.go:129`). Confirmed |
+| V7 | Eval suite fans out concurrently by default | `grep -n 'parallel"' cmd/ailang/eval_suite.go` | `fs.Int("parallel", 10, ...)` — 10 concurrent calls default. Confirmed |
+| V8 | The eval system prompt is far below the minimum cacheable prefix | Measured the literal at `ai_provider.go:116-119` | 283 chars ≈ **70 tokens** vs a 1024-token minimum. Confirmed |
+| V9 | The teaching prompt is large enough to be worth caching on every model tier | `ls -l prompts/v0.9.0.md` | 63,939 bytes ≈ **~16K tokens** — clears the 4096-token Haiku 4.5 minimum by 4×. Confirmed |
+
+**Not verified (stated as unknown, not as fact):** our actual current org-wide cache hit rate,
+and the split of Anthropic spend between API-key traffic and subscription/CLI traffic. Both live
+in the Anthropic Console / prod observatory, not in this repo.
+
+---
+
+## Axiom Compliance
+
+**Canonical reference:** [Design Axioms](/docs/references/axioms)
+
+### Axiom Scoring
+
+| Axiom | Score | Justification |
+|-------|-------|---------------|
+| A1: Determinism | 0 | Cache markers are advisory and do not change produced bytes. The one behavior-adjacent change (splitting the user message into two content blocks) is deterministic and versioned; the *behavior-changing* system-role move is explicitly deferred, not bundled |
+| A2: Replayability | 0 | Cache state is not part of the trace; replay unaffected |
+| A3: Effect Legibility | 0 | No new effect. Rides the existing `! {AI}` effect exactly as M-AI-PROMPT-CACHING established |
+| A4: Explicit Authority | 0 | No new capabilities; the AI cap remains the gate |
+| A5: Bounded Verification | 0 | Additive optional fields with zero-value defaults; type-checking unaffected |
+| A6: Safe Concurrency | +1 | Makes an existing concurrency hazard explicit and fixes it: the current parallel fan-out guarantees every concurrent request misses (an entry is readable only once the first response begins streaming). The warm-up turns an accidental worst case into a declared one |
+| A7: Machines First | +2 | Directly reduces input-token cost — the dominant cost an agent pays. This is the axiom the whole milestone serves |
+| A8: Minimal Syntax | 0 | No new AILANG syntax. One additive `Request` field; the existing `CacheBreakpoint` vocabulary gains one position value |
+| A9: Cost Visibility | +2 | Phase 3 is the point: today cache tokens are *modelled* (`provider.go:302-311`) but never *persisted* (V5), so we cannot see our own cache behavior. This makes hit rate a first-class banked metric |
+| A10: Composability | +1 | The `CachedPrefix` field is provider-neutral: Anthropic stamps it, every other provider concatenates it back and stays byte-identical |
+| A11: Structured Failure | +1 | Extends the existing one-shot `cache_hint_ignored_*` warning (`cache_warnings.go:46`) to the `Generate` path, and adds a loud below-minimum-prefix warning for the silent-no-op case that bit us in (B) |
+| A12: System Boundary | +1 | Keeps the "AILANG-side hint → provider wire shape" mapping in one place per provider, as v0.18.4 established, rather than leaking cache concerns into the eval harness |
+
+**Net Score: +8** → **Decision: ✅ Proceed to implementation**
+
+### Hard Violation Check
+
+- [x] A1 (Determinism): No new nondeterminism. The behavior-changing prompt-placement question is split out as a Deferred Decision precisely so it can be A/B'd on its own merits
+- [x] A3 (Effects): No hidden side effects; cache hints flow through the existing `! {AI}` effect
+- [x] A4 (Authority): No ambient access; no new capabilities
+- [x] A7 (Machines First): The milestone exists to cut machine-side token cost
+
+---
+
+## Problem Statement
+
+Anthropic flagged our organization's prompt-cache hit rate as very low. It is very low because
+our highest-volume Anthropic code path is physically incapable of requesting a cache.
+
+**Current State:**
+
+- **The `Generate` path cannot cache at all.** `internal/ai/anthropic/client.go` contains zero
+  references to `CacheBreakpoint` (V1). M-AI-PROMPT-CACHING wired `Step` only. `Generate` carries
+  standard-mode evals ([`ai_provider.go:126`](../../../internal/eval_harness/ai_provider.go#L126)),
+  the feedback-gate classifier ([`classifier.go:149`](../../../internal/feedbackgate/classifier.go#L149)),
+  and AILANG `ai.generate`.
+- **No Go caller opts in even where it could.** The only origin of `CacheBreakpoints` is the
+  AILANG `stepWithCache` builtin (V2) — i.e. user-written `.ail` code. Our own Go services never
+  ask for caching.
+- **The cacheable content is in the uncacheable slot.** ~16K tokens of teaching prompt sit inside
+  the user message (V6, V9) behind a 70-token system prompt (V8). The only implemented breakpoint
+  position is `system` (V4), which here is below Anthropic's minimum prefix and would cache
+  nothing — silently.
+- **Every parallel request misses.** `--parallel 10` by default (V7); a cache entry only becomes
+  readable once the first response begins streaming, so all 10 concurrent calls pay a full write.
+- **We cannot see any of this.** Zero banked eval results carry cache-token fields (V5).
+
+**Impact:**
+
+- Every 0-shot eval re-pays ~16K uncached input tokens. On a 30-benchmark suite against one
+  model that is ~480K input tokens where ~66K would do.
+- The feedback-gate classifier re-pays its full system prompt on every classification.
+- Cost regressions in this area are invisible to us — we would not notice a hit-rate collapse,
+  which is exactly why the signal arrived from Anthropic rather than from our own dashboard.
+
+---
+
+## Goals
+
+**Primary Goal:** Make our Anthropic API traffic cache-capable end to end — the `Generate` path
+can emit `cache_control`, the breakpoint can be placed where the reusable content actually is,
+and the resulting hit rate is a banked, visible metric.
+
+**Success Metrics:**
+
+- `cache_read_input_tokens > 0` in banked eval summaries for every Anthropic standard-mode run
+  (today: literally zero across 28,139 files — V5)
+- ≥ 70% cache-read share of shared-prefix input tokens on a repeat 30-benchmark suite
+- ≥ 80% reduction in shared-prefix input tokens on a warm suite vs. the v0.30.0 baseline
+- Zero wire-shape change for any request that declares no breakpoints (byte-identical, per the
+  guarantee M-AI-PROMPT-CACHING made and this doc preserves)
+- A loud warning whenever a declared breakpoint yields a below-minimum prefix — no more silent
+  no-ops
+
+---
+
+## High-Impact Decisions
+
+| Decision | Why High Impact | Chosen By | Deadline | Change Cost |
+|----------|-----------------|-----------|----------|-------------|
+| **D1: Cache the teaching prompt in-place via a user-message split, rather than moving it to the system role** | Moving it changes model inputs and therefore eval outputs, invalidating baseline comparability. The split keeps content semantically identical and lands the cost win without a re-baseline | human | design | **high** |
+| **D2: Add `Request.CachedPrefix` as the provider-neutral carrier** (vs. overloading `UserPrompt` with markers, or an Anthropic-only field) | Determines whether every other provider stays byte-identical. A provider-specific field would leak Anthropic semantics into shared code and break A10/A12 | human | design | **high** |
+| **D3: Default caching ON for Anthropic in the eval harness and feedback gate** (vs. opt-in flag) | Opt-in is why we are here — V2 shows nobody opts in. But ON-by-default changes cost accounting for every run | human | design | med |
+| **D4: Warm-up request before the parallel fan-out** | Difference between a 52% and an 86% saving (see projection). Adds one serial round-trip to every suite | agent | compile | low |
+| **D5: 5-minute `ephemeral` vs. 1-hour TTL default** | 1h costs 2× on write vs 1.25×, and needs ≥3 reads to break even. Right answer differs for a dense suite vs. a day-long rotation | agent | runtime | low |
+| **D6: Persist cache tokens into the eval summary schema** | Schema change to banked results; downstream dashboard/report readers must tolerate the new fields | agent | compile | med |
+
+### Design Freeze
+
+Before implementation begins, these must be resolved:
+
+- [x] **D1** — **RESOLVED 2026-07-29 (Mark): cache in place.** The teaching prompt stays in the
+      user message and is split into two content blocks with `cache_control` at the
+      `\n\n## Task\n\n` boundary. Full cache win, model sees identical content, v0.30.0 eval
+      baselines stay comparable. The system-role move remains deferred for its own A/B — it is a
+      quality change, not a cost change, and bundling them makes both unmeasurable.
+- [x] **D2** — **RESOLVED 2026-07-29 (agent latitude, per recommendation): `Request.CachedPrefix`
+      is the carrier.** Provider-neutral: Anthropic stamps it as a cached leading block; every
+      other provider concatenates `CachedPrefix + UserPrompt` and stays byte-identical to
+      v0.30.0.
+- [x] **D3** — **RESOLVED 2026-07-29 (Mark): ON by default** for the eval harness and feedback
+      gate on Anthropic. Opt-in is precisely why the hit rate is near zero today (V2 — no Go
+      caller ever opts in). Guard: skip the breakpoint when a run makes fewer than 2 calls per
+      model, so short runs never pay the 1.25× write premium for a cache that is never read.
+
+---
+
+## Solution Design
+
+### Overview
+
+Four changes, ordered so the pure-cost fix lands and can be measured before anything
+behavior-adjacent is considered:
+
+1. Teach the `Generate` path to emit `cache_control` (it currently cannot).
+2. Give callers a provider-neutral way to say "this leading chunk is stable" —
+   `Request.CachedPrefix` — so the breakpoint can sit where the 16K teaching prompt actually is.
+3. Turn it on by default for our own Anthropic callers, with a warm-up before the fan-out.
+4. Persist cache tokens so the hit rate becomes a metric we own.
+
+### Architecture
+
+**Components:**
+
+1. **`Request.CachedPrefix string`** (`internal/ai/provider.go`) — content that logically precedes
+   `UserPrompt`. Empty = today's behavior exactly. The contract is that
+   `CachedPrefix + UserPrompt` is what the model sees, regardless of provider; only the *encoding*
+   differs.
+
+2. **Anthropic encoding** (`internal/ai/anthropic/cache.go`, `client.go`) — when `CachedPrefix` is
+   non-empty and a `user_prefix` breakpoint is declared, the user message becomes a two-block
+   content array:
+   ```json
+   [{"type":"text","text":"<16K teaching prompt>","cache_control":{"type":"ephemeral"}},
+    {"type":"text","text":"\n\n## Task\n\n<benchmark task>"}]
+   ```
+   The system field keeps its existing `systemFieldFromPrompt` treatment. `Generate` gains the
+   same `systemFieldFromPrompt` call `Step` already has, closing V1.
+
+3. **Every other provider** — concatenates `CachedPrefix + UserPrompt` into the single user string
+   they send today. Wire shape byte-identical to v0.30.0. OpenAI keeps auto-caching ≥1024 tokens;
+   Gemini/Ollama keep the existing one-shot `cache_hint_ignored_*` warning.
+
+4. **Below-minimum guard** (`internal/ai/anthropic/cache.go`) — if a declared breakpoint's prefix
+   is under the model's minimum cacheable size, emit a one-shot structured warning naming the
+   model and the shortfall. This is the failure mode that made (B) invisible; it must be loud
+   (Principle 2 — no silent fallbacks).
+
+5. **Cache-token persistence** (`internal/eval_harness/`) — thread the existing
+   `CacheReadInputTokens` / `CacheCreationInputTokens` from `ai.Response` through `GenerateResult`
+   into the banked summary, and surface hit rate in `ailang eval-report`.
+
+### Why in-place beats moving to the system role (D1)
+
+Both placements cache equally well — Anthropic's render order is `tools → system → messages`, and
+a breakpoint works at any of them. The difference is blast radius:
+
+| | Cache win | Changes model input? | Invalidates baselines? |
+|---|---|---|---|
+| Split user message in place | Full | Content identical; encoding differs (one text block → two) | No |
+| Move teaching prompt to system role | Full | Yes — different role, different model treatment | **Yes** |
+
+The system-role move has independent motivation (teaching content in a user message is lost on
+compaction) and may well be right — but it is a *quality* change that needs its own A/B, not a
+rider on a *cost* change. Bundling them makes both unmeasurable. Deferred, not rejected.
+
+### Conflict Surface
+
+Not a parser/typechecker change, but it modifies the outgoing wire bytes for every Anthropic
+call, and v0.18.4 made an explicit bit-for-bit guarantee. Enumerating what else lives in these
+positions:
+
+1. **What this extends:** the `system` field encoding (string ↔ content array) and the user
+   message `content` field encoding (string ↔ content array).
+2. **What else already lives there:**
+   - `system` — `systemFieldFromPrompt` already switches string↔array on the `Step` path
+     (`cache.go:65-84`). `Generate` has only ever emitted a string.
+   - user `content` — already switches to an array for **tool results** (`step.go:266-278`) and
+     for **vision input** (`step.go:281-300`). A third array-producing case must not collide with
+     either.
+3. **Disambiguation:** the array form is used iff (`CachedPrefix != ""` AND a `user_prefix`
+   breakpoint is declared). Tool-result and vision messages take their existing branches first
+   and are never eligible — a tool-result message has no `CachedPrefix`, and the vision branch
+   already owns its block layout. The new branch is last in the chain.
+4. **Programs that MUST still work post-change** (all verified to exist):
+   - `examples/runnable/ai_caching.ail` — the `stepWithCache` example; exercises the existing
+     `system` breakpoint path
+   - `internal/ai/anthropic/cache_test.go` — asserts the byte-identical no-breakpoint shape
+   - `internal/ai/anthropic/step_vision_test.go` — the vision content-array branch
+   - `internal/ai/anthropic/step_edge_test.go` — tool-result correlation
+   - `internal/ai/anthropic/client_test.go` — the `Generate` request shape
+5. **What deliberately changes:** requests that declare a `user_prefix` breakpoint emit a
+   two-block user content array instead of a string. That is the whole point, and it is opt-in —
+   no declaration, no change.
+
+**The honest answer is not "no conflicts":** the user `content` field already has two
+array-producing branches, and getting the ordering wrong silently breaks vision or tool calls.
+That ordering is the single most important detail in this milestone.
+
+### Implementation Plan
+
+**Phase 1: Make `Generate` cache-capable** (~3 hours)
+- [ ] Add `CachedPrefix string` to `ai.Request` with doc comment mirroring `CacheBreakpoints`
+- [ ] Add `"user_prefix"` to the `CacheBreakpoint.Position` vocabulary (`provider.go:195-206`)
+- [ ] Extend `cache.go` with `userContentFromPrompt(cachedPrefix, userPrompt, breakpoints)`
+- [ ] Wire `systemFieldFromPrompt` + the new user-content builder into `client.go` `Generate`
+- [ ] Non-Anthropic providers: concatenate `CachedPrefix + UserPrompt` (byte-identical guard test)
+- [ ] Below-minimum-prefix one-shot warning
+
+**Phase 2: Turn it on for our own callers** (~2 hours)
+- [ ] `spec.go` — return `basePrompt` and `taskDescription` separately instead of pre-concatenated
+- [ ] `ai_provider.go` — set `CachedPrefix = basePrompt`, `UserPrompt = task`, declare the
+      breakpoint when the provider is Anthropic
+- [ ] `classifier.go` — declare a `system` breakpoint on the classifier prompt
+- [ ] Warm-up call before `runBenchmarksParallel` fan-out (D4)
+
+**Phase 3: Make the hit rate visible** (~3 hours)
+- [ ] Thread cache tokens through `GenerateResult` → banked summary schema
+- [ ] Surface cache hit rate in `ailang eval-report`
+- [ ] Backward-compatible schema (absent fields read as 0 for pre-v0.31.0 baselines)
+
+### Files to Modify/Create
+
+**Modified files:**
+- `internal/ai/provider.go` — `CachedPrefix` field + `user_prefix` position, ~25 LOC
+- `internal/ai/anthropic/cache.go` — user-content builder + minimum guard, ~90 LOC
+- `internal/ai/anthropic/client.go` — wire cache into `Generate`, ~30 LOC
+- `internal/ai/{openai,gemini,ollama,openrouter}/step.go` — concatenate `CachedPrefix`, ~10 LOC each
+- `internal/eval_harness/spec.go` — return prompt parts unconcatenated, ~25 LOC
+- `internal/eval_harness/ai_provider.go` — set `CachedPrefix` + breakpoint, ~30 LOC
+- `internal/eval_harness/ai_agent.go` — carry cache tokens on `GenerateResult`, ~20 LOC
+- `internal/feedbackgate/classifier.go` — declare system breakpoint, ~5 LOC
+- `cmd/ailang/eval_parallel.go` — warm-up before fan-out, ~30 LOC
+- `cmd/ailang/eval_tools.go` — hit-rate column in the `eval-report` renderer (`eval_tools.go:272`), ~25 LOC
+
+**New test files:**
+- `internal/ai/anthropic/cache_generate_test.go` — `Generate`-path shapes + branch ordering, ~150 LOC
+
+---
+
+## Examples
+
+### Example 1: A 30-benchmark standard-mode suite (the projection)
+
+Shared prefix = ~16K tokens (V9). Cost in units of one uncached prefix (cache read ≈ 0.1×,
+5-minute write ≈ 1.25×):
+
+**Before:**
+```
+30 calls × 1.00 (full price)                              = 30.00
+```
+
+**After (no warm-up — 10 concurrent calls all miss, V7):**
+```
+10 writes × 1.25  +  20 reads × 0.10                      = 14.50   (−52%)
+```
+
+**After (with warm-up, D4):**
+```
+ 1 write  × 1.25  +  29 reads × 0.10                      =  4.15   (−86%)
+```
+
+The warm-up is one extra serial round-trip and is worth 34 percentage points.
+
+### Example 2: The wire shape
+
+**Before** (every `Generate` call today — V1):
+```json
+{"model":"claude-sonnet-5",
+ "system":"You are a code generation engine...",
+ "messages":[{"role":"user","content":"<16K teaching prompt>\n\n## Task\n\n<task>"}]}
+```
+
+**After** (identical content, one cacheable boundary):
+```json
+{"model":"claude-sonnet-5",
+ "system":"You are a code generation engine...",
+ "messages":[{"role":"user","content":[
+   {"type":"text","text":"<16K teaching prompt>","cache_control":{"type":"ephemeral"}},
+   {"type":"text","text":"\n\n## Task\n\n<task>"}]}]}
+```
+
+A request that declares no breakpoint emits the **Before** shape byte-for-byte.
+
+---
+
+## Success Criteria
+
+- [ ] `Generate` emits `cache_control` when a breakpoint is declared (acceptance: new
+      `cache_generate_test.go` asserts the two-block shape)
+- [ ] A request with no breakpoints is byte-identical to v0.30.0 (acceptance: golden-JSON test)
+- [ ] Vision and tool-result branches still take precedence (acceptance: existing
+      `step_vision_test.go` + `step_edge_test.go` pass unmodified)
+- [ ] A below-minimum prefix warns loudly (acceptance: test asserts the warning fires for a
+      70-token prefix on a 1024-minimum model)
+- [ ] Banked eval summaries carry non-zero `cache_read_input_tokens` (acceptance: live smoke run
+      against one Anthropic model, ≥ 70% read share on the second pass)
+- [ ] `ailang eval-report` shows a cache hit-rate column
+- [ ] `make ci` green, `make check-boundaries` green
+- [ ] CHANGELOG.md updated
+
+## Testing Strategy
+
+**Unit tests:**
+- Wire-shape golden tests for all four cases: no breakpoint, system-only, user-prefix-only, both
+- Branch-ordering: a vision message and a tool-result message with `CachedPrefix` set must take
+  their existing branches
+- Non-Anthropic providers: `CachedPrefix + UserPrompt` concatenation is byte-identical to today
+- Below-minimum guard fires once, not per-call
+
+**Integration tests:**
+- `Generate` against a recorded fixture asserting `cache_control` presence
+- Eval harness end-to-end with a stub provider, asserting cache tokens reach the summary
+
+**Manual testing:**
+- Live 2-benchmark run against one Anthropic model; confirm call 1 reports
+  `cache_creation_input_tokens > 0` and call 2 reports `cache_read_input_tokens > 0`
+- Confirm the Anthropic Console hit rate moves after a full suite
+
+## Deferred Decisions
+
+- **TTL tier per workload** (D5) — agent may choose; `ephemeral` for dense suites, 1h for
+  day-long rotations. Needs ≥3 reads to beat the 2× write premium
+- **Whether the warm-up shares the real system prompt or uses `max_tokens: 0`** — agent may
+  choose; `max_tokens: 0` prefills the cache without billing output tokens
+- **Exact eval-summary field names for cache tokens** — agent may choose, provided pre-v0.31.0
+  baselines still parse
+- **Whether the feedback-gate classifier prompt clears the minimum** — agent to measure; if it
+  does not, skip the breakpoint there rather than shipping a silent no-op
+
+## Non-Goals
+
+**Not attempted in this feature:**
+- **Moving the teaching prompt to the system role** — behavior-changing, invalidates baseline
+  comparability, and deserves its own A/B. Independently motivated; tracked separately
+- **Agent-mode / `claude` CLI caching** — the CLI manages its own; session reuse is a different
+  milestone
+- **`tool_result` breakpoints for multi-turn agentic loops** — real and worth doing, but the
+  `Generate` path carries our volume today. Phase 2 of *this* line of work
+- **Gemini Context Caching API** — still deferred from v0.18.4; structurally different async API
+- **Auto-detection of "should we cache?"** — explicit opt-in, consistent with v0.18.4
+- **Retrofitting cache metrics onto pre-v0.31.0 baselines** — the data was never recorded (V5);
+  it cannot be reconstructed
+
+## Timeline
+
+**Day 1** (~5 hours):
+- Phase 1: `Generate` cache support + wire-shape tests
+- Phase 2: eval harness + classifier wiring, warm-up
+
+**Day 2** (~3 hours):
+- Phase 3: cache-token persistence + report column
+- Live smoke run, CHANGELOG, docs
+
+**Total: ~8 hours across 2 days**
+
+## Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|-----------|
+| Branch-ordering bug silently breaks vision or tool-result requests | **High** | Conflict Surface §3 fixes the order explicitly; existing vision/tool tests must pass **unmodified** — if either needs editing, the ordering is wrong |
+| Splitting one text block into two subtly changes model behavior, shifting eval results | Med | Content is identical and the split is at a natural `\n\n## Task\n\n` boundary. Mitigate by running one benchmark both ways before banking; if outputs shift materially, escalate to D1 as a full re-baseline decision |
+| Cache-write premium makes short suites *more* expensive | Med | Break-even is 2 requests at 5-min TTL. Guard: skip the breakpoint when a run has fewer than 2 calls per model |
+| New summary fields break the dashboard / report readers | Med | Additive fields only; absent = 0. Test against a pre-v0.31.0 baseline directory |
+| We ship this and the org hit rate barely moves because the volume is actually CLI/subscription traffic | Med | Check the Anthropic Console breakdown **before** starting; Phase 3 makes our own side measurable either way |
+| 5-minute TTL expires between rotation batches, so writes never amortize | Low | D5 — switch those workloads to the 1h tier |
+
+## Related Documents
+
+**Direct predecessor — read before implementing:**
+- [design_docs/implemented/v0_18_4/m-ai-prompt-caching.md](../../implemented/v0_18_4/m-ai-prompt-caching.md) (0.44) —
+  established the `CacheBreakpoint` vocabulary, the byte-identical-when-unset guarantee, and the
+  one-shot warning pattern. Its "Future Work → Phase 2 — Wider Anthropic placement" is
+  precisely this doc. Note its scope gap: it wired `Step` only and never covered `Generate`.
+
+**Implemented (may inform design):**
+- [design_docs/implemented/v0_9_8/m-cost2-dashboard-firestore-optimization-sprint-plan.md](../../implemented/v0_9_8/m-cost2-dashboard-firestore-optimization-sprint-plan.md) (0.34) — cost-metric plumbing precedent
+
+**Planned (checked for overlap — ⚠️ one real collision):**
+- [design_docs/planned/v0_31_0/m-eval-token-headroom.md](m-eval-token-headroom.md) (0.32) —
+  **⚠️ Touches the same function in the same release.** Its subject is distinct (*output*
+  headroom and truncation visibility vs. this doc's *input* cache reuse), but its Files-to-Modify
+  list includes `internal/ai/anthropic/client.go` — specifically a `FinishReason:
+  mapStopReason(result.StopReason)` line inside `Generate`, the exact function this doc rewires
+  for `cache_control`. Both target v0.31.0. Low conflict risk (different lines, no shared
+  semantics) but **they must not be implemented in parallel on separate branches.** Sequence:
+  land the headroom one-liner first — it is ~1 LOC — then build cache support on top. It also
+  touches `internal/eval_harness/models.go`; this doc does not
+- [design_docs/planned/v0_29_0/m-anthropic-sandbox.md](../v0_29_0/m-anthropic-sandbox.md) (0.33) —
+  no overlap in files, but worth noting directionally: it introduces a **new** `ANTHROPIC_API_KEY`
+  consumer (managed-agents sandbox executor). That is new API-side traffic which should be
+  cache-aware from day one rather than retrofitted — the same mistake this doc exists to correct
+
+## References
+
+- [Design Axioms](/docs/references/axioms) — the 12 non-negotiable principles
+- Anthropic prompt caching: render order `tools → system → messages`; max 4 breakpoints;
+  minimum cacheable prefix 512 (Opus 5) / 1024 (Sonnet 4.6, Sonnet 5, Opus 4.8) / 4096
+  (Haiku 4.5) tokens; cache read ≈ 0.1×, 5-min write 1.25×, 1-hour write 2×
+- `.claude/rules/coding-standards.md` — Principle 2 (no silent fallbacks) motivates the
+  below-minimum warning
+
+## Future Work
+
+- **`tool_result` / multi-turn breakpoints** — the remaining half of v0.18.4's deferred Phase 2;
+  matters once agentic loops move onto the API path
+- **System-role teaching prompt A/B** — the deferred D1 alternative, on quality grounds
+- **Auto-cache heuristic** — with Phase 3 telemetry in hand, thresholds become tunable rather
+  than guessed
+- **Cache hit rate as a dashboard panel + regression gate** — so the next hit-rate collapse is
+  caught by us, not reported to us
+
+---
+
+**Document created**: 2026-07-29
+**Last updated**: 2026-07-29

--- a/internal/ai/anthropic/cache.go
+++ b/internal/ai/anthropic/cache.go
@@ -14,6 +14,7 @@ package anthropic
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/sunholo-data/ailang/internal/ai"
 )
@@ -38,16 +39,21 @@ type systemTextBlock struct {
 	CacheControl *cacheControlBlock `json:"cache_control,omitempty"`
 }
 
-// hasSystemBreakpoint returns true iff any breakpoint targets the system
-// prompt. Used to choose between string (no cache) and content-array (cached)
-// wire shapes for the System field.
-func hasSystemBreakpoint(breakpoints []ai.CacheBreakpoint) bool {
+// hasBreakpoint reports whether any breakpoint targets the given position.
+func hasBreakpoint(breakpoints []ai.CacheBreakpoint, position string) bool {
 	for _, bp := range breakpoints {
-		if bp.Position == "system" {
+		if bp.Position == position {
 			return true
 		}
 	}
 	return false
+}
+
+// hasSystemBreakpoint returns true iff any breakpoint targets the system
+// prompt. Used to choose between string (no cache) and content-array (cached)
+// wire shapes for the System field.
+func hasSystemBreakpoint(breakpoints []ai.CacheBreakpoint) bool {
+	return hasBreakpoint(breakpoints, "system")
 }
 
 // systemFieldFromPrompt builds the JSON for the Anthropic `system` field.
@@ -81,4 +87,130 @@ func systemFieldFromPrompt(systemPrompt string, breakpoints []ai.CacheBreakpoint
 		},
 	}
 	return json.Marshal(blocks)
+}
+
+// userContentFromPrompt builds the JSON for a user message's `content` field
+// (M-ANTHROPIC-CACHE-HIT-RATE, v0.31.0). Returns one of:
+//
+//   - a bare JSON-quoted string of cachedPrefix+userPrompt — used whenever
+//     there is nothing to cache (no "user_prefix" breakpoint, or an empty
+//     prefix). Byte-identical to the pre-v0.31.0 wire shape.
+//   - a two-block content array, cache_control on the first block only.
+//
+// The invariant callers depend on: whichever shape is returned, the text the
+// model sees is exactly cachedPrefix+userPrompt. The cached encoding must never
+// change what is being asked, only how it is framed — that is what lets prompt
+// caching land without invalidating eval baseline comparability (design doc D1).
+//
+// cache_control goes on block 0 ONLY. A marker on the volatile block would key
+// the cache to content that differs every request, so it would write an entry
+// per call and never read one — the silent-miss failure this milestone exists
+// to remove.
+func userContentFromPrompt(cachedPrefix, userPrompt string, breakpoints []ai.CacheBreakpoint) (json.RawMessage, error) {
+	if cachedPrefix == "" || !hasBreakpoint(breakpoints, "user_prefix") {
+		// Nothing to cache. Concatenate and emit the legacy bare-string shape.
+		// Note this still SENDS the prefix — dropping it would corrupt the
+		// prompt for callers who set it without declaring a breakpoint.
+		return json.Marshal(cachedPrefix + userPrompt)
+	}
+
+	blocks := []systemTextBlock{
+		{
+			Type:         "text",
+			Text:         cachedPrefix,
+			CacheControl: &cacheControlBlock{Type: "ephemeral"},
+		},
+	}
+	// Anthropic rejects empty text blocks, so only append the remainder when
+	// there is one.
+	if userPrompt != "" {
+		blocks = append(blocks, systemTextBlock{Type: "text", Text: userPrompt})
+	}
+	return json.Marshal(blocks)
+}
+
+// minCacheablePrefixByModel maps a model family substring to Anthropic's
+// minimum cacheable prefix in tokens. A prefix shorter than this is SILENTLY
+// not cached by the API — no error, just cache_creation_input_tokens: 0.
+//
+// The minimum is NOT monotonic across generations (Opus 4.6 needs 8x what
+// Opus 5 needs), so this cannot be inferred from a version ordering; it has to
+// be a table. Longest-match wins, so "claude-opus-4-6" is checked before the
+// broader "claude-opus".
+var minCacheablePrefixByModel = []struct {
+	match     string
+	minTokens int
+}{
+	{"claude-opus-5", 512},
+	{"claude-fable-5", 512},
+	{"claude-mythos-5", 512},
+	{"claude-opus-4-8", 1024},
+	{"claude-opus-4-7", 2048},
+	{"claude-opus-4-6", 4096},
+	{"claude-opus-4-5", 4096},
+	{"claude-sonnet-5", 1024},
+	{"claude-sonnet-4-6", 1024},
+	{"claude-sonnet-4-5", 1024},
+	{"claude-haiku-4-5", 4096},
+	{"claude-haiku-3-5", 2048},
+}
+
+// defaultMinCacheablePrefixTokens is used for models absent from the table
+// above. 1024 is the most common tier and the conservative choice: guessing
+// too LOW would suppress a warning that should fire, whereas guessing too high
+// only risks a spurious warning. This value affects diagnostics only — it never
+// changes what is sent — so a default here does not violate the no-silent-
+// fallback rule that governs pricing and model config.
+const defaultMinCacheablePrefixTokens = 1024
+
+// minCacheablePrefixTokens returns the minimum cacheable prefix for a model.
+func minCacheablePrefixTokens(model string) int {
+	best := -1
+	bestLen := 0
+	for _, e := range minCacheablePrefixByModel {
+		if strings.Contains(model, e.match) && len(e.match) > bestLen {
+			best, bestLen = e.minTokens, len(e.match)
+		}
+	}
+	if best < 0 {
+		return defaultMinCacheablePrefixTokens
+	}
+	return best
+}
+
+// approxTokens estimates a token count from raw text at the usual ~4 chars per
+// token. This is deliberately an ESTIMATE: it gates a stderr warning, never a
+// request. Calling Anthropic's count_tokens endpoint to decide whether to print
+// a diagnostic would add a network round-trip per request to save nothing.
+func approxTokens(s string) int { return len(s) / 4 }
+
+// cachePrefixTooSmall reports the model's minimum cacheable prefix and whether
+// the supplied prefix falls under it.
+//
+// This exists because the failure is otherwise INVISIBLE. Anthropic accepts a
+// too-short cache_control marker and simply declines to cache — which is how
+// the eval harness ran with a 70-token system prompt against a 1024-token
+// minimum (design doc V8) without anyone noticing the cache never engaged.
+func cachePrefixTooSmall(model, prefix string) (minTokens int, tooSmall bool) {
+	minTokens = minCacheablePrefixTokens(model)
+	return minTokens, approxTokens(prefix) < minTokens
+}
+
+// warnIfCachePrefixTooSmall emits a one-shot warning when a request declares a
+// cache breakpoint whose target is too short for the model to cache. Purely
+// diagnostic — the request proceeds unchanged.
+func warnIfCachePrefixTooSmall(req *ai.Request) {
+	if len(req.CacheBreakpoints) == 0 {
+		return
+	}
+	check := func(position, text string) {
+		if !hasBreakpoint(req.CacheBreakpoints, position) || text == "" {
+			return
+		}
+		if minTokens, tooSmall := cachePrefixTooSmall(req.Model, text); tooSmall {
+			ai.WarnOnceCachePrefixTooSmall(req.Model, position, approxTokens(text), minTokens)
+		}
+	}
+	check("system", req.SystemPrompt)
+	check("user_prefix", req.CachedPrefix)
 }

--- a/internal/ai/anthropic/cache_generate_test.go
+++ b/internal/ai/anthropic/cache_generate_test.go
@@ -350,3 +350,45 @@ func TestGenerate_CachedPrefixWithoutBreakpoint_StillReachesModel(t *testing.T) 
 		t.Errorf("message content = %q, want %q — the prefix must not be dropped", got, want)
 	}
 }
+
+// warnIfCachePrefixTooSmall walks both breakpoint positions. Exercising each
+// keeps the silent-no-op detector itself from rotting untested — it is the only
+// thing standing between us and a repeat of the 70-token-system-prompt miss.
+func TestWarnIfCachePrefixTooSmall_BothPositions(t *testing.T) {
+	cases := []struct {
+		name string
+		req  *ai.Request
+	}{
+		{"no_breakpoints_returns_early", &ai.Request{Model: "claude-sonnet-5", SystemPrompt: "short"}},
+		{
+			name: "system_breakpoint_too_small",
+			req: &ai.Request{
+				Model:            "claude-sonnet-5",
+				SystemPrompt:     "far too short to cache",
+				CacheBreakpoints: []ai.CacheBreakpoint{{Position: "system", TTL: "ephemeral"}},
+			},
+		},
+		{
+			name: "user_prefix_breakpoint_too_small",
+			req: &ai.Request{
+				Model:            "claude-sonnet-5",
+				CachedPrefix:     "also far too short",
+				CacheBreakpoints: []ai.CacheBreakpoint{{Position: "user_prefix", TTL: "ephemeral"}},
+			},
+		},
+		{
+			name: "large_prefix_does_not_warn",
+			req: &ai.Request{
+				Model:            "claude-sonnet-5",
+				CachedPrefix:     strings.Repeat("x", 64*1024),
+				CacheBreakpoints: []ai.CacheBreakpoint{{Position: "user_prefix", TTL: "ephemeral"}},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Diagnostic only — it must never panic and never alter the request.
+			warnIfCachePrefixTooSmall(tc.req)
+		})
+	}
+}

--- a/internal/ai/anthropic/cache_generate_test.go
+++ b/internal/ai/anthropic/cache_generate_test.go
@@ -1,0 +1,352 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/ai"
+)
+
+// M-ANTHROPIC-CACHE-HIT-RATE M1.
+//
+// These tests cover the gap recorded as V1 in the design doc: before this
+// milestone, internal/ai/anthropic/client.go contained ZERO references to
+// CacheBreakpoint, so the Generate path — which carries essentially all of our
+// Anthropic traffic — could not request a prompt cache at all.
+//
+// The load-bearing assertion in this file is the back-compat one: a request
+// that declares no breakpoints must produce wire bytes identical to v0.30.0.
+
+// ---------------------------------------------------------------------------
+// userContentFromPrompt — pure wire-shape builder
+// ---------------------------------------------------------------------------
+
+// TestUserContent_Backcompat_BareString: with no user_prefix breakpoint (or no
+// CachedPrefix to cache), the user content field stays a bare JSON string —
+// byte-identical to the pre-M1 shape.
+func TestUserContent_Backcompat_BareString(t *testing.T) {
+	cases := []struct {
+		name         string
+		cachedPrefix string
+		userPrompt   string
+		breakpoints  []ai.CacheBreakpoint
+		want         string
+	}{
+		{
+			name:        "nil_breakpoints",
+			userPrompt:  "Hello",
+			breakpoints: nil,
+			want:        `"Hello"`,
+		},
+		{
+			name:        "empty_breakpoints",
+			userPrompt:  "Hello",
+			breakpoints: []ai.CacheBreakpoint{},
+			want:        `"Hello"`,
+		},
+		{
+			name:        "unrelated_breakpoint_position",
+			userPrompt:  "Hello",
+			breakpoints: []ai.CacheBreakpoint{{Position: "system", TTL: "ephemeral"}},
+			want:        `"Hello"`,
+		},
+		{
+			// A prefix with no breakpoint must still reach the model — it is
+			// concatenated, not dropped. This is the provider-neutral contract
+			// (D2): CachedPrefix + UserPrompt is what the model sees.
+			name:         "prefix_without_breakpoint_concatenates",
+			cachedPrefix: "TEACHING",
+			userPrompt:   "\n\n## Task\n\nDo it",
+			breakpoints:  nil,
+			want:         `"TEACHING\n\n## Task\n\nDo it"`,
+		},
+		{
+			// Breakpoint declared but nothing to cache — degrade to the bare
+			// string rather than emitting a one-block array.
+			name:         "breakpoint_but_empty_prefix",
+			cachedPrefix: "",
+			userPrompt:   "Hello",
+			breakpoints:  []ai.CacheBreakpoint{{Position: "user_prefix", TTL: "ephemeral"}},
+			want:         `"Hello"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := userContentFromPrompt(tc.cachedPrefix, tc.userPrompt, tc.breakpoints)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if string(out) != tc.want {
+				t.Errorf("user content wire bytes = %s, want %s (back-compat)", string(out), tc.want)
+			}
+		})
+	}
+}
+
+// TestUserContent_TwoBlockArray: the caching shape. Block 0 carries the stable
+// prefix plus cache_control; block 1 carries the volatile remainder and must
+// NOT carry a marker (a marker there would key the cache to the varying task
+// and never read).
+func TestUserContent_TwoBlockArray(t *testing.T) {
+	out, err := userContentFromPrompt(
+		"TEACHING PROMPT",
+		"\n\n## Task\n\nSolve it",
+		[]ai.CacheBreakpoint{{Position: "user_prefix", TTL: "ephemeral"}},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var blocks []struct {
+		Type         string `json:"type"`
+		Text         string `json:"text"`
+		CacheControl *struct {
+			Type string `json:"type"`
+		} `json:"cache_control"`
+	}
+	if err := json.Unmarshal(out, &blocks); err != nil {
+		t.Fatalf("expected a content array, got %s (%v)", string(out), err)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("got %d content blocks, want 2: %s", len(blocks), string(out))
+	}
+	if blocks[0].Text != "TEACHING PROMPT" {
+		t.Errorf("block[0].text = %q, want the cached prefix", blocks[0].Text)
+	}
+	if blocks[0].CacheControl == nil || blocks[0].CacheControl.Type != "ephemeral" {
+		t.Errorf("block[0] must carry cache_control{type:ephemeral}, got %+v", blocks[0].CacheControl)
+	}
+	if blocks[1].Text != "\n\n## Task\n\nSolve it" {
+		t.Errorf("block[1].text = %q, want the volatile remainder", blocks[1].Text)
+	}
+	if blocks[1].CacheControl != nil {
+		t.Error("block[1] must NOT carry cache_control — it varies per request, so a marker there never reads")
+	}
+	for i, b := range blocks {
+		if b.Type != "text" {
+			t.Errorf("block[%d].type = %q, want \"text\"", i, b.Type)
+		}
+	}
+}
+
+// TestUserContent_ConcatenationIsLossless: whatever the encoding, the text the
+// model sees must equal cachedPrefix + userPrompt. This is what protects eval
+// baseline comparability under D1 (cache in place, don't move to system role).
+func TestUserContent_ConcatenationIsLossless(t *testing.T) {
+	const prefix = "TEACHING PROMPT"
+	const task = "\n\n## Task\n\nSolve it"
+
+	cached, err := userContentFromPrompt(prefix, task,
+		[]ai.CacheBreakpoint{{Position: "user_prefix", TTL: "ephemeral"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	plain, err := userContentFromPrompt(prefix, task, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Uncached form is a bare string.
+	var plainText string
+	if err := json.Unmarshal(plain, &plainText); err != nil {
+		t.Fatalf("uncached form should be a JSON string: %v", err)
+	}
+	// Cached form is an array; concatenating its text must equal the same thing.
+	var blocks []struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(cached, &blocks); err != nil {
+		t.Fatalf("cached form should be a JSON array: %v", err)
+	}
+	var sb strings.Builder
+	for _, b := range blocks {
+		sb.WriteString(b.Text)
+	}
+	if sb.String() != plainText {
+		t.Errorf("cached encoding changes what the model sees:\n cached = %q\n plain  = %q", sb.String(), plainText)
+	}
+	if plainText != prefix+task {
+		t.Errorf("plain text = %q, want %q", plainText, prefix+task)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Minimum cacheable prefix — the silent-no-op guard
+// ---------------------------------------------------------------------------
+
+// TestCachePrefixTooSmall: Anthropic silently declines to cache a prefix under
+// the model's minimum (no error, cache_creation_input_tokens: 0). That silence
+// is exactly how the eval-harness gap (design doc V8: a 70-token system prompt
+// against a 1024-token minimum) stayed invisible. Detect it and warn.
+func TestCachePrefixTooSmall(t *testing.T) {
+	small := strings.Repeat("x", 400)     // ~100 tokens
+	big := strings.Repeat("x", 64*1024)   // ~16k tokens
+	medium := strings.Repeat("x", 8*1024) // ~2k tokens
+
+	cases := []struct {
+		name         string
+		model        string
+		prefix       string
+		wantTooSmall bool
+		wantMin      int
+	}{
+		{"opus5_small_prefix_too_small", "claude-opus-5", small, true, 512},
+		{"opus5_big_prefix_ok", "claude-opus-5", big, false, 512},
+		{"sonnet5_small_too_small", "claude-sonnet-5", small, true, 1024},
+		{"sonnet5_big_ok", "claude-sonnet-5", big, false, 1024},
+		{"haiku45_medium_too_small", "claude-haiku-4-5", medium, true, 4096},
+		{"haiku45_big_ok", "claude-haiku-4-5", big, false, 4096},
+		{"opus46_medium_too_small", "claude-opus-4-6", medium, true, 4096},
+		{"unknown_model_defaults_conservative", "some-future-model", small, true, 1024},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			min, tooSmall := cachePrefixTooSmall(tc.model, tc.prefix)
+			if tooSmall != tc.wantTooSmall {
+				t.Errorf("cachePrefixTooSmall(%s, %d chars) tooSmall = %v, want %v",
+					tc.model, len(tc.prefix), tooSmall, tc.wantTooSmall)
+			}
+			if min != tc.wantMin {
+				t.Errorf("minimum for %s = %d, want %d", tc.model, min, tc.wantMin)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Generate wire shape — end to end through the HTTP client
+// ---------------------------------------------------------------------------
+
+// captureGenerateBody runs one Generate call against a stub server and returns
+// the raw JSON request body the client actually sent.
+func captureGenerateBody(t *testing.T, req *ai.Request) map[string]any {
+	t.Helper()
+	var captured map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant",
+			"content":[{"type":"text","text":"ok"}],"model":"claude-sonnet-5",
+			"stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":2}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient("test-key", WithBaseURL(srv.URL))
+	if _, err := c.Generate(context.Background(), req); err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	return captured
+}
+
+// TestGenerate_NoBreakpoints_ByteIdenticalShape is the back-compat gate: a
+// request that declares nothing must look exactly as it did in v0.30.0 —
+// `system` a bare string, message content a bare string.
+func TestGenerate_NoBreakpoints_ByteIdenticalShape(t *testing.T) {
+	body := captureGenerateBody(t, &ai.Request{
+		Model:        "claude-sonnet-5",
+		SystemPrompt: "You are helpful.",
+		UserPrompt:   "Hello",
+		MaxTokens:    2048,
+	})
+
+	if got, ok := body["system"].(string); !ok || got != "You are helpful." {
+		t.Errorf("system = %#v, want the bare string \"You are helpful.\" (back-compat)", body["system"])
+	}
+	msgs, _ := body["messages"].([]any)
+	if len(msgs) != 1 {
+		t.Fatalf("got %d messages, want 1", len(msgs))
+	}
+	m, _ := msgs[0].(map[string]any)
+	if got, ok := m["content"].(string); !ok || got != "Hello" {
+		t.Errorf("message content = %#v, want the bare string \"Hello\" (back-compat)", m["content"])
+	}
+}
+
+// TestGenerate_UserPrefixBreakpoint_EmitsCacheControl closes V1: the Generate
+// path can now request a cache.
+func TestGenerate_UserPrefixBreakpoint_EmitsCacheControl(t *testing.T) {
+	teaching := strings.Repeat("TEACHING ", 4096) // comfortably over every minimum
+	body := captureGenerateBody(t, &ai.Request{
+		Model:            "claude-sonnet-5",
+		SystemPrompt:     "You are helpful.",
+		CachedPrefix:     teaching,
+		UserPrompt:       "\n\n## Task\n\nSolve it",
+		MaxTokens:        2048,
+		CacheBreakpoints: []ai.CacheBreakpoint{{Position: "user_prefix", TTL: "ephemeral"}},
+	})
+
+	msgs, _ := body["messages"].([]any)
+	if len(msgs) != 1 {
+		t.Fatalf("got %d messages, want 1", len(msgs))
+	}
+	m, _ := msgs[0].(map[string]any)
+	blocks, ok := m["content"].([]any)
+	if !ok {
+		t.Fatalf("message content = %#v, want a content array", m["content"])
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("got %d content blocks, want 2", len(blocks))
+	}
+	b0, _ := blocks[0].(map[string]any)
+	cc, ok := b0["cache_control"].(map[string]any)
+	if !ok || cc["type"] != "ephemeral" {
+		t.Errorf("block[0].cache_control = %#v, want {type: ephemeral}", b0["cache_control"])
+	}
+	b1, _ := blocks[1].(map[string]any)
+	if _, present := b1["cache_control"]; present {
+		t.Error("block[1] must not carry cache_control")
+	}
+}
+
+// TestGenerate_SystemBreakpoint_EmitsCacheControl: the system position works on
+// Generate too, not just on Step.
+func TestGenerate_SystemBreakpoint_EmitsCacheControl(t *testing.T) {
+	body := captureGenerateBody(t, &ai.Request{
+		Model:            "claude-sonnet-5",
+		SystemPrompt:     strings.Repeat("SYSTEM ", 4096),
+		UserPrompt:       "Hello",
+		MaxTokens:        2048,
+		CacheBreakpoints: []ai.CacheBreakpoint{{Position: "system", TTL: "ephemeral"}},
+	})
+
+	sys, ok := body["system"].([]any)
+	if !ok {
+		t.Fatalf("system = %#v, want a content array when a system breakpoint is declared", body["system"])
+	}
+	if len(sys) != 1 {
+		t.Fatalf("got %d system blocks, want 1", len(sys))
+	}
+	s0, _ := sys[0].(map[string]any)
+	cc, ok := s0["cache_control"].(map[string]any)
+	if !ok || cc["type"] != "ephemeral" {
+		t.Errorf("system block cache_control = %#v, want {type: ephemeral}", s0["cache_control"])
+	}
+}
+
+// TestGenerate_CachedPrefixWithoutBreakpoint_StillReachesModel: a caller that
+// sets CachedPrefix but declares no breakpoint must still have that text sent —
+// silently dropping it would corrupt the prompt.
+func TestGenerate_CachedPrefixWithoutBreakpoint_StillReachesModel(t *testing.T) {
+	body := captureGenerateBody(t, &ai.Request{
+		Model:        "claude-sonnet-5",
+		CachedPrefix: "TEACHING",
+		UserPrompt:   "\n\n## Task\n\nSolve it",
+		MaxTokens:    2048,
+	})
+
+	msgs, _ := body["messages"].([]any)
+	m, _ := msgs[0].(map[string]any)
+	got, ok := m["content"].(string)
+	if !ok {
+		t.Fatalf("message content = %#v, want a bare string", m["content"])
+	}
+	if want := "TEACHING\n\n## Task\n\nSolve it"; got != want {
+		t.Errorf("message content = %q, want %q — the prefix must not be dropped", got, want)
+	}
+}

--- a/internal/ai/anthropic/cache_live_test.go
+++ b/internal/ai/anthropic/cache_live_test.go
@@ -1,0 +1,90 @@
+package anthropic
+
+// Live prompt-cache verification for M-ANTHROPIC-CACHE-HIT-RATE.
+//
+// This is a MANUAL, live, API-key-gated probe. It is NEVER run in default CI:
+// it makes two real billed Anthropic calls. It exists because the rest of this
+// milestone's tests prove only the WIRE SHAPE — that we emit cache_control in
+// the right place. They cannot prove Anthropic actually created and then read a
+// cache entry, and that distinction is the whole point of the milestone: the
+// failure mode we are fixing is one where the API accepts the marker, returns
+// 200, and silently declines to cache (design doc V8).
+//
+// Run it with:
+//
+//	ANTHROPIC_API_KEY=sk-ant-... AILANG_LIVE_ANTHROPIC_CACHE=1 \
+//	  go test ./internal/ai/anthropic/ -run TestLiveGeneratePromptCache -v -timeout 5m
+//
+// Optional override:
+//
+//	AILANG_LIVE_CACHE_MODEL  (default "claude-sonnet-5")
+//
+// Expected result: call 1 reports cache_creation_input_tokens > 0 (a write),
+// call 2 reports cache_read_input_tokens > 0 (a hit). If call 2 reports a
+// second write instead of a read, the prefix is being invalidated between calls
+// and the cache is not working, no matter how correct the wire shape looks.
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/ai"
+)
+
+func TestLiveGeneratePromptCache(t *testing.T) {
+	if os.Getenv("AILANG_LIVE_ANTHROPIC_CACHE") == "" {
+		t.Skip("live probe: set AILANG_LIVE_ANTHROPIC_CACHE=1 (makes 2 real billed calls)")
+	}
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		t.Skip("live probe: ANTHROPIC_API_KEY not set")
+	}
+	model := os.Getenv("AILANG_LIVE_CACHE_MODEL")
+	if model == "" {
+		model = "claude-sonnet-5"
+	}
+
+	// A prefix comfortably over every model tier's minimum (~4k tokens). Must be
+	// byte-identical across both calls or the prefix match fails.
+	prefix := "You are a reference assistant. Background material follows.\n" +
+		strings.Repeat("Fact: the sky is blue and water is wet. ", 1500)
+
+	client := NewClient(apiKey)
+	call := func(task string) *ai.Response {
+		t.Helper()
+		resp, err := client.Generate(context.Background(), &ai.Request{
+			Model:            model,
+			CachedPrefix:     prefix,
+			UserPrompt:       "\n\n## Task\n\n" + task,
+			MaxTokens:        16,
+			CacheBreakpoints: []ai.CacheBreakpoint{{Position: "user_prefix", TTL: "ephemeral"}},
+		})
+		if err != nil {
+			t.Fatalf("Generate failed: %v", err)
+		}
+		return resp
+	}
+
+	// Call 1 writes the cache. The task differs between calls so that ONLY the
+	// shared prefix can account for any cache read on call 2.
+	first := call("Reply with the single word: one.")
+	t.Logf("call 1: input=%d cache_write=%d cache_read=%d",
+		first.InputTokens, first.CacheCreationInputTokens, first.CacheReadInputTokens)
+
+	second := call("Reply with the single word: two.")
+	t.Logf("call 2: input=%d cache_write=%d cache_read=%d",
+		second.InputTokens, second.CacheCreationInputTokens, second.CacheReadInputTokens)
+
+	if first.CacheCreationInputTokens == 0 {
+		t.Errorf("call 1 wrote no cache (cache_creation_input_tokens=0) — the marker was accepted but nothing was cached; check the prefix is above this model's minimum")
+	}
+	if second.CacheReadInputTokens == 0 {
+		t.Errorf("call 2 read no cache (cache_read_input_tokens=0) — the prefix is being invalidated between calls; something upstream of the breakpoint differs per request")
+	}
+	if second.CacheReadInputTokens > 0 && second.CacheReadInputTokens < first.CacheCreationInputTokens/2 {
+		t.Errorf("call 2 read only %d of the %d cached tokens — the breakpoint is landing mid-prefix",
+			second.CacheReadInputTokens, first.CacheCreationInputTokens)
+	}
+}

--- a/internal/ai/anthropic/client.go
+++ b/internal/ai/anthropic/client.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -69,10 +70,17 @@ func NewClient(apiKey string, opts ...ClientOption) *Client {
 }
 
 // messagesRequest represents the request body for the Messages API.
+//
+// System and messageContent.Content are json.RawMessage rather than string
+// because Anthropic accepts either a bare string or a content array in both
+// positions, and prompt caching requires the array form (a cache_control marker
+// attaches to a content block, not to a string). Marshalling a plain string
+// through RawMessage produces byte-identical output to the old `string` field,
+// so requests that declare no cache breakpoints are unchanged on the wire.
 type messagesRequest struct {
 	Model       string           `json:"model"`
 	MaxTokens   int              `json:"max_tokens"`
-	System      string           `json:"system,omitempty"`
+	System      json.RawMessage  `json:"system,omitempty"`
 	Messages    []messageContent `json:"messages"`
 	Temperature float64          `json:"temperature,omitempty"`
 	Tools       []toolDef        `json:"tools,omitempty"`
@@ -108,8 +116,17 @@ type outputConfig struct {
 }
 
 type messageContent struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role string `json:"role"`
+	// Content is a bare JSON string in the common case, or a content array when
+	// a prompt-cache breakpoint splits the turn. See userContentFromPrompt.
+	Content json.RawMessage `json:"content"`
+}
+
+// textContent wraps a plain string as the Content field's JSON. Marshalling a
+// string cannot fail, so the error is dropped deliberately.
+func textContent(s string) json.RawMessage {
+	b, _ := json.Marshal(s)
+	return b
 }
 
 // toolDef represents a tool definition for structured output via tool_use.
@@ -202,11 +219,22 @@ func (c *Client) Generate(ctx context.Context, req *ai.Request) (*ai.Response, e
 		maxTokens = 4096
 	}
 
+	// M-ANTHROPIC-CACHE-HIT-RATE: build the user turn cache-aware. With no
+	// breakpoints declared this is byte-identical to the pre-v0.31.0 shape.
+	userContent, ucErr := userContentFromPrompt(req.CachedPrefix, req.UserPrompt, req.CacheBreakpoints)
+	if ucErr != nil {
+		wrapped := ai.NewAIError(ai.CodeInternal,
+			fmt.Sprintf("anthropic: failed to marshal user content: %v", ucErr), false)
+		span.RecordError(wrapped)
+		span.SetStatus(codes.Error, wrapped.Error())
+		return nil, wrapped
+	}
+
 	apiReq := messagesRequest{
 		Model:     req.Model,
 		MaxTokens: maxTokens,
 		Messages: []messageContent{
-			{Role: "user", Content: req.UserPrompt},
+			{Role: "user", Content: userContent},
 		},
 	}
 	tb, oc, tErr := thinkingConfigFor(reasoning, req.Model)
@@ -218,9 +246,20 @@ func (c *Client) Generate(ctx context.Context, req *ai.Request) (*ai.Response, e
 	apiReq.Thinking = tb
 	apiReq.OutputConfig = oc
 
-	if req.SystemPrompt != "" {
-		apiReq.System = req.SystemPrompt
+	systemField, sysErr := systemFieldFromPrompt(req.SystemPrompt, req.CacheBreakpoints)
+	if sysErr != nil {
+		wrapped := ai.NewAIError(ai.CodeInternal,
+			fmt.Sprintf("anthropic: failed to marshal system field: %v", sysErr), false)
+		span.RecordError(wrapped)
+		span.SetStatus(codes.Error, wrapped.Error())
+		return nil, wrapped
 	}
+	apiReq.System = systemField
+
+	// Warn once if a declared breakpoint targets a prefix too short for the
+	// model to actually cache. Anthropic accepts the marker and silently skips
+	// caching, so without this the miss is invisible (design doc V8).
+	warnIfCachePrefixTooSmall(req)
 
 	if req.Temperature > 0 {
 		apiReq.Temperature = req.Temperature

--- a/internal/ai/anthropic/client_test.go
+++ b/internal/ai/anthropic/client_test.go
@@ -42,11 +42,15 @@ func TestClient_Generate_Success(t *testing.T) {
 		if reqBody.MaxTokens != 2048 {
 			t.Errorf("MaxTokens = %d, want 2048", reqBody.MaxTokens)
 		}
-		if reqBody.System != "You are helpful." {
-			t.Errorf("System = %s, want 'You are helpful.'", reqBody.System)
+		// System and Content are json.RawMessage since v0.31.0 (prompt caching
+		// needs the content-array form). With no cache breakpoints declared they
+		// must still marshal as bare JSON strings — asserting the raw bytes here
+		// is a stricter back-compat check than the old string comparison.
+		if string(reqBody.System) != `"You are helpful."` {
+			t.Errorf("System = %s, want `\"You are helpful.\"` (bare string, no cache breakpoints)", reqBody.System)
 		}
-		if len(reqBody.Messages) != 1 || reqBody.Messages[0].Content != "Hello" {
-			t.Errorf("Messages = %v, want [{user Hello}]", reqBody.Messages)
+		if len(reqBody.Messages) != 1 || string(reqBody.Messages[0].Content) != `"Hello"` {
+			t.Errorf("Messages = %v, want [{user \"Hello\"}] (bare string content)", reqBody.Messages)
 		}
 
 		// Return response

--- a/internal/ai/anthropic/reasoning_test.go
+++ b/internal/ai/anthropic/reasoning_test.go
@@ -188,7 +188,7 @@ func TestAnthropic_ThinkingWireShape_PerGeneration(t *testing.T) {
 			body, mErr := json.Marshal(messagesRequest{
 				Model:        tt.model,
 				MaxTokens:    64000,
-				Messages:     []messageContent{{Role: "user", Content: "hi"}},
+				Messages:     []messageContent{{Role: "user", Content: textContent("hi")}},
 				Thinking:     tb,
 				OutputConfig: oc,
 			})

--- a/internal/ai/cache_warnings.go
+++ b/internal/ai/cache_warnings.go
@@ -47,6 +47,28 @@ func WarnOnceCacheHintIgnored(provider, reason string) {
 		provider, reason)
 }
 
+// WarnOnceCachePrefixTooSmall emits a single structured warning per process
+// for a given (model, position) pair when a declared cache breakpoint targets
+// content shorter than the model's minimum cacheable prefix.
+//
+// This failure mode is otherwise INVISIBLE: Anthropic accepts the cache_control
+// marker, returns 200, and simply declines to cache — reporting
+// cache_creation_input_tokens: 0 with no error. The eval harness shipped in
+// exactly that state (a ~70-token system prompt against a 1024-token minimum),
+// which is why the low cache-hit rate had to be reported to us from outside
+// rather than surfacing in our own telemetry.
+//
+// The warning text is greppable as `cache_prefix_too_small_<position>`.
+func WarnOnceCachePrefixTooSmall(model, position string, gotTokens, minTokens int) {
+	key := "prefix_too_small:" + model + ":" + position
+	if _, loaded := cacheWarningsEmitted.LoadOrStore(key, struct{}{}); loaded {
+		return
+	}
+	fmt.Fprintf(os.Stderr,
+		"[ai] cache_prefix_too_small_%s: model %s needs >=%d tokens to cache, breakpoint targets ~%d — Anthropic will accept the marker and silently NOT cache (the call proceeds normally and will not be re-warned this session)\n",
+		position, model, minTokens, gotTokens)
+}
+
 // resetCacheWarningsForTesting clears the dedup set. Test-only — production
 // code never calls this.
 func resetCacheWarningsForTesting() {

--- a/internal/ai/cached_prefix_test.go
+++ b/internal/ai/cached_prefix_test.go
@@ -1,0 +1,50 @@
+package ai
+
+import "testing"
+
+// M-ANTHROPIC-CACHE-HIT-RATE M1.
+//
+// CachedPrefix is a splitting hint, not a content change. Providers that do not
+// implement cache splitting must still send the whole prompt — FullUserPrompt
+// is the single place that contract is expressed, so it is the single place it
+// can regress.
+
+func TestFullUserPrompt_ConcatenatesPrefix(t *testing.T) {
+	cases := []struct {
+		name         string
+		cachedPrefix string
+		userPrompt   string
+		want         string
+	}{
+		{"no_prefix_is_identity", "", "Hello", "Hello"},
+		{"prefix_concatenates", "TEACHING", "\n\n## Task\n\nDo it", "TEACHING\n\n## Task\n\nDo it"},
+		{"prefix_only", "TEACHING", "", "TEACHING"},
+		{"both_empty", "", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &Request{CachedPrefix: tc.cachedPrefix, UserPrompt: tc.userPrompt}
+			if got := r.FullUserPrompt(); got != tc.want {
+				t.Errorf("FullUserPrompt() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFullUserPrompt_SplitIsEquivalentToPreConcatenated is the byte-identity
+// guarantee for non-Anthropic providers: a caller that splits its prompt into
+// CachedPrefix+UserPrompt must produce exactly what a caller that pre-
+// concatenated would, so migrating a call site to the split form cannot change
+// what any provider sends.
+func TestFullUserPrompt_SplitIsEquivalentToPreConcatenated(t *testing.T) {
+	const teaching = "TEACHING PROMPT BODY"
+	const task = "\n\n## Task\n\nSolve it"
+
+	split := &Request{CachedPrefix: teaching, UserPrompt: task}
+	preConcatenated := &Request{UserPrompt: teaching + task}
+
+	if split.FullUserPrompt() != preConcatenated.FullUserPrompt() {
+		t.Errorf("split form = %q, pre-concatenated = %q — must be identical",
+			split.FullUserPrompt(), preConcatenated.FullUserPrompt())
+	}
+}

--- a/internal/ai/gemini/generate.go
+++ b/internal/ai/gemini/generate.go
@@ -142,15 +142,20 @@ func (c *Client) generateContent(ctx context.Context, req *ai.Request) (*ai.Resp
 	reasoningTokens := result.UsageMetadata.ThoughtsTokenCount
 
 	return &ai.Response{
-		Text:         text,
-		ImageData:    imageData,
-		ImageMIME:    imageMIME,
-		InputTokens:  result.UsageMetadata.PromptTokenCount,
-		OutputTokens: outputTokens,
-		TotalTokens:  result.UsageMetadata.TotalTokenCount,
-		ReasonTokens: reasoningTokens,
-		FinishReason: normalizeGeminiFinishReason(result.Candidates[0].FinishReason),
-		Model:        req.Model,
+		Text:        text,
+		ImageData:   imageData,
+		ImageMIME:   imageMIME,
+		InputTokens: result.UsageMetadata.PromptTokenCount,
+		// Gemini reports both implicit (2.5+, automatic) and explicit
+		// (CachedContent API) cache hits here. Recording it is the only way to
+		// tell whether implicit caching is engaging, since there is no
+		// request-side knob for it.
+		CacheReadInputTokens: result.UsageMetadata.CachedContentTokenCount,
+		OutputTokens:         outputTokens,
+		TotalTokens:          result.UsageMetadata.TotalTokenCount,
+		ReasonTokens:         reasoningTokens,
+		FinishReason:         normalizeGeminiFinishReason(result.Candidates[0].FinishReason),
+		Model:                req.Model,
 	}, nil
 }
 

--- a/internal/ai/gemini/generate.go
+++ b/internal/ai/gemini/generate.go
@@ -22,7 +22,7 @@ func (c *Client) generateContent(ctx context.Context, req *ai.Request) (*ai.Resp
 	}
 
 	// Build request — detect multimodal JSON input and construct proper parts
-	parts := buildParts(req.UserPrompt)
+	parts := buildParts(req.FullUserPrompt())
 	apiReq := generateRequest{
 		Contents: []content{
 			{

--- a/internal/ai/ollama/client.go
+++ b/internal/ai/ollama/client.go
@@ -126,7 +126,7 @@ func (c *Client) Generate(ctx context.Context, req *ai.Request) (*ai.Response, e
 
 	messages = append(messages, ollamaapi.Message{
 		Role:    "user",
-		Content: req.UserPrompt,
+		Content: req.FullUserPrompt(),
 	})
 
 	// Build options

--- a/internal/ai/openai/cache_usage_test.go
+++ b/internal/ai/openai/cache_usage_test.go
@@ -1,0 +1,76 @@
+package openai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/ai"
+)
+
+// M-ANTHROPIC-CACHE-HIT-RATE follow-up: OpenAI caches prompts automatically
+// (>=1024 tokens, stable prefix) — there is no request-side knob. The only
+// thing we control is whether we RECORD the hit. Before this, the Generate path
+// dropped usage.prompt_tokens_details.cached_tokens on the floor, so every
+// banked OpenAI eval showed 0 cache reads and a working cache was
+// indistinguishable from a broken one.
+//
+// This test pins the JSON tag and the mapping to the normalized field.
+func TestGenerate_RecordsAutomaticCacheHit_ChatCompletions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-1","object":"chat.completion","model":"gpt-5",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":16500,"completion_tokens":5,"total_tokens":16505,
+			         "prompt_tokens_details":{"cached_tokens":16000}}
+		}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient("test-key", WithBaseURL(srv.URL))
+	resp, err := c.Generate(context.Background(), &ai.Request{
+		Model:      "gpt-4o", // legacy models route to Chat Completions
+		UserPrompt: "hello",
+		MaxTokens:  16,
+	})
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	if resp.CacheReadInputTokens != 16000 {
+		t.Errorf("CacheReadInputTokens = %d, want 16000 — automatic cache hits must reach the normalized field or they never get banked",
+			resp.CacheReadInputTokens)
+	}
+}
+
+// The Responses API (gpt-5, o1, o3, codex) reports the same automatic cache
+// under a different key — input_tokens_details.cached_tokens. Both paths must
+// land on the normalized field or half our OpenAI fleet stays unmeasurable.
+func TestGenerate_RecordsAutomaticCacheHit_ResponsesAPI(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"resp_1","object":"response","model":"gpt-5",
+			"output":[{"type":"message","role":"assistant",
+			           "content":[{"type":"output_text","text":"ok"}]}],
+			"usage":{"input_tokens":16500,"output_tokens":5,"total_tokens":16505,
+			         "input_tokens_details":{"cached_tokens":16000}}
+		}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient("test-key", WithBaseURL(srv.URL))
+	resp, err := c.Generate(context.Background(), &ai.Request{
+		Model:      "gpt-5",
+		UserPrompt: "hello",
+		MaxTokens:  16,
+	})
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	if resp.CacheReadInputTokens != 16000 {
+		t.Errorf("CacheReadInputTokens = %d, want 16000 (Responses API input_tokens_details.cached_tokens)",
+			resp.CacheReadInputTokens)
+	}
+}

--- a/internal/ai/openai/chat.go
+++ b/internal/ai/openai/chat.go
@@ -24,7 +24,7 @@ func (c *Client) generateChat(ctx context.Context, req *ai.Request, reasoning ai
 
 	messages = append(messages, chatMessage{
 		Role:    "user",
-		Content: req.UserPrompt,
+		Content: req.FullUserPrompt(),
 	})
 
 	// Build request

--- a/internal/ai/openai/chat.go
+++ b/internal/ai/openai/chat.go
@@ -140,12 +140,13 @@ func (c *Client) generateChat(ctx context.Context, req *ai.Request, reasoning ai
 	}
 
 	return &ai.Response{
-		Text:         text,
-		InputTokens:  result.Usage.PromptTokens,
-		OutputTokens: outputTokens,
-		TotalTokens:  result.Usage.TotalTokens,
-		ReasonTokens: reasoningTokens,
-		FinishReason: MapChatFinishReason(result.Choices[0].FinishReason),
-		Model:        result.Model,
+		Text:                 text,
+		InputTokens:          result.Usage.PromptTokens,
+		CacheReadInputTokens: result.Usage.PromptTokensDetails.CachedTokens,
+		OutputTokens:         outputTokens,
+		TotalTokens:          result.Usage.TotalTokens,
+		ReasonTokens:         reasoningTokens,
+		FinishReason:         MapChatFinishReason(result.Choices[0].FinishReason),
+		Model:                result.Model,
 	}, nil
 }

--- a/internal/ai/openai/responses.go
+++ b/internal/ai/openai/responses.go
@@ -27,7 +27,7 @@ func (c *Client) generateResponses(ctx context.Context, req *ai.Request, reasoni
 
 	input = append(input, responsesInput{
 		Role:    "user",
-		Content: req.UserPrompt,
+		Content: req.FullUserPrompt(),
 	})
 
 	// Build request

--- a/internal/ai/openai/responses.go
+++ b/internal/ai/openai/responses.go
@@ -148,11 +148,12 @@ func (c *Client) generateResponses(ctx context.Context, req *ai.Request, reasoni
 	}
 
 	return &ai.Response{
-		Text:         text,
-		InputTokens:  result.Usage.InputTokens,
-		OutputTokens: outputTokens,
-		TotalTokens:  result.Usage.TotalTokens,
-		ReasonTokens: reasoningTokens,
-		Model:        result.Model,
+		Text:                 text,
+		InputTokens:          result.Usage.InputTokens,
+		CacheReadInputTokens: result.Usage.InputDetails.CachedTokens,
+		OutputTokens:         outputTokens,
+		TotalTokens:          result.Usage.TotalTokens,
+		ReasonTokens:         reasoningTokens,
+		Model:                result.Model,
 	}, nil
 }

--- a/internal/ai/openai/types.go
+++ b/internal/ai/openai/types.go
@@ -63,6 +63,14 @@ type chatUsage struct {
 	CompletionTokensDetails struct {
 		ReasoningTokens int `json:"reasoning_tokens"`
 	} `json:"completion_tokens_details,omitempty"`
+	// PromptTokensDetails.CachedTokens reports OpenAI's AUTOMATIC prompt cache
+	// (prompts >=1024 tokens with a stable prefix). There is no request-side
+	// knob to set — the only thing we control is whether we RECORD it. Without
+	// this the Generate path banked 0 for every OpenAI run and we could not tell
+	// a working cache from a broken one (M-ANTHROPIC-CACHE-HIT-RATE follow-up).
+	PromptTokensDetails struct {
+		CachedTokens int `json:"cached_tokens"`
+	} `json:"prompt_tokens_details,omitempty"`
 }
 
 // errorResponse represents an error response from the API.
@@ -166,6 +174,10 @@ type responsesUsage struct {
 	OutputDetails struct {
 		ReasoningTokens int `json:"reasoning_tokens"`
 	} `json:"output_tokens_details,omitempty"`
+	// See chatUsage.PromptTokensDetails — same automatic cache, Responses-API name.
+	InputDetails struct {
+		CachedTokens int `json:"cached_tokens"`
+	} `json:"input_tokens_details,omitempty"`
 }
 
 // ensureStrictSchemaCompliance makes a JSON Schema compatible with OpenAI's strict

--- a/internal/ai/openrouter/chat.go
+++ b/internal/ai/openrouter/chat.go
@@ -36,7 +36,7 @@ func (c *Client) generateChat(ctx context.Context, req *ai.Request, reasoning ai
 
 	messages = append(messages, chatMessage{
 		Role:    "user",
-		Content: req.UserPrompt,
+		Content: req.FullUserPrompt(),
 	})
 
 	// Build request. OpenRouter normalizes max_tokens for upstream providers,

--- a/internal/ai/openrouter/chat.go
+++ b/internal/ai/openrouter/chat.go
@@ -183,17 +183,21 @@ func (c *Client) generateChat(ctx context.Context, req *ai.Request, reasoning ai
 	}
 
 	return &ai.Response{
-		Text:             text,
-		InputTokens:      result.Usage.PromptTokens,
-		OutputTokens:     outputTokens,
-		TotalTokens:      result.Usage.TotalTokens,
-		ReasonTokens:     reasoningTokens,
-		FinishReason:     openai.MapChatFinishReason(result.Choices[0].FinishReason),
-		CachedTokens:     result.Usage.PromptTokensDetails.CachedTokens,
-		CostUSD:          costUSD,
-		Model:            result.Model,
-		RequestedModel:   req.Model,
-		ResolvedProvider: result.Provider,
-		FallbackChain:    fallbackChain,
+		Text:         text,
+		InputTokens:  result.Usage.PromptTokens,
+		OutputTokens: outputTokens,
+		TotalTokens:  result.Usage.TotalTokens,
+		ReasonTokens: reasoningTokens,
+		FinishReason: openai.MapChatFinishReason(result.Choices[0].FinishReason),
+		CachedTokens: result.Usage.PromptTokensDetails.CachedTokens,
+		// Also populate the normalized field. Setting only the deprecated
+		// CachedTokens meant banked eval metrics recorded 0 cache reads for every
+		// OpenRouter model, hiding whatever upstream caching was actually working.
+		CacheReadInputTokens: result.Usage.PromptTokensDetails.CachedTokens,
+		CostUSD:              costUSD,
+		Model:                result.Model,
+		RequestedModel:       req.Model,
+		ResolvedProvider:     result.Provider,
+		FallbackChain:        fallbackChain,
 	}, nil
 }

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -83,6 +83,28 @@ type Request struct {
 	// Options contains provider-specific options
 	Options map[string]any
 
+	// CachedPrefix is a stable leading chunk of the user turn, split out so a
+	// prompt-cache breakpoint can be placed at the boundary between it and the
+	// volatile remainder (M-ANTHROPIC-CACHE-HIT-RATE, v0.31.0).
+	//
+	// The provider-neutral contract is that the model always sees
+	// CachedPrefix + UserPrompt. Only the ENCODING differs by provider:
+	//
+	//   - Anthropic: when a CacheBreakpoint with Position "user_prefix" is also
+	//     declared, the user turn is emitted as a two-block content array with
+	//     cache_control on the first block. Without that breakpoint, the two
+	//     strings are concatenated and the wire shape is unchanged.
+	//   - Every other provider: concatenated, byte-identical to pre-v0.31.0.
+	//
+	// Empty (the zero value) means "no split" and is bit-for-bit identical to
+	// the pre-v0.31.0 wire shape on every provider.
+	//
+	// Why a separate field rather than markers inside UserPrompt: the split
+	// point is structural, not textual. Keeping it typed means non-Anthropic
+	// providers can ignore caching entirely while still sending the full prompt,
+	// and no provider has to parse sentinel strings out of user content.
+	CachedPrefix string
+
 	// Routing is an optional dynamic-routing policy. When set with HasRouting()
 	// returning true, only providers that support routing (currently: openrouter)
 	// will accept the request. Other providers return ErrRoutingNotSupported.
@@ -192,14 +214,41 @@ func (StreamUsage) streamChunkMarker() {
 	// Marker method — intentionally empty. See StreamContentDelta.
 }
 
+// FullUserPrompt returns the complete user-turn text the model must see:
+// CachedPrefix followed by UserPrompt.
+//
+// Every provider that does NOT implement prompt-cache splitting must send this
+// rather than UserPrompt alone — otherwise setting CachedPrefix would silently
+// truncate the prompt. Providers that DO implement splitting (currently only
+// Anthropic) encode the same text as separate content blocks instead.
+//
+// Keeping this as one method means a new provider cannot forget the prefix by
+// reaching for the more obvious req.UserPrompt field: the contract lives in one
+// place with one doc comment.
+func (r *Request) FullUserPrompt() string {
+	if r.CachedPrefix == "" {
+		return r.UserPrompt
+	}
+	return r.CachedPrefix + r.UserPrompt
+}
+
 // CacheBreakpoint is a single opt-in prompt-cache hint. Mirrors the AILANG
 // `std/ai.CacheBreakpoint` record shape byte-for-byte.
 //
-//	Position : "system" | "last_user" | "tool_result"
-//	           Phase 1 supports "system" only; others reserved for Phase 2.
+//	Position : "system" | "user_prefix" | "last_user" | "tool_result"
+//	           "system"      — cache the system prompt (v0.18.4).
+//	           "user_prefix" — cache Request.CachedPrefix, the stable leading
+//	                           chunk of the user turn (v0.31.0). Use this when
+//	                           the reusable content is large but lives in the
+//	                           user message, which is the common shape for
+//	                           teaching-prompt-plus-task requests.
+//	           "last_user" / "tool_result" — reserved, still unimplemented.
 //	TTL      : "ephemeral" | "5m"
 //	           Anthropic ephemeral = ~5min server TTL; longer Anthropic tiers TBD.
 //	           Providers that don't expose TTL choices ignore this field.
+//
+// A breakpoint whose Position names nothing cacheable in the request (e.g.
+// "user_prefix" with an empty CachedPrefix) is a no-op, not an error.
 type CacheBreakpoint struct {
 	Position string
 	TTL      string

--- a/internal/eval_analysis/cache_aggregate_test.go
+++ b/internal/eval_analysis/cache_aggregate_test.go
@@ -1,0 +1,50 @@
+package eval_analysis
+
+import "testing"
+
+// M-ANTHROPIC-CACHE-HIT-RATE M3 (deferred item): the hit rate has to be derived
+// from the right denominator or it is worse than no number at all.
+func TestCalculateAggregates_CacheHitRate(t *testing.T) {
+	// A warm run: most input served from cache, a little uncached remainder.
+	// Anthropic reports these as THREE separate buckets — r.InputTokens is the
+	// uncached remainder only, NOT the total.
+	results := []*BenchmarkResult{
+		{InputTokens: 500, CacheReadInputTokens: 0, CacheCreationInputTokens: 16000, TotalTokens: 16800},
+		{InputTokens: 500, CacheReadInputTokens: 16000, CacheCreationInputTokens: 0, TotalTokens: 16800},
+		{InputTokens: 500, CacheReadInputTokens: 16000, CacheCreationInputTokens: 0, TotalTokens: 16800},
+	}
+
+	agg := calculateAggregates(results)
+
+	if agg.CacheReadTokens != 32000 {
+		t.Errorf("CacheReadTokens = %d, want 32000", agg.CacheReadTokens)
+	}
+	if agg.CacheCreationTokens != 16000 {
+		t.Errorf("CacheCreationTokens = %d, want 16000", agg.CacheCreationTokens)
+	}
+
+	// Denominator = every input token seen: 1500 uncached + 32000 read + 16000 written.
+	// Using InputTokens alone (1500) would report a nonsensical >2000%.
+	wantRate := 32000.0 / 49500.0
+	if diff := agg.CacheHitRate - wantRate; diff > 0.001 || diff < -0.001 {
+		t.Errorf("CacheHitRate = %.4f, want %.4f (reads / all input tokens)", agg.CacheHitRate, wantRate)
+	}
+	if agg.CacheHitRate > 1.0 {
+		t.Errorf("CacheHitRate = %.4f exceeds 100%% — wrong denominator", agg.CacheHitRate)
+	}
+}
+
+// Pre-v0.31.0 baselines carry no cache fields; the rate must be 0, not NaN.
+func TestCalculateAggregates_LegacyResultsNoNaN(t *testing.T) {
+	results := []*BenchmarkResult{
+		{InputTokens: 16000, TotalTokens: 16500},
+		{InputTokens: 16000, TotalTokens: 16500},
+	}
+	agg := calculateAggregates(results)
+	if agg.CacheHitRate != 0 {
+		t.Errorf("CacheHitRate = %v, want 0 for pre-v0.31.0 results", agg.CacheHitRate)
+	}
+	if agg.CacheReadTokens != 0 || agg.CacheCreationTokens != 0 {
+		t.Error("legacy results should aggregate to zero cache activity")
+	}
+}

--- a/internal/eval_analysis/cache_aggregate_test.go
+++ b/internal/eval_analysis/cache_aggregate_test.go
@@ -1,6 +1,9 @@
 package eval_analysis
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -80,5 +83,40 @@ func TestFormatMatrix_CacheLineIsConditional(t *testing.T) {
 	}
 	if got := FormatMatrix(noCache, false); strings.Contains(got, "Cache hit rate") {
 		t.Error("cache line must be omitted when nothing reported cache activity — a bare 0.0% reads as a broken cache")
+	}
+}
+
+// The JSON export is the dashboard feed — it is how the cache hit rate actually
+// reaches a human. Pin that the three cache keys are emitted, so a rename or a
+// dropped line shows up here rather than as a silently missing dashboard panel.
+func TestExportBenchmarkJSON_EmitsCacheKeys(t *testing.T) {
+	matrix := &PerformanceMatrix{
+		Version: "v0.31.0",
+		Aggregates: Aggregates{
+			TotalTokens:         50000,
+			CacheReadTokens:     32000,
+			CacheCreationTokens: 16000,
+			CacheHitRate:        0.646,
+		},
+	}
+	out := filepath.Join(t.TempDir(), "latest.json")
+	if _, err := ExportBenchmarkJSON(matrix, nil, nil, out); err != nil {
+		t.Fatalf("export failed: %v", err)
+	}
+
+	blob, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read export: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(blob, &got); err != nil {
+		t.Fatalf("export is not valid JSON: %v", err)
+	}
+
+	body := string(blob)
+	for _, key := range []string{"cacheReadTokens", "cacheCreationTokens", "cacheHitRate"} {
+		if !strings.Contains(body, key) {
+			t.Errorf("dashboard export is missing %q — the hit rate would never reach the dashboard", key)
+		}
 	}
 }

--- a/internal/eval_analysis/cache_aggregate_test.go
+++ b/internal/eval_analysis/cache_aggregate_test.go
@@ -1,6 +1,9 @@
 package eval_analysis
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // M-ANTHROPIC-CACHE-HIT-RATE M3 (deferred item): the hit rate has to be derived
 // from the right denominator or it is worse than no number at all.
@@ -46,5 +49,36 @@ func TestCalculateAggregates_LegacyResultsNoNaN(t *testing.T) {
 	}
 	if agg.CacheReadTokens != 0 || agg.CacheCreationTokens != 0 {
 		t.Error("legacy results should aggregate to zero cache activity")
+	}
+}
+
+// FormatMatrix renders the human-readable summary. The cache line is
+// conditional: it appears only when some provider actually reported activity,
+// because a flat "0.0%" for a fleet that never reports would read as "caching is
+// broken" rather than "nothing measured here".
+func TestFormatMatrix_CacheLineIsConditional(t *testing.T) {
+	withCache := &PerformanceMatrix{
+		Version: "v0.31.0",
+		Aggregates: Aggregates{
+			TotalTokens:         50000,
+			CacheReadTokens:     32000,
+			CacheCreationTokens: 16000,
+			CacheHitRate:        0.646,
+		},
+	}
+	out := FormatMatrix(withCache, false)
+	if !strings.Contains(out, "Cache hit rate") {
+		t.Error("expected a cache hit rate line when cache activity was reported")
+	}
+	if !strings.Contains(out, "64.6%") {
+		t.Errorf("expected the rate rendered as a percentage, got:\n%s", out)
+	}
+
+	noCache := &PerformanceMatrix{
+		Version:    "v0.30.0",
+		Aggregates: Aggregates{TotalTokens: 50000},
+	}
+	if got := FormatMatrix(noCache, false); strings.Contains(got, "Cache hit rate") {
+		t.Error("cache line must be omitted when nothing reported cache activity — a bare 0.0% reads as a broken cache")
 	}
 }

--- a/internal/eval_analysis/export_json.go
+++ b/internal/eval_analysis/export_json.go
@@ -121,13 +121,16 @@ func ExportBenchmarkJSON(matrix *PerformanceMatrix, history []*Baseline, results
 
 	// Convert aggregates to camelCase for JavaScript
 	aggregatesJS := map[string]interface{}{
-		"zeroShotSuccess":   matrix.Aggregates.ZeroShotSuccess,
-		"finalSuccess":      matrix.Aggregates.FinalSuccess,
-		"repairUsed":        matrix.Aggregates.RepairUsed,
-		"repairSuccessRate": matrix.Aggregates.RepairSuccessRate,
-		"totalTokens":       matrix.Aggregates.TotalTokens,
-		"totalCostUSD":      matrix.Aggregates.TotalCostUSD,
-		"avgDurationMs":     matrix.Aggregates.AvgDurationMs,
+		"zeroShotSuccess":     matrix.Aggregates.ZeroShotSuccess,
+		"finalSuccess":        matrix.Aggregates.FinalSuccess,
+		"repairUsed":          matrix.Aggregates.RepairUsed,
+		"repairSuccessRate":   matrix.Aggregates.RepairSuccessRate,
+		"totalTokens":         matrix.Aggregates.TotalTokens,
+		"cacheReadTokens":     matrix.Aggregates.CacheReadTokens,
+		"cacheCreationTokens": matrix.Aggregates.CacheCreationTokens,
+		"cacheHitRate":        matrix.Aggregates.CacheHitRate,
+		"totalCostUSD":        matrix.Aggregates.TotalCostUSD,
+		"avgDurationMs":       matrix.Aggregates.AvgDurationMs,
 		// Agent metrics (M-EVAL-AGENT)
 		"agentRuns":        len(agentResults),
 		"agentSuccessRate": agentSuccessRate,

--- a/internal/eval_analysis/formatter.go
+++ b/internal/eval_analysis/formatter.go
@@ -154,6 +154,15 @@ func FormatMatrix(matrix *PerformanceMatrix, useColor bool) string {
 	sb.WriteString(fmt.Sprintf("Repairs used:      %d\n", matrix.Aggregates.RepairUsed))
 	sb.WriteString(fmt.Sprintf("Repair success:    %.1f%%\n", matrix.Aggregates.RepairSuccessRate*100))
 	sb.WriteString(fmt.Sprintf("Total tokens:      %d\n", matrix.Aggregates.TotalTokens))
+	// Shown only when some provider actually reported cache activity. Printing
+	// "0.0%" for a run of providers that never report it would read as "caching
+	// is broken" rather than "nothing measured here".
+	if matrix.Aggregates.CacheReadTokens > 0 || matrix.Aggregates.CacheCreationTokens > 0 {
+		sb.WriteString(fmt.Sprintf("Cache hit rate:    %.1f%% (%d read, %d written)\n",
+			matrix.Aggregates.CacheHitRate*100,
+			matrix.Aggregates.CacheReadTokens,
+			matrix.Aggregates.CacheCreationTokens))
+	}
 	sb.WriteString(fmt.Sprintf("Total cost:        $%.4f\n", matrix.Aggregates.TotalCostUSD))
 	sb.WriteString(fmt.Sprintf("Avg duration:      %.0fms\n", matrix.Aggregates.AvgDurationMs))
 	sb.WriteString("\n")

--- a/internal/eval_analysis/matrix.go
+++ b/internal/eval_analysis/matrix.go
@@ -56,6 +56,8 @@ func calculateAggregates(results []*BenchmarkResult) Aggregates {
 	totalTokens := 0
 	totalCost := 0.0
 	totalDuration := int64(0)
+	cacheRead := 0
+	cacheCreate := 0
 
 	for _, r := range results {
 		if r.FirstAttemptOk {
@@ -74,6 +76,8 @@ func calculateAggregates(results []*BenchmarkResult) Aggregates {
 		totalTokens += r.TotalTokens
 		totalCost += r.CostUSD
 		totalDuration += r.DurationMs
+		cacheRead += r.CacheReadInputTokens
+		cacheCreate += r.CacheCreationInputTokens
 	}
 
 	agg.ZeroShotSuccess = safeDiv(float64(firstAttemptSuccess), float64(len(results)))
@@ -83,6 +87,17 @@ func calculateAggregates(results []*BenchmarkResult) Aggregates {
 	agg.TotalTokens = totalTokens
 	agg.TotalCostUSD = totalCost
 	agg.AvgDurationMs = safeDiv(float64(totalDuration), float64(len(results)))
+	agg.CacheReadTokens = cacheRead
+	agg.CacheCreationTokens = cacheCreate
+	// Denominator is every input token the model saw. r.InputTokens is the
+	// UNCACHED remainder only — cached tokens are reported separately — so the
+	// three must be summed. Dividing by InputTokens alone would overstate the
+	// hit rate wildly on a warm run (potentially >100%).
+	totalInput := 0
+	for _, r := range results {
+		totalInput += r.InputTokens + r.CacheReadInputTokens + r.CacheCreationInputTokens
+	}
+	agg.CacheHitRate = safeDiv(float64(cacheRead), float64(totalInput))
 
 	return agg
 }

--- a/internal/eval_analysis/types.go
+++ b/internal/eval_analysis/types.go
@@ -12,22 +12,26 @@ import (
 // BenchmarkResult represents the result of a single benchmark execution
 // This mirrors the JSON structure from internal/eval_harness/metrics.go
 type BenchmarkResult struct {
-	ID            string  `json:"id"`
-	Lang          string  `json:"lang"`
-	Model         string  `json:"model"`
-	Executor      string  `json:"executor,omitempty"` // Executor used: "claude", "gemini", etc. (agent mode)
-	Seed          int64   `json:"seed"`
-	InputTokens   int     `json:"input_tokens"`
-	OutputTokens  int     `json:"output_tokens"`
-	TotalTokens   int     `json:"total_tokens"`
-	CostUSD       float64 `json:"cost_usd"`
-	CompileOk     bool    `json:"compile_ok"`
-	RuntimeOk     bool    `json:"runtime_ok"`
-	StdoutOk      bool    `json:"stdout_ok"`
-	DurationMs    int64   `json:"duration_ms"`
-	CompileMs     int64   `json:"compile_ms"`
-	ExecuteMs     int64   `json:"execute_ms"`
-	ErrorCategory string  `json:"error_category"`
+	ID           string `json:"id"`
+	Lang         string `json:"lang"`
+	Model        string `json:"model"`
+	Executor     string `json:"executor,omitempty"` // Executor used: "claude", "gemini", etc. (agent mode)
+	Seed         int64  `json:"seed"`
+	InputTokens  int    `json:"input_tokens"`
+	OutputTokens int    `json:"output_tokens"`
+	TotalTokens  int    `json:"total_tokens"`
+	// Prompt-cache activity as banked by the harness (M-ANTHROPIC-CACHE-HIT-RATE).
+	// Absent in pre-v0.31.0 baselines, where both read as 0.
+	CacheReadInputTokens     int     `json:"cache_read_input_tokens,omitempty"`
+	CacheCreationInputTokens int     `json:"cache_creation_input_tokens,omitempty"`
+	CostUSD                  float64 `json:"cost_usd"`
+	CompileOk                bool    `json:"compile_ok"`
+	RuntimeOk                bool    `json:"runtime_ok"`
+	StdoutOk                 bool    `json:"stdout_ok"`
+	DurationMs               int64   `json:"duration_ms"`
+	CompileMs                int64   `json:"compile_ms"`
+	ExecuteMs                int64   `json:"execute_ms"`
+	ErrorCategory            string  `json:"error_category"`
 
 	// Validity marks whether this row is a MEASUREMENT at all (vs a failure to
 	// measure: dead subject, harness error, wrong config). NIL means valid —
@@ -170,6 +174,14 @@ type Aggregates struct {
 	TotalTokens       int     `json:"total_tokens"`
 	TotalCostUSD      float64 `json:"total_cost_usd"`
 	AvgDurationMs     float64 `json:"avg_duration_ms"`
+	// Prompt-cache aggregates. CacheHitRate is cache reads as a share of ALL
+	// input tokens the model saw (reads + writes + uncached), so it answers "how
+	// much of our input did we avoid paying full price for". 0 means either no
+	// caching or a provider that does not report it — indistinguishable here,
+	// which is why the raw token counts are exposed alongside it.
+	CacheReadTokens     int     `json:"cache_read_tokens,omitempty"`
+	CacheCreationTokens int     `json:"cache_creation_tokens,omitempty"`
+	CacheHitRate        float64 `json:"cache_hit_rate,omitempty"`
 }
 
 // ModelStats contains per-model performance

--- a/internal/eval_analyzer/design_generator.go
+++ b/internal/eval_analyzer/design_generator.go
@@ -99,6 +99,9 @@ func NewDesignGenerator(model string, seed int64) (*DesignGenerator, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create AI agent: %w", err)
 	}
+	// Design generation is one-shot: there is no second call to read a cache
+	// entry back, so opt out of the ~1.25x cache-write premium.
+	agent.SetExpectedCalls(1)
 
 	// Load template
 	tmplPath := filepath.Join("internal", "eval_analyzer", "templates", "design_template.md")

--- a/internal/eval_harness/ai_agent.go
+++ b/internal/eval_harness/ai_agent.go
@@ -102,6 +102,24 @@ func (a *AIAgent) GenerateCodeSplit(ctx context.Context, cachedPrefix, task stri
 	return a.adapter.generate(ctx, cachedPrefix, task)
 }
 
+// GenerateCodeWarmup issues a deliberately tiny call whose only purpose is to
+// make the provider prefill — and therefore cache — cachedPrefix
+// (M-ANTHROPIC-CACHE-HIT-RATE, D4).
+//
+// maxTokens caps the output; 1 is enough, because the prefill that writes the
+// cache happens regardless of how much the model is then allowed to say. The
+// result is normally discarded — it is returned so a caller can assert on
+// cache-creation tokens to verify the warm-up actually landed.
+//
+// The adapter's previous budget is restored on return so a warmed agent is not
+// left crippled for real work.
+func (a *AIAgent) GenerateCodeWarmup(ctx context.Context, cachedPrefix, task string, maxTokens int) (*GenerateResult, error) {
+	prev := a.adapter.maxTokens
+	a.adapter.setMaxTokens(maxTokens)
+	defer a.adapter.setMaxTokens(prev)
+	return a.adapter.generate(ctx, cachedPrefix, task)
+}
+
 // GenerateResult contains the result of code generation
 type GenerateResult struct {
 	Code         string

--- a/internal/eval_harness/ai_agent.go
+++ b/internal/eval_harness/ai_agent.go
@@ -105,12 +105,16 @@ func (a *AIAgent) GenerateCodeSplit(ctx context.Context, cachedPrefix, task stri
 // GenerateResult contains the result of code generation
 type GenerateResult struct {
 	Code         string
-	InputTokens  int    // Prompt tokens (input to LLM)
-	OutputTokens int    // Completion tokens (generated code, reasoning excluded)
-	ReasonTokens int    // Hidden reasoning/thinking tokens (billed as output)
-	TotalTokens  int    // Total tokens (for billing; includes reasoning)
-	FinishReason string // Normalized stop reason ("stop", "length", ...); "" if unreported
-	Model        string
+	InputTokens  int // Prompt tokens (input to LLM)
+	OutputTokens int // Completion tokens (generated code, reasoning excluded)
+	ReasonTokens int // Hidden reasoning/thinking tokens (billed as output)
+	// Prompt-cache activity, when the provider reports it (Anthropic, OpenAI,
+	// Gemini). Zero means "not reported", not "no cache".
+	CacheReadInputTokens     int
+	CacheCreationInputTokens int
+	TotalTokens              int    // Total tokens (for billing; includes reasoning)
+	FinishReason             string // Normalized stop reason ("stop", "length", ...); "" if unreported
+	Model                    string
 }
 
 // RetryConfig configures retry behavior

--- a/internal/eval_harness/ai_agent.go
+++ b/internal/eval_harness/ai_agent.go
@@ -66,6 +66,17 @@ func NewAIAgent(model string, seed int64) (*AIAgent, error) {
 	}, nil
 }
 
+// SetExpectedCalls declares how many generation calls this run will make
+// against the model (M-ANTHROPIC-CACHE-HIT-RATE M2).
+//
+// Pass 1 for genuinely one-shot work to opt OUT of prompt caching — a cache
+// write that is never read costs ~1.25x for nothing. Leave it unset for suite
+// runs: Anthropic's cache is server-side and shared across agent instances, so
+// a per-agent call count says nothing about whether the entry gets reused.
+func (a *AIAgent) SetExpectedCalls(n int) {
+	a.adapter.setExpectedCalls(n)
+}
+
 // WithAttribution sets OpenRouter app-attribution overrides for this agent.
 func (a *AIAgent) WithAttribution(attr *ai.Attribution) *AIAgent {
 	a.attribution = attr
@@ -73,8 +84,22 @@ func (a *AIAgent) WithAttribution(attr *ai.Attribution) *AIAgent {
 }
 
 // GenerateCode generates code using the unified provider.
+//
+// The whole prompt is treated as volatile, so nothing is cached. Prefer
+// GenerateCodeSplit when the prompt has a stable teaching-prompt prefix.
 func (a *AIAgent) GenerateCode(ctx context.Context, prompt string) (*GenerateResult, error) {
-	return a.adapter.generate(ctx, prompt)
+	return a.adapter.generate(ctx, "", prompt)
+}
+
+// GenerateCodeSplit generates code from a prompt already split into a stable
+// cacheable prefix and a per-benchmark task (M-ANTHROPIC-CACHE-HIT-RATE M2).
+//
+// The model sees cachedPrefix+task, identical to passing the joined string to
+// GenerateCode. On Anthropic the split additionally lets a cache breakpoint sit
+// at the boundary, so repeat calls in a suite re-read the teaching prompt at
+// ~10% of input price instead of re-paying it in full.
+func (a *AIAgent) GenerateCodeSplit(ctx context.Context, cachedPrefix, task string) (*GenerateResult, error) {
+	return a.adapter.generate(ctx, cachedPrefix, task)
 }
 
 // GenerateResult contains the result of code generation

--- a/internal/eval_harness/ai_provider.go
+++ b/internal/eval_harness/ai_provider.go
@@ -18,7 +18,15 @@ import (
 
 // providerAdapter wraps ai.Provider for eval harness use.
 type providerAdapter struct {
-	provider           ai.Provider
+	provider ai.Provider
+	// providerType is the RESOLVED provider (models.yml is the source of truth,
+	// falling back to name inference). Retained so cache decisions can be made
+	// without re-guessing from the model string.
+	providerType ai.ProviderType
+	// expectedCalls is 1 when the caller knows this is a one-shot run, and 0
+	// ("undeclared") otherwise. Only 1 disables caching — see cacheBreakpointsFor
+	// for why an adapter-local call count is the wrong thing to gate on.
+	expectedCalls      int
 	model              string
 	maxTokens          int             // Max output tokens; 0 means use defaultMaxTokens
 	reasoningMaxTokens int             // Cap on hidden thinking tokens; 0 = uncapped
@@ -76,11 +84,19 @@ func newProviderAdapter(model string, apiKey string, explicitProvider ai.Provide
 	}
 
 	return &providerAdapter{
-		provider:    provider,
-		model:       model,
-		maxTokens:   0, // 0 => defaultMaxTokens; set via setMaxTokens
-		attribution: nil,
+		provider:     provider,
+		providerType: providerType,
+		model:        model,
+		maxTokens:    0, // 0 => defaultMaxTokens; set via setMaxTokens
+		attribution:  nil,
 	}, nil
+}
+
+// setExpectedCalls records how many generate() calls this adapter will receive
+// in the current run, so caching can be skipped when a write could never be
+// read back. See cacheBreakpointsFor.
+func (p *providerAdapter) setExpectedCalls(n int) {
+	p.expectedCalls = n
 }
 
 // setAttribution sets OpenRouter app-attribution overrides. Retained for the
@@ -111,8 +127,48 @@ func (p *providerAdapter) setReasoningEffort(e string) {
 	p.reasoningEffort = e
 }
 
+// cacheBreakpointsFor decides whether this request declares a prompt-cache
+// breakpoint (M-ANTHROPIC-CACHE-HIT-RATE M2, design decision D3).
+//
+// ON by default rather than behind a flag: opt-in is precisely why our hit rate
+// was near zero — the v0.18.4 mechanism shipped and no Go caller ever set it.
+//
+// Two guards keep it from costing more than it saves:
+//   - Only Anthropic. Other providers no-op on hints (OpenAI auto-caches,
+//     Gemini needs a different API), and declaring one there just emits a
+//     "hint ignored" warning per session for nothing.
+//   - Only when the caller has told us this is a genuinely single-shot run.
+//     A cache WRITE costs ~1.25x, so a prefix read zero times is a small pure
+//     loss; break-even at 5-minute TTL is two requests.
+//
+// The default when nothing is declared (expectedCalls == 0) is to CACHE.
+//
+// That default is deliberate and was corrected during implementation. The
+// obvious-looking rule — "only cache when this adapter will see >= 2 calls" —
+// is wrong here, because Anthropic's cache is SERVER-SIDE and keyed by prompt
+// prefix, not by client object. The eval harness constructs a fresh AIAgent per
+// benchmark (cmd/ailang/eval_benchmark.go, inside runSingleBenchmark), so every
+// adapter sees exactly one generation call, and a >= 2 rule would have disabled
+// caching for the entire suite while looking correct. Benchmark N+1 reads the
+// entry written by benchmark N precisely because the cache does not live in the
+// client. Callers that really are one-shot opt out via SetExpectedCalls(1).
+func cacheBreakpointsFor(providerType ai.ProviderType, cachedPrefix string, expectedCalls int) []ai.CacheBreakpoint {
+	if providerType != ai.ProviderAnthropic || cachedPrefix == "" {
+		return nil
+	}
+	if expectedCalls == 1 {
+		return nil
+	}
+	return []ai.CacheBreakpoint{{Position: "user_prefix", TTL: "ephemeral"}}
+}
+
 // generate calls the unified provider and converts to GenerateResult.
-func (p *providerAdapter) generate(ctx context.Context, prompt string) (*GenerateResult, error) {
+//
+// cachedPrefix is the stable leading chunk of the prompt (the teaching prompt);
+// prompt is the volatile remainder (the benchmark task). The model always sees
+// cachedPrefix+prompt — passing "" for cachedPrefix is exactly the pre-v0.31.0
+// behavior.
+func (p *providerAdapter) generate(ctx context.Context, cachedPrefix, prompt string) (*GenerateResult, error) {
 	systemPrompt := "You are a code generation engine. Output ONLY a complete, runnable program that solves the given task. " +
 		"Do NOT output explanations, markdown formatting, or conversational text. " +
 		"Do NOT output placeholder or stub code — implement the full solution. " +
@@ -126,9 +182,16 @@ func (p *providerAdapter) generate(ctx context.Context, prompt string) (*Generat
 	req := &ai.Request{
 		Model:        p.model,
 		SystemPrompt: systemPrompt,
+		CachedPrefix: cachedPrefix,
 		UserPrompt:   prompt,
 		MaxTokens:    maxTokens,
 		Attribution:  p.attribution,
+		// Note the breakpoint targets the USER prefix, not the system prompt:
+		// systemPrompt above is ~70 tokens, far below every model's minimum
+		// cacheable prefix, so a system breakpoint here would be a silent no-op.
+		// The ~16K-token teaching prompt is what is worth caching, and it lives
+		// in the user turn.
+		CacheBreakpoints: cacheBreakpointsFor(p.providerType, cachedPrefix, p.expectedCalls),
 	}
 	if p.reasoningMaxTokens > 0 || p.reasoningEffort != "" {
 		req.Options = map[string]any{}

--- a/internal/eval_harness/ai_provider.go
+++ b/internal/eval_harness/ai_provider.go
@@ -209,13 +209,15 @@ func (p *providerAdapter) generate(ctx context.Context, cachedPrefix, prompt str
 	}
 
 	return &GenerateResult{
-		Code:         extractCodeFromMarkdown(resp.Text),
-		InputTokens:  resp.InputTokens,
-		OutputTokens: resp.OutputTokens,
-		ReasonTokens: resp.ReasonTokens,
-		TotalTokens:  resp.TotalTokens,
-		FinishReason: resp.FinishReason,
-		Model:        resp.Model,
+		Code:                     extractCodeFromMarkdown(resp.Text),
+		InputTokens:              resp.InputTokens,
+		OutputTokens:             resp.OutputTokens,
+		ReasonTokens:             resp.ReasonTokens,
+		CacheReadInputTokens:     resp.CacheReadInputTokens,
+		CacheCreationInputTokens: resp.CacheCreationInputTokens,
+		TotalTokens:              resp.TotalTokens,
+		FinishReason:             resp.FinishReason,
+		Model:                    resp.Model,
 	}, nil
 }
 

--- a/internal/eval_harness/cache_breakpoint_test.go
+++ b/internal/eval_harness/cache_breakpoint_test.go
@@ -1,0 +1,99 @@
+package eval_harness
+
+import (
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/ai"
+)
+
+// M-ANTHROPIC-CACHE-HIT-RATE M2 — the D3 default-ON policy and its guards.
+//
+// The regression this file exists to prevent is subtle and was hit during
+// implementation: gating on "will THIS adapter make >= 2 calls" looks correct
+// and silently disables caching everywhere, because the eval harness builds a
+// fresh AIAgent per benchmark while Anthropic's cache lives server-side.
+
+func TestCacheBreakpointsFor(t *testing.T) {
+	const prefix = "a long stable teaching prompt"
+
+	cases := []struct {
+		name           string
+		provider       ai.ProviderType
+		cachedPrefix   string
+		expectedCalls  int
+		wantBreakpoint bool
+	}{
+		{
+			// The load-bearing case: one call per adapter is the NORMAL eval
+			// shape, and it must still cache.
+			name:           "anthropic_undeclared_calls_caches",
+			provider:       ai.ProviderAnthropic,
+			cachedPrefix:   prefix,
+			expectedCalls:  0,
+			wantBreakpoint: true,
+		},
+		{
+			name:           "anthropic_declared_one_shot_does_not_cache",
+			provider:       ai.ProviderAnthropic,
+			cachedPrefix:   prefix,
+			expectedCalls:  1,
+			wantBreakpoint: false,
+		},
+		{
+			name:           "anthropic_multi_call_caches",
+			provider:       ai.ProviderAnthropic,
+			cachedPrefix:   prefix,
+			expectedCalls:  30,
+			wantBreakpoint: true,
+		},
+		{
+			name:           "no_prefix_nothing_to_cache",
+			provider:       ai.ProviderAnthropic,
+			cachedPrefix:   "",
+			expectedCalls:  30,
+			wantBreakpoint: false,
+		},
+		{
+			// Other providers no-op on hints; declaring one buys nothing and
+			// emits a per-session "hint ignored" warning.
+			name:           "openai_does_not_declare",
+			provider:       ai.ProviderOpenAI,
+			cachedPrefix:   prefix,
+			expectedCalls:  30,
+			wantBreakpoint: false,
+		},
+		{
+			name:           "gemini_does_not_declare",
+			provider:       ai.ProviderGoogle,
+			cachedPrefix:   prefix,
+			expectedCalls:  30,
+			wantBreakpoint: false,
+		},
+		{
+			name:           "ollama_does_not_declare",
+			provider:       ai.ProviderOllama,
+			cachedPrefix:   prefix,
+			expectedCalls:  30,
+			wantBreakpoint: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cacheBreakpointsFor(tc.provider, tc.cachedPrefix, tc.expectedCalls)
+			if tc.wantBreakpoint {
+				if len(got) != 1 {
+					t.Fatalf("got %d breakpoints, want exactly 1", len(got))
+				}
+				if got[0].Position != "user_prefix" {
+					t.Errorf("breakpoint position = %q, want \"user_prefix\" — the cacheable content is the teaching prompt in the USER turn, not the ~70-token system prompt", got[0].Position)
+				}
+				if got[0].TTL != "ephemeral" {
+					t.Errorf("breakpoint TTL = %q, want \"ephemeral\"", got[0].TTL)
+				}
+			} else if len(got) != 0 {
+				t.Errorf("got %d breakpoints, want none", len(got))
+			}
+		})
+	}
+}

--- a/internal/eval_harness/cache_metrics_test.go
+++ b/internal/eval_harness/cache_metrics_test.go
@@ -1,0 +1,80 @@
+package eval_harness
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// M-ANTHROPIC-CACHE-HIT-RATE M3.
+//
+// Before v0.31.0 cache tokens were modelled on ai.Response but never persisted:
+// zero of 28,139 banked result files carried them, so our own cache hit rate was
+// invisible in our own data. These tests pin the two properties that keep it
+// visible AND keep old baselines readable.
+
+// TestRunMetrics_CacheTokensRoundTrip: the fields survive a JSON round-trip, so
+// a warm run's hit rate is actually recoverable from a banked file.
+func TestRunMetrics_CacheTokensRoundTrip(t *testing.T) {
+	m := NewRunMetrics("bench1", "ailang", "claude-sonnet-5", 42)
+	m.InputTokens = 500
+	m.CacheReadInputTokens = 16000
+	m.CacheCreationInputTokens = 0
+
+	blob, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var got RunMetrics
+	if err := json.Unmarshal(blob, &got); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if got.CacheReadInputTokens != 16000 {
+		t.Errorf("cache_read_input_tokens = %d, want 16000", got.CacheReadInputTokens)
+	}
+	if got.CacheCreationInputTokens != 0 {
+		t.Errorf("cache_creation_input_tokens = %d, want 0", got.CacheCreationInputTokens)
+	}
+}
+
+// TestRunMetrics_PreV031BaselinesStillParse: the fields are additive and
+// omitempty, so a baseline banked before v0.31.0 (which has neither key) must
+// still load, reading them as 0 rather than erroring. Without this, adding the
+// metric would break every historical comparison.
+func TestRunMetrics_PreV031BaselinesStillParse(t *testing.T) {
+	// A pre-v0.31.0 record: no cache keys at all.
+	legacy := `{
+		"id": "bench1", "lang": "ailang", "model": "claude-sonnet-5", "seed": 42,
+		"input_tokens": 12000, "output_tokens": 300, "total_tokens": 12300,
+		"cost_usd": 0.05, "compile_ok": true, "runtime_ok": true, "stdout_ok": true
+	}`
+
+	var m RunMetrics
+	if err := json.Unmarshal([]byte(legacy), &m); err != nil {
+		t.Fatalf("pre-v0.31.0 baseline failed to parse: %v", err)
+	}
+	if m.InputTokens != 12000 {
+		t.Errorf("InputTokens = %d, want 12000", m.InputTokens)
+	}
+	if m.CacheReadInputTokens != 0 || m.CacheCreationInputTokens != 0 {
+		t.Errorf("absent cache fields should read as 0, got read=%d create=%d",
+			m.CacheReadInputTokens, m.CacheCreationInputTokens)
+	}
+}
+
+// TestRunMetrics_CacheFieldsOmittedWhenZero keeps rows for providers that do not
+// report cache activity free of misleading zero-valued keys.
+func TestRunMetrics_CacheFieldsOmittedWhenZero(t *testing.T) {
+	m := NewRunMetrics("bench1", "ailang", "gemma4:26b", 1)
+	blob, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var generic map[string]any
+	if err := json.Unmarshal(blob, &generic); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if _, present := generic["cache_read_input_tokens"]; present {
+		t.Error("cache_read_input_tokens should be omitted when zero")
+	}
+}

--- a/internal/eval_harness/metrics.go
+++ b/internal/eval_harness/metrics.go
@@ -11,28 +11,38 @@ import (
 
 // RunMetrics captures the results of a single benchmark run
 type RunMetrics struct {
-	ID             string    `json:"id"`
-	Lang           string    `json:"lang"`
-	Model          string    `json:"model"`
-	Executor       string    `json:"executor,omitempty"` // Executor used: "claude", "gemini", etc. (agent mode only)
-	Seed           int64     `json:"seed"`
-	InputTokens    int       `json:"input_tokens"`            // Prompt tokens (recorded but not primary metric)
-	OutputTokens   int       `json:"output_tokens"`           // Generated code tokens (PRIMARY METRIC; reasoning excluded)
-	ReasonTokens   int       `json:"reason_tokens,omitempty"` // Hidden reasoning/thinking tokens (billed as output)
-	TotalTokens    int       `json:"total_tokens"`            // Total for billing (includes reasoning)
-	CostUSD        float64   `json:"cost_usd"`
-	CompileOk      bool      `json:"compile_ok"`
-	RuntimeOk      bool      `json:"runtime_ok"`
-	StdoutOk       bool      `json:"stdout_ok"`
-	DurationMs     int64     `json:"duration_ms"`    // Total time (startup + compile + execution)
-	CompileMs      int64     `json:"compile_ms"`     // Time spent in compilation (if separate)
-	ExecuteMs      int64     `json:"execute_ms"`     // Time spent in execution (if measurable)
-	ErrorCategory  string    `json:"error_category"` // compile_error | runtime_error | logic_error | none
-	Stdout         string    `json:"stdout,omitempty"`
-	Stderr         string    `json:"stderr,omitempty"`
-	ExpectedStdout string    `json:"expected_stdout,omitempty"`
-	Timestamp      time.Time `json:"timestamp"`
-	Code           string    `json:"code,omitempty"` // Generated code (optional, for debugging)
+	ID           string `json:"id"`
+	Lang         string `json:"lang"`
+	Model        string `json:"model"`
+	Executor     string `json:"executor,omitempty"` // Executor used: "claude", "gemini", etc. (agent mode only)
+	Seed         int64  `json:"seed"`
+	InputTokens  int    `json:"input_tokens"`            // Prompt tokens (recorded but not primary metric)
+	OutputTokens int    `json:"output_tokens"`           // Generated code tokens (PRIMARY METRIC; reasoning excluded)
+	ReasonTokens int    `json:"reason_tokens,omitempty"` // Hidden reasoning/thinking tokens (billed as output)
+	// CacheReadInputTokens / CacheCreationInputTokens record prompt-cache
+	// activity (M-ANTHROPIC-CACHE-HIT-RATE M3). Before v0.31.0 these were
+	// modelled on ai.Response but never persisted, so NONE of the 28,139 banked
+	// result files carried them and our own cache hit rate was unmeasurable from
+	// our own data — the low rate had to be reported to us from outside.
+	//
+	// omitempty keeps pre-v0.31.0 baselines parsing unchanged (absent reads as 0)
+	// and keeps rows for providers without cache reporting free of noise.
+	CacheReadInputTokens     int       `json:"cache_read_input_tokens,omitempty"`
+	CacheCreationInputTokens int       `json:"cache_creation_input_tokens,omitempty"`
+	TotalTokens              int       `json:"total_tokens"` // Total for billing (includes reasoning)
+	CostUSD                  float64   `json:"cost_usd"`
+	CompileOk                bool      `json:"compile_ok"`
+	RuntimeOk                bool      `json:"runtime_ok"`
+	StdoutOk                 bool      `json:"stdout_ok"`
+	DurationMs               int64     `json:"duration_ms"`    // Total time (startup + compile + execution)
+	CompileMs                int64     `json:"compile_ms"`     // Time spent in compilation (if separate)
+	ExecuteMs                int64     `json:"execute_ms"`     // Time spent in execution (if measurable)
+	ErrorCategory            string    `json:"error_category"` // compile_error | runtime_error | logic_error | none
+	Stdout                   string    `json:"stdout,omitempty"`
+	Stderr                   string    `json:"stderr,omitempty"`
+	ExpectedStdout           string    `json:"expected_stdout,omitempty"`
+	Timestamp                time.Time `json:"timestamp"`
+	Code                     string    `json:"code,omitempty"` // Generated code (optional, for debugging)
 
 	// Validity marks whether this row is a MEASUREMENT at all, as opposed to a
 	// failure to measure (dead subject, harness error, wrong config). NIL means

--- a/internal/eval_harness/prompt_split_test.go
+++ b/internal/eval_harness/prompt_split_test.go
@@ -1,0 +1,105 @@
+package eval_harness
+
+import (
+	"strings"
+	"testing"
+)
+
+// M-ANTHROPIC-CACHE-HIT-RATE M2.
+//
+// Splitting the eval prompt into a cacheable base + a volatile task is a
+// COST change, not a behaviour change. If the split ever alters the bytes the
+// model receives, every v0.30.0 baseline becomes incomparable and the cache win
+// is unmeasurable — the exact outcome design decision D1 exists to avoid.
+//
+// This test is the guard on that invariant.
+
+func TestPromptParts_RejoinIsByteIdentical(t *testing.T) {
+	specs := []struct {
+		name string
+		spec *BenchmarkSpec
+	}{
+		{
+			name: "task_prompt_field",
+			spec: &BenchmarkSpec{
+				ID:         "b1",
+				Languages:  []string{"ailang", "python"},
+				TaskPrompt: "Write a program that prints hello.",
+			},
+		},
+		{
+			name: "legacy_prompt_field",
+			spec: &BenchmarkSpec{
+				ID:        "b2",
+				Languages: []string{"ailang", "python"},
+				Prompt:    "Compute the first 10 primes.",
+			},
+		},
+		{
+			name: "no_task_description",
+			spec: &BenchmarkSpec{
+				ID:        "b3",
+				Languages: []string{"ailang", "python"},
+			},
+		},
+	}
+
+	for _, tc := range specs {
+		for _, lang := range []string{"ailang", "python"} {
+			t.Run(tc.name+"/"+lang, func(t *testing.T) {
+				joined := tc.spec.PromptForLanguage(lang)
+				base, task := tc.spec.PromptPartsForLanguage(lang)
+
+				if base+task != joined {
+					t.Errorf("split prompt does not rejoin byte-identically for %s/%s\n"+
+						"  len(base)=%d len(task)=%d len(base+task)=%d len(joined)=%d",
+						tc.name, lang, len(base), len(task), len(base+task), len(joined))
+				}
+			})
+		}
+	}
+}
+
+// TestPromptParts_SplitIsAtTheTaskBoundary: the base must be the reusable part.
+// If the task text leaked into the base, the "stable" prefix would differ per
+// benchmark and every request would write a fresh cache entry it never reads —
+// a silent 1.25x cost increase rather than a saving.
+func TestPromptParts_SplitIsAtTheTaskBoundary(t *testing.T) {
+	const task = "UNIQUE-TASK-TEXT-b7f3"
+	spec := &BenchmarkSpec{
+		ID:         "b1",
+		Languages:  []string{"ailang"},
+		TaskPrompt: task,
+	}
+
+	base, taskSection := spec.PromptPartsForLanguage("ailang")
+
+	if strings.Contains(base, task) {
+		t.Error("task text leaked into the cacheable base — the prefix would differ per benchmark and never produce a cache hit")
+	}
+	if !strings.Contains(taskSection, task) {
+		t.Errorf("task section %q does not contain the task text", taskSection)
+	}
+	if !strings.HasPrefix(taskSection, "\n\n## Task\n\n") {
+		t.Errorf("task section should start at the '## Task' boundary, got %q", taskSection[:min(40, len(taskSection))])
+	}
+}
+
+// TestPromptParts_BaseIsStableAcrossBenchmarks is the property that makes
+// caching pay: two different benchmarks in the same language must share a
+// byte-identical base.
+func TestPromptParts_BaseIsStableAcrossBenchmarks(t *testing.T) {
+	a := &BenchmarkSpec{ID: "a", Languages: []string{"ailang"}, TaskPrompt: "Task A"}
+	b := &BenchmarkSpec{ID: "b", Languages: []string{"ailang"}, TaskPrompt: "Task B totally different"}
+
+	baseA, _ := a.PromptPartsForLanguage("ailang")
+	baseB, _ := b.PromptPartsForLanguage("ailang")
+
+	if baseA != baseB {
+		t.Errorf("cacheable base differs between benchmarks (len %d vs %d) — nothing would ever hit the cache",
+			len(baseA), len(baseB))
+	}
+	if len(baseA) == 0 {
+		t.Error("cacheable base is empty — there is nothing to cache")
+	}
+}

--- a/internal/eval_harness/repair.go
+++ b/internal/eval_harness/repair.go
@@ -180,10 +180,37 @@ type attemptResult struct {
 	ConstraintViolations []string // non-empty: source rejected before execution
 }
 
+// splitCacheablePrefix separates the stable teaching prompt from the volatile
+// remainder so a prompt-cache breakpoint can sit at the boundary
+// (M-ANTHROPIC-CACHE-HIT-RATE M2).
+//
+// It asks the spec for its own base rather than searching for a "## Task"
+// sentinel, then only splits when the prompt genuinely STARTS with that base.
+// The callers upstream assemble `prompt` through several branches (custom
+// prompt versions, registry fallbacks, repair-attempt suffixes); anything that
+// does not begin with the known base falls through uncached rather than being
+// guessed at.
+//
+// Because the split is HasPrefix/TrimPrefix, prefix+remainder is the original
+// string by construction — the model cannot see different bytes than before.
+//
+// Repair attempts append to the prompt rather than replacing it, so they still
+// start with the base and still hit the cache.
+func (r *RepairRunner) splitCacheablePrefix(prompt string) (cachedPrefix, remainder string) {
+	base, _ := r.spec.PromptPartsForLanguage(r.runner.Language())
+	if base == "" || !strings.HasPrefix(prompt, base) {
+		return "", prompt
+	}
+	return base, strings.TrimPrefix(prompt, base)
+}
+
 // runSingleAttempt executes one code generation + execution cycle
 func (r *RepairRunner) runSingleAttempt(ctx context.Context, prompt string) (*attemptResult, error) {
-	// Generate code using AI
-	genResult, err := r.agent.GenerateCode(ctx, prompt)
+	// Generate code using AI. Split off the cacheable teaching prompt so
+	// providers that support prompt caching can re-read it instead of re-paying
+	// for it on every benchmark in the suite.
+	cachedPrefix, remainder := r.splitCacheablePrefix(prompt)
+	genResult, err := r.agent.GenerateCodeSplit(ctx, cachedPrefix, remainder)
 	if err != nil {
 		return nil, fmt.Errorf("code generation failed: %w", err)
 	}

--- a/internal/eval_harness/repair.go
+++ b/internal/eval_harness/repair.go
@@ -152,6 +152,8 @@ func (r *RepairRunner) Run(ctx context.Context, prompt string) (*RunMetrics, err
 		metrics.ErrorCategory = "none"
 		// Add repair tokens to totals (reasoning included — billed as output)
 		metrics.InputTokens += repairResult.InputTokens
+		metrics.CacheReadInputTokens += repairResult.CacheReadTokens
+		metrics.CacheCreationInputTokens += repairResult.CacheCreationTokens
 		metrics.OutputTokens += repairResult.OutputTokens
 		metrics.ReasonTokens += repairResult.ReasonTokens
 		metrics.TotalTokens += repairResult.InputTokens + repairResult.OutputTokens + repairResult.ReasonTokens
@@ -172,6 +174,8 @@ type attemptResult struct {
 	InputTokens          int
 	OutputTokens         int
 	ReasonTokens         int    // hidden reasoning/thinking tokens (billed as output)
+	CacheReadTokens      int    // prompt-cache tokens served from cache (0 = not reported)
+	CacheCreationTokens  int    // prompt-cache tokens written this call
 	FinishReason         string // normalized stop reason; "length" = output truncated at cap
 	RunResult            *RunResult
 	CompileOk            bool
@@ -224,6 +228,8 @@ func (r *RepairRunner) runSingleAttempt(ctx context.Context, prompt string) (*at
 			return &attemptResult{
 				Code:                 genResult.Code,
 				InputTokens:          genResult.InputTokens,
+				CacheReadTokens:      genResult.CacheReadInputTokens,
+				CacheCreationTokens:  genResult.CacheCreationInputTokens,
 				OutputTokens:         genResult.OutputTokens,
 				ReasonTokens:         genResult.ReasonTokens,
 				FinishReason:         genResult.FinishReason,
@@ -247,21 +253,25 @@ func (r *RepairRunner) runSingleAttempt(ctx context.Context, prompt string) (*at
 	stdoutOk := GradeStdout(r.spec, runResult.Stdout, genResult.Code)
 
 	return &attemptResult{
-		Code:         genResult.Code,
-		InputTokens:  genResult.InputTokens,
-		OutputTokens: genResult.OutputTokens,
-		ReasonTokens: genResult.ReasonTokens,
-		FinishReason: genResult.FinishReason,
-		RunResult:    runResult,
-		CompileOk:    runResult.CompileOk,
-		RuntimeOk:    runResult.RuntimeOk,
-		StdoutOk:     stdoutOk,
+		Code:                genResult.Code,
+		InputTokens:         genResult.InputTokens,
+		CacheReadTokens:     genResult.CacheReadInputTokens,
+		CacheCreationTokens: genResult.CacheCreationInputTokens,
+		OutputTokens:        genResult.OutputTokens,
+		ReasonTokens:        genResult.ReasonTokens,
+		FinishReason:        genResult.FinishReason,
+		RunResult:           runResult,
+		CompileOk:           runResult.CompileOk,
+		RuntimeOk:           runResult.RuntimeOk,
+		StdoutOk:            stdoutOk,
 	}, nil
 }
 
 // populateMetrics fills in RunMetrics from an attemptResult
 func (r *RepairRunner) populateMetrics(metrics *RunMetrics, result *attemptResult) {
 	metrics.InputTokens = result.InputTokens
+	metrics.CacheReadInputTokens = result.CacheReadTokens
+	metrics.CacheCreationInputTokens = result.CacheCreationTokens
 	metrics.OutputTokens = result.OutputTokens
 	metrics.ReasonTokens = result.ReasonTokens
 	metrics.FinishReason = result.FinishReason

--- a/internal/eval_harness/spec.go
+++ b/internal/eval_harness/spec.go
@@ -206,8 +206,27 @@ func (s *BenchmarkSpec) SupportsLanguage(lang string) bool {
 	return false
 }
 
-// PromptForLanguage returns the prompt with language-specific base prompt + task prompt
+// PromptForLanguage returns the prompt with language-specific base prompt + task prompt.
+//
+// Defined as the concatenation of PromptPartsForLanguage so the split form and
+// the joined form cannot drift: any change to prompt assembly lands in one
+// place. Callers that want prompt caching should use the parts version and pass
+// the base as ai.Request.CachedPrefix (M-ANTHROPIC-CACHE-HIT-RATE).
 func (s *BenchmarkSpec) PromptForLanguage(lang string) string {
+	base, task := s.PromptPartsForLanguage(lang)
+	return base + task
+}
+
+// PromptPartsForLanguage returns the prompt split at the boundary between the
+// stable teaching prompt and the per-benchmark task.
+//
+// The split point matters: the base is identical across every benchmark for a
+// given language (~16K tokens for AILANG), while the task differs per
+// benchmark. That is exactly the shape prompt caching needs — a long stable
+// prefix followed by a short volatile suffix. Concatenating base+task must
+// reproduce PromptForLanguage byte-for-byte, which is what keeps eval baselines
+// comparable across the caching change.
+func (s *BenchmarkSpec) PromptPartsForLanguage(lang string) (base, task string) {
 	var basePrompt string
 	var taskDescription string
 
@@ -270,10 +289,12 @@ func (s *BenchmarkSpec) PromptForLanguage(lang string) string {
 		}
 	}
 
-	// Build full prompt
-	fullPrompt := basePrompt
+	// Build the task section separately from the base so the two can be handed
+	// to a provider as a cacheable prefix + volatile suffix. Joined, they are
+	// byte-identical to the pre-split single string.
+	taskSection := ""
 	if taskDescription != "" {
-		fullPrompt = fullPrompt + "\n\n## Task\n\n" + taskDescription
+		taskSection = "\n\n## Task\n\n" + taskDescription
 	}
 
 	// Normalize language names for <LANG> placeholder
@@ -282,8 +303,11 @@ func (s *BenchmarkSpec) PromptForLanguage(lang string) string {
 		langName = l.DisplayName()
 	}
 
-	// Replace <LANG> placeholder
-	return replaceAll(fullPrompt, "<LANG>", langName)
+	// Replace <LANG> placeholder in BOTH parts. Doing it per-part rather than on
+	// the joined string is equivalent here because the placeholder never spans
+	// the boundary — the boundary is a literal "\n\n## Task\n\n" we just built.
+	return replaceAll(basePrompt, "<LANG>", langName),
+		replaceAll(taskSection, "<LANG>", langName)
 }
 
 // getDefaultPrompt returns a minimal default prompt for a language

--- a/internal/eval_harness/warmup_agent_test.go
+++ b/internal/eval_harness/warmup_agent_test.go
@@ -1,0 +1,86 @@
+package eval_harness
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/ai"
+)
+
+// recordingProvider captures the last request so tests can assert on what the
+// adapter actually sent, without any network.
+type recordingProvider struct{ last *ai.Request }
+
+func (p *recordingProvider) Generate(_ context.Context, req *ai.Request) (*ai.Response, error) {
+	p.last = req
+	return &ai.Response{Text: "ok", InputTokens: 1, OutputTokens: 1}, nil
+}
+func (p *recordingProvider) Step(_ context.Context, _ *ai.Request) (*ai.Response, error) {
+	return nil, nil
+}
+func (p *recordingProvider) Name() string { return "recording" }
+
+func newTestAgent(p ai.Provider, providerType ai.ProviderType) (*AIAgent, *providerAdapter) {
+	ad := &providerAdapter{provider: p, providerType: providerType, model: "test-model", maxTokens: 4096}
+	return &AIAgent{friendlyName: "test-model", model: "test-model", adapter: ad}, ad
+}
+
+// M-ANTHROPIC-CACHE-HIT-RATE D4: the warm-up narrows the output budget to make
+// the prefill cheap. If it failed to restore the previous budget, every real
+// generation after a warm-up would be truncated to a single token — a far worse
+// bug than the cost it saves. Nothing else pins this.
+func TestGenerateCodeWarmup_RestoresPreviousMaxTokens(t *testing.T) {
+	p := &recordingProvider{}
+	agent, ad := newTestAgent(p, ai.ProviderAnthropic)
+
+	if _, err := agent.GenerateCodeWarmup(context.Background(), "PREFIX", "\n\n## Task\n\nok", 1); err != nil {
+		t.Fatalf("warm-up failed: %v", err)
+	}
+
+	if p.last.MaxTokens != 1 {
+		t.Errorf("warm-up sent MaxTokens=%d, want 1 — the prefill should be cheap", p.last.MaxTokens)
+	}
+	if ad.maxTokens != 4096 {
+		t.Errorf("adapter budget left at %d after warm-up, want the original 4096 restored", ad.maxTokens)
+	}
+}
+
+// The warm-up must carry the cacheable prefix as CachedPrefix (so a breakpoint
+// can attach), not fold it into the user prompt.
+func TestGenerateCodeWarmup_SendsPrefixAsCachedPrefix(t *testing.T) {
+	p := &recordingProvider{}
+	agent, _ := newTestAgent(p, ai.ProviderAnthropic)
+
+	if _, err := agent.GenerateCodeWarmup(context.Background(), "PREFIX", "TASK", 1); err != nil {
+		t.Fatalf("warm-up failed: %v", err)
+	}
+	if p.last.CachedPrefix != "PREFIX" {
+		t.Errorf("CachedPrefix = %q, want %q", p.last.CachedPrefix, "PREFIX")
+	}
+	if len(p.last.CacheBreakpoints) != 1 {
+		t.Errorf("warm-up declared %d breakpoints, want 1 — without one it caches nothing and is pure cost",
+			len(p.last.CacheBreakpoints))
+	}
+	if got := p.last.FullUserPrompt(); got != "PREFIXTASK" {
+		t.Errorf("model would see %q, want %q", got, "PREFIXTASK")
+	}
+}
+
+// SetExpectedCalls(1) is the documented opt-out for one-shot callers.
+func TestSetExpectedCalls_OptsOutOfCaching(t *testing.T) {
+	p := &recordingProvider{}
+	agent, _ := newTestAgent(p, ai.ProviderAnthropic)
+	agent.SetExpectedCalls(1)
+
+	if _, err := agent.GenerateCodeSplit(context.Background(), "PREFIX", "TASK"); err != nil {
+		t.Fatalf("generate failed: %v", err)
+	}
+	if len(p.last.CacheBreakpoints) != 0 {
+		t.Error("a declared one-shot run must not declare a cache breakpoint")
+	}
+	// The prefix must still REACH the model — opting out of caching is not
+	// opting out of the prompt.
+	if got := p.last.FullUserPrompt(); got != "PREFIXTASK" {
+		t.Errorf("model would see %q, want %q", got, "PREFIXTASK")
+	}
+}

--- a/internal/feedbackgate/cache_decision_test.go
+++ b/internal/feedbackgate/cache_decision_test.go
@@ -1,0 +1,23 @@
+package feedbackgate
+
+import "testing"
+
+// M-ANTHROPIC-CACHE-HIT-RATE M2: records WHY the classifier declares no prompt-
+// cache breakpoint, so the decision is re-checked against evidence rather than
+// re-litigated from memory.
+//
+// Anthropic silently declines to cache a prefix below the model's minimum — no
+// error, cache_creation_input_tokens: 0. Declaring a breakpoint here would look
+// like a win and do nothing.
+func TestClassifierPromptIsBelowCacheMinimum(t *testing.T) {
+	// claude-haiku-4-5 (the default classifier model) requires 4096 tokens.
+	const haiku45MinCacheableTokens = 4096
+
+	approxTokens := len(DefaultPrompt()) / 4
+	if approxTokens >= haiku45MinCacheableTokens {
+		t.Fatalf("classifier prompt is now ~%d tokens, at or above the %d-token minimum for claude-haiku-4-5 —"+
+			" caching it is now worthwhile, so revisit the deliberate no-breakpoint decision in classifier.go",
+			approxTokens, haiku45MinCacheableTokens)
+	}
+	t.Logf("classifier prompt ~%d tokens vs %d-token minimum: correctly not cached", approxTokens, haiku45MinCacheableTokens)
+}

--- a/internal/feedbackgate/classifier.go
+++ b/internal/feedbackgate/classifier.go
@@ -144,6 +144,13 @@ func applyClassifier(ctx context.Context, in Input, cfg FeedbackGateConfig) (Ver
 		return Verdict{Action: ActionFile, Reason: ReasonClassifierError}, nil
 	}
 
+	// No prompt-cache breakpoint here, deliberately (M-ANTHROPIC-CACHE-HIT-RATE
+	// M2, measured 2026-07-29): the classifier prompt is ~439 tokens and the
+	// default classifier model is claude-haiku-4-5, whose minimum cacheable
+	// prefix is 4096 tokens — roughly 9x larger. Declaring a breakpoint would be
+	// accepted by the API and then silently ignored, which is the exact
+	// failure mode this milestone exists to remove. Revisit only if the prompt
+	// grows past the minimum or the model changes tier.
 	req := &ai.Request{
 		Model:          cfg.ClassifierModel,
 		SystemPrompt:   cl.prompt,


### PR DESCRIPTION
Anthropic reported our org prompt-cache hit rate as very low. It was very low because the code path carrying essentially all of our Anthropic traffic **could not request a cache at all** — `internal/ai/anthropic/client.go` contained zero references to `CacheBreakpoint`. M-AI-PROMPT-CACHING (v0.18.4) wired `Step`; every 0-shot eval, classifier call and `ai.generate` goes through `Generate`.

Three problems, each hiding the next:

| | Problem |
|---|---|
| Capability | `Generate` had no `cache_control` support whatsoever |
| Placement | Only the `system` position was implemented, but our reusable content is a ~16K-token teaching prompt in the **user** turn, behind a ~70-token system prompt — below every model's minimum cacheable prefix |
| Visibility | Cache tokens were modelled but never persisted — **0 of 28,139** banked result files carried them |

## Commits

- `b9dcdf796` M1 — `Generate` emits `cache_control`; adds `ai.Request.CachedPrefix` + the `user_prefix` position
- `9f99ad6be` M2 — teaching prompt cached in place on Anthropic evals, on by default
- `449839532` M3 — cache tokens banked into eval metrics + CHANGELOG
- `5587778fe` status record

~920 LOC, 17 new tests. `lint` / `fmt-check` / `check-boundaries` / `check-file-sizes` green.

## Design decisions

**Cached in place, not moved to the system role.** Both cache equally well, but moving it changes model inputs and would invalidate every v0.30.0 baseline in the same commit as a cost change. The split is `HasPrefix`/`TrimPrefix` against the spec's own base, so prefix+remainder is the original string by construction — byte-equality is asserted by test.

**Classifier measured and deliberately NOT cached** — ~439 tokens against `claude-haiku-4-5`'s 4096-token minimum. A breakpoint there would be accepted and silently ignored. A test fails if the prompt outgrows the minimum.

**Silent no-ops now warn.** Anthropic accepts a too-short marker, returns 200, and quietly declines to cache. A model-tier minimum table (512/1024/2048/4096 — not monotonic across generations) drives a one-shot warning.

## Correction found during implementation

The planned "only cache when this adapter will see >= 2 calls" guard would have shipped the feature **dead**: the harness builds a fresh `AIAgent` per benchmark, so every adapter sees exactly one call. Anthropic's cache is server-side and keyed by prefix, so benchmark N+1 reads what N wrote. Guard inverted — cache unless a caller declares itself one-shot.

## Not yet proven

No `ANTHROPIC_API_KEY` was available in this window (quota returns ~2026-08-01), so **no real cache hit has been observed**. Everything is verified at wire-shape and unit level. The live check is written and gated:

```bash
AILANG_LIVE_ANTHROPIC_CACHE=1 go test ./internal/ai/anthropic/ -run TestLiveGeneratePromptCache -v
```

Deferred: pre-fan-out warm-up (worth ~34pp of the saving) and the `eval-report` hit-rate column (presentation only — data is banked).

Design doc: `design_docs/planned/v0_31_0/m-anthropic-cache-hit-rate.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)