### PR TITLE
fix(test): a suite whose properties ran zero cases no longer reports success (#517 Lane A)

### DIFF
--- a/.ailang/state/sprints/sprint_M-PROPERTY-GENERATOR-LANE-A.json
+++ b/.ailang/state/sprints/sprint_M-PROPERTY-GENERATOR-LANE-A.json
@@ -1,6 +1,6 @@
 {
   "sprint_id": "M-PROPERTY-GENERATOR-LANE-A",
-  "status": "planned",
+  "status": "completed",
   "created": "2026-07-30T00:00:00Z",
   "design_doc": "design_docs/planned/v0_31_0/m-property-generator-coverage.md",
   "sprint_plan": "design_docs/planned/v0_31_0/m-property-generator-coverage-lane-a-sprint-plan.md",
@@ -56,10 +56,10 @@
         "make check-file-sizes green (runner.go must stay <= 800 lines; it is 774 today, 26 headroom).",
         "Commands use flags BEFORE the path (#534). go test ./cmd/ailang/... reported as UNINFORMATIVE UNDER SANDBOX."
       ],
-      "passes": null,
-      "started": null,
-      "completed": null,
-      "notes": null
+      "passes": true,
+      "started": "2026-07-30T00:00:00Z",
+      "completed": "2026-07-30T00:13:28Z",
+      "notes": "Added reachable TypeApp list generation with recursive no-fallback behavior; informative internal/testing and file-size gates passed; corpus probes confirmed list properties execute."
     },
     {
       "id": "M2_A2_TOTAL_SKIP_TAXONOMY",
@@ -78,10 +78,10 @@
         "go test ./internal/testing/... -count=1 green; make check-file-sizes green.",
         "No existing test assertion modified (A-10 precondition)."
       ],
-      "passes": null,
-      "started": null,
-      "completed": null,
-      "notes": null
+      "passes": true,
+      "started": "2026-07-30T00:04:00Z",
+      "completed": "2026-07-30T00:13:28Z",
+      "notes": "Added total six-site skip taxonomy, fail-closed VacuousSkips accounting, and both CLI aggregation merges without changing Success semantics."
     },
     {
       "id": "M3_A3_A4_EXIT_SEMANTICS_AND_REPORTER",
@@ -101,10 +101,10 @@
         "A-10 (NEW, refutes the doc's 'deliberately updated tests' requirement): `git diff -U0 -- '*_test.go'` shows NO REMOVED LINES in pre-existing test files. Measured: the set of tests needing updates is EMPTY - every existing Success()/AllSkipped()/SuccessAllowingSkips() test (result_test.go:126,137,145; named_test_test.go:161,164,175,185,299,309) builds its suite with AddTestResult, and TestResult has no SkipKind, so VacuousSkips stays 0 and all verdicts hold. Additive JSON fields are safe too: reporter_test.go reads output[\"success\"].(bool) by key and integration_test.go:113-125 uses strings.Contains - neither asserts a closed key set.",
         "go test ./internal/testing/... -count=1 green; make check-file-sizes green."
       ],
-      "passes": null,
-      "started": null,
-      "completed": null,
-      "notes": null
+      "passes": true,
+      "started": "2026-07-30T00:06:00Z",
+      "completed": "2026-07-30T00:13:28Z",
+      "notes": "Vacuous mixed suites now fail by default, --allow-skips remains permissive, JSON exposes taxonomy, and human reports show skipped-property reasons and case counts."
     },
     {
       "id": "M4_A5_JSON_IS_JSON",
@@ -120,10 +120,10 @@
         "Human mode preamble is UNCHANGED on stdout: `ailang test F` still prints `-> Running tests in F` to stdout.",
         "go test ./internal/testing/... -count=1 green; make check-file-sizes green."
       ],
-      "passes": null,
-      "started": null,
-      "completed": null,
-      "notes": null
+      "passes": true,
+      "started": "2026-07-30T00:08:00Z",
+      "completed": "2026-07-30T00:13:28Z",
+      "notes": "Routed all four JSON-mode preamble writes to stderr and added temp-directory subprocess coverage for single-file and package modes."
     },
     {
       "id": "M5_CLOSEOUT_CHANGELOG_AND_FOLLOWUPS",
@@ -141,10 +141,10 @@
         "make check-file-sizes, make lint, go test ./internal/testing/... -count=1 all green; make verify-examples green (should be unaffected - it invokes `ailang run`, never `ailang test`).",
         "Executor reports, per milestone, exactly which files changed and why, and leaves a clean reviewable working diff for the controller to commit (executor cannot commit in this worktree)."
       ],
-      "passes": null,
-      "started": null,
-      "completed": null,
-      "notes": null
+      "passes": true,
+      "started": "2026-07-30T00:11:00Z",
+      "completed": "2026-07-30T00:13:28Z",
+      "notes": "Documented the breaking change, Lane A landing and plan corrections, plus follow-ups F1/F2/F3; final quality gates recorded by executor."
     }
   ],
   "discrepancies_found": [

--- a/.ailang/state/sprints/sprint_M-PROPERTY-GENERATOR-LANE-A.json
+++ b/.ailang/state/sprints/sprint_M-PROPERTY-GENERATOR-LANE-A.json
@@ -128,7 +128,7 @@
     {
       "id": "M5_CLOSEOUT_CHANGELOG_AND_FOLLOWUPS",
       "description": "Closeout: CHANGELOG breaking-change entry in changelogs/v0.18-current.md [Unreleased]; mark Lane A landed in design_docs/planned/v0_31_0/m-property-generator-coverage.md and record the plan's corrections there (R-2 especially, so the stale before/after table does not mislead Lane B's planner); file follow-ups F1/F2/F3 WITHOUT implementing them.",
-      "estimated_loc": 0,
+      "estimated_loc": 80,
       "dependencies": [
         "M4_A5_JSON_IS_JSON"
       ],

--- a/.ailang/state/sprints/sprint_M-PROPERTY-GENERATOR-LANE-A.json
+++ b/.ailang/state/sprints/sprint_M-PROPERTY-GENERATOR-LANE-A.json
@@ -1,0 +1,267 @@
+{
+  "sprint_id": "M-PROPERTY-GENERATOR-LANE-A",
+  "status": "planned",
+  "created": "2026-07-30T00:00:00Z",
+  "design_doc": "design_docs/planned/v0_31_0/m-property-generator-coverage.md",
+  "sprint_plan": "design_docs/planned/v0_31_0/m-property-generator-coverage-lane-a-sprint-plan.md",
+  "github_issues": [
+    517
+  ],
+  "risk_level": "medium",
+  "metadata": {
+    "planner-model": "claude-opus-4-8",
+    "mission_iteration": 121,
+    "scope": "Lane A ONLY (A1-A6) of m-property-generator-coverage. IN: A1 reachable list generator (ast.TypeApp{\"list\"} arm), A2 total skip taxonomy (SkipKind over all SIX StatusSkip sites), A3 Success() gains VacuousSkips==0, A4 reporter honesty (property skip reasons + new summary branch), A5 --format json preamble to stderr, A6 mixed-shape regression fixtures. OUT: Lane B entirely (B1 structural derivation, B2 deferred on evaluator fuel budget). Lane A ships without any part of Lane B - verified: A1's list arm recurses into createGeneratorForType for the element type and returns nil,nil for non-derivable elements (probe-verified on list[Tree]).",
+    "estimated_effort": "1.0 day (doc says ~0.5d; +0.5d is measured A1 triage the doc assigned to Lane B)",
+    "base_commit": "6c70a6c36826dc3b992d407e739a3d9f75c1a116",
+    "base_note": "= 4ebd85873 + 2 doc-only commits. `git diff 4ebd85873 HEAD -- internal/testing cmd/ailang/test.go` is EMPTY, so every controller measurement taken at 4ebd85873 transfers unchanged.",
+    "premises_verified_live": true,
+    "verification_binary": "/tmp/ailang_planner121 built from this worktree via `go build -o /tmp/ailang_planner121 ./cmd/ailang` (reports commit 4ebd858-dirty: known go-build-in-worktree VCS-stamp quirk; verified behaviourally, not by stamp)",
+    "verification_date": "2026-07-30",
+    "read_only_main_checkout": true,
+    "worktree_left_clean": true,
+    "a1_probe": "The A1 patch was applied to a scratch copy of internal/testing/runner.go, built to /tmp/ailang_probeA1, measured, then runner.go was restored byte-identically (sha256 prefix 72398a36013964db before and after; `git status --short` empty). No git operations were used.",
+    "six_skip_sites": "grep -n StatusSkip internal/testing/runner.go -> 249, 331, 373, 454, 490, 536. ALL SIX are PropertyResult sites. TestResult is NEVER assigned StatusSkip anywhere in non-test Go under internal/ or cmd/ - so the six-site taxonomy is EXHAUSTIVE and totality (A-8) is a checkable invariant.",
+    "taxonomy_hole_resolution": "Sites 331/454 get the class name `unsupported` and FAIL the suite (counted into VacuousSkips alongside no_generator). Reasons: (1) a contract that ran ZERO cases is vacuous by definition, identically to no_generator - out_of_contract is categorically different because the contract DID execute (TestsRun>=1) and an input was discarded; (2) zero live blast radius, because those two sites are proven unreachable from any parsed AILANG program (see refutation R-1), so `fail` costs nothing today and installs the honest default for when the parser grows top-level contracts; (3) default-deny - the defect being fixed IS an 'unclassified => forgiven' default, so AddPropertyResult treats an empty SkipKind on a StatusSkip property as vacuous (fail-closed) and A-8 asserts totality so that arm is never reached. NOT deferred: cost is ~2 LOC plus one white-box unit test constructing PropertyCase{Property:&ast.Property{Kind:ast.EnsuresKind}, Function:nil}. No .ail fixture and no triage budget is spent, because R-1 proves there is no live bug there.",
+    "sandbox_gates": "INFORMATIVE: `go test ./internal/testing/... -count=1` (binds no sockets). UNINFORMATIVE UNDER SANDBOX (must be labelled as such, never pass/fail): `go test ./cmd/ailang/...` and `make test` (= go test ./...), because cmd/ailang has 6 socket-binding test files: configdriven_callstream_test.go, configdriven_dispatch_test.go, configdriven_harvest_test.go, configdriven_streaming_span_snapshot_test.go, configdriven_streaming_test.go, messages_send_test.go.",
+    "executor_cannot_commit": "Executor is codex gpt-5.6-sol under --sandbox workspace-write and cannot commit in this linked worktree. Leave a clean reviewable working diff and report per-milestone file changes; the controller commits each milestone separately.",
+    "flags_before_path": "MANDATORY. `ailang test f.ail --format json` silently ignores --format (measured: human text, rc=0) because Go's flag stops at the first non-flag arg (cmd/ailang/main.go:120). Filed as #534, OUT OF SCOPE. Every command in the plan is flags-first.",
+    "file_size_gate": "internal/testing/runner.go = 774 lines; make check-file-sizes fails >800 (make/code-health.mk:123). Only 26 lines of headroom. SkipKind constants and any classification helper go in internal/testing/result.go (122 lines) if needed.",
+    "no_examples_dir_files": "Do NOT add files under examples/runnable/ - that reds make verify-examples via scripts/validate_manifest.go --ci (make/examples.mk:24) unless examples/manifest.json gains a matching entry. Fixtures go in Go tests via t.TempDir() + os.WriteFile, the convention at internal/testing/runner_ensures_test.go:19-21. Coding-standards' 'every language feature needs an example' does not bite: Lane A adds zero syntax (doc's own A8 score = 0).",
+    "no_ci_gate_reds": "Re-verified with positive control: ZERO `ailang test` invocations across make/, Makefile, .github/workflows/, tools/, scripts/ (positive control: 8 `ailang check` hits). Sole programmatic consumer is cmd/ailang/coordinator_cloud.go:586, itself guarded by len(testFiles)>0 over *_test.ail at :583-584 - so the escalate-to-AI flip only reaches packages that actually ship test files.",
+    "net_exit_code_change": "Exactly 4 in-repo files flip rc 0 -> 1 at M3: inbox_injection_v2.ail, inbox_v2_app.ail, park.ail, record_discovery_verify.ail. cross_module_functions_lib.ail MUST stay rc 0 (out_of_contract forgiven) - the single most important false-red guard in the sprint. At M1 alone, 3 files change: hof_verify rc 1->0, list_verify success true->false with a genuine failure surfaced, list_recursive_verify rc 1->0 (see H1).",
+    "gitignore_note": "`.ailang/` is gitignored (.gitignore:77) but sprint JSONs are tracked. The controller MUST use `git add -f .ailang/state/sprints/sprint_M-PROPERTY-GENERATOR-LANE-A.json` or this file is silently dropped from the commit.",
+    "bounded_waits": "`timeout` is NOT on PATH on this rig (returns rc 127). Five contract examples (recursive_verify, scoring, showcase, string_verify, temperature) are pathologically slow under `ailang test` - recursive_verify.ail emitted only the preamble and no JSON after several minutes. Exclude them from per-milestone gate sweeps and report UNMEASURED (exceeds bounded wait); never let a slow example block a gate."
+  },
+  "velocity": {
+    "target_loc_per_day": 397,
+    "estimated_total_loc": 397,
+    "estimated_days": 1,
+    "loc_note": "397 = 107 impl + 290 test. Deliberately test-heavy: impl is small (a generator arm, a string field, one boolean term, four Printf stream changes), and the value is in the mutation-backed acceptance suite plus the totality invariant. The 1-day budget is gated by M1's measured triage of 16 newly-executing properties, not by typing volume."
+  },
+  "features": [
+    {
+      "id": "M1_A1_REACHABLE_LIST_GENERATOR",
+      "description": "A1: add a *ast.TypeApp arm to createGeneratorForType (internal/testing/runner.go:629) matching Constructor==\"list\" && len(Args)==1, recursing into createGeneratorForType(app.Args[0]) and returning nil,nil when the element generator is nil. [T]/list[T] has parsed to ast.TypeApp{Constructor:\"list\"} since DX-17 Phase 2 (internal/parser/parser_type.go:56,:112), so the existing *ast.ListType arm is unreachable from parsed programs (ZERO non-test constructors under internal/, cmd/, scripts/; positive control: 21 constructions in _test.go). KEEP the ListType arm - deleting it breaks those 21 test constructions for no benefit (coding-standards: never delete because the linter says unused). Ordered FIRST deliberately: it shrinks the vacuous surface before M3 flips exit codes, so M3's measured blast radius is the final one. Includes 0.4d triage of 16 previously-never-executed properties across 5 files.",
+      "estimated_loc": 72,
+      "dependencies": [],
+      "acceptance_criteria": [
+        "A-3: mixed fixture's headOr(xs: [int], d: int) ensures-property runs 100 cases and passes (probe-verified: skip/0 -> pass/100). Red-turning mutation: delete the new *ast.TypeApp \"list\" arm.",
+        "A-9 (NEW): list[Tree] in examples/runnable/contracts/cross_module_types.ail remains a no_generator vacuous skip - the element ADT is non-derivable and the arm must return nil,nil. Red-turning mutation: substitute a default int/unit generator when the element generator is nil (CLAUDE.md principle 2 - a silent fallback here would test wrong values).",
+        "The *ast.ListType arm is still present and go test ./internal/testing/... -count=1 is green (its 21 test-only constructors still work).",
+        "examples/runnable/contracts/hof_verify.ail: rc 1 -> 0 (both list[int] properties pass 100 cases). MEASURED via probe.",
+        "examples/runnable/contracts/list_verify.ail: rc stays 1 but success flips true -> false with a GENUINE failure surfaced (brokenAllPositive_property_2, 2 cases) - deliberate latent-bug detection, not a regression. MEASURED via probe.",
+        "examples/runnable/contracts/list_recursive_verify.ail: rc 1 -> 0 with 2 pass + 4 out_of_contract skips - DISCLOSED, see H1. Must be recorded in the executor report, not silently accepted. MEASURED via probe.",
+        "examples/runnable/contracts/invoice.ail: 2 list[int] properties now run; 13 nogen vacuous skips remain.",
+        "make check-file-sizes green (runner.go must stay <= 800 lines; it is 774 today, 26 headroom).",
+        "Commands use flags BEFORE the path (#534). go test ./cmd/ailang/... reported as UNINFORMATIVE UNDER SANDBOX."
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": null
+    },
+    {
+      "id": "M2_A2_TOTAL_SKIP_TAXONOMY",
+      "description": "A2: add PropertyResult.SkipKind string (result.go:27-35) with named constants SkipKindNoGenerator=\"no_generator\", SkipKindUnsupported=\"unsupported\", SkipKindOutOfContract=\"out_of_contract\" declared in result.go (keeps runner.go under the 800-line gate). Assign at ALL SIX StatusSkip sites: 249/373/490 -> no_generator; 331/454 -> unsupported; 536 -> out_of_contract. Add SuiteResult.VacuousSkips int, incremented in AddPropertyResult when Status==StatusSkip && SkipKind != SkipKindOutOfContract (so no_generator, unsupported, AND fail-closed for an unexpected empty kind). Merge VacuousSkips in BOTH aggregation loops: cmd/ailang/test.go:52-58 (single-file) and :181-187 (package mode) - missing either silently zeroes the counter for that mode. Success() is NOT touched here: M2 must be provably behaviour-inert.",
+      "estimated_loc": 125,
+      "dependencies": [
+        "M1_A1_REACHABLE_LIST_GENERATOR"
+      ],
+      "acceptance_criteria": [
+        "A-8 (NEW, closes the six-sites hole permanently): a table-driven test asserts every StatusSkip PropertyResult the runner can produce carries a non-empty SkipKind, covering all six sites. Sites 331/454 are reached by constructing PropertyCase{Property:&ast.Property{Kind:ast.EnsuresKind|ast.RequiresKind}, Function:nil} directly - the only way, since they are unreachable from parsed programs (R-1). Red-turning mutation: remove the SkipKind assignment at ANY ONE of the six sites.",
+        "Sites 331 and 454 classify as SkipKindUnsupported and are counted into VacuousSkips (the stated decision; see metadata.taxonomy_hole_resolution for the reason).",
+        "An unexpected empty SkipKind on a StatusSkip PropertyResult is counted as VACUOUS (fail-closed), never forgiven. Red-turning mutation: change the AddPropertyResult condition to == SkipKindNoGenerator only.",
+        "A-4 classification: examples/runnable/contracts/cross_module_functions_lib.ail's single skip has skip_kind==\"out_of_contract\" and vacuous_skips==0. Red-turning mutation: set SkipKind = SkipKindNoGenerator at runner.go:536.",
+        "BOTH aggregation loops merge VacuousSkips - assert non-zero VacuousSkips reaches the reporter in single-file mode AND in --package mode. Red-turning mutation: delete the merge line from either loop.",
+        "INERTNESS PROOF: re-run the 33-file examples/runnable/contracts sweep and diff against M1's table - exit codes and success values must be BYTE-IDENTICAL to M1 (Success() is unchanged in this milestone).",
+        "go test ./internal/testing/... -count=1 green; make check-file-sizes green.",
+        "No existing test assertion modified (A-10 precondition)."
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": null
+    },
+    {
+      "id": "M3_A3_A4_EXIT_SEMANTICS_AND_REPORTER",
+      "description": "A3: result.go:97 Success() becomes `ran > 0 && sr.FailedTests == 0 && sr.VacuousSkips == 0`. AllSkipped() (:104) and SuccessAllowingSkips() (:110) stay UNCHANGED, so --allow-skips forgives vacuous skips for free via the existing `succeeded := Success() || (allowSkips && SuccessAllowingSkips())` at test.go:80 and :208 - no new flag. A4: reporter.go:47-64 JSON gains top-level \"vacuous_skips\" and per-property \"skip_kind\" (\"success\" at :56 tracks A3 automatically); reporter.go:181 widens `if prop.Status == StatusFail` to `|| prop.Status == StatusSkip`, mirroring the existing test-side condition at :148; reporter.go:205-219 gains a summary branch BETWEEN case result.AllSkipped() and case result.Success() naming the count and --allow-skips.",
+      "estimated_loc": 155,
+      "dependencies": [
+        "M2_A2_TOTAL_SKIP_TAXONOMY"
+      ],
+      "acceptance_criteria": [
+        "A-1 (CORRECTED fixture - see refutation R-2): mixed fixture anchor(x: int) [pass] + shiftX(p: Point, dx: int) [vacuous record] + headOr(xs: [int], d: int) [pass after A1] gives `ailang test --format json F` -> rc 1, success=false, vacuous_skips=1, with 2 passing siblings. The doc's own `mixed` module (dbl + headOr) is UNUSABLE for this: probe-measured post-A1 it yields 2 pass / 0 skip / success=true / rc 0. Red-turning mutation: revert Success() to `ran > 0 && FailedTests == 0`.",
+        "A-2: same fixture with `ailang test --allow-skips --format json F` -> rc 0. Flags BEFORE the path (#534). Note this criterion is non-discriminating before M3 (the fixture already exits 0 today) - assert it only now. Red-turning mutation: make the allow-skips branch also require VacuousSkips == 0.",
+        "A-4: examples/runnable/contracts/cross_module_functions_lib.ail stays rc 0 with vacuous_skips=0 and skip_kind==\"out_of_contract\". THE false-red guard: out-of-contract skips must not acquire a vacuous label. Red-turning mutation: set SkipKind = SkipKindNoGenerator at runner.go:536.",
+        "A-6: human output for the mixed fixture contains `no generator for parameter` and does NOT contain `All tests passed!`. Assert the *parameter* form specifically - TWO distinct texts exist (site 249 emits `no generator for type %v`; :373/:490 emit `no generator for parameter %s: %v`), so a generic \"no generator\" substring assertion is forbidden. Both texts stay byte-unchanged; skip_kind carries the machine signal. Red-turning mutation: revert reporter.go:181 to StatusFail-only (drops the reason) / remove the new summary branch (restores the headline).",
+        "A-7 (MUTATION CORRECTED): an all-skipped suite whose only skip is out_of_contract still prints `NO TESTS RAN` and exits 1. Unit-level SuiteResult fixture (no in-repo file has this shape). Red-turning mutation: DROP the `ran > 0` term from Success(), leaving `FailedTests == 0 && VacuousSkips == 0`. The doc's mutation (Success() returns FailedTests == 0) also turns A-1 red and therefore does not isolate A-7; and the fixture must be out-of-contract-only, because a no_generator all-skipped suite stays red via VacuousSkips regardless of ran > 0.",
+        "H1 DISCLOSURE: verify the widened reporter.go:181 condition surfaces the reason AND the (N cases) count for out_of_contract skips too, not only no_generator. list_recursive_verify.ail stays rc 0 with 4 near-unvalidated properties; that must be legible in human output.",
+        "Full 33-file sweep matches the plan's 'after M3' column: EXACTLY 4 files flip rc 0 -> 1 (inbox_injection_v2, inbox_v2_app, park, record_discovery_verify) and cross_module_functions_lib stays rc 0.",
+        "A-10 (NEW, refutes the doc's 'deliberately updated tests' requirement): `git diff -U0 -- '*_test.go'` shows NO REMOVED LINES in pre-existing test files. Measured: the set of tests needing updates is EMPTY - every existing Success()/AllSkipped()/SuccessAllowingSkips() test (result_test.go:126,137,145; named_test_test.go:161,164,175,185,299,309) builds its suite with AddTestResult, and TestResult has no SkipKind, so VacuousSkips stays 0 and all verdicts hold. Additive JSON fields are safe too: reporter_test.go reads output[\"success\"].(bool) by key and integration_test.go:113-125 uses strings.Contains - neither asserts a closed key set.",
+        "go test ./internal/testing/... -count=1 green; make check-file-sizes green."
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": null
+    },
+    {
+      "id": "M4_A5_JSON_IS_JSON",
+      "description": "A5: route preamble lines to stderr when formatStr==\"json\" (human mode unchanged). FOUR write sites, not one: cmd/ailang/test.go:18 (`-> Running tests in %s`, single-file mode) and :163, :164, :173 (package mode: `-> Package %s`, the `%s source modules, %s test files` line, and the trailing blank fmt.Println()). Moving only the first leaves package-mode stdout unparseable.",
+      "estimated_loc": 45,
+      "dependencies": [
+        "M3_A3_A4_EXIT_SEMANTICS_AND_REPORTER"
+      ],
+      "acceptance_criteria": [
+        "A-5: `ailang test --format json F 2>/dev/null | jq .` parses on raw stdout with ZERO preprocessing, in single-file mode. Verified failing today (jq: parse error at line 1 column 4). Red-turning mutation: restore any preamble fmt.Printf to stdout in JSON mode.",
+        "A-5 package mode: `ailang test --package --format json . 2>/dev/null | jq .` also parses - all three package-mode preamble writes moved.",
+        "Assert on STDOUT ONLY. Do NOT assert stderr is empty: a legitimate `Warning: stdlib version mismatch: ...` (166 bytes, internal/loader/stdlib_resolver.go:310) already writes to stderr for some files. The controller's '0 bytes stderr' measurement was taken on a file without that warning.",
+        "Human mode preamble is UNCHANGED on stdout: `ailang test F` still prints `-> Running tests in F` to stdout.",
+        "go test ./internal/testing/... -count=1 green; make check-file-sizes green."
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": null
+    },
+    {
+      "id": "M5_CLOSEOUT_CHANGELOG_AND_FOLLOWUPS",
+      "description": "Closeout: CHANGELOG breaking-change entry in changelogs/v0.18-current.md [Unreleased]; mark Lane A landed in design_docs/planned/v0_31_0/m-property-generator-coverage.md and record the plan's corrections there (R-2 especially, so the stale before/after table does not mislead Lane B's planner); file follow-ups F1/F2/F3 WITHOUT implementing them.",
+      "estimated_loc": 0,
+      "dependencies": [
+        "M4_A5_JSON_IS_JSON"
+      ],
+      "acceptance_criteria": [
+        "changelogs/v0.18-current.md [Unreleased] has a BREAKING entry: mixed suites with no_generator/unsupported property skips now exit 1 (escape: --allow-skips); additive JSON fields vacuous_skips + skip_kind; JSON-mode stdout is now pure JSON; [T]/list[T] parameters now get generators. Names the 4 in-repo files that flip rc 0 -> 1.",
+        "The design doc records: Lane A landed; the R-2 before/after-table correction; the `unsupported` class decision and its reason; that the six-site taxonomy is exhaustive (R-3).",
+        "F1 filed (NOT implemented): out-of-contract discard rate is a generator-quality vacuous pass (H1). A property that out_of_contract-skips after 1-2 of 100 cases is near-unvalidated yet forgiven; list_recursive_verify.ail goes rc 1 -> 0 under it. Needs a threshold policy = a human-owned semantic decision outside Lane A.",
+        "F2 filed: #534 already exists - reference it, do not re-file.",
+        "F3 filed/noted: Lane B1 structural derivation remains the fix for the 6 files still vacuous after Lane A.",
+        "make check-file-sizes, make lint, go test ./internal/testing/... -count=1 all green; make verify-examples green (should be unaffected - it invokes `ailang run`, never `ailang test`).",
+        "Executor reports, per milestone, exactly which files changed and why, and leaves a clean reviewable working diff for the controller to commit (executor cannot commit in this worktree)."
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": null
+    }
+  ],
+  "discrepancies_found": [
+    {
+      "id": "R-1",
+      "severity": "high",
+      "doc_claim": "CONTROLLER directive item 7: sites 331 and 454 are an unclassified class that A2 would silently treat as non-vacuous, and 'That is very likely the same bug one layer over: the user wrote a contract, it never ran, and the suite reports success.'",
+      "finding": "REFUTES THE CONTROLLER'S INFERENCE (the measurement is upheld). Sites 331/454 are UNREACHABLE from any parsed AILANG program. (1) runEnsuresProperty/runRequiresProperty are entered only from runProperty's dispatch on Property.Kind in {EnsuresKind, RequiresKind} (runner.go:225-228). (2) The only producer of those Kinds is parseContractPredicate (parser_contracts.go:129-148, the sole ast.Property{} construction in the parser that sets Kind), reached only via parseContractBlocks (:22), called only from parseFunctionDeclaration (parser_func.go:121), whose results are appended to fn.Properties (parser_func.go:124-125) - always inside a FuncDecl. (3) The collector has exactly three PropertyCase{} sites (collector.go:48/84/138; ZERO in _test.go); the only one leaving Function nil is collectPropertyDecl (:84), fed by *ast.PropertyDecl, and parsePropertyDecl (parser_test_decl.go:75-118) builds its Property via parseProperty (parser_testing.go:235-301) which sets NO Kind => PropertyKind, the zero value (ast_decl.go:93). (4) BEHAVIORAL PROOF: a module with a passing ensures sibling plus a top-level `property \"commutes\" { forall(a: int, b: int) => a + b == b + a }` - the only construct producing Function==nil - routes to the FORALL path and reports status: fail, error: 'test 0: evaluation failed: empty program', rc=1. It does NOT emit 'top-level ensures not supported'.",
+      "action": "Still classify them as `unsupported` and FAIL the suite (future-proofing + default-deny; see metadata.taxonomy_hole_resolution), but spend NO .ail fixture and NO triage budget on a live bug that does not exist. A-8 reaches the sites via a white-box Go unit test. The evaluator must not expect a live repro."
+    },
+    {
+      "id": "R-2",
+      "severity": "high",
+      "doc_claim": "Design doc lines 330-341, Lane A before/after table: uses the `mixed` module (dbl(x: int) + headOr(xs: [int], d: int)) and claims in the same After column both `vacuous_skips: 1` / exit 1 AND `headOr ([int]) -> pass, 100 cases (list-arm fix)`.",
+      "finding": "INTERNALLY CONTRADICTORY, and it survived BOTH quorum rounds in the section certified byte-identical and unobjected. Probe-measured with the A1 patch applied, that module yields 2 pass, 0 skip, success=true, rc=0 - A1 removes the file's ONLY vacuous skip, so it cannot also demonstrate a vacuous-pass exit-1. A-1 would have been unimplementable as specified.",
+      "action": "The A-1 fixture must carry a shape Lane A does NOT derive. Use anchor(x: int) [pass] + shiftX(p: Point, dx: int) [vacuous record] + headOr(xs: [int], d: int) [pass after A1] -> 2 pass + 1 vacuous, rc 1, vacuous_skips=1, mixed shape with 2 passing siblings, and it pins A-3 in the same file. Record the correction in the design doc at M5."
+    },
+    {
+      "id": "R-3",
+      "severity": "medium",
+      "doc_claim": "Design doc 'Programs that MUST still work' #3: 'examples/runnable/contracts/unencodable_callee_skip.ail - the Z3-unencodable skip class; must remain unaffected by property-skip taxonomy.'",
+      "finding": "REFUTED. The file exists, but its single skip is measured as `requires not satisfied by random input (consider tighter generators): x=-65.42045367635684` - site 536, out_of_contract - and the file already fails (1 real property failure, rc 1). There is NO Z3-unencodable skip class in `ailang test` at all: all six StatusSkip assignments in the entire non-test Go tree under internal/ + cmd/ are PropertyResult sites in runner.go, and TestResult is NEVER assigned StatusSkip anywhere (reporter.go:148's test-skip branch is dead code today).",
+      "action": "Replace the fixture assertion with: its skip classifies out_of_contract and it stays rc 1. Upside: the six-site taxonomy is EXHAUSTIVE, which is exactly what makes A-8's totality invariant checkable rather than best-effort."
+    },
+    {
+      "id": "R-4",
+      "severity": "medium",
+      "doc_claim": "Doc: 'Five files currently exhibit the fully-silent mixed shape' (inbox_injection_v2 10, inbox_v2_app 10, list_verify 6, park 6, record_discovery_verify 6). Controller item 6: 17 files with skipping properties, listing invoice 2/18, basic 1/3, inbox_injection 4/2, cross_module_functions 2/2, cross_module_functions_lib 2/1 as such, plus '6 all-skipped files that already exit 1' (naming 8).",
+      "finding": "CORRECTED by a first-party sweep of all 33 files in examples/runnable/contracts/ (not 17). (a) The genuinely silent set (success=true with >=1 skip) is SIX files, not five - the doc's five PLUS cross_module_functions_lib.ail (2 pass / 1 skip), which the doc missed and which is the out_of_contract shape that must STAY GREEN. (b) Counts differ: park has 7 skips (doc: 6), record_discovery_verify has 8 (doc: 6). (c) Files the controller implied were silent-green but which are ALREADY rc 1 today: basic (4 fails), invoice (1), inbox_injection (4), cross_module_functions (1), finance (1), quantifier_verify (3), per_function_depth_verify (4) - their exit codes cannot flip. (d) quantifier_verify's 4 skips are all out_of_contract, not a mysterious 'non-generator class', and because it already has 3 failures the doc's 'must still exit as today' assertion is non-discriminating.",
+      "action": "Use the plan's measured per-file table as the M1/M2/M3 gate. Net semantic change at M3 is EXACTLY 4 files flipping rc 0 -> 1. Use cross_module_functions_lib.ail (not quantifier_verify) as the out_of_contract-stays-green regression fixture."
+    },
+    {
+      "id": "R-5",
+      "severity": "medium",
+      "doc_claim": "Doc Conflict Surface + controller UNVERIFIED list: 'Tests asserting Success()==true for pass+skip mixes without kind classification: updated deliberately - the executor enumerates each in the sprint log; anything updated beyond that list is a regression.'",
+      "finding": "THE SET IS EMPTY. Every existing test touching Success()/AllSkipped()/SuccessAllowingSkips() (result_test.go:126,137,145; named_test_test.go:161,164,175,185,299,309) builds its suite with AddTestResult, and TestResult has no SkipKind, so VacuousSkips stays 0 and every verdict holds unchanged. The nearest candidate, TestSuiteResult_AllSkipped_False_HasPassed (named_test_test.go:170-178), asserts only AllSkipped()==false, never Success(). Additive JSON fields are also safe: reporter_test.go reads output[\"success\"].(bool) by key, integration_test.go:113-125 uses strings.Contains - neither asserts a closed key set.",
+      "action": "Upgrade the soft 'enumerate what you touched' requirement to the HARD checkable invariant A-10: `git diff -U0 -- '*_test.go'` must show NO REMOVED LINES in pre-existing test files. Any removal is a regression signal for the evaluator."
+    },
+    {
+      "id": "H1",
+      "severity": "high",
+      "doc_claim": "Doc success metric: 'Requires-out-of-contract skips (deliberate semantics, runner.go:532-540) still exit 0 - no false reds introduced.' Doc attributes the latent-bug-detector / newly-running-properties risk to Lane B only.",
+      "finding": "NEW HONESTY DEFECT THAT LANE A ITSELF INTRODUCES - live and reachable, unlike sites 331/454. With the A1 patch applied, examples/runnable/contracts/list_recursive_verify.ail goes rc 1 -> rc 0, success=true - from honestly-red ('NO TESTS RAN', all 6 properties vacuous) to GREEN - while 4 of its 6 properties are out_of_contract skips that executed only 1-2 of 100 cases (containsImpliesNonEmpty_property_1 skip/1, extractBounded_property_1 skip/2, _2 skip/1, _3 skip/2). It STAYS green after M3 because out_of_contract is deliberately forgiven. This sprint therefore converts an honest red into a green suite in which two-thirds of the contracts are essentially unvalidated - the #517 class, one layer over. Separately, A1 starts executing 16 previously-never-executed properties across 5 files, triage the doc budgeted only for Lane B.",
+      "action": "Bounded resolution inside Lane A: (a) do NOT change out_of_contract's exit semantics - a human-owned High-Impact Decision, and flipping it would red 8+ in-repo files; (b) A4's reporter widening already surfaces the reason AND the (N cases) count for these skips - the plan REQUIRES this be verified for out_of_contract, not just no_generator; (c) skip_kind + existing tests_run make the class machine-countable, so no new counter; (d) the rc 1 -> 0 transition is recorded explicitly in the plan's per-file table so the evaluator reads it as DISCLOSED, not accidental; (e) filed as follow-up F1 - a discard-rate threshold is a semantic decision outside Lane A's remit. Plus 0.5d triage budget added to M1."
+    },
+    {
+      "id": "R-6",
+      "severity": "medium",
+      "doc_claim": "Doc Files to Modify: internal/testing/runner.go (+25/-5). No mention of the file-size gate.",
+      "finding": "internal/testing/runner.go is 774 lines and make check-file-sizes fails at >800 (make/code-health.mk:123, over find internal cmd -name '*.go'). The doc's budget lands at ~794 - SIX lines of margin. Lane B's additional +40/-10 would definitively blow it.",
+      "action": "make check-file-sizes is a gate on EVERY milestone. SkipKind constants and any classification helper go in internal/testing/result.go (122 lines), not runner.go."
+    },
+    {
+      "id": "R-7",
+      "severity": "medium",
+      "doc_claim": "Controller directive item 4: 'internal/testing and cmd/ailang/test.go are unlikely to bind sockets, but cmd/ailang's package tests may - flag it if so.'",
+      "finding": "CONFIRMED AND SHARPENED. internal/testing has ZERO socket-binding test files. cmd/ailang has SIX: configdriven_callstream_test.go, configdriven_dispatch_test.go, configdriven_harvest_test.go, configdriven_streaming_span_snapshot_test.go, configdriven_streaming_test.go, messages_send_test.go. make test is `go test ./...` (make/test.mk:15-17) so it includes them.",
+      "action": "`go test ./internal/testing/... -count=1` is the INFORMATIVE gate. `go test ./cmd/ailang/...` and `make test` MUST be reported as UNINFORMATIVE UNDER SANDBOX, never pass/fail; the controller re-runs them outside the sandbox."
+    },
+    {
+      "id": "R-8",
+      "severity": "medium",
+      "doc_claim": "Doc Files to Modify: 'examples/runnable/contracts/ - mixed-shape fixture file (new, small)'.",
+      "finding": "TRAP. Adding any .ail file under examples/runnable/ reds make verify-examples via its manifest-drift gate (scripts/validate_manifest.go --ci, make/examples.mk:24) unless examples/manifest.json gains a matching entry (path/status/tags/description/modules), and verify_examples.go will also try to `ailang run` it. Meanwhile internal/testing already has an established fixture convention: t.TempDir() + os.WriteFile (runner_ensures_test.go:19-21); there is no testdata/ dir.",
+      "action": "Lane A fixtures live as in-test sources via t.TempDir() + os.WriteFile. Coding-standards' 'every language feature needs examples/feature_name.ail' does not bite: Lane A adds ZERO syntax (the doc's own A8 axiom score is 0). If the executor adds an examples/ file anyway it MUST add the manifest entry and run make verify-examples."
+    },
+    {
+      "id": "V-OK",
+      "severity": "info",
+      "doc_claim": "Controller VERIFIED items 1, 2, 3, 4, 5, 8, 9 and the UNVERIFIED inherited line numbers.",
+      "finding": "ALL UPHELD first-party. (1) createGeneratorForType has exactly two arms (runner.go:629-661); ast.ListType{} has ZERO non-test constructors (positive control: 21 in _test.go). (2) mixed-shape file -> success=true, rc 0, tests: [] with properties[] a separate array. (3) all-skipped -> rc 1, 'NO TESTS RAN (1 skipped)'; Success() at result.go:97 is ran>0 && FailedTests==0; AllSkipped() :104, SuccessAllowingSkips() :110. (4) A5 reproduced: jq fails on raw stdout. (5) no CI/Makefile/tools/scripts consumer of `ailang test` (positive control: 8 `ailang check` hits); sole consumer cmd/ailang/coordinator_cloud.go:586, additionally guarded by len(testFiles)>0 at :583-584. (8) two distinct no-generator texts confirmed (:249 `no generator for type %v`; :373/:490 `no generator for parameter %s: %v`). (9) :536 is out_of_contract with TestsRun>=1; its full text ends `: %s` with the formatted inputs. Inherited line numbers: aggregation loops are test.go:52-58 and :181-187 (doc said 52-59 / 181-188); reporter hooks confirmed at :56, :181, :205, :210.",
+      "action": "No action - recorded so the evaluator can see these were re-checked, not inherited."
+    },
+    {
+      "id": "R-9",
+      "severity": "low",
+      "doc_claim": "Doc/controller treat the examples/runnable/contracts sweep as a cheap, complete measurement (17 files quoted).",
+      "finding": "Five of the 33 files are pathologically slow under `ailang test`: recursive_verify.ail emitted only the `-> Running tests in ...` preamble and produced NO JSON after several minutes (run killed). scoring, showcase, string_verify, temperature behave the same. Also: `timeout` is NOT on PATH on this rig (rc 127), so a naive bounded sweep silently reports nothing.",
+      "action": "Exclude those five from the per-milestone gate sweep and report them as UNMEASURED (exceeds bounded wait), never pass/fail. Use gtimeout or a perl alarm for bounded waits, not `timeout`. Do not let a slow example block a milestone gate."
+    }
+  ],
+  "risks": [
+    {
+      "id": "RISK-1",
+      "risk": "M1's list-arm fix starts executing 16 previously-never-executed properties across 5 files; some fail on real latent bugs.",
+      "impact": "sprint time",
+      "mitigation": "0.5d triage budget in M1. Outcomes for the three list-dominated files are already probe-measured (hof_verify rc 1->0; list_verify surfaces a genuine deliberate failure; list_recursive_verify rc 1->0). Failures are the feature working - do not treat as regressions."
+    },
+    {
+      "id": "RISK-2",
+      "risk": "Exit-code strictness produces a false red on the deliberate requires-out-of-contract semantics.",
+      "impact": "high if missed",
+      "mitigation": "A-4 pins it at the CLI level using the in-repo file cross_module_functions_lib.ail (2 pass + 1 out_of_contract skip, rc 0 today, must stay rc 0). Taxonomy is per-site explicit, never inferred from message text."
+    },
+    {
+      "id": "RISK-3",
+      "risk": "H1: A1 turns an honest red (list_recursive_verify.ail all-skipped) into a green suite with 4 near-unvalidated out_of_contract properties.",
+      "impact": "medium (honesty)",
+      "mitigation": "Disclosed in the plan's per-file table; reason + case count surfaced in human output by A4; skip_kind + tests_run make it machine-countable; follow-up F1 filed. out_of_contract exit semantics deliberately NOT changed (human-owned decision)."
+    },
+    {
+      "id": "RISK-4",
+      "risk": "runner.go crosses the 800-line CI gate (774 today, 26 headroom).",
+      "impact": "medium (gate red)",
+      "mitigation": "make check-file-sizes on every milestone; SkipKind constants and helpers go in result.go."
+    },
+    {
+      "id": "RISK-5",
+      "risk": "Acceptance commands written flags-last silently test nothing (#534).",
+      "impact": "high (false green on the sprint's own gates)",
+      "mitigation": "Every command in the plan is flags-first; stated as executor constraint 0.1."
+    },
+    {
+      "id": "RISK-6",
+      "risk": "Sandbox denies loopback binds, so cmd/ailang and make test results are meaningless.",
+      "impact": "medium (misread gate)",
+      "mitigation": "Label them UNINFORMATIVE UNDER SANDBOX; go test ./internal/testing/... is the informative gate; controller re-runs the rest outside the sandbox."
+    }
+  ]
+}

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -39,6 +39,33 @@
 
 ### Changed
 
+- **BREAKING:** `ailang test` now exits 1 for mixed suites whose
+  `no_generator` or `unsupported` properties ran zero cases; pass
+  `--allow-skips` to retain the former permissive exit behavior. JSON reports
+  additive `vacuous_skips` and per-property `skip_kind` fields, and JSON mode
+  now writes pure JSON to stdout. Property parameters spelled `[T]` or
+  `list[T]` now use the reachable list generator. In the in-repo contracts
+  corpus this changes the exit status of `inbox_injection_v2.ail`,
+  `inbox_v2_app.ail`, `park.ail`, and `record_discovery_verify.ail` from 0 to 1.
+
+  Two consequences worth calling out, because neither follows from the above:
+
+  - **Some suites get *less* red, not more.** Making `[T]` generators reachable
+    means properties that never ran now execute — and a property that runs can
+    then be discarded as out-of-contract, which is forgiven. So
+    `list_recursive_verify.ail` can move from exit 1 to exit **0**. A property
+    surviving only 1–2 of 100 generated cases before the rest are discarded is
+    near-unvalidated yet reported as passing; that residual gap is tracked as
+    follow-up **F1** and is *not* closed here. Newly-running properties may also
+    surface genuine contract violations that were previously invisible (observed
+    in `list_verify.ail`).
+  - **The per-file list above is not reproducible run-to-run.** Property
+    generation is seeded from the wall clock, so the same file on the same binary
+    can yield a different exit code between runs (#535). The `vacuous_skips`
+    classification added here is stable; `failed_tests` counts, and therefore
+    some exit codes, are not. Treat the corpus list as illustrative rather than
+    as a contract until #535 is fixed.
+
 - **Breaking for out-of-repo shell callers:** `ai-check` now exits 1 when its
   emitted JSON reports `verify.errors > 0`; complete JSON is still written
   before the exit decision. Skips remain exit 0.
@@ -5040,4 +5067,3 @@ Patch release on top of v0.18.0's M-MOTOKO-EXECUTOR-ADAPTER. Local smoke testing
 **Bedrock compat (final unblocker):** Live smoke initially failed because three extensions (omnigraph, context-mode, exa-search) advertised tool aliases with dots (`omnigraph.query`, `ctx.execute`, `exa.search`, etc — 28 aliases total). Direct Anthropic API + Vertex accept dots; OpenRouter routes to Amazon Bedrock which validates against `^[a-zA-Z0-9_-]{1,128}$` and rejects them. Fix in [ailang-packages `5e2eaef`](https://github.com/sunholo-data/ailang-packages/commit/5e2eaef) drops the dotted aliases from the OUTPUT (advertised) tool lists; INPUT normalizers still accept the dotted forms for back-compat. Pair with motoko `af9cd68` (forward `MOTOKO_COST_*` in TS childEnv whitelist, same gotcha as MOTOKO_REPO had).
 
 **LOC tally:** ~80 LOC AILANG-side (parser fallback, HealthCheck enhancement, env-var emit), ~250 LOC motoko-side (TS profile mirror, --headless/--version flags, sanitizer, cost env override, AILANG resolve_profile_dir + env_int). 11 new tests across both repos (3 parser fallback, 6 session-logger sanitization, 2 budget passthrough). One new design doc captures the v0.19.0 follow-up: M-FS-SANDBOX-DIAGNOSTICS for the silent-false `fileExists` issue.
-

--- a/cmd/ailang/test.go
+++ b/cmd/ailang/test.go
@@ -15,7 +15,11 @@ import (
 // runTestsV2 executes all tests in the given path.
 // Replaces the stub implementation in main.go.
 func runTestsV2(path string, formatStr string, colorEnabled bool, allowSkips bool) {
-	fmt.Printf("%s Running tests in %s\n", cyan("→"), path)
+	preambleWriter := os.Stdout
+	if formatStr == "json" {
+		preambleWriter = os.Stderr
+	}
+	fmt.Fprintf(preambleWriter, "%s Running tests in %s\n", cyan("→"), path)
 
 	// Collect all test files
 	var testFiles []string
@@ -55,6 +59,7 @@ func runTestsV2(path string, formatStr string, colorEnabled bool, allowSkips boo
 			aggregateResults.PassedTests += fileResult.PassedTests
 			aggregateResults.FailedTests += fileResult.FailedTests
 			aggregateResults.SkippedTests += fileResult.SkippedTests
+			aggregateResults.VacuousSkips += fileResult.VacuousSkips
 			aggregateResults.TotalDuration += fileResult.TotalDuration
 		}
 	}
@@ -160,8 +165,12 @@ func runPackageTests(dir string, formatStr string, colorEnabled bool, allowSkips
 	}
 
 	// Print package info
-	fmt.Printf("%s Package %s\n", cyan("→"), bold(manifest.Package.Name))
-	fmt.Printf("  %s source modules, %s test files\n",
+	preambleWriter := os.Stdout
+	if formatStr == "json" {
+		preambleWriter = os.Stderr
+	}
+	fmt.Fprintf(preambleWriter, "%s Package %s\n", cyan("→"), bold(manifest.Package.Name))
+	fmt.Fprintf(preambleWriter, "  %s source modules, %s test files\n",
 		cyan(fmt.Sprintf("%d", len(sourceFiles))),
 		cyan(fmt.Sprintf("%d", len(testFiles))))
 
@@ -170,7 +179,7 @@ func runPackageTests(dir string, formatStr string, colorEnabled bool, allowSkips
 		os.Exit(0)
 	}
 
-	fmt.Println()
+	fmt.Fprintln(preambleWriter)
 
 	// Aggregate results across all test files
 	aggregateResults := ailangTesting.NewSuiteResult(manifest.Package.Name)
@@ -184,6 +193,7 @@ func runPackageTests(dir string, formatStr string, colorEnabled bool, allowSkips
 			aggregateResults.PassedTests += fileResult.PassedTests
 			aggregateResults.FailedTests += fileResult.FailedTests
 			aggregateResults.SkippedTests += fileResult.SkippedTests
+			aggregateResults.VacuousSkips += fileResult.VacuousSkips
 			aggregateResults.TotalDuration += fileResult.TotalDuration
 		}
 	}

--- a/cmd/ailang/test_json_output_test.go
+++ b/cmd/ailang/test_json_output_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const jsonOutputTestSource = `module json_output_test
+
+test "passes" { true }
+`
+
+const mixedVacuousTestSource = `module mixed_vacuous_test
+
+export type Point = { x: int, y: int }
+
+export func anchor(x: int) -> int ! {}
+ensures { result == x }
+{
+  x
+}
+
+export func shiftX(p: Point, dx: int) -> int ! {}
+ensures { result == p.x + dx }
+{
+  p.x + dx
+}
+
+export func headOr(xs: list[int], d: int) -> int ! {}
+ensures { result == result }
+{
+  match xs { [] => d, ::(x, _) => x }
+}
+
+export func main() -> int ! {} { 0 }
+`
+
+func TestTestCommand_MixedVacuousSuiteExitSemantics(t *testing.T) {
+	bin := buildAilang(t)
+	file := filepath.Join(t.TempDir(), "mixed_vacuous_test.ail")
+	if err := os.WriteFile(file, []byte(mixedVacuousTestSource), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, exit := runAilangBin(t, bin, "test", "--format", "json", file)
+	if exit != 1 {
+		t.Fatalf("expected vacuous mixed suite to exit 1, got %d\nstdout:\n%s\nstderr:\n%s", exit, stdout, stderr)
+	}
+	var output struct {
+		Success      bool `json:"success"`
+		PassedTests  int  `json:"passed_tests"`
+		VacuousSkips int  `json:"vacuous_skips"`
+		Properties   []struct {
+			Name     string `json:"name"`
+			Status   string `json:"status"`
+			TestsRun int    `json:"tests_run"`
+			SkipKind string `json:"skip_kind"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("stdout is not pure JSON: %v\n%s", err, stdout)
+	}
+	if output.Success || output.PassedTests != 2 || output.VacuousSkips != 1 {
+		t.Fatalf("unexpected mixed result: %+v", output)
+	}
+	if len(output.Properties) != 3 {
+		t.Fatalf("expected 3 properties, got %d", len(output.Properties))
+	}
+	if output.Properties[1].SkipKind != "no_generator" {
+		t.Fatalf("shiftX skip kind = %q", output.Properties[1].SkipKind)
+	}
+	if output.Properties[2].Status != "pass" || output.Properties[2].TestsRun != 100 {
+		t.Fatalf("headOr did not run 100 passing cases: %+v", output.Properties[2])
+	}
+
+	_, _, allowExit := runAilangBin(t, bin, "test", "--allow-skips", "--format", "json", file)
+	if allowExit != 0 {
+		t.Fatalf("--allow-skips expected exit 0, got %d", allowExit)
+	}
+
+	human, _, humanExit := runAilangBin(t, bin, "test", file)
+	if humanExit != 1 {
+		t.Fatalf("human mode expected exit 1, got %d", humanExit)
+	}
+	if !strings.Contains(human, "no generator for parameter p: Point") {
+		t.Fatalf("human output missing exact skip reason:\n%s", human)
+	}
+	if strings.Contains(human, "All tests passed!") {
+		t.Fatalf("human output retained false-green headline:\n%s", human)
+	}
+}
+
+func TestTestCommand_JSONStdoutSingleFile(t *testing.T) {
+	bin := buildAilang(t)
+	file := filepath.Join(t.TempDir(), "json_output_test.ail")
+	if err := os.WriteFile(file, []byte(jsonOutputTestSource), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, exit := runAilangBin(t, bin, "test", "--format", "json", file)
+	if exit != 0 {
+		t.Fatalf("expected exit 0, got %d\nstderr:\n%s", exit, stderr)
+	}
+	var output map[string]any
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("stdout is not pure JSON: %v\nstdout:\n%s", err, stdout)
+	}
+	if !strings.Contains(stderr, "Running tests in") {
+		t.Fatalf("expected preamble on stderr, got %q", stderr)
+	}
+
+	humanStdout, _, humanExit := runAilangBin(t, bin, "test", file)
+	if humanExit != 0 {
+		t.Fatalf("expected human mode exit 0, got %d", humanExit)
+	}
+	if !strings.Contains(humanStdout, "Running tests in") {
+		t.Fatalf("human preamble moved off stdout: %q", humanStdout)
+	}
+}
+
+func TestTestCommand_JSONStdoutPackage(t *testing.T) {
+	bin := buildAilang(t)
+	dir := t.TempDir()
+	manifest := `[package]
+name = "test/json_output"
+version = "0.1.0"
+edition = "1"
+`
+	if err := os.WriteFile(filepath.Join(dir, "ailang.toml"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "json_output_test.ail"), []byte(jsonOutputTestSource), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, exit := runAilangBin(t, bin, "test", "--package", "--format", "json", dir)
+	if exit != 0 {
+		t.Fatalf("expected exit 0, got %d\nstderr:\n%s", exit, stderr)
+	}
+	var output map[string]any
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("package stdout is not pure JSON: %v\nstdout:\n%s", err, stdout)
+	}
+	if !strings.Contains(stderr, "Package test/json_output") {
+		t.Fatalf("expected package preamble on stderr, got %q", stderr)
+	}
+}

--- a/design_docs/planned/v0_31_0/m-property-generator-coverage-lane-a-sprint-plan.md
+++ b/design_docs/planned/v0_31_0/m-property-generator-coverage-lane-a-sprint-plan.md
@@ -1,0 +1,468 @@
+# Sprint Plan — M-PROPERTY-GENERATOR-COVERAGE **Lane A only**
+
+**Design doc**: [m-property-generator-coverage.md](m-property-generator-coverage.md) (Lane A = A1–A6)
+**Sprint ID**: `M-PROPERTY-GENERATOR-LANE-A`
+**Upstream filing**: sunholo-data/ailang#517
+**Branch / worktree**: `sprint/m-property-generator-lane-a` @ `.claude/worktrees/sprint-m-property-generator-lane-a`
+**Base**: `6c70a6c36` (= `4ebd85873` + 2 doc-only commits; `git diff 4ebd85873 HEAD -- internal/testing cmd/ailang/test.go` is **empty**, so all controller measurements taken at `4ebd85873` transfer unchanged)
+**Planner**: iteration 121, V1 mission. All facts below re-measured first-party in this worktree with `go build -o /tmp/ailang_planner121 ./cmd/ailang`.
+**Estimate**: 1.0 day (doc says ~0.5d; +0.5d is measured triage the doc did not budget — see H1 / M1)
+**Risk**: medium (semantic exit-code change; 3 in-repo example files change exit status at M1 alone)
+
+**Scope**: Lane A only. Lane B (B1 structural derivation, B2 deferred) is **OUT**. Lane A ships
+without any part of Lane B — confirmed: A1's list arm recurses into `createGeneratorForType` for the
+element type and correctly returns `nil, nil` when the element is non-derivable (probe-verified on
+`list[Tree]`), so no derivation machinery is required.
+
+---
+
+## 0. Executor operating constraints (read first)
+
+1. **Flags BEFORE the positional path, always.** `ailang test f.ail --format json` silently ignores
+   `--format` (measured: human text, rc=0). Root cause is Go `flag` stopping at the first non-flag
+   arg (`cmd/ailang/main.go:120`, `_ = testFlags.Parse(flag.Args()[1:])`); filed as **#534**,
+   systemic across subcommands, **explicitly out of scope**. Every command in this plan is written
+   flags-first. If you write a command flags-last, your acceptance check tests nothing.
+2. **You cannot commit in this worktree** (sandbox blocks the linked worktree's git metadata). Leave a
+   clean, reviewable working diff and report, per milestone, exactly which files changed and why. The
+   controller commits each milestone separately.
+3. **Sandbox-uninformative gates.** `go test ./internal/testing/...` binds no sockets — **informative**.
+   `go test ./cmd/ailang/...` and `make test` (= `go test ./...`) do bind loopback sockets in 6 test
+   files (`configdriven_callstream_test.go`, `configdriven_dispatch_test.go`,
+   `configdriven_harvest_test.go`, `configdriven_streaming_span_snapshot_test.go`,
+   `configdriven_streaming_test.go`, `messages_send_test.go`) and MUST be reported as
+   **`UNINFORMATIVE UNDER SANDBOX`**, never pass or fail. The controller re-runs them outside the sandbox.
+4. **`make check-file-sizes` is a gate on every milestone.** `internal/testing/runner.go` is **774
+   lines**; the gate fails at >800 (`make/code-health.mk:123`). You have **26 lines of headroom in that
+   one file**. If the TypeApp arm plus SkipKind assignments would exceed it, put the `SkipKind`
+   constants and any classification helper in `internal/testing/result.go` (122 lines) instead.
+5. **Do not add files under `examples/runnable/`.** That trips the manifest-drift gate
+   (`scripts/validate_manifest.go --ci`, `make/examples.mk:24`) unless `examples/manifest.json` gains a
+   matching entry. Lane A fixtures go in Go tests via `t.TempDir()` + `os.WriteFile`, the convention
+   already used at `internal/testing/runner_ensures_test.go:19-21`. Coding-standards' "every language
+   feature needs an example" does not apply: Lane A adds **zero syntax** (the doc's own A8 score is 0).
+   If you add an examples/ file anyway you MUST add the manifest entry and run `make verify-examples`.
+6. **Do not modify any existing test assertion.** Measured: **zero** existing Go tests need updating
+   (see A-10). `git diff -U0 -- '*_test.go'` must show no removed lines in pre-existing test files.
+7. **For the controller**: `.ailang/` is gitignored (`.gitignore:77`) but sprint JSONs are tracked, so
+   the progress file needs `git add -f .ailang/state/sprints/sprint_M-PROPERTY-GENERATOR-LANE-A.json`.
+   Without `-f` it will be silently dropped from the commit.
+8. **Bounded waits when sweeping examples.** `timeout` is **not on PATH** on this rig (rc 127). Five
+   contract examples are pathologically slow — see R-9.
+
+---
+
+## 1. Ground truth measured for this plan
+
+### 1.1 The six `StatusSkip` sites are the *entire* skip surface
+
+`grep -n StatusSkip internal/testing/runner.go` → **249, 331, 373, 454, 490, 536**. All six are
+`PropertyResult` sites. `TestResult` is **never** assigned `StatusSkip` anywhere in non-test Go under
+`internal/` or `cmd/` — the only hits are those six lines. (`reporter.go:148`'s test-skip branch is
+therefore dead code today; it is still the correct model for the A4 property fix.)
+
+| Site | Message text | Class | `TestsRun` at return |
+|---|---|---|---|
+| 249 | `no generator for type %v` (forall binder) | `no_generator` | 0 |
+| 331 | `ensures property has no function context (top-level ensures not supported)` | `unsupported` | 0 |
+| 373 | `no generator for parameter %s: %v` (ensures) | `no_generator` | 0 |
+| 454 | `requires property has no function context (top-level requires not supported)` | `unsupported` | 0 |
+| 490 | `no generator for parameter %s: %v` (requires) | `no_generator` | 0 |
+| 536 | `requires not satisfied by random input (consider tighter generators): %s` | `out_of_contract` | **≥1** |
+
+Because the six sites are exhaustive, the taxonomy can be made **total** and that totality is a
+checkable invariant (A-8) rather than a best-effort convention.
+
+### 1.2 Two distinct no-generator texts (resolves the doc's ambiguous "keep the existing message text")
+
+Site 249 emits `no generator for type %v`; sites 373/490 emit `no generator for parameter %s: %v`.
+**Resolution: both texts stay byte-unchanged.** Lane A adds no diagnostic text. The machine-readable
+signal is `skip_kind`, not the prose. No test may assert a generic `"no generator"` substring as if
+there were one message.
+
+### 1.3 In-repo exit-status table (all 33 files in `examples/runnable/contracts/`, measured today)
+
+`succ` = JSON `success`; `s` classified by originating site. **`rc` today = 1 whenever `succ=false`.**
+
+| File | today `succ` / p / f / s | skip classes today | after **M1** (A1) | after **M3** (A3) |
+|---|---|---|---|---|
+| access_control | false 0/0/4 | nogen×4 (Role) | unchanged (rc 1) | rc 1 |
+| basic | false 1/4/3 | ooc×3 | unchanged (rc 1, 4 real fails) | rc 1 |
+| cross_function | false 0/0/5 | nogen×5 (Priority, Region) | unchanged (rc 1) | rc 1 |
+| cross_module_functions | false 2/1/2 | ooc×2 | unchanged (rc 1) | rc 1 |
+| **cross_module_functions_lib** | **true 2/0/1** | **ooc×1** | **unchanged (rc 0)** | **rc 0 — A-4 fixture, MUST stay green** |
+| cross_module_types | false 1/1/6 | nogen×5 (`()`, Cell, `list[Tree]`), ooc×1 | `list[Tree]` **stays vacuous** (A-9) | rc 1 |
+| cross_module_types_lib | false 0/0/0 | — (no tests) | unchanged (rc 1) | rc 1 |
+| ensures_violation_demo | false 1/1/0 | — | unchanged (rc 1) | rc 1 |
+| finance | false 0/1/5 | nogen×4 (TaxBracket), ooc×1 | unchanged (rc 1) | rc 1 |
+| **hof_verify** | false 0/0/2 | nogen×2 (`list[int]`) | **rc 1 → 0** (2 pass ×100) | rc 0 |
+| inbox_injection | false 4/4/2 | ooc×2 | unchanged (rc 1) | rc 1 |
+| inbox_injection_v2 | **true 1/0/10** | nogen×10 (`string<email>`) | unchanged (rc 0) | **rc 0 → 1** |
+| inbox_v2_app | **true 1/0/10** | nogen×10 (Mail, `string<email>`) | unchanged (rc 0) | **rc 0 → 1** |
+| inbox_v2_lib | false 0/0/0 | — (no tests) | unchanged (rc 1) | rc 1 |
+| insurance | false 0/0/6 | nogen×6 (AgeBand, Coverage, RiskTier) | unchanged (rc 1) | rc 1 |
+| invoice | false 2/1/18 | nogen×15, ooc×3 | 2 `list[int]` now run; 13 vacuous remain (rc 1) | rc 1 |
+| **list_recursive_verify** | false 0/0/6 | nogen×6 (`list[int]`) | **rc 1 → 0 — see H1** | **rc 0 (stays green)** |
+| **list_verify** | **true 1/0/6** | nogen×6 (`list[int]`) | **rc 1** — 5 pass + **1 real fail** (`brokenAllPositive_property_2`) + 1 ooc | rc 1 |
+| nested_record_verify | false 0/0/5 | nogen×5 (nested anon record) | unchanged (rc 1) | rc 1 |
+| park | **true 1/0/7** | nogen×6 (Season), ooc×1 | unchanged (rc 0) | **rc 0 → 1** |
+| per_function_depth_verify | false 0/4/3 | ooc×3 | unchanged (rc 1) | rc 1 |
+| quantifier_verify | false 0/3/4 | **ooc×4** | unchanged (rc 1) | rc 1 |
+| record_adt_cycle_verify | false 0/0/1 | nogen×1 (Doc) | unchanged (rc 1) | rc 1 |
+| record_adt_sort_verify | false 0/0/1 | nogen×1 (Proposal) | unchanged (rc 1) | rc 1 |
+| record_discovery_verify | **true 2/0/8** | nogen×6 (anon records), ooc×2 | unchanged (rc 0) | **rc 0 → 1** |
+| record_pattern_verify | false 0/0/5 | nogen×5 (`{x,y}`) | unchanged (rc 1) | rc 1 |
+| record_verify | false 0/0/15 | nogen×15 (`{x,y}`) | unchanged (rc 1) | rc 1 |
+| unencodable_callee_skip | false 0/1/1 | **ooc×1** (not a Z3 class — see R-3) | unchanged (rc 1) | rc 1 |
+| recursive_verify, scoring, showcase, string_verify, temperature | **UNMEASURED — see R-9** | | | |
+
+**R-9 — these 5 files are pathologically slow under `ailang test`.** `recursive_verify.ail` emitted only
+the `→ Running tests in …` preamble and produced **no JSON after several minutes** (measured; the run
+was killed). The other four behave the same. Use a **bounded wait** when sweeping (`gtimeout`/`perl
+alarm` — note plain `timeout` is **not** on PATH on this rig, it returns rc 127) and **exclude these
+five from the per-milestone gate sweep**, reporting them as `UNMEASURED (exceeds bounded wait)` rather
+than pass/fail. They contain no `list[…]` params in the shapes A1 touches as far as could be
+determined, so they are not expected to change; if the executor can measure them under a bound, record
+the result. Do **not** let a slow example block a milestone gate.
+
+**Net semantic change at M3: exactly 4 files flip rc 0 → 1** — `inbox_injection_v2`, `inbox_v2_app`,
+`park`, `record_discovery_verify`. That is the honesty fix landing, and it is the whole point.
+**`cross_module_functions_lib` must NOT flip** (out_of_contract forgiven) — that is the false-red guard.
+
+### 1.4 Blast-radius reality check on `ailang test`
+
+Zero invocations of `ailang test` across `make/`, `Makefile`, `.github/workflows/`, `tools/`,
+`scripts/` (positive control in the same search: 8 `ailang check` hits). Sole programmatic consumer is
+`cmd/ailang/coordinator_cloud.go:586`, itself guarded by `len(testFiles) > 0` over `*_test.ail`
+(`:583-584`) — so the escalate-to-AI flip only reaches packages that actually ship test files.
+**Lane A's exit-code flip reds no CI gate.**
+
+---
+
+## 2. Resolution of the six-skip-sites taxonomy hole (REQUIRED decision, stated)
+
+**Class name: `unsupported`.** Sites 331 and 454. **Decision: it FAILS the suite** — counted into
+`VacuousSkips` alongside `no_generator`.
+
+**Reasons:**
+
+1. **Semantics.** A `requires`/`ensures` clause the user wrote that executed **zero** cases is vacuous
+   by definition, identically to `no_generator`. `out_of_contract` is categorically different: the
+   contract *did* execute (`TestsRun ≥ 1`) and a random input was discarded.
+2. **Zero live blast radius**, because these two sites are **currently unreachable from any parsed
+   AILANG program** (proof in §6, Refutation R-1). Choosing "fail" therefore costs nothing today and
+   installs the honest default for the day the parser grows top-level contracts.
+3. **Default-deny.** The defect this sprint closes *is* an "unclassified ⇒ forgiven" default. Leaving a
+   fourth silent bucket would reproduce it. Hence `AddPropertyResult` treats an **empty `SkipKind` on a
+   `StatusSkip` property as vacuous (fail-closed)**, and A-8 asserts the taxonomy is total so the
+   fail-closed arm is never actually reached.
+
+**Not deferred.** Cost is two `SkipKind` assignments (~2 LOC) plus one unit test that constructs
+`PropertyCase{Property: &ast.Property{Kind: ast.EnsuresKind}, Function: nil}` directly — the only way
+to reach the sites, and a legitimate white-box test of a defensive guard. No `.ail` fixture and no
+triage budget is spent, because there is no live bug there (R-1).
+
+---
+
+## 3. Milestones
+
+Each milestone is independently committable and has its own gate. **Every** gate additionally requires
+`make check-file-sizes` green and `gofmt`/`make lint` clean on touched files.
+
+### M1 — A1: reachable list generator (`*ast.TypeApp{"list"}` arm)
+
+**Why first**: it shrinks the vacuous surface *before* M3 flips exit codes, so M3's measured blast
+radius is the final one, not an intermediate.
+
+**Change** — `internal/testing/createGeneratorForType` (runner.go:629): add, before the existing
+`*ast.ListType` arm, a `*ast.TypeApp` arm matching `Constructor == "list" && len(Args) == 1`, recursing
+into `createGeneratorForType(app.Args[0])` and returning `nil, nil` when the element generator is nil.
+`[T]` / `list[T]` has parsed to `ast.TypeApp{Constructor: "list"}` since DX-17 Phase 2
+(`internal/parser/parser_type.go:56`, `:112`).
+
+**Keep the `*ast.ListType` arm.** It has **zero** non-test constructors under `internal/`, `cmd/`,
+`scripts/` (positive control: **21** constructions in `_test.go` files), so it is dead from parsed
+programs but live from Go tests. Deleting it would break those tests for no benefit —
+coding-standards.md's "never delete because the linter says unused" applies.
+
+**Probe-verified outcome** (planner applied this exact patch to a scratch copy, built, measured, then
+restored `runner.go` byte-identically — worktree left clean):
+- `headOr(xs: [int], d: int)` ensures-property: `skip / 0 cases` → **`pass / 100 cases`**.
+- `list[Tree]`: **stays** a `no_generator` vacuous skip (element ADT non-derivable) — correct, pinned by A-9.
+- In-repo: `hof_verify` rc 1→0; `list_verify` rc stays 1 but `success` true→**false** with a **genuine
+  failure** surfaced (`brokenAllPositive_property_2`, 2 cases); `list_recursive_verify` rc **1→0** (H1);
+  `invoice` gains 2 running properties.
+
+**Triage budget: 0.5 day** — the doc attributes the latent-bug-detector risk to Lane B only, but A1
+starts executing **16 previously-never-executed properties across 5 files**. `list_verify`'s new
+failure is deliberate (`brokenAllPositive*`); `hof_verify`'s and `list_recursive_verify`'s outcomes
+are measured above; the rest must be triaged, not treated as regressions.
+
+**Gate M1**
+```bash
+go test ./internal/testing/... -count=1                 # informative under sandbox
+make check-file-sizes                                    # runner.go must stay <=800
+# behavioral, flags BEFORE path:
+ailang test --format json <tmp mixed fixture>            # headOr: tests_run == 100, status pass
+ailang test --format json examples/runnable/contracts/hof_verify.ail        # rc 0
+ailang test --format json examples/runnable/contracts/list_verify.ail       # rc 1, 1 real fail
+ailang test --format json examples/runnable/contracts/cross_module_types.ail # list[Tree] still nogen skip
+```
+Report `go test ./cmd/ailang/...` as `UNINFORMATIVE UNDER SANDBOX`.
+
+**Est. LOC**: 12 impl / 60 test.
+
+---
+
+### M2 — A2: total skip taxonomy (behaviour-inert)
+
+**Change**
+- `PropertyResult.SkipKind string` (result.go:27-35).
+- Named constants: `SkipKindNoGenerator = "no_generator"`, `SkipKindUnsupported = "unsupported"`,
+  `SkipKindOutOfContract = "out_of_contract"` (in `result.go` — keeps runner.go under the size gate).
+- Assign at **all six** sites: 249/373/490 → `no_generator`; **331/454 → `unsupported`**; 536 → `out_of_contract`.
+- `SuiteResult.VacuousSkips int`, incremented in `AddPropertyResult` when
+  `Status == StatusSkip && SkipKind != SkipKindOutOfContract` — i.e. `no_generator`, `unsupported`, **and
+  fail-closed for an unexpected empty kind**.
+- Merge `VacuousSkips` in **both** aggregation loops: `cmd/ailang/test.go:52-58` (single-file) and
+  `:181-187` (package mode). Missing either silently zeroes the counter for that mode.
+
+**`Success()` is NOT touched in this milestone.** M2 must be provably inert.
+
+**Gate M2**
+```bash
+go test ./internal/testing/... -count=1
+make check-file-sizes
+# INERTNESS PROOF: re-run the §1.3 sweep and diff against the M1 table — must be byte-identical
+```
+Plus the new unit tests: A-8 (totality), A-4 classification, and the `Function == nil` white-box test
+reaching sites 331/454.
+
+**Est. LOC**: 35 impl / 90 test.
+
+---
+
+### M3 — A3 + A4: exit/`success` semantics + reporter honesty
+
+**Change**
+- `result.go:97` — `Success()` becomes `ran > 0 && sr.FailedTests == 0 && sr.VacuousSkips == 0`.
+  `AllSkipped()` (`:104`) and `SuccessAllowingSkips()` (`:110`) stay **unchanged**, so
+  `--allow-skips` forgives vacuous skips for free through the existing
+  `succeeded := Success() || (allowSkips && SuccessAllowingSkips())` at `test.go:80` and `:208`. No new flag.
+- `reporter.go:47-64` (JSON) — add top-level `"vacuous_skips"` and per-property `"skip_kind"`.
+  `"success"` (`:56`) tracks A3 automatically.
+- `reporter.go:181` (human) — widen `if prop.Status == StatusFail` to
+  `if prop.Status == StatusFail || prop.Status == StatusSkip`, mirroring the existing test-side
+  condition at `:148`. **Verify this surfaces the reason for `out_of_contract` skips too**, not only
+  `no_generator` (H1 disclosure depends on it).
+- `reporter.go:205-219` — add a summary branch **between** `case result.AllSkipped():` and
+  `case result.Success():` that names the count and `--allow-skips`, e.g.
+  `✗ N properties never ran (no generator) — use --allow-skips to permit`.
+
+**Gate M3**: acceptance criteria A-1, A-2, A-4, A-6, A-7, A-10 (§4) plus the full §1.3 sweep matching
+the "after M3" column — in particular **exactly 4** files flip rc 0→1 and
+`cross_module_functions_lib.ail` stays rc 0.
+
+**Est. LOC**: 45 impl / 110 test.
+
+---
+
+### M4 — A5: `--format json` writes only JSON to stdout
+
+**Change** — route preamble lines to **stderr when `formatStr == "json"`**, human mode unchanged:
+- `cmd/ailang/test.go:18` — `→ Running tests in %s` (single-file mode).
+- `cmd/ailang/test.go:163`, `:164`, `:173` — package-mode preamble (`→ Package %s`, the
+  `%s source modules, %s test files` line, and the blank `fmt.Println()`). **Three writes, not one** —
+  the doc's `:163-173` range is right but it is easy to move only the first.
+
+**Note**: the assertion is on **stdout only**. stderr is *not* guaranteed empty — a legitimate
+`Warning: stdlib version mismatch: …` (166 bytes, `internal/loader/stdlib_resolver.go:310`) already
+goes to stderr on some files. Do not assert `stderr == ""`.
+
+**Gate M4**
+```bash
+ailang test --format json <fixture> 2>/dev/null | jq .           # must parse, zero preprocessing
+ailang test --package --format json . 2>/dev/null | jq .          # package mode too
+ailang test <fixture>                                             # human mode preamble UNCHANGED on stdout
+go test ./internal/testing/... -count=1 && make check-file-sizes
+```
+
+**Est. LOC**: 15 impl / 30 test.
+
+---
+
+### M5 — closeout: CHANGELOG, doc status, follow-ups
+
+- `changelogs/v0.18-current.md` `[Unreleased]` — **BREAKING**: mixed suites with `no_generator` /
+  `unsupported` property skips now exit 1; escape is `--allow-skips`. Additive JSON fields
+  `vacuous_skips`, `skip_kind`. JSON-mode stdout is now pure JSON. `[T]`/`list[T]` parameters now get
+  generators. Name the 4 in-repo files that flip.
+- `design_docs/planned/v0_31_0/m-property-generator-coverage.md` — mark Lane A landed; record the
+  corrections in §6 (R-2 in particular, so the stale before/after table does not mislead Lane B's planner).
+- File follow-ups (**do not implement**):
+  - **F1** — out-of-contract discard rate is a generator-quality vacuous pass (H1). A property that
+    `out_of_contract`-skips after 1–2 of 100 cases is near-unvalidated yet forgiven; `list_recursive_verify.ail`
+    goes rc 1 → 0 under it. Needs a threshold policy, which is a human-owned semantic decision.
+  - **F2** — #534: flags after the positional path are silently ignored across `flag.NewFlagSet` subcommands.
+  - **F3** — Lane B1 (structural derivation) remains the fix for the 6 files still vacuous after Lane A.
+
+**Gate M5**: `make check-file-sizes`, `make lint`, `go test ./internal/testing/... -count=1`, and
+`make verify-examples` (should be unaffected — it invokes `ailang run`, never `ailang test`).
+
+**Est. LOC**: 0 impl / 0 test (docs ~80 lines).
+
+---
+
+## 4. Acceptance criteria — validated against the code, with red-turning mutations
+
+Doc rows A-1…A-7 checked one by one; corrections marked. A-8…A-10 are **new**, added because the code
+disagreed with the doc.
+
+| # | Criterion (corrected) | Red-turning production mutation | Status vs doc |
+|---|---|---|---|
+| **A-1** | Mixed fixture — `anchor(x: int)` [pass] + `shiftX(p: Point, dx: int)` [vacuous] + `headOr(xs: [int], d: int)` [pass after A1] — gives `ailang test --format json F` → **rc 1**, `success=false`, `vacuous_skips=1`, 2 passing siblings | Revert `Success()` to `ran > 0 && FailedTests == 0` (drop the `VacuousSkips` term) | **CORRECTED** — the doc's fixture is unusable, see R-2 |
+| **A-2** | Same fixture, `ailang test --allow-skips --format json F` → **rc 0** | Make the allow-skips branch also require `VacuousSkips == 0` | OK — but note this is **non-discriminating before M3** (the fixture already exits 0 today); assert it only post-M3 |
+| **A-3** | `headOr(xs: [int], d: int)` ensures-property runs **100 cases** and passes | Delete the new `*ast.TypeApp` "list" arm | **VERIFIED by probe** (0 → 100 cases, pass) |
+| **A-4** | `examples/runnable/contracts/cross_module_functions_lib.ail` (2 pass + 1 out-of-contract skip): **rc 0**, `vacuous_skips=0`, that property's `skip_kind == "out_of_contract"` | Set `SkipKind = SkipKindNoGenerator` at runner.go:536 | OK — **fixture already exists in repo**, no new file needed |
+| **A-5** | `ailang test --format json F 2>/dev/null \| jq .` parses on raw **stdout** (single-file **and** `--package` mode) | Restore any preamble `fmt.Printf` to stdout in JSON mode | **VERIFIED** (`jq` fails today) — scope corrected: 4 write sites, and **do not** assert `stderr == ""` |
+| **A-6** | Human output for the mixed fixture contains `no generator for parameter` and does **not** contain `All tests passed!` | Revert reporter.go:181 to `StatusFail`-only (drops the reason) / remove the new summary branch (restores the headline) | OK — but two distinct texts exist (§1.2); assert the *parameter* form for this fixture, never a generic `"no generator"` substring |
+| **A-7** | All-skipped suite whose only skip is **`out_of_contract`** still prints `NO TESTS RAN` + rc 1 | **Drop the `ran > 0` term** from `Success()` (leaving `FailedTests == 0 && VacuousSkips == 0`) | **MUTATION CORRECTED** — the doc's mutation (`Success()` returns `FailedTests == 0`) also turns A-1 red, so it does not isolate A-7; and the fixture must be out-of-contract-only, because a `no_generator` all-skipped suite stays red via `VacuousSkips` regardless of `ran > 0`. Unit-level `SuiteResult` fixture. |
+| **A-8** | **NEW — taxonomy totality**: every `StatusSkip` `PropertyResult` the runner can produce carries a non-empty `SkipKind`; a table-driven test covers all six sites, reaching 331/454 by constructing `PropertyCase{Property: &ast.Property{Kind: ast.EnsuresKind/RequiresKind}, Function: nil}` | Remove the `SkipKind` assignment at **any one** of the six sites | **NEW** — this is what permanently closes the six-sites hole |
+| **A-9** | **NEW — no silent element fallback**: `list[Tree]` (list of a non-derivable element, live in `cross_module_types.ail`) remains a `no_generator` vacuous skip after A1 | Make the new TypeApp arm substitute a default (int/unit) generator when the element generator is nil, instead of returning `nil, nil` | **NEW** — CLAUDE.md principle 2; without it A1 would silently test wrong values |
+| **A-10** | **NEW — no test was quietly widened**: `git diff -U0 -- '*_test.go'` shows **no removed lines** in pre-existing test files | Any deletion/edit of an existing assertion | **NEW, and it REFUTES the doc** — see R-5: the doc's "deliberately updated tests" list is **empty** |
+
+---
+
+## 5. Regression fixtures — corrected
+
+| # | Doc entry | Verdict |
+|---|---|---|
+| 1 | `basic.ail` — "passing properties must keep passing with unchanged case counts" | Valid but weak: measured **1 pass / 4 fail / 3 out_of_contract skips**, already rc 1. Assert the 1 pass and the 3 `skip_kind=="out_of_contract"`; do **not** assert rc changes. |
+| 2 | `quantifier_verify.ail` — "4 skips with vacuous=0 (non-generator skip class)" | **Class misnamed**: its 4 skips are all `out_of_contract` (site 536). And with **3 failures** it is already rc 1, so "must still exit as today" is non-discriminating. Keep it only as a `vacuous_skips == 0` assertion. |
+| 3 | `unencodable_callee_skip.ail` — "the Z3-unencodable skip class" | **WRONG — see R-3.** The file exists, but its one skip is `out_of_contract`, and **there is no Z3-unencodable skip class in `ailang test` at all**. Replace with: assert its skip classifies `out_of_contract` and it stays rc 1 (it has 1 real failure). |
+| 4 | `ensures_violation_demo.ail` — failing suite keeps failing for the failure reason | Valid, measured 1 pass / 1 fail / 0 skips → assert rc 1 and `vacuous_skips == 0`. |
+| 5 | New mixed-shape fixture | Valid — built per A-1 above, as an in-test `t.TempDir()` source (see §0.5). |
+| 6 | A requires-out-of-contract case ⇒ exit 0 preserved | Valid, and **`cross_module_functions_lib.ail` already is it** (2 pass + 1 ooc skip, rc 0). This is the single most important false-red guard in the sprint. |
+
+---
+
+## 6. Refutations and new findings (read before executing)
+
+### R-1 — REFUTES the controller's impact claim on sites 331/454 (measurement upheld, inference refuted)
+
+The controller's **measurement** is correct: six sites at 249/331/373/454/490/536 with the texts as
+quoted. The **inference** — "That is very likely the same bug one layer over: the user wrote a
+contract, it never ran, and the suite reports success" — is **refuted**. Sites 331 and 454 are
+**unreachable from any parsed AILANG program**:
+
+1. `runEnsuresProperty` / `runRequiresProperty` are entered only from `runProperty`'s dispatch on
+   `propCase.Property.Kind ∈ {EnsuresKind, RequiresKind}` (runner.go:225-228).
+2. The only producer of those Kinds is `parseContractPredicate` (parser_contracts.go:129-148) — the sole
+   `ast.Property{}` construction in the parser that sets `Kind` — reached only via `parseContractBlocks`
+   (parser_contracts.go:22), called only from `parseFunctionDeclaration` (parser_func.go:121), whose
+   results are appended to `fn.Properties` (parser_func.go:124-125). Always inside a `FuncDecl`.
+3. The collector has exactly three `PropertyCase{…}` sites (collector.go:48 / 84 / 138; **zero** in
+   `_test.go`). The only one leaving `Function` nil is `collectPropertyDecl` (:84), fed by
+   `*ast.PropertyDecl`; and `parsePropertyDecl` (parser_test_decl.go:75-118) builds its `Property` via
+   `parseProperty` (parser_testing.go:235-301), which sets **no** `Kind` ⇒ `PropertyKind`, the zero
+   value (ast_decl.go:93). Inline `properties [...]` (parser_func.go:173) likewise.
+4. **Behavioral proof**: a module with a passing `ensures` sibling plus a top-level
+   `property "commutes" { forall(a: int, b: int) => a + b == b + a }` — the only construct producing
+   `Function == nil` — routes to the **forall** path and reports
+   `status: fail, error: "test 0: evaluation failed: empty program"`, rc=1. It does **not** emit
+   "top-level ensures not supported".
+
+So no user-writable program silently passes through 331/454 today. They are defensive nil-guards,
+structurally the same species as the dead `ListType` arm A1 fixes. They are still classified
+(`unsupported`, fail-closed) for the future-proofing reason in §2 — but **no fixture and no triage
+budget is spent on a live bug that does not exist**, and the evaluator must not expect one.
+
+### R-2 — REFUTES the design doc's Lane A before/after table (survived BOTH quorum rounds)
+
+Doc lines 330-341 use the `mixed` module (`dbl(x: int)` + `headOr(xs: [int], d: int)`) as the single
+Lane A example and claim, in the same "After" column, `vacuous_skips: 1` / exit 1 **and**
+`headOr … pass, 100 cases (list-arm fix)`. **Probe-measured with the A1 patch applied, that module
+yields 2 pass, 0 skip, `success=true`, rc=0** — A1 removes the file's only vacuous skip, so it cannot
+also demonstrate a vacuous-pass exit-1. The A-1 fixture must carry a shape Lane A does **not** derive
+(record / ADT / tuple). Lane A was certified "byte-identical and unobjected across both quorum
+rounds"; this defect survived both, and it would have made A-1 unimplementable as specified.
+
+### R-3 — REFUTES the doc's "Z3-unencodable skip class"
+
+All six `StatusSkip` assignments in the entire non-test Go tree under `internal/` + `cmd/` are
+`PropertyResult` sites in runner.go; **`TestResult` is never assigned `StatusSkip` anywhere**
+(`reporter.go:148`'s test-skip branch is dead code today). `unencodable_callee_skip.ail`'s single skip
+is measured as `requires not satisfied by random input … x=-65.42` — site 536, `out_of_contract`.
+There is no Z3-unencodable skip class in `ailang test`. The upside: the six-site taxonomy is
+**exhaustive**, which is exactly what makes A-8's totality invariant checkable.
+
+### R-4 — CORRECTS the controller's and the doc's blast-radius counts
+
+Measured across all **33** files in `examples/runnable/contracts/` (the doc/controller worked from 17):
+- The genuinely silent set (`success=true` with ≥1 skip) is **6 files, not 5** — the doc's five plus
+  **`cross_module_functions_lib.ail`**, which the doc missed and which is the *out_of_contract* shape
+  that must stay green. Counts also differ: `park` 7 skips (doc: 6), `record_discovery_verify` 8 (doc: 6).
+- Files the controller listed as "have skipping properties", implying silent-green, that are **already
+  rc 1 today**: `basic` (4 fails), `invoice` (1), `inbox_injection` (4), `cross_module_functions` (1),
+  `finance` (1), `quantifier_verify` (3), `per_function_depth_verify` (4). Their exit codes cannot flip.
+- Only **4** files actually flip rc 0 → 1 at M3 (§1.3).
+
+### R-5 — REFUTES the doc's "tests deliberately updated" requirement (it is a no-op)
+
+The doc requires the executor to enumerate every test it updates because "tests asserting
+`Success()==true` for pass+skip mixes get deliberately updated". Measured: **that set is empty.**
+Every existing test touching `Success()` / `AllSkipped()` / `SuccessAllowingSkips()`
+(`result_test.go:126,137,145`; `named_test_test.go:161,164,175,185,299,309`) builds its suite with
+`AddTestResult`, and `TestResult` has no `SkipKind`, so `VacuousSkips` stays 0 and every one of them
+keeps its current verdict. The nearest candidate, `TestSuiteResult_AllSkipped_False_HasPassed`
+(named_test_test.go:170-178), asserts only `AllSkipped() == false`, never `Success()`.
+Additive JSON fields are also safe: `reporter_test.go` reads `output["success"].(bool)` by key, and
+`integration_test.go:113-125` uses `strings.Contains` — neither asserts a closed key set.
+**So the requirement is upgraded from a soft "enumerate what you touched" to the hard, checkable
+invariant A-10: no removed lines in pre-existing `_test.go` files.**
+
+### H1 — NEW honesty defect that Lane A itself introduces (live, unlike 331/454)
+
+With the A1 patch applied, `examples/runnable/contracts/list_recursive_verify.ail` goes
+**rc 1 → rc 0, `success=true`** — from honestly-red ("NO TESTS RAN", all 6 properties vacuous) to
+green — while **4 of its 6 properties are `out_of_contract` skips that executed only 1–2 of 100 cases**
+(`containsImpliesNonEmpty_property_1` skip/1, `extractBounded_property_1` skip/2, `_2` skip/1,
+`_3` skip/2). It **stays** green after M3, because `out_of_contract` is deliberately forgiven. So this
+sprint converts an honest red into a green suite in which two-thirds of the contracts are essentially
+unvalidated — the #517 class, one layer over, **live and reachable**.
+
+**Resolution inside Lane A (bounded, deliberate):**
+(a) Do **not** change `out_of_contract`'s exit semantics — that is a human-owned High-Impact Decision
+in the doc, and flipping it would red 8+ in-repo files. (b) A4's reporter widening already surfaces the
+reason **and** the `(N cases)` count for these skips — the plan requires this be *verified for
+`out_of_contract`*, not just `no_generator`. (c) `skip_kind` + the existing `tests_run` make the class
+machine-countable, so no new counter is needed. (d) The rc 1 → 0 transition is recorded explicitly in
+§1.3 so the evaluator reads it as **disclosed, not accidental**. (e) Filed as follow-up **F1**;
+a discard-rate threshold is a semantic decision outside Lane A's remit.
+
+### Additional risks not in the doc
+
+- **R-6 file-size gate**: `internal/testing/runner.go` = **774** lines; `make check-file-sizes` fails
+  >800 (`make/code-health.mk:123`). The doc's runner.go budget (+25/-5 ⇒ 794) leaves **6 lines**.
+  Mitigation in §0.4 — constants and helpers go to `result.go`.
+- **R-7 sandbox**: `internal/testing` binds no sockets (informative); `cmd/ailang` has 6
+  socket-binding test files, so `go test ./cmd/ailang/...` and `make test` are
+  **UNINFORMATIVE UNDER SANDBOX**. §0.3.
+- **R-8 manifest drift**: any new file under `examples/runnable/` reds `make verify-examples` via
+  `validate_manifest.go --ci` unless `examples/manifest.json` is updated. §0.5.
+
+---
+
+## 7. Velocity & sizing
+
+| Milestone | impl LOC | test LOC | est. |
+|---|---|---|---|
+| M1 A1 list arm (+ triage) | 12 | 60 | 0.5 d (0.1 code + 0.4 triage) |
+| M2 total taxonomy | 35 | 90 | 0.2 d |
+| M3 exit/success + reporter | 45 | 110 | 0.2 d |
+| M4 JSON-is-JSON | 15 | 30 | 0.05 d |
+| M5 closeout + follow-ups | 0 | 0 (+80 docs) | 0.05 d |
+| **Total** | **107** | **290** | **1.0 d** |
+
+The doc's ~0.5 d covers M2–M5 accurately. The extra 0.5 d is M1's measured triage of 16
+newly-executing properties — real work the doc assigned to Lane B but which A1 triggers.

--- a/design_docs/planned/v0_31_0/m-property-generator-coverage.md
+++ b/design_docs/planned/v0_31_0/m-property-generator-coverage.md
@@ -272,12 +272,24 @@ export func genPoint(seed: int) -> Point ! {}
 ### Files to Modify/Create
 
 **Lane A:**
-- `internal/testing/runner.go` (+25/-5) — TypeApp list arm; SkipKind at 4 skip sites
+
+> **Implementation status (2026-07-30): LANDED on
+> `sprint/m-property-generator-lane-a`.** Lane A uses a total six-site property
+> skip taxonomy: `no_generator`, `unsupported`, and `out_of_contract`.
+> `unsupported` is vacuous/failing because a written contract that executes
+> zero cases must fail closed, although its two defensive runner sites are
+> currently unreachable from parsed programs. An empty or future unknown
+> `skip_kind` also fails closed. Lane B remains unimplemented.
+
+- `internal/testing/runner.go` — reachable TypeApp list arm; SkipKind at all 6 skip sites
 - `internal/testing/result.go` (+15/-3) — `SkipKind`, `VacuousSkips`, `Success()` change
 - `internal/testing/reporter.go` (+25/-2) — JSON fields; human skip reasons + summary branch
 - `cmd/ailang/test.go` (+15/-5) — aggregate `VacuousSkips`; preamble→stderr in JSON mode
-- `internal/testing/result_test.go`, `reporter_test.go`, `named_test_test.go` — new mixed-shape tests + **deliberate** updates to tests asserting old semantics (enumerated in Conflict Surface)
-- `examples/runnable/contracts/` — mixed-shape fixture file (new, small)
+- New focused `internal/testing/*_test.go` files and
+  `cmd/ailang/test_json_output_test.go` — taxonomy, verdict, reporter, and CLI
+  regressions; no existing assertion was widened or removed.
+- Mixed-shape fixtures are written under `t.TempDir()` by Go tests; no
+  `examples/runnable/` manifest entry is added.
 
 **Lane B (B1 only — B2 file impact deferred with B2):**
 - `internal/testing/derive.go` (new, ~200 LOC) — type resolution, structural derivation, depth budget (`gen<TypeName>` lookup deferred with B2)
@@ -327,7 +339,14 @@ ensures { result == x }
 
 Verified current output: `shiftX_property_1` skip (`no generator for parameter p: Point`), `level_property_1` skip (`s: Shade`), `fst2_property_1` skip (`pair: (int, int)`), `anchor_property_1` pass ×100 — `success=true`, rc=0.
 
-**Before/after, Lane A** (the `mixed` module from Problem Statement):
+**Before/after, Lane A** (corrected implementation fixture):
+
+The earlier table incorrectly used only `dbl` plus `headOr`. Once A1 supplies
+the list generator, that shape has no vacuous property and correctly remains
+green. The implemented regression fixture instead uses `anchor(x: int)`
+(passes), `shiftX(p: Point, dx: int)` (still vacuous), and
+`headOr(xs: list[int], d: int)` (passes after A1). It therefore retains two
+passing siblings while isolating one vacuous property.
 
 | | Before | After |
 |---|---|---|
@@ -579,6 +598,16 @@ objection was overridden, and no controller-invented resolution was substituted 
 
 ## Future Work
 
+- **F1 — out-of-contract discard threshold:** `out_of_contract` remains
+  forgiven even when a property discards after only 1–2 of 100 intended cases.
+  Lane A makes the reason and `tests_run` count visible but does not choose a
+  threshold. `list_recursive_verify.ail` consequently moves rc 1 → 0 with four
+  near-unvalidated properties. Choosing a minimum executed-case/discard-rate
+  policy is a human-owned semantic decision.
+- **F2 — positional flag parsing:** issue #534 already tracks flags silently
+  ignored after the positional path. Lane A does not duplicate or implement it.
+- **F3 — structural generators:** Lane B1 remains the fix for the six corpus
+  files still vacuous after Lane A (records, ADTs, tuples, and related shapes).
 - **Evaluator step-fuel budget** (deterministic total-work bound: fuel charged per evaluation reduction and function application, not just call depth) — **now the named BLOCKING DEPENDENCY for deferred B2** (quorum 2026-07-29): the depth guard bounds recursive divergence, not total work. Benefits the whole test harness (function-under-test calls share the same exposure), not just generators. When it lands, B2 unparks with no semantic change to its retained spec (exhaustion is already specced as structured Fail).
 - Typechecker-env-based type resolution (unlocks imported types) — supersedes the same-file bound
 - Refinement-aware generation for `string<...>` taint/refined types

--- a/design_docs/planned/v0_31_0/m-property-generator-coverage.md
+++ b/design_docs/planned/v0_31_0/m-property-generator-coverage.md
@@ -174,7 +174,9 @@ func (sr *SuiteResult) Success() bool {
   - `()` (unit) → constant generator (one line; in-repo occurrence verified: `cross_module_types.ail` `_: ()`).
   - `*ast.TypeApp` over a user type with args → substitute args into the decl's `TypeParams`, bounded by depth.
 - **Recursion bound**: depth budget (default 3) threaded through derivation; at the bound, restrict ADT choice to non-recursive constructors (compute per-constructor recursiveness once per decl); if none exist → return no generator (vacuous skip, loud per Lane A). `NewSizedGenerator` exists if the implementer prefers it.
-- **Value splice** (load-bearing, easy to miss): generated values flow into the harness via `astExprToCore(r.valueToLiteral(v))` (runner.go:393, :510). Verified: `astExprToCore` (harness.go:156) already handles `ast.Record`, `ast.Tuple`, `ast.List`, `ast.FuncCall` (constructor application), `ast.Identifier` — but **`valueToLiteral` (runner.go:691) falls through to a silent unit literal** for anything beyond scalar/list. B1 must add arms: `RecordValue → ast.Record`, `TupleValue → ast.Tuple`, `TaggedValue → ast.FuncCall(Identifier(ctor), fields)` (bare `Identifier` for nullary constructors) — and change the default arm to a loud error (signature becomes `(ast.Expr, error)`; a failure surfaces as a property **Fail**, not a skip). Without this, a derived record generator would silently test `f(())` — the same vacuous-pass bug one layer down.
+- **Value splice** (load-bearing, easy to miss): generated values flow into the harness via `astExprToCore(r.valueToLiteral(v))` (runner.go:393, :510). Verified: `astExprToCore` (harness.go:156) already handles `ast.Record`, `ast.Tuple`, `ast.List`, `ast.FuncCall` (constructor application), `ast.Identifier` — but **`valueToLiteral` (runner.go:691) falls through to a silent unit literal** for anything beyond scalar/list. B1 must add arms: **`UnitValue → ast.Literal{Kind: ast.UnitLit}`**, `RecordValue → ast.Record`, `TupleValue → ast.Tuple`, `TaggedValue → ast.FuncCall(Identifier(ctor), fields)` (bare `Identifier` for nullary constructors) — **all four arms MUST be in place BEFORE** the default arm becomes a loud error (signature becomes `(ast.Expr, error)`; a failure surfaces as a property **Fail**, not a skip). Without this, a derived record generator would silently test `f(())` — the same vacuous-pass bug one layer down.
+
+> **The explicit `UnitValue` arm is mandatory, not optional.** Raised by `gemini-3-1-pro` in quorum round 2 and applied here verbatim under the narrow-refinement carve-out. B1 adds a `()` constant generator (unit bullet above), but today's *silent* default arm is exactly what makes unit work: `runner.go:720-724` returns `&ast.Literal{Kind: ast.UnitLit, Value: struct{}{}}` for everything unrecognised. Converting that default to a loud error **without** an explicit `UnitValue` arm would send every value produced by the new `()` generator down the error path and fail the harness — a direct contradiction between two B1 bullets. **Ordering is the fix: add the arms first, flip the default last.** Controller-verified first-party that `eval.UnitValue` and `ast.UnitLit` both exist and map exactly as written.
 - **Shrinking**: minimal honest scope — per-element `TupleShrinker` and per-field `RecordShrinker` (composing existing field shrinkers); ADTs shrink within-constructor via existing `NewADTShrinker`. Cross-constructor shrinking (e.g. `Dark(n)` → `Light`) is out of scope v1. **Shrinking behaviour for derived generators was NOT investigated beyond code reading — treat quality of shrunk counterexamples as unvalidated until B1's tests exist.**
 
 **B2. User-supplied generator escape hatch — DEFERRED, not in Lane B's shippable scope** (~1 day when unparked) — ask (3) of #517:
@@ -399,6 +401,7 @@ All verified to exist and their current behavior measured (2026-07-29 sweep):
 | B-2 | Anonymous record param `{x: int, y: int}` (e.g. `record_verify.ail`'s `getX`) runs 100 cases | Restrict derivation to named `TypeDecl`s only (drop the direct `*ast.RecordType` arm) |
 | B-3 | ADT-generated `TaggedValue`s pattern-match correctly in `match` inside the function under test (the `level`/`Shade` property passes, both constructors observed across the run) | Restore hardcoded `ModulePath: "test", TypeName: "ADT"` in `ADTGenerator.Generate` |
 | B-4 | `valueToLiteral` on an unknown `eval.Value` produces a property **Fail** with an explicit error, never a silent `()` splice | Restore the silent unit-literal default arm |
+| B-4a | A property with a `_: ()` unit parameter still runs its 100 cases AFTER the default arm becomes a loud error (i.e. the explicit `UnitValue` arm carries it, not the removed fallback) | Delete the explicit `UnitValue → ast.Literal{Kind: ast.UnitLit}` arm — the `()` generator's values then hit the loud-error path and the property fails |
 | B-5 | Recursive ADT (`type Tree = Leaf \| Node(kids: [Tree])`) generation terminates within depth bound; property runs 100 cases | Remove the depth budget (test then hangs/overflows — enforce with a test timeout) |
 | B-7 | Imported named type still vacuous-skips **loudly** (exit 1, existing `no generator for parameter …` message text — the `gen<TypeName>` hint is deferred with B2) | Make unresolvable types silently return a unit-constant generator |
 
@@ -534,7 +537,35 @@ Both objections landed exclusively on Lane B2; neither reviewer objected to Lane
 | gemini-3-1-pro | REJECT | Anonymous/refined-type hint text told users to alias the type to `T` and define `genT` but omitted changing the function's parameter type to `T` — since `gen<TypeName>` discovery only fires on named-type resolution, following the hint re-emits the same error (structurally ineffective instructions; DX trap) | Hint wording in the (deferred) B2 spec now reads `…, define export func genT(seed: int) -> T, and change the parameter type to T`, with the mandatory-clause rationale recorded inline; acceptance criterion B-9 updated to assert the signature-change clause and to name its omission as a red-turning mutation |
 
 Lane A (A1–A6, its acceptance-criteria table, and mutation column) was left **byte-identical** in
-this revision — no reviewer objected to it; it routes to the sprint-planner unchanged.
+this revision — no reviewer objected to it; it routes to the sprint-planner unchanged. Verified by
+`sha256`-comparing the extracted Lane A section before/after (the only differing lines were the
+`### Lane B` heading lines that terminate the range); `A-*` acceptance rows: 7 before, 7 after.
+
+**2026-07-29 — round 2 re-quorum: BLOCKED (rc=3), N−1 DEGRADED; narrow-refinement carve-out applied.**
+Artifact: `.ailang/state/mission-quorum/m-property-generator-coverage-2026-07-29T22-02-53Z.json`.
+
+- ⚠ **`gpt5-6-sol` was ABSENT** in round 2 (`present: false`, `cost_usd: 0`) — recorded by name, never
+  a silent pass. Its round-1 objection had already been resolved by deferral, but it did **not**
+  re-review that resolution. The quorum therefore degraded to N−1 and this is **FLAGGED** in the
+  mission log's routing-evidence row.
+- **`gemini-3-1-pro` — REJECT, a NEW objection, and it is a genuine catch.** B1 adds a `()` constant
+  generator while also mandating that `valueToLiteral`'s default arm become a loud error — but the
+  arm list omitted `UnitValue`, and that silent default *is* what makes unit work today. Every value
+  from the new `()` generator would have hit the error path and failed the harness.
+  **Reproduced first-party before acting on it** (per the judge-findings discipline): doc line 174
+  does add the unit generator, the arm list did omit `UnitValue`, and `runner.go:720-724` is indeed
+  the unit fallback; `eval.UnitValue` and `ast.UnitLit` both exist.
+  **Resolution — carve-out, reviewer's fix verbatim**: the arm list now leads with
+  `UnitValue → ast.Literal{Kind: ast.UnitLit}` and states the ordering constraint (arms first,
+  default last), with the rationale inline; new acceptance row **B-4a** asserts a `_: ()` property
+  still runs 100 cases after the default becomes loud, its red-turning mutation being deletion of the
+  unit arm.
+
+**Carve-out justification (both limbs met):** the sole remaining blocking objection (a) carried a
+concrete reviewer-authored `proposed_fix`, applied verbatim, and (b) disputed **completeness**, not
+the design DIRECTION — it is a missing-arm/ordering defect inside B1, which is **not in this sprint's
+scope** in any case. Lane A remains unobjected across **both** rounds. This is not force-passing: no
+objection was overridden, and no controller-invented resolution was substituted for a reviewer's.
 
 ---
 

--- a/design_docs/planned/v0_31_0/m-property-generator-coverage.md
+++ b/design_docs/planned/v0_31_0/m-property-generator-coverage.md
@@ -1,0 +1,555 @@
+# M-PROPERTY-GENERATOR-COVERAGE: Vacuous-Pass Honesty + Structural Generator Derivation for Contract Property Tests
+
+**Status**: Planned
+**Target**: v0.31.0 (Lane A); Lane B may slip to a later minor without harming Lane A
+**Priority**: P2 (explicitly NOT a v1.0 bar item — sized accordingly)
+**Estimated**: Lane A ~0.5 day; Lane B = B1 only, ~1.5–2 days (independently shippable; Lane A first). B2 (user-supplied generators) **DEFERRED** — see Lane B2.
+**Dependencies**: Lane A and Lane B1: None. **Deferred B2: BLOCKED ON a deterministic evaluator fuel/step budget** (fuel charged per evaluation reduction and function application — see Future Work; quorum 2026-07-29). Related-but-independent: [m-forall-properties-direct-core-eval](../v1_1_0/m-forall-properties-direct-core-eval.md) (P3, parked)
+**Created**: 2026-07-29 (V1 mission iteration 121, DESIGNER role)
+**Upstream filing**: sunholo-data/ailang#517 (open)
+
+---
+
+## Related Documents
+
+- [m-named-test-blocks](../../implemented/v0_29_0/m-named-test-blocks.md) — **implemented v0.29.0** — introduced the *all*-skipped honesty guard this doc extends: `AllSkipped()`, `SuccessAllowingSkips()`, `--allow-skips`, "NO TESTS RAN" + exit 1. This doc closes the *partial*-skip gap that design deliberately left open.
+- [m-forall-properties-direct-core-eval](../v1_1_0/m-forall-properties-direct-core-eval.md) — **planned, P3, deferred** — the `properties [forall(...) => ...]` surface is known-broken (`empty program`) on a *different* axis (evaluation path, not generator coverage). **Distinct scope**: this doc touches only `createGeneratorForType` and result/exit semantics; since the forall path shares `createGeneratorForType` (runner.go:247), Lane B's derived generators benefit it automatically *once that doc's fix lands* — no coupling in either direction.
+- [m-dx26-property-test-empty-program](../../implemented/v0_21_0/m-dx26-property-test-empty-program.md) (Phases 5/5.1/5.2; sprint plan in [v0_20_0](../../implemented/v0_20_0/m-dx26-ensures-result-binding-sprint-plan.md)) — built the ensures/requires harness paths this doc extends, including the deliberate requires-out-of-contract-⇒-Skip semantics that constrain Lane A's design (see Conflict Surface).
+
+Duplicate gate: SimHash search over 93 planned + 1003 implemented docs returned only keyword noise (top genuine hits found by targeted grep are the three above; none covers generator coverage or partial-skip honesty).
+
+---
+
+## Problem Statement
+
+AILANG's contract-derived property tests (`ensures`/`requires` clauses) silently run **zero cases** for any parameter whose type `createGeneratorForType` does not cover, while the suite still reports `success: true` and exits 0 — provided at least one other test passes. This is the mission's **vacuous-pass class**: a check reporting success for work it never performed (prior instances: `ai-check` silently skipping when `z3` is absent; Go tests `t.Skip`-ing in CI).
+
+**Root cause** (verified by reading `internal/testing/runner.go:630-661` at `origin/dev` @ `3901c14a8`): `createGeneratorForType` has exactly two arms — `*ast.SimpleType` with name in {`int`, `float`, `bool`, `string`}, and `*ast.ListType` — and the `*ast.ListType` arm is **unreachable from any parsed program** (see Verification Log V4: since DX-17 Phase 2, `[T]` parses to `ast.TypeApp{Constructor: "list"}` at `parser_type.go:56`; `ListType` is constructed only in Go test files). So the *effective* generator coverage is four scalar types. Everything else — lists, tuples, records (named or anonymous), ADTs, unit, refined types — produces `Status: skip, tests_run: 0`.
+
+**Live minimal repro** (verified with a binary built from this worktree; `ailang check` clean):
+
+```ailang
+module mixed
+
+export func dbl(x: int) -> int ! {}
+ensures { result == x + x }
+{
+  x + x
+}
+
+export func headOr(xs: [int], d: int) -> int ! {}
+ensures { result >= 0 || result < 0 }
+{
+  d
+}
+```
+
+`ailang test --format json mixed.ail` → **rc=0**, `success: true`, `passed=1 failed=0 skipped=1`; properties: `dbl_property_1 pass tests_run=100`, `headOr_property_1 skip tests_run=0` with `"no generator for parameter xs: list[int]"`. Note the skipping parameter is `[int]` — the very shape the dead `ListType` arm exists to serve.
+
+**Impact bound — do not oversell this.** The honesty guard is **half-present, not absent**:
+
+- An **all-skipped** suite already exits 1 (`AllSkipped()` at `result.go:104`, "NO TESTS RAN" at `reporter.go:205-209`, shipped in m-named-test-blocks v0.29.0). A minimal single-function repro therefore exits 1 and **reads as already-fixed**.
+- The silent shape requires **≥1 passing test alongside ≥1 vacuous skip** — which is every real module. Any regression test that does not use the MIXED shape passes for the wrong reason.
+- This is a P2 testing-honesty item, not a soundness hole in the language: nothing wrong is *proven*; checks are silently *not run*.
+
+**Measured in-repo blast radius** (sweep of `examples/runnable/contracts/*.ail` with the worktree binary, 2026-07-29): vacuous skips are pervasive — `{x: int, y: int}` anonymous records, named record aliases (`Cell`, `Mail`, `Proposal`), ADTs (`Role`, `Region`, `Season`, `TaxBracket`, `RiskTier`, `Doc`), `list[int]`, `list[Tree]`, unit `()`, and refined `string<email>`. **Five files currently exhibit the fully-silent mixed shape** (`success=true` with vacuous skips): `inbox_injection_v2.ail` (10 skipped properties), `inbox_v2_app.ail` (10), `list_verify.ail` (6), `park.ail` (6), `record_discovery_verify.ail` (6). The first two are the **prompt-injection safety demos — their safety properties have never executed**.
+
+**The original filing reproduces exactly at HEAD** (verified): `ailang test --format json sketches/effectbroker.ail` (cwd = `ailang-world/design_docs`, cwd-sensitive for module resolution) → rc=0, `success=true`, `total=38 passed=33 skipped=5`, five properties skip with `no generator for parameter c: Capability` / `rec: EffectRecord` (both are **record type aliases**, not ADTs), two pass at `tests_run=100`.
+
+**Note on #517's framing**: the filing says "ADTs and records". Reality is **wider**: tuples, `[T]`/`list[T]` (dead-arm bug), unit `()`, anonymous record types in parameter position, and refined types (`string<email>`) all skip too. The filing's own repro types are records, not ADTs.
+
+**Two adjacent honesty defects, same class** (both verified):
+
+1. **Human mode is softer than JSON mode.** `reportPropertyHuman` prints `prop.Error` only when `Status == StatusFail` (`reporter.go:181`), so the `no generator for parameter …` reason is **dropped entirely** in human output — while *test* skips DO show their reason (`reporter.go:148`). The headline is `✓ All tests passed!` (`reporter.go:210-214`) whenever `Success()` is true.
+2. **`--format json` output is not JSON.** `runTestsV2` prints `→ Running tests in <file>` to **stdout** (`cmd/ailang/test.go:18`) before the JSON object (package mode adds more preamble at `test.go:163-173`), so raw stdout does not parse with `jq` without stripping. A JSON formatter whose output isn't JSON is the same honesty class; it is small and in scope for Lane A (sized at ~10 LOC; if it doesn't fit the sprint, drop it *explicitly* into a follow-up, not silently).
+
+---
+
+## Goals
+
+**Primary goal**: a contract property that never ran can no longer be mistaken for a passing one — at the exit-code level, in JSON, and in human output — and the most common parameter shapes actually get generators so the question arises less often.
+
+**Success metrics**:
+- Mixed-shape suite (≥1 pass + ≥1 no-generator skip): exit code 0 → **1** (with `--allow-skips` escape).
+- `[int]` / `list[int]` parameter properties: `tests_run` 0 → **100**.
+- After Lane B1, the five silent-shape example files above run their skipped properties (or fail honestly).
+- `ailang test --format json … | jq .` parses with **zero** preprocessing.
+- Requires-out-of-contract skips (deliberate semantics, runner.go:532-540) **still** exit 0 — no false reds introduced.
+
+---
+
+## High-Impact Decisions
+
+| Decision | Why High Impact | Chosen By | Deadline | Change Cost |
+|----------|-----------------|-----------|----------|-------------|
+| Strictness is **skip-class-scoped** (only `no_generator` skips fail the suite), not blanket "any skip fails" | Blanket strictness breaks the deliberate requires-out-of-contract-⇒-Skip semantics (runner.go:532-540) and Z3-unencodable skips — would flip legitimate suites red repo-wide | human | design | med |
+| `success` in JSON + exit code change semantics; `--allow-skips` is the single opt-out (forgives vacuous skips too, via unchanged `SuccessAllowingSkips()`) | External consumers gate on it ("JSON output for CI" is documented); in-repo the only programmatic consumer is `cmd/ailang/coordinator_cloud.go:586` (`:588` = escalate-to-AI branch) | human | design | med |
+| Lane B derives generators from **surface-AST `TypeDecl`s in the same file** (`r.executor.sourceFile`), not from the typechecker env | Bounds scope: imported/cross-module named types stay vacuous-skip in v1 (honest, loud). A typechecker-env approach is strictly better but ~2× the work — wrong trade for P2 | human | design | high |
+| Escape hatch = **naming convention** `gen<TypeName>(seed: int) -> T`, no new syntax **(deferred with B2)** | A8 (minimal syntax); no parser change ⇒ no parser conflict surface; discoverable via error text | human | design | med |
+| `valueToLiteral` default arm becomes a **loud error**, not silent unit fallback | CLAUDE.md principle 2 (no silent fallbacks affecting data integrity) — a derived generator feeding `()` into an ensures harness is this bug all over again, one layer down | human | design | low |
+
+### Design Freeze
+
+Before implementation begins:
+
+- [ ] Skip-class taxonomy field name + JSON spelling (`skip_kind`: `"no_generator"` \| `"out_of_contract"`; suite counter `vacuous_skips`) — approve or rename
+- [ ] `Success()` becomes `ran > 0 && failed == 0 && vacuousSkips == 0`; `--allow-skips` restores old behavior — approve semantic change
+- [ ] Lane B derivation source = same-file surface AST (imported types out of scope v1) — approve bound
+- [ ] Escape-hatch naming convention `gen<TypeName>` — approve spelling *(deferred with B2; approve when B2 unparks)*
+
+### Deferred Decisions
+
+Intentionally left to the implementer (agent may choose):
+
+- Whether the dead `*ast.ListType` arm in `createGeneratorForType` is kept (it IS reachable from Go tests that hand-construct ASTs: `verify_callee_sort_gate_test.go`, `cycles_test.go`, `adt_test.go`) or deleted with those constructions retargeted. Recommendation: **keep both arms** — one line, and coding-standards.md's "never delete because linter says unused" rule applies.
+- Exact human-mode summary wording for vacuous-skip failure (must name the count and `--allow-skips`).
+- Whether the runner.go:454 skip ("top-level requires not supported") is classified `no_generator`-adjacent or left unclassified. Recommendation: leave unclassified (out of scope; it is an unsupported-construct skip, not a coverage gap).
+- Lane B: recursion depth default (recommendation: 3) and whether depth exhaustion with no non-recursive constructor available reports as vacuous skip (recommendation: yes — honest).
+- Test fixture file organization.
+
+---
+
+## Solution Design
+
+### Overview
+
+Two lanes, **separable**; Lane A lands first and is independently shippable. Recommendation: **sprint Lane A alone first** — it is the honesty fix (the mission's actual concern) plus a one-arm bug fix; Lane B is capability work that reduces how often the honest failure fires.
+
+### Lane A — "make it loud" (~0.5 day)
+
+**A1. Fix the dead list arm** (straight bug fix, not a design question). In `createGeneratorForType` (runner.go:630), add:
+
+```go
+// [T] / list[T] parses to TypeApp{Constructor: "list"} since DX-17 Phase 2.
+if app, ok := typ.(*ast.TypeApp); ok {
+    if app.Constructor == "list" && len(app.Args) == 1 {
+        elemGen, elemShrink := r.createGeneratorForType(app.Args[0])
+        if elemGen == nil {
+            return nil, nil
+        }
+        config := DefaultConfig()
+        return NewListGenerator(elemGen, 0, config.MaxSize), NewListShrinker(elemShrink)
+    }
+}
+```
+
+The existing `*ast.ListType` arm stays (or goes — deferred decision above).
+
+**A2. Skip-class taxonomy.** `PropertyResult` gains `SkipKind string` (`"no_generator"`, `"out_of_contract"`, else empty). The three no-generator sites (runner.go:249 forall, :373 ensures, :490 requires) set `no_generator`; the out-of-contract site (:536) sets `out_of_contract`. `SuiteResult` gains `VacuousSkips int`, incremented in `AddPropertyResult` when `SkipKind == "no_generator"` (and merged in the two aggregation loops in `cmd/ailang/test.go:52-59, 181-188`).
+
+**A3. Exit/`success` semantics.**
+
+```go
+// Success: tests ran, none failed, and no property was silently
+// skipped for lack of a generator (vacuous pass — see #517).
+func (sr *SuiteResult) Success() bool {
+    ran := sr.PassedTests + sr.FailedTests
+    return ran > 0 && sr.FailedTests == 0 && sr.VacuousSkips == 0
+}
+```
+
+`AllSkipped()` and `SuccessAllowingSkips()` are **unchanged** — `--allow-skips` therefore already forgives vacuous skips through the existing `succeeded := Success() || (allowSkips && SuccessAllowingSkips())` at test.go:80/:208. No new flag. Composition with m-named-test-blocks is strictly additive: all-skipped stays exit 1, mixed-vacuous becomes exit 1, `--allow-skips` remains the single escape for both.
+
+**A4. Reporter honesty.**
+- JSON: add top-level `"vacuous_skips": N` and per-property `"skip_kind"`. (`success` reflects A3 automatically since reporter.go:56 calls `Success()`.)
+- Human: show the skip reason for properties exactly as `reportTestHuman` already does for tests (extend the condition at reporter.go:181 to include `StatusSkip`); add a summary branch between the `AllSkipped()` and `Success()` cases: `✗ N properties never ran (no generator) — use --allow-skips to permit` + the existing non-zero exit.
+
+**A5. JSON is JSON.** In `runTestsV2` and `runPackageTests`, route the preamble lines (test.go:18 and :163-173) to **stderr when `--format json`** (human mode unchanged). ~10 LOC. If the sprint runs over, this drops to a named follow-up — explicitly, in the sprint close-out.
+
+**A6. Mixed-shape regression tests** — see Testing Strategy. The fixture MUST be the mixed shape (fact: a single-function repro already exits 1 via `AllSkipped()` and would pass for the wrong reason).
+
+**No new diagnostic code is allocated** — Lane A changes exit/reporting semantics only; the existing `no generator for parameter …` message text is kept (now surfaced in human mode and classified in JSON).
+
+### Lane B — derive generators structurally (B1 only, ~1.5–2 days; B2 deferred)
+
+**Discovery that shrinks this lane** (verified): the combinator layer already exists in `internal/testing/generator_advanced.go` — `NewRecordGenerator`, `NewTupleGenerator`, `NewADTGenerator`, `NewOneOfGenerator`, `NewFrequencyGenerator`, `NewSizedGenerator` — plus `NewADTShrinker` in shrink.go. **None of it is wired into `createGeneratorForType`.** This is the repo's recurring guard-the-call-site-not-the-helper shape, a second time in the same function. Lane B is therefore mostly *derivation + wiring + value-splice plumbing*, not generator implementation.
+
+**B1. Structural derivation** (~1.5–2 days):
+
+- **Type resolution**: for `*ast.SimpleType{Name: "Point"}` not in the scalar set, look up a `TypeDecl` named `Point` in `r.executor.sourceFile.Decls` (surface AST — the runner already holds it via `SetSourceFile`). Same-file only in v1; imported types remain vacuous skips (honest, and now loud per Lane A).
+- **Derivation rules**:
+  - `TypeDecl{Definition: *ast.RecordType}` and **anonymous** `*ast.RecordType` in parameter position (the single most common shape in the examples sweep) → `NewRecordGenerator` over per-field derived generators.
+  - `TypeDecl{Definition: *ast.AlgebraicType}` → sum-over-constructors: `NewOneOfGenerator` of one `NewADTGenerator(ctor, fieldGens, true)` per constructor. **Prerequisite fix**: `ADTGenerator.Generate` hardcodes `ModulePath: "test", TypeName: "ADT"` (generator_advanced.go:171-176) — parameterize with the real module path + type name or generated `TaggedValue`s won't match/typecheck in the harness.
+  - `*ast.TupleType` → `NewTupleGenerator`.
+  - `()` (unit) → constant generator (one line; in-repo occurrence verified: `cross_module_types.ail` `_: ()`).
+  - `*ast.TypeApp` over a user type with args → substitute args into the decl's `TypeParams`, bounded by depth.
+- **Recursion bound**: depth budget (default 3) threaded through derivation; at the bound, restrict ADT choice to non-recursive constructors (compute per-constructor recursiveness once per decl); if none exist → return no generator (vacuous skip, loud per Lane A). `NewSizedGenerator` exists if the implementer prefers it.
+- **Value splice** (load-bearing, easy to miss): generated values flow into the harness via `astExprToCore(r.valueToLiteral(v))` (runner.go:393, :510). Verified: `astExprToCore` (harness.go:156) already handles `ast.Record`, `ast.Tuple`, `ast.List`, `ast.FuncCall` (constructor application), `ast.Identifier` — but **`valueToLiteral` (runner.go:691) falls through to a silent unit literal** for anything beyond scalar/list. B1 must add arms: `RecordValue → ast.Record`, `TupleValue → ast.Tuple`, `TaggedValue → ast.FuncCall(Identifier(ctor), fields)` (bare `Identifier` for nullary constructors) — and change the default arm to a loud error (signature becomes `(ast.Expr, error)`; a failure surfaces as a property **Fail**, not a skip). Without this, a derived record generator would silently test `f(())` — the same vacuous-pass bug one layer down.
+- **Shrinking**: minimal honest scope — per-element `TupleShrinker` and per-field `RecordShrinker` (composing existing field shrinkers); ADTs shrink within-constructor via existing `NewADTShrinker`. Cross-constructor shrinking (e.g. `Dark(n)` → `Light`) is out of scope v1. **Shrinking behaviour for derived generators was NOT investigated beyond code reading — treat quality of shrunk counterexamples as unvalidated until B1's tests exist.**
+
+**B2. User-supplied generator escape hatch — DEFERRED, not in Lane B's shippable scope** (~1 day when unparked) — ask (3) of #517:
+
+> **DEFERRAL (quorum 2026-07-29).** The 2-reviewer quorum BLOCKED this doc on B2, and this doc
+> adopts reviewer gpt5-6-sol's own first proposed option: **defer B2** rather than ship
+> user-supplied generator execution under the recursion-depth guard alone. **B2 is BLOCKED ON a
+> deterministic evaluator fuel/step budget** — one that charges fuel for every evaluation
+> reduction and function application, so total evaluator work (not just call-stack depth) is
+> deterministically bounded, with fuel exhaustion mapping to the same structured property Fail
+> specced below. That fuel budget is a separate, larger piece of work (see Future Work) and is
+> deliberately NOT designed here.
+>
+> **Why depth alone was judged insufficient** (credit: gpt5-6-sol's objection, adopted): the
+> depth guard is real and verified — `maxRecursionDepth = 10,000` enforced at every function
+> application in `evalCoreApp` (eval_operations.go:55-60, error `RT_REC_003`), no TCO in the
+> tree-walking harness evaluator (TCO exists only in the bytecode VM), deterministic, and
+> live-verified through the exact call path B2 would reuse: an infinitely tail-recursive pure
+> generator dies in ~8ms with identical output across runs (V25/V26/V27). But that guard bounds
+> **call-stack depth, not total evaluator work**: a depth-9,999 exponential-fanout generator
+> passes the guard and runs arbitrarily slowly. Determinism does not make that wait operationally
+> bounded, and B-8 below proves only the recursive-divergence half — it does not cover
+> bounded-depth computations with explosive step or allocation growth. An earlier revision of
+> this doc argued the residual was acceptable by symmetry with the function-under-test path; the
+> quorum rejected that position and it is withdrawn, not overridden — B2 waits for fuel.
+>
+> **Consequence for v1 scope**: shapes B1 cannot derive — refined types (`string<email>`),
+> imported types, function-typed fields — have **no escape hatch in v1**; they remain vacuous
+> skips, made loud by Lane A (exit 1 + reason). Controller-measured 2026-07-29: 17 in-repo
+> example files under `examples/runnable/contracts/` currently have skipping properties (e.g.
+> `invoice.ail` 2 passed / 18 skipped, `record_discovery_verify.ail` 2/8, `inbox_injection_v2.ail`
+> 1/10; six are all-skipped and therefore already exit 1 today). B1 covers the structurally
+> derivable subset; the remainder waits on B2.
+>
+> The spec below is retained (with the quorum's hint-text correction applied) so B2 can unpark
+> without re-design once the fuel budget lands.
+
+Convention: an **exported, pure** function `gen<TypeName>(seed: int) -> <TypeName>` in the same module takes precedence over structural derivation for `<TypeName>`. Verified to compile (`ailang check` clean):
+
+> **Escape-hatch naming applies to NAMED types only.** `<TypeName>` in this convention is always a
+> declared type name (`Mail` → `genMail`). For anonymous/compound shapes there is no valid
+> identifier to derive — see the hint-text branching below, which routes users through a type
+> alias instead of instructing them to write invalid syntax.
+
+```ailang
+module escape
+
+export type Point = { x: int, y: int }
+
+export func genPoint(seed: int) -> Point ! {}
+{
+  { x: seed % 100, y: (seed / 100) % 100 }
+}
+```
+
+- Runner detects `gen<TypeName>` while resolving a named type; per generated case it evaluates `gen<TypeName>(seed_i)` (seeds from the existing suite RNG) through the same executor machinery the harness already uses to call the function under test (`ExtractFunctionBinding` + the Core-call path; exact plumbing is implementer's choice — the harness demonstrably supports calling module functions with literal args).
+- **Bounded evaluation (REQUIRED — bounded-waits axiom): deterministic fuel budget, not depth
+  alone.** Every `gen<TypeName>(seed_i)` invocation MUST run under the deterministic evaluator
+  **fuel/step budget** named in the deferral block above (fuel charged per evaluation reduction
+  and function application), *in addition to* the existing recursion-depth guard
+  (`maxRecursionDepth = 10,000`, `RT_REC_003`, verified V25/V26/V27). The depth guard alone
+  deterministically stops recursive divergence but not total-work explosion — see "Why depth
+  alone was judged insufficient" above. Both bounds are step-deterministic (never wall clock),
+  so pass/fail results stay reproducible. **B2 does not unpark until the fuel budget exists.**
+- **Exhaustion = structured property Fail, never skip or fallback.** Any error from a
+  `gen<TypeName>` invocation — `RT_REC_003` depth exhaustion or fuel exhaustion alike — flows
+  through the runner's existing error branch (runner.go:397-404 shape) into `Status: fail` with
+  the diagnostic text, exactly as harness-evaluation errors already do. Explicitly forbidden:
+  (a) reporting the property as *skip* (that would re-open the vacuous-pass hole this doc
+  exists to close), and (b) silently falling back to structural derivation (a user generator
+  that errors must surface, not be second-guessed). **No wall-clock timeout is used anywhere in
+  this lane** — a wall-clock bound would make pass/fail nondeterministic across machines.
+- Once unparked, this is the *only* answer for shapes that cannot be derived: refined types (`string<email>`), imported types, function-typed fields. Until then those shapes remain vacuous skips, made loud by Lane A.
+- **Vacuous-skip hint text branches on type shape** (A11: never instruct the user to write
+  invalid syntax). Naive formatting (`gen<%v>` over the AST type) would produce identifiers like
+  `genstring<email>` or `gen{x: int}` — syntactically invalid AILANG. The message logic:
+  - **Named `*ast.SimpleType`** (e.g. `Mail`): the type name IS a valid identifier suffix —
+    `no generator for parameter m: Mail (define export func genMail(seed: int) -> Mail to supply one)`.
+  - **Anything else** (anonymous records `{x: int}`, tuples, refined types `string<email>`,
+    `TypeApp`s): no valid identifier can be derived — emit the alias-first path instead:
+    `no generator for parameter p: {x: int} (to supply one, alias this type via export type T = ..., define export func genT(seed: int) -> T, and change the parameter type to T)`.
+    The **`change the parameter type to T` clause is mandatory** (credit: gemini-3-1-pro, quorum
+    2026-07-29): `gen<TypeName>` discovery only triggers when the runner resolves a *named* type,
+    so aliasing + defining `genT` without changing the function signature leaves the runner
+    facing the same anonymous/refined shape — structural derivation still fails and the same
+    error re-emits. The pre-revision wording omitted the clause and was a DX trap: structurally
+    ineffective instructions that could not resolve the error they accompany.
+  Both instructed shapes are live-verified to compile: `genMail(seed: int) -> Mail` for a named
+  record type, and the alias-first `export type T = { x: int }` + `genT(seed: int) -> T` +
+  a function whose parameter type was changed to `p: T` (V28).
+- Ordering within Lane B: **B2 is deferred entirely; Lane B ships as B1 alone.** When unparked, B1 before B2 (B2 reuses B1's type-resolution walk). The hint-text branching above is part of B2 and defers with it (the hint advertises B2's convention) — until then, Lane A keeps the existing `no generator for parameter …` message text unchanged.
+
+### Files to Modify/Create
+
+**Lane A:**
+- `internal/testing/runner.go` (+25/-5) — TypeApp list arm; SkipKind at 4 skip sites
+- `internal/testing/result.go` (+15/-3) — `SkipKind`, `VacuousSkips`, `Success()` change
+- `internal/testing/reporter.go` (+25/-2) — JSON fields; human skip reasons + summary branch
+- `cmd/ailang/test.go` (+15/-5) — aggregate `VacuousSkips`; preamble→stderr in JSON mode
+- `internal/testing/result_test.go`, `reporter_test.go`, `named_test_test.go` — new mixed-shape tests + **deliberate** updates to tests asserting old semantics (enumerated in Conflict Surface)
+- `examples/runnable/contracts/` — mixed-shape fixture file (new, small)
+
+**Lane B (B1 only — B2 file impact deferred with B2):**
+- `internal/testing/derive.go` (new, ~200 LOC) — type resolution, structural derivation, depth budget (`gen<TypeName>` lookup deferred with B2)
+- `internal/testing/runner.go` (+40/-10) — wire derivation; `valueToLiteral` record/tuple/tagged arms + loud default
+- `internal/testing/generator_advanced.go` (+15/-8) — parameterize ADTGenerator module/type
+- `internal/testing/shrink.go` (+80) — TupleShrinker, RecordShrinker
+- `internal/testing/derive_test.go` (new, ~300 LOC)
+- `examples/` — one feature example per coding-standards (record+ADT+tuple ensures module; the `shapes.ail` in Examples below is ready-made)
+
+### Examples
+
+All snippets below were verified with `ailang check` and `ailang test` using a binary built from this worktree (`go build -o /tmp/ailang_designer ./cmd/ailang` @ `3901c14a8`).
+
+**The canonical mixed-shape module** (today: `success=true`, 1 pass + 3 vacuous skips; post-Lane-A: exit 1; post-Lane-B: 4 × 100 cases):
+
+```ailang
+module shapes
+
+export type Point = { x: int, y: int }
+
+export type Shade = Light | Dark(level: int)
+
+export func shiftX(p: Point, dx: int) -> int ! {}
+ensures { result == p.x + dx }
+{
+  p.x + dx
+}
+
+export func level(s: Shade) -> int ! {}
+ensures { result >= 0 }
+{
+  match s { Light => 0, Dark(l) => if l >= 0 then l else 0 }
+}
+
+export func fst2(pair: (int, int)) -> int ! {}
+ensures { result == result }
+{
+  match pair { (a, _) => a }
+}
+
+export func anchor(x: int) -> int ! {}
+ensures { result == x }
+{
+  x
+}
+```
+
+Verified current output: `shiftX_property_1` skip (`no generator for parameter p: Point`), `level_property_1` skip (`s: Shade`), `fst2_property_1` skip (`pair: (int, int)`), `anchor_property_1` pass ×100 — `success=true`, rc=0.
+
+**Before/after, Lane A** (the `mixed` module from Problem Statement):
+
+| | Before | After |
+|---|---|---|
+| exit code | 0 | 1 |
+| JSON `success` | `true` | `false` |
+| JSON extras | — | `"vacuous_skips": 1`, `"skip_kind": "no_generator"` |
+| human summary | `✓ All tests passed!` | `✗ 1 property never ran (no generator) …` + reason line under `⊘` |
+| with `--allow-skips` | 0 | 0 |
+| `headOr` (`[int]`) | skip 0 cases | **pass, 100 cases** (list-arm fix) |
+| `jq .` on stdout | parse error (preamble) | parses |
+
+---
+
+## Conflict Surface
+
+This design touches `internal/testing/` + `cmd/ailang/test.go` and **reads** `internal/ast` type nodes. No parser, lexer, typechecker, or codegen changes — the conflict surface is semantic (exit codes, schema, skip semantics), not syntactic.
+
+### Consumers of the touched surfaces (enumerated)
+
+| Surface | Consumers (verified by grep/read) | Effect of change |
+|---|---|---|
+| `SuiteResult.Success()` | `cmd/ailang/test.go:80,208` (exit codes); `reporter.go:56` (JSON `success`); `reporter.go:210` (human headline) | All four are the *point* of Lane A; change together |
+| `AllSkipped()` | `reporter.go:205` | Unchanged |
+| `SuccessAllowingSkips()` | test.go both call sites | Unchanged — becomes the vacuous-skip escape automatically |
+| `createGeneratorForType` | runner.go:247 (forall), :371 (ensures), :488 (requires) — no callers outside runner.go | Lane A/B extend all three uniformly; forall path stays broken upstream of generation (separate doc) |
+| `--format json` schema | In-repo: only `internal/testing/reporter_test.go`, `integration_test.go:117`. External: documented "JSON output for CI"; agents told to run `ailang test` in eval-harness prompts (`agent_prompt.go:397`, `agent_task_ailang.txt:39`); ailang-world sketches | Additive fields safe; `success` semantic change is deliberate (see below) |
+| `ailang test` exit code | **No CI workflow, Makefile target, or tools/ script invokes `ailang test`** (verified; `tools/test-concurrency.sh`'s `"test"` is an API arg string, not this command). Only programmatic consumer: `cmd/ailang/coordinator_cloud.go:586` (`ailang test --package .` deterministic gate in execute-job, no `--allow-skips`) | A package whose properties vacuously skip flips from silent-green to escalate-to-AI — the honest behavior; noted, accepted |
+| Go tests asserting current semantics | `named_test_test.go` (AllSkipped/Success suite, lines 153-310), `result_test.go`, `reporter_test.go` | AllSkipped tests keep passing (semantics unchanged). Tests asserting `Success()==true` for pass+skip mixes without kind classification: **updated deliberately** — the executor enumerates each in the sprint log; anything updated beyond that list is a regression |
+
+### Programs that MUST still work (regression fixtures)
+
+All verified to exist and their current behavior measured (2026-07-29 sweep):
+
+1. `examples/runnable/contracts/basic.ail` — scalar-typed properties; its passing properties must keep passing with unchanged case counts.
+2. `examples/runnable/contracts/quantifier_verify.ail` — 4 skips with **vacuous=0** (non-generator skip class); must still exit as today: its skips are NOT reclassified.
+3. `examples/runnable/contracts/unencodable_callee_skip.ail` — the Z3-unencodable skip class; must remain unaffected by property-skip taxonomy.
+4. `examples/runnable/contracts/ensures_violation_demo.ail` — a failing suite; must keep failing for the *failure* reason, not acquire a vacuous-skip label.
+5. New mixed-shape fixture (this doc) — the Lane A acceptance fixture.
+6. A requires-out-of-contract case (runner.go:532-540 semantics): out-of-contract skip + passing sibling test ⇒ **exit 0 preserved**.
+
+### What deliberately changes
+
+- Mixed suites with `no_generator` property skips: exit 0 → 1 (escape: `--allow-skips`). Anything relying on the current false green — that reliance is the bug (same stance as m-named-test-blocks' deliberate change).
+- JSON `success` may flip `true→false` for such suites; two additive JSON fields.
+- JSON-mode stdout carries only JSON (preamble → stderr).
+- Lane B: previously-skipped properties on derivable types now run — a *latent-bug detector*: ensures clauses that were never exercised may genuinely fail (e.g. `record_verify.ail`'s deliberately-`brokenDistance` properties will start counterexampling, and `park.ail`/`list_verify.ail`'s never-run properties may fail). Expected, honest; the sprint must budget triage time for newly-failing examples rather than treat them as regressions.
+
+---
+
+## Testing Strategy
+
+**Every acceptance criterion names a concrete production-code mutation that turns it red.**
+
+### Lane A acceptance criteria
+
+| # | Criterion | Red-turning mutation |
+|---|---|---|
+| A-1 | Mixed-shape fixture (1 passing scalar property + 1 `Point`-param property): `ailang test` exits **1**, JSON `success=false`, `vacuous_skips=1` | Revert `Success()` to `ran > 0 && failed == 0` (drop the `VacuousSkips` term) |
+| A-2 | Same fixture with `--allow-skips`: exit **0** | Make the allow-skips branch check `VacuousSkips == 0` too (i.e. stop forgiving vacuous) |
+| A-3 | `headOr(xs: [int], …)` ensures-property runs **100 cases** and passes | Delete the new `*ast.TypeApp` "list" arm in `createGeneratorForType` |
+| A-4 | Requires-out-of-contract skip + passing sibling: exit **0**, `vacuous_skips=0`, `skip_kind="out_of_contract"` | Set `SkipKind = "no_generator"` at runner.go:536 (misclassify) |
+| A-5 | `ailang test --format json f.ail \| jq .` succeeds on raw stdout | Restore the `fmt.Printf("→ Running tests…")` to stdout in JSON mode |
+| A-6 | Human output for the mixed fixture contains `no generator for parameter` and does NOT contain `All tests passed!` | Revert reporter.go:181 condition to `StatusFail`-only (reason drop) / revert summary branch (headline) |
+| A-7 | All-skipped suite still prints `NO TESTS RAN` + exit 1 (m-named-test-blocks invariant) | Make `Success()` return `FailedTests == 0` (would claim success for all-skipped) |
+
+### Lane B acceptance criteria (B1 — in shippable scope)
+
+| # | Criterion | Red-turning mutation |
+|---|---|---|
+| B-1 | `shapes.ail` (above): all four properties run 100 cases, exit 0 | Delete the `RecordType` (resp. `AlgebraicType`, `TupleType`) derivation arm — the property reverts to vacuous skip, which Lane A makes exit 1 |
+| B-2 | Anonymous record param `{x: int, y: int}` (e.g. `record_verify.ail`'s `getX`) runs 100 cases | Restrict derivation to named `TypeDecl`s only (drop the direct `*ast.RecordType` arm) |
+| B-3 | ADT-generated `TaggedValue`s pattern-match correctly in `match` inside the function under test (the `level`/`Shade` property passes, both constructors observed across the run) | Restore hardcoded `ModulePath: "test", TypeName: "ADT"` in `ADTGenerator.Generate` |
+| B-4 | `valueToLiteral` on an unknown `eval.Value` produces a property **Fail** with an explicit error, never a silent `()` splice | Restore the silent unit-literal default arm |
+| B-5 | Recursive ADT (`type Tree = Leaf \| Node(kids: [Tree])`) generation terminates within depth bound; property runs 100 cases | Remove the depth budget (test then hangs/overflows — enforce with a test timeout) |
+| B-7 | Imported named type still vacuous-skips **loudly** (exit 1, existing `no generator for parameter …` message text — the `gen<TypeName>` hint is deferred with B2) | Make unresolvable types silently return a unit-constant generator |
+
+### Deferred B2 acceptance criteria (apply only when B2 unparks; not part of any sprint until the fuel budget lands)
+
+| # | Criterion | Red-turning mutation |
+|---|---|---|
+| B-6 | `genPoint` escape hatch: with a `gen<TypeName>` producing only `x >= 0` values and an `ensures { p.x >= 0 => … }`-style property that structural generation would counterexample, the suite passes (user generator took precedence) | Remove the `gen<TypeName>` lookup (structural derivation generates negative `x`, property fails) |
+| B-8 | **Nonterminating generator is deterministically bounded**: a fixture whose `genT` infinitely recurses (tail-recursively, to also pin no-TCO) terminates the suite promptly with property `Status: fail` whose error contains `RT_REC_003`, identical JSON (modulo durations) across two consecutive runs; never a skip, never a hang (enforce with a Go test timeout). **Scope note (quorum 2026-07-29): this proves only the recursive-divergence half. On unpark, add a sibling criterion: a bounded-depth exponential-fanout `genT` fails with the fuel-exhaustion diagnostic under the fuel budget** | In the B2 generator-invocation path, catch the evaluation error and fall back to structural derivation (or map it to `StatusSkip`) instead of failing — B-8's fail-status and diagnostic assertions go red |
+| B-9 | **Hint text never emits an invalid identifier AND its instructions are structurally effective**: for a named-type parameter (`m: Mail`) the skip hint contains `genMail(seed: int) -> Mail`; for an anonymous-record parameter (`p: {x: int}`) and a refined-type parameter (`s: string<email>`) the hint contains the alias-first wording — `export type T = ...`, `define export func genT(seed: int) -> T`, **and `change the parameter type to T`** — and does NOT contain `gen{` or `genstring<` | Collapse the two hint branches into the naive single-branch `fmt.Sprintf("gen%v", typ)` formatting (invalid identifiers emit, negative assertions go red); OR drop the `change the parameter type to T` clause — the instructions become structurally ineffective (`gen<TypeName>` discovery only fires on named-type resolution, so the runner re-encounters the anonymous shape and re-emits the same error) and B-9's clause assertion goes red |
+
+**Unit tests**: skip-classification per runner site; `Success()`/`VacuousSkips` truth table; derivation per type shape; `valueToLiteral` round-trips (value → literal → core → harness-evaluated equality). **Integration**: CLI-level runs of the fixture files pinning exit code + parsed JSON. **Regression-surface**: one test per "Programs that MUST still work" entry above.
+
+---
+
+## Non-Goals
+
+- **Fixing the `properties [forall(...) => ...]` evaluation path** — known-broken (`empty program`), separately documented and parked (P3) in [m-forall-properties-direct-core-eval](../v1_1_0/m-forall-properties-direct-core-eval.md). Not re-derived here; not a new finding.
+- **User-supplied generator execution (B2)** — DEFERRED, blocked on a deterministic evaluator fuel budget (quorum 2026-07-29; see Lane B2).
+- **Imported / cross-module named types** in Lane B v1 — remain honest vacuous skips (loud per Lane A); the deferred B2 escape hatch covers them when unparked.
+- **Refined types** (`string<email>`) — no structural derivation (would need refinement-aware generation); no v1 path — deferred B2 escape hatch when unparked.
+- **Cross-constructor ADT shrinking** and shrink-quality guarantees for derived generators.
+- **Polymorphic parameter types** (`a` with class constraints) — out of scope.
+- **New CLI flags or syntax** — `--allow-skips` is reused; the escape hatch is a naming convention.
+- **Changing test-level (non-property) skip semantics** — Z3-unencodable and other test skips keep current behavior.
+
+---
+
+## Timeline
+
+**Lane A (~0.5 day)**: list arm + taxonomy + `Success()` + reporter (3h) · preamble-to-stderr (0.5h) · mixed-shape fixtures + deliberate test updates (2h).
+
+**Lane B (B1 only, ~1.5–2 days)**: B1 derivation + splice + shrinkers + tests (1.5–2d) · triage of newly-running example properties (budgeted inside B1 — triage volume is measured, not speculative: controller sweep 2026-07-29 found 17 contract example files with skipping properties, e.g. `invoice.ail` 2 passed / 18 skipped, `record_discovery_verify.ail` 2/8).
+
+**B2 (~1 day when unparked): DEFERRED** — blocked on the deterministic evaluator fuel budget (quorum 2026-07-29; see Lane B2 and Future Work). Not scheduled in any sprint from this doc.
+
+Honest sizing note: this is a P2. If only Lane A ever ships, the mission's vacuous-pass concern is addressed; Lane B is capability, not honesty.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|-----------|
+| Exit-code strictness flips consumer suites red (external users, ailang-world sketches, coordinator execute-job) | Med | Scoped to `no_generator` class only; `--allow-skips` escape; CHANGELOG breaking-change entry; in-repo audit found no CI consumer |
+| Blanket-skip misclassification breaks requires-discard semantics | High if missed | A-4 regression test pins it; taxonomy is per-site explicit, not inferred from message text |
+| Lane B generated values don't survive the `valueToLiteral → astExprToCore` splice for some shape | Med | B-4's loud-error default converts silent corruption into visible Fail; round-trip unit tests |
+| Newly-running properties fail on real bugs in examples (`brokenDistance` is deliberate; others unknown) | Med (sprint time) | Budgeted triage in B1; failures are the feature working |
+| `gen<TypeName>` convention collides with an existing user function of that shape but different intent *(deferred with B2)* | Low | Precedence documented + hint text; type-checked signature must match `(int) -> T` exactly or it is ignored with a stderr note |
+| Depth-bound recursion misses non-obvious cycles (mutual recursion via records-of-ADTs) | Med | Depth budget decrements on *every* derivation step, not just ADT arms — B-5 uses `list[Tree]` (verified in-repo occurrence, `cross_module_types.ail`) |
+| User-supplied `gen<TypeName>` runs unbounded total work — depth guard bounds call-stack depth, not evaluator steps (bounded-waits axiom) | High if shipped under depth alone | **Resolved by deferral (quorum 2026-07-29)**: B2 is out of shippable scope, BLOCKED ON a deterministic evaluator fuel budget. The verified depth guard (V25/V26/V27) closes only the recursive-divergence case; exhaustion-as-structured-Fail and no-wall-clock-timeout remain specced for unpark (B-8) |
+
+---
+
+## Axiom Compliance
+
+**Canonical reference:** [Design Axioms](/docs/references/axioms)
+
+| Axiom | Score | Justification |
+|-------|-------|---------------|
+| A1: Determinism | 0 | Derived generators use the existing seeded RNG (`newRNG(config.Seed)`); no new nondeterminism |
+| A2: Replayability | 0 | No trace-surface change |
+| A3: Effect Legibility | 0 | Properties remain over pure code; escape-hatch generators are pure functions |
+| A4: Explicit Authority | 0 | No capability change |
+| A5: Bounded Verification | +2 | The headline: contract checks that reported success without running now either run (Lane B) or fail loudly (Lane A). Five in-repo modules' never-executed safety properties start executing |
+| A6: Safe Concurrency | 0 | No concurrency change |
+| A7: Machines First | +1 | `--format json` becomes actually machine-parseable; exit codes stop lying to agents that gate on them |
+| A8: Minimal Syntax | 0 | Zero new syntax (escape hatch is a naming convention; flag reused) |
+| A9: Cost Visibility | 0 | No cost-model change |
+| A10: Composability | +1 | Wires the existing-but-orphaned generator combinator layer into the type-driven path; composes with m-named-test-blocks' exit semantics instead of adding a parallel mechanism |
+| A11: Structured Failure | +1 | Skip taxonomy (`skip_kind`) turns an ambiguous skip string into structured, classifiable failure data |
+| A12: System Boundary | 0 | No FFI/boundary change |
+
+**Net Score: +5** → Proceed.
+
+### Hard Violation Check
+
+- [x] A1 (Determinism): no implicit nondeterminism introduced
+- [x] A3 (Effects): no hidden side effects
+- [x] A4 (Authority): no ambient access granted
+- [x] A7 (Machines First): actively improves machine consumers
+
+---
+
+## Verification Log
+
+All commands run 2026-07-29 in worktree `.wt-iter121` (branch `sprint/m-property-generator-coverage`, base `origin/dev` @ `3901c14a8`), binary `go build -o /tmp/ailang_designer ./cmd/ailang`.
+
+| # | Claim | Evidence |
+|---|---|---|
+| V1 | `createGeneratorForType` has exactly 2 arms (4 scalars + ListType); all else `nil, nil` | Read `runner.go:630-661` |
+| V2 | Honesty guard half-present: `Success()` requires ran>0; `AllSkipped()`, `SuccessAllowingSkips()`, `--allow-skips` exist and are wired | Read `result.go:95-112`, `test.go:80,208`, `main.go:117` |
+| V3 | Mixed-shape repro: rc=0, `success=true`, 1 pass + 1 vacuous skip; `ailang check` clean | Live run of `mixed.ail` (Problem Statement); JSON captured |
+| V4 | `*ast.ListType` arm unreachable from parsed programs | (a) grep `ListType{` over non-test `.go`: constructions ONLY in `verify_callee_sort_gate_test.go`, `cycles_test.go`, `format/node_coverage_test.go`, `apiserver/named_args_test.go`, `gen/golang/adt_test.go`; (b) `parser_type.go:56` builds `TypeApp{Constructor: "list"}`; (c) **behavioral**: V3's `[int]` param skips with `list[int]` in the message |
+| V5 | #517 reproduces exactly at HEAD | Live run in `ailang-world/design_docs` (cwd-sensitive: from repo root, module resolution fails with LDR001 instead): `success=true, total=38, passed=33, skipped=5, len(tests)=31, len(properties)=7`; skip reasons `c: Capability`, `rec: EffectRecord` |
+| V6 | `Capability`/`EffectRecord` are record aliases, not ADTs | `grep "type Capability" effectbroker.ail` → `export type Capability = {` (line 16); `EffectRecord` line 154 |
+| V7 | Human mode drops property-skip reasons but shows test-skip reasons; headline `✓ All tests passed!` on `Success()` | Read `reporter.go:148` (tests: Fail *or* Skip) vs `:181` (properties: Fail only); `:205-219` summary switch |
+| V8 | JSON preamble on stdout | Read `test.go:18` (Printf before reporter, same stream); live: first stdout line `→ Running tests in mixed.ail`, then JSON |
+| V9 | Requires out-of-contract ⇒ whole-property Skip is deliberate | Read `runner.go:431-443` (doc comment), `:532-540` (implementation) |
+| V10 | Explicit `properties [forall…]` surface is known-broken (`empty program`), separately planned | `design_docs/planned/v1_1_0/m-forall-properties-direct-core-eval.md` exists (P3, 2026-05-15); runner.go:220-223 comment confirms "broken EvaluateExpression source-synthesis path" |
+| V11 | **Negative**: no CI workflow / Makefile target / tools script consumes `ailang test` exit code | grep `.github/workflows/*.yml`, `Makefile`, `tools/` — only `tools/test-concurrency.sh` matches on an unrelated API arg string; sole programmatic consumer `cmd/ailang/coordinator_cloud.go:586` (path corrected in revision pass — see V30) |
+| V12 | **Negative**: JSON schema fields consumed in-repo only by the package's own tests | grep `passed_tests\|total_tests\|skipped_tests` repo-wide → `reporter.go`, `reporter_test.go`, `integration_test.go:117` only |
+| V13 | Record/Tuple/ADT/OneOf/Frequency/Sized generators + ADTShrinker already exist, unwired | Read `generator_advanced.go` (constructors at :155-261), `shrink.go:255`; V1 shows no wiring |
+| V14 | `ADTGenerator.Generate` hardcodes `ModulePath: "test", TypeName: "ADT"` | Read `generator_advanced.go:171-176` |
+| V15 | **Negative**: no RecordShrinker/TupleShrinker exists | grep `func New.*Shrinker` in `shrink.go` → Int/Float/String/List/ADT/NoOp only |
+| V16 | `valueToLiteral` silently falls back to unit for non-scalar/list values | Read `runner.go:691-727` (default arm returns `UnitLit`) |
+| V17 | `astExprToCore` covers `Record`/`Tuple`/`List`/`FuncCall`/`Identifier`; panics loudly on default | Read `harness.go:156-249` |
+| V18 | All AILANG snippets in this doc compile | `ailang check` clean on `mixed.ail`, `shapes.ail`, `escape.ail` (worktree binary) |
+| V19 | `shapes.ail` behavior: record/ADT/tuple params all vacuous-skip; scalar passes; `success=true` | Live `ailang test --format json` run (Examples section) |
+| V20 | In-repo blast radius: 5 example files in silent mixed shape; vacuous skips across ~15 contract examples incl. anonymous records, unit, `string<email>`, `list[Tree]` | Per-file sweep of `examples/runnable/contracts/*.ail` with worktree binary (output archived in iteration log) |
+| V21 | `quantifier_verify.ail` has 4 skips with vacuous=0 (distinct skip class exists in the wild) | Same sweep |
+| V22 | **Negative**: no new diagnostic code allocated by this design (nothing to collide) | Design decision — Lane A reuses existing message text + adds JSON fields |
+| V23 | Escape-hatch function shape compiles | `ailang check` clean on `escape.ail` (`genPoint(seed: int) -> Point`) |
+| V24 | `AddPropertyResult` counts property skips into the same counters as tests; aggregation duplicated in `test.go:52-59,181-188` | Read `result.go:80-93`, `test.go` |
+| V25 | **The bounded-evaluation API exists and is on the property-test call path**: `CoreEvaluator.maxRecursionDepth` (default 10,000, `eval_evaluator.go:148`; setter `SetMaxRecursionDepth` at `:519-521`; CLI `--max-recursion-depth`), enforced on every `*FunctionValue` application in `evalCoreApp` (`eval_operations.go:55-60`, error `RT_REC_003`); the harness reaches it via `evaluateEnsuresHarnessCore` → fresh `eval.NewCoreEvaluator()` (`executor.go:150`) → `EvalCoreProgram` (`:162`) | Read all four sites (revision pass, binary `go build -o /tmp/ailang_designer2 ./cmd/ailang`) |
+| V26 | **Live**: a nonterminating pure function invoked through the ensures-property harness terminates deterministically — `spin(x) = spin(x)` (tail-recursive, so this also proves the guard is not TCO-evaded) → property `status: fail`, `error: "test 0: ensures harness evaluation failed: RT_REC_003: max recursion depth 10000 exceeded…"`, `tests_run: 1`, suite `success: false`, rc=1, wall time ~8ms; two consecutive runs byte-identical modulo `duration` fields | Live `ailang test --format json` on `diverge.ail` (worktree binary), run twice + diff |
+| V27 | TCO exists **only** in the bytecode VM (`internal/vm`, `OpTailCall`), not in the tree-walking `CoreEvaluator` the test harness uses; v0_7_3 design doc states "No TCO in AILANG. Recursion guarded by depth counter" | grep `TailCall\|tail-recursion` repo-wide → hits only in `internal/vm`, `internal/bytecode`, archived codegen docs; behavioral proof in V26 |
+| V28 | **Both hint-text instructed shapes compile**: named-type `genMail(seed: int) -> Mail` and alias-first `export type T = { x: int }` + `genT(seed: int) -> T` + consumer `getX(p: T)` — `ailang check` clean | Live check of `aliashint.ail` (worktree binary) |
+| V29 | **Negative, instrument-proven**: the evaluator has NO step/fuel counter — only the depth budget (V25) and *effect* budgets (`EffectBudgets`/`@limit`, `value.go:311`, which bound effect operations, not pure computation steps). The same grep instrument that found the effect-budget positives found no step/fuel machinery | grep `fuel\|Fuel\|StepBudget\|MaxSteps\|StepLimit` over `internal/` → 0 hits; grep `budget\|Budget\|[Ll]imit` over `internal/eval/` → effect budgets + recursion depth only (positive control: same pattern found both known mechanisms) |
+| V30 | `cmd/ailang/coordinator_cloud.go:586` is `exec.CommandContext(ctx, "ailang", "test", "--package", ".")`; `:588` is the `testErr != nil` → `"ailang test failed (escalating to AI)"` branch | Read `cmd/ailang/coordinator_cloud.go:578-592` (revision pass; corrects V11's path, which omitted the `cmd/ailang/` directory) |
+
+**Not verified / open for the executor**: shrink quality of derived generators (V-none — flagged in Lane B); whether external (out-of-repo) consumers parse `success` (unknowable from here; mitigated by `--allow-skips` + CHANGELOG). The `gen<TypeName>` call path's *depth-bounded evaluation and error-to-Fail behavior* is verified (V25/V26), but B2 is deferred regardless — depth bounds divergence, not total work (quorum 2026-07-29); the verified envelope is retained for unpark.
+
+### Quorum verification log
+
+**2026-07-29 — 2-reviewer quorum BLOCKED (rc=3); bounded revision pass applied same day.**
+Artifact: `.ailang/state/mission-quorum/m-property-generator-coverage-2026-07-29T21-50-41Z.json`.
+Both objections landed exclusively on Lane B2; neither reviewer objected to Lane A or B1.
+
+| Reviewer | Verdict | Objection (one line) | Resolution applied |
+|---|---|---|---|
+| gpt5-6-sol | REJECT | B2's recursion-depth guard bounds call-stack depth, not total evaluator work — the doc explicitly permitted a depth-9,999 exponential-fanout generator to run arbitrarily slowly; determinism does not make that wait operationally bounded, and B-8 proves only the divergence half | Adopted the reviewer's **first** proposed option: **B2 DEFERRED** out of Lane B's shippable scope, BLOCKED ON a deterministic evaluator fuel budget (fuel per evaluation reduction / function application) — **deferred on the reviewer's own proposal, not overridden**. No fuel-budget design was invented here. Updated: Dependencies + Estimated headers, Lane B heading, B2 section (deferral block), Files, acceptance tables (B-6/B-8/B-9 moved to a deferred table; B-7 re-scoped), Timeline, Risks, Non-Goals, Future Work. Lane B = B1 only. The withdrawn depth-alone-sufficiency prose ("Bounded evaluation (REQUIRED…)" block + "Honest residual" paragraph) was relocated under deferred B2 as "why depth alone was judged insufficient", crediting the objection |
+| gemini-3-1-pro | REJECT | Anonymous/refined-type hint text told users to alias the type to `T` and define `genT` but omitted changing the function's parameter type to `T` — since `gen<TypeName>` discovery only fires on named-type resolution, following the hint re-emits the same error (structurally ineffective instructions; DX trap) | Hint wording in the (deferred) B2 spec now reads `…, define export func genT(seed: int) -> T, and change the parameter type to T`, with the mandatory-clause rationale recorded inline; acceptance criterion B-9 updated to assert the signature-change clause and to name its omission as a red-turning mutation |
+
+Lane A (A1–A6, its acceptance-criteria table, and mutation column) was left **byte-identical** in
+this revision — no reviewer objected to it; it routes to the sprint-planner unchanged.
+
+---
+
+## References
+
+- **Upstream filing**: sunholo-data/ailang#517 (open) — asks: (1) derive record/ADT generators, (2) loud skips, (3) user-supplied generator hook. This doc covers all three; notes the filing's type coverage framing is narrower than measured reality.
+- [m-named-test-blocks](../../implemented/v0_29_0/m-named-test-blocks.md) — the half of the guard that already shipped
+- [m-forall-properties-direct-core-eval](../v1_1_0/m-forall-properties-direct-core-eval.md) — the parked sibling surface
+- [m-dx26-property-test-empty-program](../../implemented/v0_21_0/m-dx26-property-test-empty-program.md) — harness paths extended here
+- Program north star: [design_docs/PROGRAM.md](../../PROGRAM.md) — vacuous-pass class tracking
+
+## Future Work
+
+- **Evaluator step-fuel budget** (deterministic total-work bound: fuel charged per evaluation reduction and function application, not just call depth) — **now the named BLOCKING DEPENDENCY for deferred B2** (quorum 2026-07-29): the depth guard bounds recursive divergence, not total work. Benefits the whole test harness (function-under-test calls share the same exposure), not just generators. When it lands, B2 unparks with no semantic change to its retained spec (exhaustion is already specced as structured Fail).
+- Typechecker-env-based type resolution (unlocks imported types) — supersedes the same-file bound
+- Refinement-aware generation for `string<...>` taint/refined types
+- Cross-constructor ADT shrinking; integrated shrink-quality metrics
+- Surface `vacuous_skips` in the eval-harness bank schema so agent-written contract tests are scored on *executed* properties

--- a/internal/testing/reporter.go
+++ b/internal/testing/reporter.go
@@ -52,6 +52,7 @@ func (r *Reporter) reportJSON(result *SuiteResult) error {
 		"passed_tests":   result.PassedTests,
 		"failed_tests":   result.FailedTests,
 		"skipped_tests":  result.SkippedTests,
+		"vacuous_skips":  result.VacuousSkips,
 		"total_duration": result.TotalDuration.String(),
 		"success":        result.Success(),
 		"tests":          r.formatTestsJSON(result.Tests),
@@ -90,6 +91,7 @@ func (r *Reporter) formatPropertiesJSON(properties []PropertyResult) []map[strin
 			"duration":  prop.Duration.String(),
 			"tests_run": prop.TestsRun,
 			"location":  prop.Location,
+			"skip_kind": prop.SkipKind,
 		}
 		if prop.Error != "" {
 			output[i]["error"] = prop.Error
@@ -177,16 +179,20 @@ func (r *Reporter) reportPropertyHuman(prop PropertyResult) {
 
 	fmt.Fprintln(r.writer)
 
-	// Show error details if property failed
-	if prop.Status == StatusFail {
+	// Show error details for failed and skipped properties.
+	if prop.Status == StatusFail || prop.Status == StatusSkip {
+		lineColor := colorRed
+		if prop.Status == StatusSkip {
+			lineColor = colorYellow
+		}
 		if prop.FailingInput != "" {
 			fmt.Fprintf(r.writer, "      %s: %s\n",
-				r.color(colorRed, "Failing input"), prop.FailingInput)
+				r.color(lineColor, "Failing input"), prop.FailingInput)
 		}
 		if prop.Error != "" {
 			errorLines := strings.Split(prop.Error, "\n")
 			for _, line := range errorLines {
-				fmt.Fprintf(r.writer, "      %s\n", r.color(colorRed, line))
+				fmt.Fprintf(r.writer, "      %s\n", r.color(lineColor, line))
 			}
 		}
 	}
@@ -207,6 +213,12 @@ func (r *Reporter) reportSummaryHuman(result *SuiteResult) {
 		fmt.Fprintf(r.writer, "%s %s\n",
 			r.color(colorYellow, "⚠"),
 			r.color(colorBold, fmt.Sprintf("NO TESTS RAN (%d skipped)", result.SkippedTests)))
+	case result.VacuousSkips > 0 && result.FailedTests == 0:
+		fmt.Fprintf(r.writer, "%s %s\n",
+			r.color(colorRed, "✗"),
+			r.color(colorBold, fmt.Sprintf(
+				"%d properties never ran (no generator) — use --allow-skips to permit",
+				result.VacuousSkips)))
 	case result.Success():
 		// ran>0 && failed==0 (may include skips)
 		fmt.Fprintf(r.writer, "%s %s\n",

--- a/internal/testing/reporter_vacuous_test.go
+++ b/internal/testing/reporter_vacuous_test.go
@@ -1,0 +1,82 @@
+package testing
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestReporter_VacuousPropertyDetails(t *testing.T) {
+	result := NewSuiteResult("test.ail")
+	result.AddTestResult(TestResult{Name: "anchor", Status: StatusPass})
+	result.AddPropertyResult(PropertyResult{
+		Name:     "shiftX",
+		Status:   StatusSkip,
+		SkipKind: SkipKindNoGenerator,
+		Error:    "no generator for parameter p: Point",
+	})
+
+	var jsonBuf bytes.Buffer
+	if err := NewReporter(FormatJSON, &jsonBuf, false).Report(result); err != nil {
+		t.Fatal(err)
+	}
+	var output struct {
+		Success      bool `json:"success"`
+		VacuousSkips int  `json:"vacuous_skips"`
+		Properties   []struct {
+			SkipKind string `json:"skip_kind"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(jsonBuf.Bytes(), &output); err != nil {
+		t.Fatal(err)
+	}
+	if output.Success || output.VacuousSkips != 1 {
+		t.Fatalf("expected success=false and vacuous_skips=1, got %+v", output)
+	}
+	if got := output.Properties[0].SkipKind; got != SkipKindNoGenerator {
+		t.Fatalf("expected skip_kind %q, got %q", SkipKindNoGenerator, got)
+	}
+
+	var humanBuf bytes.Buffer
+	if err := NewReporter(FormatHuman, &humanBuf, false).Report(result); err != nil {
+		t.Fatal(err)
+	}
+	human := humanBuf.String()
+	if !strings.Contains(human, "no generator for parameter p: Point") {
+		t.Fatalf("missing skip reason in human report:\n%s", human)
+	}
+	if !strings.Contains(human, "1 properties never ran") {
+		t.Fatalf("missing vacuous summary in human report:\n%s", human)
+	}
+	if strings.Contains(human, "All tests passed!") {
+		t.Fatalf("vacuous suite reported success:\n%s", human)
+	}
+}
+
+func TestReporter_OutOfContractShowsReasonAndCases(t *testing.T) {
+	result := NewSuiteResult("test.ail")
+	result.AddTestResult(TestResult{Name: "anchor", Status: StatusPass})
+	result.AddPropertyResult(PropertyResult{
+		Name:     "bounded",
+		Status:   StatusSkip,
+		SkipKind: SkipKindOutOfContract,
+		TestsRun: 2,
+		Error:    "requires not satisfied by random input",
+	})
+
+	var buf bytes.Buffer
+	if err := NewReporter(FormatHuman, &buf, false).Report(result); err != nil {
+		t.Fatal(err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "(2 cases,") {
+		t.Fatalf("missing executed case count:\n%s", output)
+	}
+	if !strings.Contains(output, "requires not satisfied by random input") {
+		t.Fatalf("missing out-of-contract reason:\n%s", output)
+	}
+	if !strings.Contains(output, "All tests passed!") {
+		t.Fatalf("forgiven out-of-contract skip should stay green:\n%s", output)
+	}
+}

--- a/internal/testing/result.go
+++ b/internal/testing/result.go
@@ -14,6 +14,12 @@ const (
 	StatusSkip TestStatus = "skip"
 )
 
+const (
+	SkipKindNoGenerator   = "no_generator"
+	SkipKindUnsupported   = "unsupported"
+	SkipKindOutOfContract = "out_of_contract"
+)
+
 // TestResult represents the outcome of a single test execution.
 type TestResult struct {
 	Name     string        // Test name
@@ -32,6 +38,7 @@ type PropertyResult struct {
 	FailingInput string        // Minimal failing input (if failed)
 	Error        string        // Error message (if failed)
 	Location     string        // Source location
+	SkipKind     string        // Machine-readable reason when StatusSkip
 }
 
 // SuiteResult aggregates results from all tests in a test suite.
@@ -43,6 +50,7 @@ type SuiteResult struct {
 	PassedTests   int              // Number of passing tests
 	FailedTests   int              // Number of failing tests
 	SkippedTests  int              // Number of skipped tests
+	VacuousSkips  int              // Skipped properties that executed no meaningful cases
 	TotalDuration time.Duration    // Total execution time
 }
 
@@ -89,6 +97,9 @@ func (sr *SuiteResult) AddPropertyResult(result PropertyResult) {
 		sr.FailedTests++
 	case StatusSkip:
 		sr.SkippedTests++
+		if result.SkipKind != SkipKindOutOfContract {
+			sr.VacuousSkips++
+		}
 	}
 }
 
@@ -96,7 +107,7 @@ func (sr *SuiteResult) AddPropertyResult(result PropertyResult) {
 // An all-skipped suite (run==0, skipped>0) is NOT success — it exits non-zero.
 func (sr *SuiteResult) Success() bool {
 	ran := sr.PassedTests + sr.FailedTests
-	return ran > 0 && sr.FailedTests == 0
+	return ran > 0 && sr.FailedTests == 0 && sr.VacuousSkips == 0
 }
 
 // AllSkipped returns true when every recorded test was skipped and at least

--- a/internal/testing/result_vacuous_success_test.go
+++ b/internal/testing/result_vacuous_success_test.go
@@ -1,0 +1,52 @@
+package testing
+
+import "testing"
+
+func TestSuiteResult_Success_MixedVacuousPropertyFails(t *testing.T) {
+	result := NewSuiteResult("test.ail")
+	result.AddTestResult(TestResult{Name: "sibling", Status: StatusPass})
+	result.AddPropertyResult(PropertyResult{
+		Name:     "vacuous",
+		Status:   StatusSkip,
+		SkipKind: SkipKindNoGenerator,
+	})
+
+	if result.Success() {
+		t.Fatal("mixed suite with a vacuous property must not succeed")
+	}
+	if !result.SuccessAllowingSkips() {
+		t.Fatal("--allow-skips semantics must forgive vacuous properties")
+	}
+}
+
+func TestSuiteResult_Success_MixedOutOfContractPropertyPasses(t *testing.T) {
+	result := NewSuiteResult("test.ail")
+	result.AddTestResult(TestResult{Name: "sibling", Status: StatusPass})
+	result.AddPropertyResult(PropertyResult{
+		Name:     "discarded",
+		Status:   StatusSkip,
+		SkipKind: SkipKindOutOfContract,
+		TestsRun: 1,
+	})
+
+	if !result.Success() {
+		t.Fatal("out-of-contract discard must not make a mixed suite fail")
+	}
+}
+
+func TestSuiteResult_Success_AllSkippedOutOfContractFails(t *testing.T) {
+	result := NewSuiteResult("test.ail")
+	result.AddPropertyResult(PropertyResult{
+		Name:     "discarded",
+		Status:   StatusSkip,
+		SkipKind: SkipKindOutOfContract,
+		TestsRun: 1,
+	})
+
+	if result.Success() {
+		t.Fatal("all-skipped suite must not succeed")
+	}
+	if !result.AllSkipped() {
+		t.Fatal("all-skipped suite must retain NO TESTS RAN classification")
+	}
+}

--- a/internal/testing/result_vacuous_test.go
+++ b/internal/testing/result_vacuous_test.go
@@ -1,0 +1,29 @@
+package testing
+
+import "testing"
+
+func TestAddPropertyResult_VacuousSkipClassification(t *testing.T) {
+	tests := []struct {
+		name string
+		kind string
+		want int
+	}{
+		{name: "no generator", kind: SkipKindNoGenerator, want: 1},
+		{name: "unsupported", kind: SkipKindUnsupported, want: 1},
+		{name: "empty fails closed", kind: "", want: 1},
+		{name: "out of contract forgiven", kind: SkipKindOutOfContract, want: 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := NewSuiteResult("test.ail")
+			result.AddPropertyResult(PropertyResult{
+				Status:   StatusSkip,
+				SkipKind: tc.kind,
+			})
+			if result.VacuousSkips != tc.want {
+				t.Fatalf("expected %d vacuous skips, got %d", tc.want, result.VacuousSkips)
+			}
+		})
+	}
+}

--- a/internal/testing/runner.go
+++ b/internal/testing/runner.go
@@ -247,6 +247,7 @@ func (r *Runner) runProperty(propCase PropertyCase) PropertyResult {
 		gen, shrink := r.createGeneratorForType(binder.Type)
 		if gen == nil {
 			result.Status = StatusSkip
+			result.SkipKind = SkipKindNoGenerator
 			result.Error = fmt.Sprintf("no generator for type %v", binder.Type)
 			result.Duration = time.Since(start)
 			return result
@@ -329,6 +330,7 @@ func (r *Runner) runEnsuresProperty(propCase PropertyCase) PropertyResult {
 
 	if propCase.Function == nil {
 		result.Status = StatusSkip
+		result.SkipKind = SkipKindUnsupported
 		result.Error = "ensures property has no function context (top-level ensures not supported)"
 		result.Duration = time.Since(start)
 		return result
@@ -371,6 +373,7 @@ func (r *Runner) runEnsuresProperty(propCase PropertyCase) PropertyResult {
 		gen, _ := r.createGeneratorForType(p.Type)
 		if gen == nil {
 			result.Status = StatusSkip
+			result.SkipKind = SkipKindNoGenerator
 			result.Error = fmt.Sprintf("no generator for parameter %s: %v", p.Name, p.Type)
 			result.Duration = time.Since(start)
 			return result
@@ -452,6 +455,7 @@ func (r *Runner) runRequiresProperty(propCase PropertyCase) PropertyResult {
 
 	if propCase.Function == nil {
 		result.Status = StatusSkip
+		result.SkipKind = SkipKindUnsupported
 		result.Error = "requires property has no function context (top-level requires not supported)"
 		result.Duration = time.Since(start)
 		return result
@@ -488,6 +492,7 @@ func (r *Runner) runRequiresProperty(propCase PropertyCase) PropertyResult {
 		gen, _ := r.createGeneratorForType(p.Type)
 		if gen == nil {
 			result.Status = StatusSkip
+			result.SkipKind = SkipKindNoGenerator
 			result.Error = fmt.Sprintf("no generator for parameter %s: %v", p.Name, p.Type)
 			result.Duration = time.Since(start)
 			return result
@@ -534,6 +539,7 @@ func (r *Runner) runRequiresProperty(propCase PropertyCase) PropertyResult {
 			// We mark the property Skipped (not Fail) because random inputs that
 			// violate `requires` aren't a function bug.
 			result.Status = StatusSkip
+			result.SkipKind = SkipKindOutOfContract
 			result.Error = fmt.Sprintf("requires not satisfied by random input (consider tighter generators): %s", formatEnsuresInputs(params, generatedValues))
 			result.TestsRun = testNum + 1
 			result.Duration = time.Since(start)
@@ -643,6 +649,16 @@ func (r *Runner) createGeneratorForType(typ ast.Type) (Generator, Shrinker) {
 			config := DefaultConfig()
 			return NewStringGenerator(0, config.MaxSize, ""), NewStringShrinker()
 		}
+	}
+
+	// The parser represents both [a] and list[a] as TypeApp.
+	if app, ok := typ.(*ast.TypeApp); ok && app.Constructor == "list" && len(app.Args) == 1 {
+		elemGen, elemShrink := r.createGeneratorForType(app.Args[0])
+		if elemGen == nil {
+			return nil, nil
+		}
+		config := DefaultConfig()
+		return NewListGenerator(elemGen, 0, config.MaxSize), NewListShrinker(elemShrink)
 	}
 
 	// Check for list types [a]

--- a/internal/testing/runner_skip_kind_test.go
+++ b/internal/testing/runner_skip_kind_test.go
@@ -1,0 +1,101 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/ast"
+)
+
+func TestRunProperty_SkipTaxonomyIsTotal(t *testing.T) {
+	runner := NewRunner("test.ail")
+	cases := []struct {
+		name string
+		run  func() PropertyResult
+		want string
+	}{
+		{
+			name: "forall no generator",
+			run: func() PropertyResult {
+				return runner.runProperty(PropertyCase{
+					Name: "forall",
+					Property: &ast.Property{Binders: []*ast.Binder{
+						{Name: "tree", Type: &ast.SimpleType{Name: "Tree"}},
+					}},
+				})
+			},
+			want: SkipKindNoGenerator,
+		},
+		{
+			name: "ensures unsupported",
+			run: func() PropertyResult {
+				return runner.runProperty(PropertyCase{
+					Name:     "ensures",
+					Property: &ast.Property{Kind: ast.EnsuresKind},
+				})
+			},
+			want: SkipKindUnsupported,
+		},
+		{
+			name: "requires unsupported",
+			run: func() PropertyResult {
+				return runner.runProperty(PropertyCase{
+					Name:     "requires",
+					Property: &ast.Property{Kind: ast.RequiresKind},
+				})
+			},
+			want: SkipKindUnsupported,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.run()
+			if got.Status != StatusSkip {
+				t.Fatalf("expected skip, got %s", got.Status)
+			}
+			if got.SkipKind != tc.want {
+				t.Fatalf("expected skip kind %q, got %q", tc.want, got.SkipKind)
+			}
+		})
+	}
+}
+
+func TestRunContractProperties_SkipKinds(t *testing.T) {
+	src := `module skip_kinds
+
+type Point = { x: int }
+
+export pure func unsupported(p: Point) -> int
+  requires { p.x > 0 }
+  ensures { result > 0 }
+{
+  p.x
+}
+
+export pure func outOfContract(x: int) -> int
+  requires { false }
+{
+  x
+}
+
+export func main() -> int ! {} { 0 }
+`
+	result := runEnsuresFromSource(t, src)
+	if len(result.Properties) != 3 {
+		t.Fatalf("expected 3 property results, got %d", len(result.Properties))
+	}
+
+	want := []string{
+		SkipKindNoGenerator,
+		SkipKindNoGenerator,
+		SkipKindOutOfContract,
+	}
+	for i, prop := range result.Properties {
+		if prop.Status != StatusSkip {
+			t.Fatalf("property %d: expected skip, got %s (%s)", i, prop.Status, prop.Error)
+		}
+		if prop.SkipKind != want[i] {
+			t.Fatalf("property %d: expected skip kind %q, got %q", i, want[i], prop.SkipKind)
+		}
+	}
+}

--- a/internal/testing/runner_typeapp_generator_test.go
+++ b/internal/testing/runner_typeapp_generator_test.go
@@ -1,0 +1,34 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/ast"
+)
+
+func TestCreateGeneratorForType_TypeAppList(t *testing.T) {
+	runner := NewRunner("test.ail")
+
+	gen, shrink := runner.createGeneratorForType(&ast.TypeApp{
+		Constructor: "list",
+		Args:        []ast.Type{&ast.SimpleType{Name: "int"}},
+	})
+	if gen == nil {
+		t.Fatal("expected generator for list[int] TypeApp")
+	}
+	if shrink == nil {
+		t.Fatal("expected shrinker for list[int] TypeApp")
+	}
+}
+
+func TestCreateGeneratorForType_TypeAppListUnsupportedElement(t *testing.T) {
+	runner := NewRunner("test.ail")
+
+	gen, shrink := runner.createGeneratorForType(&ast.TypeApp{
+		Constructor: "list",
+		Args:        []ast.Type{&ast.SimpleType{Name: "Tree"}},
+	})
+	if gen != nil || shrink != nil {
+		t.Fatalf("expected no generator fallback for list[Tree], got generator=%T shrinker=%T", gen, shrink)
+	}
+}


### PR DESCRIPTION
Lane A of `m-property-generator-coverage` — closes the partial-skip half of **#517** (`[world-DEMAND]`, filed by the sibling Ailang World mission).

## The bug

`ailang test` reported `success: true` and **exit 0** for a suite in which properties executed **zero cases**, provided at least one other test passed. Measured at `4ebd85873`: a file with one `int` property plus ADT, anonymous-record, tuple and `[int]` params gave exit 0 and the headline `✓ All tests passed!` with **4 of 5 properties never run** — the reason visible only in JSON `properties[].error`.

The guard was half-present: an *all*-skipped suite already exits 1 (`AllSkipped()`, shipped in v0.29.0), so the silent shape needs ≥1 passing sibling — which is every real module, and why **a one-function repro exits 1 and reads as already-fixed**. Every fixture here uses the mixed shape.

## What changed

| M | Change |
|---|---|
| **M1** | Added the reachable `*ast.TypeApp{Constructor:"list"}` generator arm. The `*ast.ListType` arm has been **dead since `b9ab84e6f`** made the parser emit `TypeApp` for `[T]` — zero non-test constructors. `[T]`/`list[T]` params now generate instead of skipping. |
| **M2** | Skip taxonomy over **all six** `StatusSkip` sites (`no_generator`, `unsupported`, `out_of_contract`), **fail-closed** — an unclassified skip counts as vacuous. Behaviour-inert alone. |
| **M3** | `Success()` additionally requires `VacuousSkips == 0`; `--allow-skips` stays the single opt-out via the unchanged `SuccessAllowingSkips()`. Reporter surfaces skip reasons and stops claiming "All tests passed!". |
| **M4** | `--format json` writes only JSON to stdout (preamble → stderr at all four write sites), so `\| jq` works with no preprocessing. |
| **M5** | CHANGELOG, doc status, follow-ups F1–F3. |

**Strictness is class-scoped, not "any skip".** `out_of_contract` skips are a deliberate semantic from `m-dx26` and stay forgiven — `cross_module_functions_lib.ail` is the discriminator and **stays exit 0**.

## Verification

Gates re-run by the controller **outside** the codex sandbox (which denies loopback binds, making `cmd/ailang` results uninformative there):

```
go test ./internal/testing/... -count=1   rc=0
go test ./cmd/ailang/...      -count=1    rc=0   (272s)
make check-file-sizes                     rc=0   (runner.go 790/800)
make lint                                 rc=0
make verify-examples                      rc=0
```

**Five mutations observed RED** with `-count=1`, each reverted `sha256`-byte-identical — including one the evaluator ran that the controller had not (dropping the `ran > 0` term):

1. drop `&& VacuousSkips == 0` from `Success()` → mixed-vacuous + reporter tests red
2. neuter the `TypeApp` `"list"` arm → list-generator test red
3. invert the fail-closed skip condition → 4 tests red, incl. the out-of-contract discriminator
4. restore the JSON preamble to stdout → both JSON-stdout tests red ("stdout is not pure JSON")
5. drop `ran > 0` → all-skipped-out-of-contract test red

**Evaluator** (sonnet, independent of the OpenAI executor): **PASS 88/100 round 1, zero blocking findings.**

## Disclosed, not fixed here

- **#535 (pre-existing, filed this iteration): property generation is wall-clock seeded**, so per-file exit codes are **not reproducible run-to-run** — the same file on the same binary gave `rc=1, rc=1, rc=0`. The `vacuous_skips` classification added here **is** stable; `failed_tests` counts are not. This is why the executor's and controller's corpus measurements differed — neither was wrong. The CHANGELOG says so rather than publishing an unreproducible file list as a contract.
- **Some suites get *less* red**: making `[T]` generators reachable lets properties run and then be *discarded* as out-of-contract, so `list_recursive_verify.ail` can move exit 1 → **0**. A property surviving 1–2 of 100 cases is near-unvalidated yet passing → follow-up **F1**. Newly-running properties also surfaced genuine contract violations in `list_verify.ail`.
- **Lane B** (structural derivation for records/ADTs/tuples) is the real fix for the shapes still vacuous, and is **not** in this PR. **B2 was deferred by quorum** on a reviewer's own proposed option, blocked on a deterministic evaluator fuel budget.
- **#534**: flags after the positional path are silently ignored across all `flag.NewFlagSet` subcommands. Every command here puts flags *before* the path.

`runner.go` is at **790/800** lines — 10 lines of headroom, flagged for Lane B1 (evaluator NB-3).

Design doc stays in `planned/` with its sprint plan beside it: it covers both lanes and Lane B is unimplemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
