### PR TITLE
fix(ci): one binary build, not fourteen — cmd/ailang had grown into its Windows timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,6 +312,15 @@ jobs:
       # still get caught — a 5min ceiling is well above any healthy test.
       # If a test is genuinely Windows-incompatible (not just slow), fix it or
       # skip it with a `// TODO(windows-ci): <reason>` + tracked GH issue.
+      #
+      # MARGIN, measured — this ceiling has been reached once (red dev
+      # 2026-07-29). cmd/ailang is the long pole: it drifted 157s (07-27) ->
+      # 225s (07-29) and then crossed 300s on a slow runner. Cause was NOT
+      # slow tests but 14 duplicate `go build ./cmd/ailang` sites; collapsing
+      # them onto one sync.Once builder took the package to ~26s locally.
+      # If cmd/ailang creeps back toward ~2min here, look for a NEW per-test
+      # build site before raising this number — the same package already
+      # outgrew a 60s Linux ceiling in July, and raising it just defers the red.
       run: go test -timeout 300s ./...
 
     # Same anti-silent-skip gate as the Linux job (minus z3, which isn't

--- a/cmd/ailang/budget_scoping_e2e_test.go
+++ b/cmd/ailang/budget_scoping_e2e_test.go
@@ -12,59 +12,20 @@ package main
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
-	"sync"
 	"testing"
 )
 
-var (
-	budgetBinOnce sync.Once
-	budgetBinPath string
-	budgetBinErr  error
-)
-
-// budgetBin builds the ailang binary once for the whole matrix into a temp dir
-// that survives across all tests (NOT a per-test t.TempDir, which is removed
-// when the first test returns and would delete the shared binary).
-func budgetBin(t *testing.T) string {
-	t.Helper()
-	budgetBinOnce.Do(func() {
-		projectRoot, err := filepath.Abs(filepath.Join("..", ".."))
-		if err != nil {
-			budgetBinErr = err
-			return
-		}
-		binName := "ailang-budget-e2e"
-		if runtime.GOOS == "windows" {
-			binName += ".exe"
-		}
-		dir, err := os.MkdirTemp("", "ailang-budget-e2e")
-		if err != nil {
-			budgetBinErr = err
-			return
-		}
-		budgetBinPath = filepath.Join(dir, binName)
-		cmd := exec.Command("go", "build", "-o", budgetBinPath, "./cmd/ailang")
-		cmd.Dir = projectRoot
-		if out, err := cmd.CombinedOutput(); err != nil {
-			budgetBinErr = err
-			t.Logf("build output:\n%s", out)
-		}
-	})
-	if budgetBinErr != nil {
-		t.Fatalf("ailang binary build failed: %v", budgetBinErr)
-	}
-	return budgetBinPath
-}
+// budgetBin returns the shared ailang test binary. It used to keep its own
+// sync.Once + build of the identical `./cmd/ailang` target; that duplicate is
+// gone so the whole package pays for exactly one `go build` (see buildAilang).
 
 // runBudget writes src to a temp module and runs `main` with --caps IO.
 // Returns combined stdout, stderr, and exit code.
 func runBudget(t *testing.T, name, src string) (stdout, stderr string, exit int) {
 	t.Helper()
-	bin := budgetBin(t)
+	bin := buildAilang(t)
 	dir := t.TempDir()
 	file := filepath.Join(dir, name+".ail")
 	if err := os.WriteFile(file, []byte(src), 0o644); err != nil {

--- a/cmd/ailang/main_test.go
+++ b/cmd/ailang/main_test.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/sunholo-data/ailang/internal/effects"
@@ -425,26 +427,64 @@ func TestSetupNetHandler(t *testing.T) {
 
 // TestCLI_NetAllowHTTPFlag_Exists is a regression test ensuring the
 // --net-allow-http flag is recognized by the CLI (not just documented).
-// buildAilang builds the ailang binary once per test run and returns its path.
-// Uses a compiled binary instead of "go run" so exit codes propagate correctly.
+var (
+	ailangBinOnce sync.Once
+	ailangBinDir  string
+	ailangBinPath string
+	ailangBinErr  error
+)
+
+// buildAilang builds the ailang binary ONCE for the whole test binary and
+// returns its path. Uses a compiled binary instead of "go run" so exit codes
+// propagate correctly.
+//
+// The sync.Once is load-bearing, not an optimisation. This doc comment claimed
+// "once per test run" for months while the body rebuilt on EVERY call: one
+// `go build ./cmd/ailang` costs ~10s, and the package accumulated 14 separate
+// build sites, so ~150s of cmd/ailang's runtime was the same binary compiled
+// over and over. That put the package at ~225s against the 300s Windows CI
+// ceiling and turned dev red on 2026-07-29 when a slow runner crossed 300s.
+//
+// The binary goes in an os.MkdirTemp dir, NOT a per-test t.TempDir: a t.TempDir
+// is removed when the FIRST caller returns, which would delete the shared
+// binary out from under every later test. TestMain removes the dir at exit.
 func buildAilang(t *testing.T) string {
 	t.Helper()
-	projectRoot, err := filepath.Abs(filepath.Join("..", ".."))
-	if err != nil {
-		t.Fatalf("Failed to get project root: %v", err)
+	ailangBinOnce.Do(func() {
+		projectRoot, err := filepath.Abs(filepath.Join("..", ".."))
+		if err != nil {
+			ailangBinErr = fmt.Errorf("failed to get project root: %w", err)
+			return
+		}
+		binName := "ailang"
+		if runtime.GOOS == "windows" {
+			binName = "ailang.exe"
+		}
+		dir, err := os.MkdirTemp("", "ailang-test-bin")
+		if err != nil {
+			ailangBinErr = fmt.Errorf("failed to create temp dir for test binary: %w", err)
+			return
+		}
+		ailangBinDir = dir
+		ailangBinPath = filepath.Join(dir, binName)
+		cmd := exec.Command("go", "build", "-o", ailangBinPath, "./cmd/ailang")
+		cmd.Dir = projectRoot
+		if out, err := cmd.CombinedOutput(); err != nil {
+			ailangBinErr = fmt.Errorf("failed to build ailang: %w\n%s", err, out)
+		}
+	})
+	if ailangBinErr != nil {
+		t.Fatalf("%v", ailangBinErr)
 	}
-	binName := "ailang"
-	if runtime.GOOS == "windows" {
-		binName = "ailang.exe"
+	return ailangBinPath
+}
+
+// cleanupAilangBin removes the shared test binary's temp dir. Called from
+// TestMain so the os.MkdirTemp above is not leaked on every `go test` run.
+func cleanupAilangBin() {
+	if ailangBinDir != "" {
+		_ = os.RemoveAll(ailangBinDir)
 	}
-	binPath := filepath.Join(t.TempDir(), binName)
-	cmd := exec.Command("go", "build", "-o", binPath, "./cmd/ailang")
-	cmd.Dir = projectRoot
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to build ailang: %v\n%s", err, out)
-	}
-	return binPath
 }
 
 // runAilangBin runs a pre-built ailang binary and returns stdout, stderr, exit code.

--- a/cmd/ailang/pkg_lock_ratchet_test.go
+++ b/cmd/ailang/pkg_lock_ratchet_test.go
@@ -27,9 +27,11 @@ func TestWarnSilentRatchet_WarnWhenVersionBumpsWithoutMessage(t *testing.T) {
 
 	// Point ~/.ailang to a temp dir with an empty DB (no upgrade-available messages).
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", origHome)
+	// AILANG_STATE_DIR, not HOME: GetDefaultDatabasePath falls back to
+	// os.UserHomeDir(), which ignores HOME on Windows (it reads %USERPROFILE%),
+	// so a HOME-only override isolated nothing there — these tests opened,
+	// migrated and closed the runner's REAL ~/.ailang DB instead.
+	t.Setenv("AILANG_STATE_DIR", tmpDir)
 
 	warnSilentRatchet(resolved, prevLF)
 
@@ -66,9 +68,11 @@ func TestWarnSilentRatchet_NoWarnWhenVersionUnchanged(t *testing.T) {
 	os.Stderr = w
 
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", origHome)
+	// AILANG_STATE_DIR, not HOME: GetDefaultDatabasePath falls back to
+	// os.UserHomeDir(), which ignores HOME on Windows (it reads %USERPROFILE%),
+	// so a HOME-only override isolated nothing there — these tests opened,
+	// migrated and closed the runner's REAL ~/.ailang DB instead.
+	t.Setenv("AILANG_STATE_DIR", tmpDir)
 
 	warnSilentRatchet(resolved, prevLF)
 
@@ -95,9 +99,11 @@ func TestWarnSilentRatchet_NoWarnWhenMessageExists(t *testing.T) {
 
 	// Create a temp DB and insert an upgrade-available message for 0.1.1.
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", origHome)
+	// AILANG_STATE_DIR, not HOME: GetDefaultDatabasePath falls back to
+	// os.UserHomeDir(), which ignores HOME on Windows (it reads %USERPROFILE%),
+	// so a HOME-only override isolated nothing there — these tests opened,
+	// migrated and closed the runner's REAL ~/.ailang DB instead.
+	t.Setenv("AILANG_STATE_DIR", tmpDir)
 
 	dbPath := messaging.GetDefaultDatabasePath()
 	store, err := messaging.OpenStore(dbPath)
@@ -160,9 +166,11 @@ func TestWarnSilentRatchet_SkipsRegistryDeps(t *testing.T) {
 	os.Stderr = w
 
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", origHome)
+	// AILANG_STATE_DIR, not HOME: GetDefaultDatabasePath falls back to
+	// os.UserHomeDir(), which ignores HOME on Windows (it reads %USERPROFILE%),
+	// so a HOME-only override isolated nothing there — these tests opened,
+	// migrated and closed the runner's REAL ~/.ailang DB instead.
+	t.Setenv("AILANG_STATE_DIR", tmpDir)
 
 	warnSilentRatchet(resolved, prevLF)
 

--- a/cmd/ailang/prompt_test.go
+++ b/cmd/ailang/prompt_test.go
@@ -297,5 +297,9 @@ func TestMain(m *testing.M) {
 		}
 	}
 
-	os.Exit(m.Run())
+	code := m.Run()
+	// Remove the shared ailang test binary built by buildAilang (os.MkdirTemp,
+	// so it outlives every t.TempDir and must be cleaned up explicitly).
+	cleanupAilangBin()
+	os.Exit(code)
 }

--- a/cmd/ailang/serve_api_mcp_surface_test.go
+++ b/cmd/ailang/serve_api_mcp_surface_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 )
@@ -18,18 +17,12 @@ func TestServeAPI_MCPToolSurface(t *testing.T) {
 	if testing.Short() {
 		t.Skip("builds and drives the serve-api stdio MCP binary")
 	}
-	// Windows refuses to exec a file without the .exe suffix, failing with
-	// "executable file not found in %PATH%" — which reads like a missing
+	// Shared with every other CLI test in this package: buildAilang compiles
+	// ./cmd/ailang exactly once per test binary, and appends .exe on Windows —
+	// which refuses to exec a file without the suffix, failing with
+	// "executable file not found in %PATH%". That reads like a missing
 	// toolchain rather than the naming bug it actually is.
-	binaryName := "ailang"
-	if runtime.GOOS == "windows" {
-		binaryName += ".exe"
-	}
-	binary := filepath.Join(t.TempDir(), binaryName)
-	build := exec.Command("go", "build", "-o", binary, ".")
-	if output, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("go build: %v\n%s", err, output)
-	}
+	binary := buildAilang(t)
 
 	moduleRoot := t.TempDir()
 	modulePath := filepath.Join(moduleRoot, "api", "surface.ail")


### PR DESCRIPTION
## The red

`test-windows` failed on `c4463b00b` with `panic: test timed out after 5m0s` in `cmd/ailang`.

**That commit did not cause it.** It changes one shell script and **zero Go files** (`git diff --name-only 90b27d3d8 c4463b00b -- '*.go'` is empty), and its parent was green. The package had grown into its ceiling:

| date | cmd/ailang on windows-latest |
|---|---|
| 2026-07-27 | 156.8s / 175.9s |
| 2026-07-28 | 210.5s / 216.3s / 217.0s |
| 2026-07-29 | 209.4s / 223.6s / 235.5s → **301.2s (timeout)** |

Ceiling is a fixed `-timeout 300s`. ci.yml claimed *"a 5min ceiling is well above any healthy test"* — no longer true.

## Root cause: 14 compiles of the same binary

`buildAilang`'s doc comment said it built the binary **"once per test run"**. The body had **no `sync.Once`** and built into a per-test `t.TempDir()`, so each of its **12 callers** paid a full `go build ./cmd/ailang` (~10s). Two more ad-hoc build sites brought it to 14.

The timing distribution is the tell — 14 tests clustered at ~10.6–11.0s, ≈150s of the package's 174s local runtime.

Its neighbour `budgetBin` already did this correctly, with a comment explaining why the shared binary needs `os.MkdirTemp` rather than `t.TempDir` (the first caller's cleanup would delete it).

## The fix

All three build sites collapse onto one `sync.Once` builder, freed in `TestMain`:

| | before | after |
|---|---|---|
| local `cmd/ailang` | 174.4s | **25.5s** (6.8×) |
| tests | 526 pass + 22 skip | 526 pass + 22 skip |
| unique test names | 548 | 548, **set-identical** |

A faster suite that runs fewer tests would be this repo's vacuous-pass class, so the before/after test-name sets were diffed: **no test lost, none added.**

## Bonus: the isolation that wasn't

`TestWarnSilentRatchet_*` — the test blocked in `sqlite3_close_v2` when the alarm fired — isolated the messaging DB via `HOME`. But `GetDefaultDatabasePath()` falls back to `os.UserHomeDir()`, which reads **`%USERPROFILE%` on Windows and ignores `HOME`**. So on the exact platform that went red, the isolation was a no-op and the tests opened, migrated and closed the runner's **real `~/.ailang` DB**.

Switched to `AILANG_STATE_DIR`, which the function consults *first* and which works on every platform (already the convention in `internal/storage/backend_test.go`).

## Verification

- `go vet` clean, `gofmt` clean
- full `cmd/ailang` package: 526 pass, **0 fail**
- 4 ratchet tests pass with the real `~/.ailang` DB **mtime unchanged**
- `cmd/wasm` `go build ./...` noise is pre-existing (`//go:build js && wasm`; builds rc=0 for its real target)

The Windows half is reasoned from `os.UserHomeDir` semantics + code, **not measured locally** — `test-windows` on this PR is the confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)