### PR TITLE
fix(nightly): the summary no longer prints an empty insufficient-history line, or a literal \n (#541)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,12 +140,12 @@ jobs:
 
     - name: Assert nightly classifier tests ran (no silent skips)
       run: |
-        # Floor tracks the measured suite size (71 on 2026-07-30) with a four-test rename buffer.
+        # Floor tracks the measured suite size (74 on 2026-07-30) with a four-test rename buffer.
         # It drifted to 20-vs-40 before iteration 119 caught it: a floor set
         # once and never revisited is the same vacuous-check class this suite
         # exists to prevent. Raise it whenever you add tests.
         PASSES=$(grep -c -- '--- PASS:' nightly_classifier.log || true)
-        if [ "$PASSES" -lt 67 ]; then
+        if [ "$PASSES" -lt 70 ]; then
           echo "::error::nightly classifier emitted only $PASSES PASS lines; tests were skipped, renamed, or did not run"
           exit 1
         fi

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -26,6 +26,16 @@
 
 ### Fixed
 
+- The nightly summary no longer carries an empty
+  `insufficient history:  ( over  nights, failing /3 toward escalation)` line in
+  every run, and no longer prints a literal `\n` mid-message instead of a
+  newline. The first was an unguarded `awk` over an empty variable (`echo ""`
+  still emits one line); the second was `\\n` inside a single-quoted `awk`
+  program, at both the suspected-flake and insufficient-history sites. The
+  suspected-flake site also needed a real newline in the message template,
+  because command substitution strips the trailing one. The classifier suite now
+  measures 74 tests and CI requires at least 70 PASS markers (refs #541).
+
 - Nightly escalation now distinguishes `SUSTAINED-FAILURE` from a genuine
   solid-window `REGRESSION`, while retaining the K=3 achievability backstop and
   the pages-at-most-once-per-all-fail-run invariant across legacy history.

--- a/tools/launchd/nightly-eval.sh
+++ b/tools/launchd/nightly-eval.sh
@@ -561,11 +561,12 @@ fi
 
 if [[ -n "$SUSPECTED" ]]; then
     SCOUNT=$(echo "$SUSPECTED" | wc -l | tr -d ' ')
-    SUSPECTED_BODY=$(echo "$SUSPECTED" | awk -F'\t' '{printf "%s (%s over %s nights, failing %s/3 toward escalation)\\n",$1,$3,$4,$5}')
+    SUSPECTED_BODY=$(echo "$SUSPECTED" | awk -F'\t' '{printf "%s (%s over %s nights, failing %s/3 toward escalation)\n",$1,$3,$4,$5}')
     log "suspected flakes (${SCOUNT}, no Discord): $(echo "$SUSPECTED" | cut -f1 | tr '\n' '; ')"
     ailang messages send controlplane \
         "Nightly eval: ${SCOUNT} suspected flake(s) on ${DATE} (no alert).
-${SUSPECTED_BODY}Model: ${MODEL} | Tiers: ${BENCH_TIERS}" \
+${SUSPECTED_BODY}
+Model: ${MODEL} | Tiers: ${BENCH_TIERS}" \
         --title "Nightly eval: ${SCOUNT} suspected-flake(s) (${DATE})" \
         --from "nightly-eval" \
         --type "note" 2>/dev/null || true
@@ -591,7 +592,10 @@ REG_NAMES=$( [[ -n "$REGRESSIONS" ]] && echo "$REGRESSIONS" | cut -f1 | tr '\n' 
 SUSTAINED_NAMES=$( [[ -n "$SUSTAINED" ]] && echo "$SUSTAINED" | cut -f1 | tr '\n' ' ' || echo "none" )
 GAP_NAMES=$( [[ -n "$GAPS" ]] && echo "$GAPS" | cut -f1 | tr '\n' ' ' || echo "none" )
 SUSPECTED_NAMES=$( [[ -n "$SUSPECTED" ]] && echo "$SUSPECTED" | cut -f1 | tr '\n' ' ' || echo "none" )
-INSUFFICIENT_BODY=$(echo "$INSUFFICIENT" | awk -F'\t' '{printf "insufficient history: %s (%s over %s nights, failing %s/3 toward escalation)\\n",$1,$3,$4,$5}')
+INSUFFICIENT_BODY=""
+if [[ -n "$INSUFFICIENT" ]]; then
+    INSUFFICIENT_BODY=$(echo "$INSUFFICIENT" | awk -F'\t' '{printf "insufficient history: %s (%s over %s nights, failing %s/3 toward escalation)\n",$1,$3,$4,$5}')
+fi
 ailang messages send controlplane \
     "${HEALTH}
 Nightly eval complete: ${PASS} (${RATE}) on ${DATE}.

--- a/tools/test_nightly_classify.py
+++ b/tools/test_nightly_classify.py
@@ -1209,6 +1209,38 @@ class RoutingContractTests(unittest.TestCase):
         self.assertIn("Sustained failures: chronic", logged)
         self.assertIn("Nightly eval:", logged)  # known-positive summary control
 
+    def test_Routing_summary_omits_empty_insufficient_history(self):
+        logged = self._run_route(
+            "HEALTH\thistory: fixture\n"
+            "GAP\tknown_gap\t[compile_error]\t0/10\t5\t2"
+        )
+        self.assertIn("Nightly eval complete:", logged)
+        self.assertNotIn("insufficient history:", logged)
+
+    def test_Routing_summary_separates_insufficient_history_rows(self):
+        logged = self._run_route(
+            "HEALTH\thistory: fixture\n"
+            "INSUFFICIENT-HISTORY\tnew_one\t[compile_error]\t2/2\t1\t1\n"
+            "INSUFFICIENT-HISTORY\tnew_two\t[compile_error]\t3/3\t1\t2"
+        )
+        first = "insufficient history: new_one (2/2 over 1 nights, failing 1/3 toward escalation)"
+        second = "insufficient history: new_two (3/3 over 1 nights, failing 2/3 toward escalation)"
+        self.assertIn(first, logged)
+        self.assertIn(second, logged)
+        self.assertIn(f"{first}\n{second}", logged)
+        self.assertNotIn("\\n", logged)
+
+    def test_Routing_suspected_flake_body_has_real_newline_before_model(self):
+        logged = self._run_route(
+            "HEALTH\thistory: fixture\n"
+            "SUSPECTED-FLAKE\tpipeline\t[compile_error]\t6/10\t5\t1"
+        )
+        self.assertIn(
+            "pipeline (6/10 over 5 nights, failing 1/3 toward escalation)\nModel:",
+            logged,
+        )
+        self.assertNotIn("\\n", logged)
+
     def test_Routing_sustained_body_claims_no_break(self):
         logged = self._run_route(
             "HEALTH\thistory: fixture\n"


### PR DESCRIPTION
Fixes the two text defects in `tools/launchd/nightly-eval.sh` that corrupt the nightly summary a human reads every morning (`#541`). Both were reproduced first-party against the **live 06:47 2026-07-30 inbox message** before any code changed, and a census of all of `tools/` found exactly these two sites and no others.

## The defects

**D1 — an empty line in EVERY nightly.** Line 594 computed `INSUFFICIENT_BODY` unguarded, unlike its five siblings at 496/509/543/562/575. `echo ""` still emits one line, so awk ran once with empty fields:

```
insufficient history:  ( over  nights, failing /3 toward escalation)
```

**D2 — a literal `\n` mid-message.** Lines 564 and 594 put `\\n` inside a **single-quoted** awk program, so awk's `printf` emitted a literal backslash-n. Verified with `od -c` (bytes `5c 6e`). Visible in the live message as `...toward escalation)\nModel: ...`.

> Note for anyone re-checking by hand: zsh's builtin `echo` **interprets** `\n`, so this defect looks already-fixed under `echo`. Use `printf '%s'` or `od -c`.

## The executor refuted the directive

The awk-only `\\n` → `\n` fix is **not sufficient** for the suspected-flake site: command substitution strips trailing newlines, so `${SUSPECTED_BODY}` loses its final newline and the old literal `\n` was what separated the last row from `Model:`. The message template now carries a real newline. **MUT-4 pins exactly this** — reverting only the template newline while keeping the awk fix still reds the test.

## Guards

Three tests in `tools/test_nightly_classify.py` over the existing `_run_route` harness (run by `make test-nightly-classifier`, gated in `ci.yml` behind an anti-vacuity PASS floor):

- no insufficient rows → no `insufficient history:` text at all (with a known-positive summary control in the same assertion)
- two rows → separate real lines, and `assertNotIn` the literal backslash-n
- suspected-flake body → real newline before `Model:`

Suite **71 → 74**; CI floor **67 → 70** (74 minus the existing four-test rename buffer), and the comment's stated suite size updated with it.

## Verification (all re-run by the controller OUTSIDE the codex sandbox)

| Gate | Result |
|---|---|
| `python3 tools/test_nightly_classify.py` | **74 PASS**, rc=0 (was 71) |
| `bash -n` | rc=0 |
| `shellcheck` | rc=0 |
| `git diff --check` | rc=0 |
| Mutations | **4/4 RED**, each on exactly its target test, each restore **sha256-identical** |

End-to-end render confirms tomorrow's summary drops the bogus line and the flake message breaks before `Model:`. No other consumer parses these strings (grep over go/py/sh/ts, control-verified).

**Known residual, outside `#541`'s scope:** with no insufficient rows the summary ends with one trailing blank line.

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)