### PR TITLE
fix(testing): strip whole declarations, not first lines — ailang test no longer corrupts its own temp modules (#548)

### DIFF
--- a/.ailang/state/sprints/sprint_M-STRIP-DECL-AWARE.json
+++ b/.ailang/state/sprints/sprint_M-STRIP-DECL-AWARE.json
@@ -1,0 +1,78 @@
+{
+  "sprint_id": "M-STRIP-DECL-AWARE",
+  "created": "2026-08-01",
+  "plan_path": "design_docs/planned/v0_31_0/m-strip-contract-awareness-sprint-plan.md",
+  "design_doc": null,
+  "design_doc_rationale": "Bug-fix lane. FORUM RULE (charter L158) scopes the full quorum pipeline to FEATURE-shaped work; precedent m-nightly-run-validity-gate/#524. No new syntax, flag, or user-visible semantics. The one policy call (empty effect annotation == pure) has two in-repo precedents: cmd/ailang/verify.go:160-168 and cmd/ailang/ai_check.go:231-232.",
+  "github_issues": [
+    548
+  ],
+  "base_commit": "858b067d4",
+  "worktree": "/tmp/wt-iter127",
+  "velocity": {
+    "target_loc_per_day": 250,
+    "estimated_total_loc": 415,
+    "estimated_days": 1.75
+  },
+  "features": [
+    {
+      "id": "M1_DECL_AWARE_STRIP",
+      "description": "Move stripNonPureFunctions to new internal/testing/source_strip.go and rewrite it to delete the WHOLE declaration (leading annotations .. Span.End.Line) instead of a single signature line. Kills the source-corruption class for contracts, multi-line bodies, and annotated declarations alike.",
+      "estimated_loc": 270,
+      "dependencies": [],
+      "acceptance_criteria": [
+        "AC1.1: ./bin/ailang test internal/testing/testdata/strip/named_test_multiline.ail -> rc=0, output has '1 passed' and '0 failed', no PAR_NO_PREFIX_PARSE (pre-fix: rc=1, 'unexpected token in expression: }')",
+        "AC1.2: ./bin/ailang test internal/testing/testdata/strip/named_test_effectful.ail -> rc=0, '0 failed', no PAR_NO_PREFIX_PARSE (proves a genuinely ! {IO} decl is removed whole)",
+        "AC1.3: ./bin/ailang test internal/testing/testdata/strip/named_test_annotated.ail -> rc=0, '0 failed', no PAR_ATTR_REQUIRES_FUNC (leading @verify removed with its decl)",
+        "AC1.4: ./bin/ailang test internal/testing/testdata/strip/named_test_contract.ail -> rc=0, '0 failed' (#548 verbatim; pre-fix rc=1 '3 tests: 1 passed, 1 failed, 1 skipped')",
+        "AC1.5: go test ./internal/testing/... -> ok (baseline at 858b067d4 is ok, measured)",
+        "AC1.6: make check-file-sizes -> exit 0; internal/testing/executor.go under 800 lines (739 today, 61 headroom)",
+        "AC1.7: ./bin/ailang test tests/record_update_regression_test.ail && ./bin/ailang test internal/pkg/testdata/multi_module/src/core_test.ail -> both rc=0 (live in-repo non-regression control)",
+        "NON-VACUITY: every table asserting ABSENCE of PAR_NO_PREFIX_PARSE must include malformed_control.ail asserting PRESENCE, in the same test function",
+        "Defensive fallback for Span.End.Line == 0 (hand-built ASTs, extern decls) has its own unit test"
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": null
+    },
+    {
+      "id": "M2_PURITY_AND_KEEPSET",
+      "description": "Add a LOCAL isEffectivelyPure predicate (f.IsPure || (f.Effects != nil && len(f.Effects) == 0)) mirroring cmd/ailang/verify.go:160-168, plus a keep-set so the function under test always survives at ExtractFunctionBinding and ExtractPureClusterForFunction. Unblocks AC9 of m-property-seed-determinism. Parser IsPure is NOT touched (internal/format/decl.go:57 would make ailang fmt insert a 'pure' keyword the author never wrote).",
+      "estimated_loc": 130,
+      "dependencies": [
+        "M1_DECL_AWARE_STRIP"
+      ],
+      "acceptance_criteria": [
+        "AC2.1 (the AC9 blocker): ./bin/ailang test internal/testing/testdata/strip/moduleless_contract.ail -> rc=0, '0 failed', contains neither 'failed to extract function binding' nor PAR_NO_PREFIX_PARSE, and shows a passing big_property_2 (pre-fix: rc=1, 'failed to extract function binding for big: ... PAR_NO_PREFIX_PARSE ... 3:1: requires')",
+        "AC2.2 (control): ./bin/ailang test internal/testing/testdata/strip/moduleless_contract_control.ail -> rc=0, '0 failed'. Module-ful twin; passes today (measured '2 tests: 1 passed, 0 failed, 1 skipped') and must still pass",
+        "AC2.3: ./bin/ailang test internal/testing/testdata/strip/named_test_contract.ail -> rc=0, '0 failed' (#548 closed with the function present, not merely parseable)",
+        "AC2.4: go test -run TestStrip ./internal/testing/... -v -> every TestStrip* shows --- PASS, and at least one --- PASS line appears (zero-test run is a FAIL)",
+        "AC2.5: go test ./... -> clean, or ONLY 'bind: operation not permitted' lines, which are UNINFORMATIVE UNDER SANDBOX and re-run by the controller outside",
+        "AC2.6: ./bin/ailang test examples/runnable/contracts/basic.ail -> rc unchanged vs the pre-M1 baseline captured in step 1",
+        "NON-VACUITY: the AC9 unit test asserts binding != nil AND binding.Name == \"big\"; paired negative control asserts ExtractFunctionBinding(\"nonexistent\") still returns \"function 'nonexistent' not found\""
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": null
+    },
+    {
+      "id": "M3_DEAD_STRIP_DISPOSITION",
+      "description": "ExtractPureClusterForFunction (executor.go:682) passes Filename: e.modulePath, so the module pipeline loads from disk and strippedSource is never lexed - its only observable effect is a WRONG file.size_bytes telemetry attribute (internal/pipeline/pipeline_module.go:38). Preferred (i): stop computing it, pass the real source, comment the routing (pipeline.go:163-169). Option (ii) making it live is REJECTED as scope.",
+      "estimated_loc": 15,
+      "dependencies": [
+        "M2_PURITY_AND_KEEPSET"
+      ],
+      "acceptance_criteria": [
+        "AC3.1: go test ./internal/testing/... ./internal/pipeline/... -> ok for both",
+        "AC3.2: ./bin/ailang test examples/runnable/contracts/cross_function.ail -> rc unchanged vs the pre-M1 baseline (exercises the cluster path)",
+        "Commit message states which option (i or ii) was taken and why"
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": null
+    }
+  ]
+}

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -6,6 +6,21 @@
 
 ### Fixed
 
+- **`ailang test` no longer corrupts the temp modules it generates (#548).**
+  The internal strip that removes effectful functions before re-elaboration
+  deleted only the *first line* of a declaration and treated any function not
+  written with the `pure` keyword as effectful. Multi-line bodies, `requires` /
+  `ensures` clauses, and `@verify` annotations were left behind as orphaned
+  top-level tokens, so the generated file failed to parse and the error was
+  reported against a `_namedtest_body_*.ail` the user never wrote. Any file
+  combining a named `test "..." { ... }` block with a contract-bearing or
+  multi-line function was affected, as was every module-less file carrying a
+  contract. The strip now removes whole declaration spans (including leading
+  annotations), treats an explicit empty effect annotation `! {}` as pure, and
+  keeps the function currently under extraction. Purity inference is local to
+  the test harness — `ast.FuncDecl.IsPure` and `ailang fmt` are unchanged, so
+  no user source is rewritten. Hidden wall-clock seeding (#535) remains open.
+
 - **Property `ensures` checks now respect their function's complete `requires`
   domain (#547).** Generated tuples that fail any comma-separated precondition
   are discarded before the function is called. A property passes only after

--- a/design_docs/planned/v0_31_0/m-property-seed-determinism-sprint-plan.md
+++ b/design_docs/planned/v0_31_0/m-property-seed-determinism-sprint-plan.md
@@ -80,6 +80,18 @@ named `test` block and a contract-bearing function has a broken named-test path 
 
 ### 0.3 REFUTED — AC9's fixture does not parse; AC9 needs a new fixture
 
+> **DISCHARGED 2026-08-01 (iteration 127) — AC9 IS NO LONGER BLOCKED. Do not re-derive this.**
+> The cause was never the contract form. `stripNonPureFunctions` deleted a single line of a
+> declaration that spans several, and treated "not declared `pure`" as non-pure — so the function
+> under extraction was cut out of the temp module and its `requires`/`ensures` were left orphaned.
+> Fixed by the declaration-aware strip in `internal/testing/source_strip.go`.
+> **AC9's fixture below, verbatim and unmodified, now passes.** Paired measurement:
+> pre-fix binary → `rc=1`, `PAR_NO_PREFIX_PARSE at ...:3:1: unexpected token in expression: ensures`;
+> post-fix binary → `rc=0`, `1 tests: 1 passed, 0 failed, 0 skipped`.
+> Committed regression fixture: `internal/testing/testdata/strip/moduleless_contract.ail`.
+> **M2 may keep AC9 exactly as originally written** — no restatement over a module-bearing file is
+> needed, so §5.4's fallback is moot. The rest of this section is kept as the historical record.
+
 AC9's fixture is module-less by design (it exists to prove module-less identity derivation):
 
 ```ailang
@@ -588,13 +600,17 @@ captured once in `cmd/ailang/main.go` before path walking.
 
 Design-doc AC5, AC6, AC7 verbatim, plus the `--seed 42` forms of AC1/AC3/AC8 restored.
 
-### 5.3 M2/M3 blocker to resolve at re-arm
+### 5.3 M2/M3 blocker to resolve at re-arm — ✅ RESOLVED 2026-08-01, NOTHING OWED
 
-AC9 is **unimplementable as written** (§0.3). Before M2 starts, the re-arm session must either
-produce a module-less contract fixture that survives `ExtractFunctionBinding`'s temp-file round-trip,
-or restate AC9 over a module-bearing file at the same workspace-relative path under two absolute
-roots. Do not start M2 with AC9 unresolved — it is the only criterion that proves `WorkspaceRoot`
-actually reached the derivation, and it is the highest-risk part of M2.
+**This blocker is discharged; M2 starts unblocked.** Iteration 127 landed the declaration-aware
+strip (`internal/testing/source_strip.go`), and AC9's original module-less fixture now parses and
+exits 0 — verified with a paired pre-fix/post-fix control (§0.3). **Keep AC9 as written**; do not
+spend re-arm time producing a substitute fixture or restating it over a module-bearing file.
+Regression cover: `internal/testing/testdata/strip/moduleless_contract.ail`.
+
+Historical statement of the blocker, retained: AC9 was **unimplementable as written** (§0.3), and
+M2 was not to start until it was resolved, it being the only criterion proving `WorkspaceRoot`
+actually reached the derivation.
 
 ### 5.4 What "M1 only" leaves in the tree — precisely
 
@@ -656,7 +672,7 @@ the safe direction and is exactly what tonight ships.
 |---|---|---|---|
 | B1 | AC1/AC3/AC8 use `--seed 42`, which M1 does not add | **was blocking** | RESOLVED — §4 restates them seed-free; probabilistic margins computed in §0.4 |
 | B2 | AC3 fixture unparseable (`assert`) + named-test synthesizer breaks on contract files | **was blocking** | RESOLVED — §4 AC3-M1 uses a second contract function instead. Underlying bug routed OUT of scope; file a new issue at landing |
-| B3 | AC9 fixture does not parse | blocking **for M2**, not M1 | PARKED — must be resolved at the 2026-08-03 re-arm before M2 starts (§5.3) |
+| B3 | AC9 fixture does not parse | blocking **for M2**, not M1 | ✅ RESOLVED 2026-08-01 (iter 127) — declaration-aware strip landed; AC9's original fixture passes, keep it as written (§0.3, §5.3) |
 | R1 | `runner.go` 10 lines from the 800 cap | high | §3.1 pure-move-first, enforced by AC10-M1's `-le 700` |
 | R2 | 1,000-attempt cap × sparse list domains is slow | medium | AC13-M1 wall-clock bound; do **not** lower the cap |
 | R3 | Filtering hides a real failure | high | AC2-M1's `x=[1-9][0-9]{2,}` counterexample assertion + T4 |

--- a/design_docs/planned/v0_31_0/m-strip-contract-awareness-sprint-plan.md
+++ b/design_docs/planned/v0_31_0/m-strip-contract-awareness-sprint-plan.md
@@ -1,0 +1,539 @@
+# Sprint Plan — `m-strip-decl-aware` (declaration-aware source stripping in `internal/testing`)
+
+**Sprint ID**: `M-STRIP-DECL-AWARE`
+**Mission**: V1 outer loop, iteration 127
+**Planner**: Opus (sprint-planner role)
+**Planner-Lane**: opus
+**Date**: 2026-08-01
+**Base**: `/tmp/wt-iter127`, detached at `origin/dev` `858b067d4`
+**GitHub issues**: `#548` (closes), AC9 blocker for `#535` M2 (unblocks — `#535` itself stays OPEN)
+**Design doc**: **NONE — bug-fix lane** (judgement in §1)
+**Risk**: low-medium
+**Estimated**: ~380 LOC (impl ~150, tests ~230), ~1.5 executor-days
+
+---
+
+## 0. Verification posture
+
+Everything in §2 and §3 was measured first-party in this worktree with
+`/tmp/wt-iter127/bin/ailang` (built from `858b067d4`). Every claim carries its command.
+Fixture texts in §6 were validated with `ailang check` before being written down.
+
+**Sandbox caveat (executor is `codex:gpt-5.6-sol`)**: the sandbox cannot bind loopback
+sockets. Any `bind: operation not permitted` from `go test ./cmd/ailang/...` or any test that
+starts a listener is **UNINFORMATIVE UNDER SANDBOX** — neither a pass nor a failure. Record it
+as such and move on; the controller re-runs those gates outside the sandbox. Do **not** attempt
+to "fix" a bind denial.
+
+**Commit posture**: codex cannot `git commit` in a linked worktree. Leave the tree dirty and
+clean; the controller finalizes commits.
+
+---
+
+## 1. JUDGEMENT: no design doc, no quorum — bug-fix lane
+
+**Recommendation: proceed straight to execution. No design doc, no quorum round.**
+
+Reasons, in order of weight:
+
+1. **The FORUM RULE (charter line 158) scopes the full pipeline to FEATURE-shaped work.**
+   This ships no new syntax, no new CLI flag, no new user-visible semantics. It makes an
+   existing internal transform stop corrupting the source it produces. The observable delta is
+   "programs that already had a defined meaning now get it".
+
+2. **Precedent is direct**: `m-nightly-run-validity-gate` / `#524` ran doc-less as a bug fix
+   inside one file. This is the same shape — one function (`stripNonPureFunctions`,
+   `internal/testing/executor.go:475`) with three call sites in the same file.
+
+3. **The one policy-ish decision has an in-repo ratified precedent, so it is convergence, not
+   invention.** Treating an explicit empty effect annotation (`! {}`) as pure is already done,
+   verbatim, at two sites:
+   - `cmd/ailang/verify.go:160-168` — *"functions with `! {}` (empty effects) are semantically
+     pure but the parser only sets `IsPure` for the explicit `pure` keyword"*
+   - `cmd/ailang/ai_check.go:231-232` — same fixup
+   Adopting the same local predicate inside `internal/testing` aligns a third consumer with an
+   existing convention. A quorum round would be spent ratifying a decision the codebase already
+   made twice.
+
+If the controller disagrees and wants the gate, the item parks cleanly to the 08-03 re-arm —
+but it then takes the AC9 blocker with it, and `#535` M2 cannot start.
+
+---
+
+## 2. Premises REFUTED
+
+The controller supplied 8 measured premises. Six hold. **Two are refuted**, one of them in a way
+that materially widens the fix.
+
+### R1 — REFUTED (material): the root cause is NOT contract-specific. It is *any* multi-line declaration.
+
+The controller's premise 3, and `#548`'s own root-cause paragraph, both say the bug is that
+contracts are left orphaned. That is one **instance**. The actual defect is that
+`stripNonPureFunctions` deletes exactly **one line** — the line matching `export func <name>` —
+for a declaration that may span many lines. Everything else in the declaration is orphaned:
+contracts, the body, and the closing brace.
+
+Measured — a non-pure function with **no contract at all**, multi-line body, beside a named test:
+
+```
+$ /tmp/wt-iter127/bin/ailang test /tmp/iter127v/c2_multiline.ail
+  ✗ big works
+      PAR_NO_PREFIX_PARSE at .../_namedtest_body_2080421920.ail:4:1: unexpected token in expression: }
+rc=1
+```
+
+Same class for a genuinely effectful (`! {IO}`) multi-line function (`c5_effectful.ail`, same
+`unexpected token: }`), which the `! {}`-purity remedy alone would **not** fix. And a third
+variant the naive span fix would still miss:
+
+```
+$ /tmp/wt-iter127/bin/ailang test /tmp/iter127v/c7_annot.ail
+      PAR_ATTR_REQUIRES_FUNC at _namedtest_body_1026338386.ail:4:3: annotations must be followed by a function declaration
+      PAR_NO_PREFIX_PARSE at _namedtest_body_1026338386.ail:5:1: unexpected token in expression: }
+```
+
+Leading `@verify` / `@route` annotations sit **above** `FuncDecl.Span.Start` and are orphaned by
+a span-based strip too. Consequence for the plan: the strip must delete
+`min(annotation lines) .. Span.End.Line`, not "the declaration line plus its contracts".
+
+Also, on the AST: contracts are **not** separate top-level forms. They are
+`ast.FuncDecl.Properties []*Property` (`internal/ast/ast_decl.go:52`), attached by the parser
+and merely *printed* on their own source lines. The controller's premise-6 wording ("reachable
+from the AST") is right; premise-3's wording ("SEPARATE TOP-LEVEL FORMS") is wrong about the
+AST, right about the text.
+
+### R2 — REFUTED: `#548`'s "known-positive control" is weak; it passes for the wrong reason.
+
+`#548`'s control is `test "trivial" { true }` — a body that **calls nothing**. It therefore
+cannot detect that the function was deleted. With a control whose body actually calls the
+function, the "no contract" case fails too, with a *different* error:
+
+```
+$ /tmp/wt-iter127/bin/ailang test /tmp/iter127v/c1_oneline.ail    # one-line body, no contract
+      pipeline error: type error ... undefined variable: big at _namedtest_body_1446843359.ail:5:4
+rc=1
+```
+
+So even when the strip produces *parseable* output, it removes the function the named test is
+about. This is exactly the trap the controller's design question anticipated — and it is
+already live today, not merely a hazard introduced by fixing the parse error. It is why M2
+exists.
+
+### Premises that HOLD (re-verified)
+
+| # | Premise | Status |
+|---|---|---|
+| 1 | `#548` reproduces (`PAR_NO_PREFIX_PARSE` on `requires`/`ensures` in `_namedtest_body_*.ail`) | HOLDS — `named_test_contract.ail`, rc=1 |
+| 2 | AC9 shape reproduces (`failed to extract function binding for big: … requires`) | HOLDS — `moduleless_contract.ail`, rc=1; module-ful twin rc=0 |
+| 4 | `IsPure` set only by the `pure` keyword (`parser_func.go:22-24, 33`) | HOLDS |
+| 5 | Adding `pure` makes the AC9 case pass | HOLDS — `ml_pure.ail` rc=0, `2 tests: 1 passed, 0 failed, 1 skipped` |
+| 6 | `f.Properties` with `Kind`/`Pos` is reachable; brace-depth machinery reusable | HOLDS — but §3 uses `Span`, which is strictly better |
+| 7 | Three call sites: `executor.go:197`, `:401`, `:682` | HOLDS |
+| 8 | Module pipeline loads by filename; `src.Code` bypassed | HOLDS, and **sharper** — see §4 |
+
+`#548`'s blast-radius claim also re-verified: 7 in-repo `.ail` files contain a named `test "`
+block; the two live ones (`tests/record_update_regression_test.ail`,
+`internal/pkg/testdata/multi_module/src/core_test.ail`) both pass at HEAD (rc=0). Latent trap,
+zero live in-repo breakage. Confirmed.
+
+---
+
+## 3. The design decision (the question the controller said not to paper over)
+
+**Chosen: (a′) — declaration-aware strip with a keep-set, plus a LOCAL effectively-pure
+predicate. Option (b) (fix `IsPure` in the parser) is REJECTED on measured blast radius.**
+
+### Why (b) is rejected
+
+`ast.FuncDecl.IsPure` is read outside `internal/testing`:
+
+```
+$ grep -rn "IsPure" --include="*.go" internal/ cmd/ | grep -v _test.go
+internal/format/decl.go:57          if d.IsPure {          <-- ailang fmt emits the `pure` keyword
+internal/types/typechecker.go       if d.IsPure || isValue(d.Body) {
+internal/ast/ast_decl.go            String()
+internal/testing/executor.go:70,478
+```
+
+`internal/format/decl.go:57` is decisive. Flipping `IsPure` at the parser would make `ailang fmt`
+**rewrite user source**, inserting a `pure` keyword the author never typed, on every
+`! {}` function in the corpus. That is precisely the silent-rewrite class that cost this project
+two weeks and −74% tokens on the fmt A/B. `internal/types/typechecker.go` reading it for the
+value restriction is a second, independent generalization hazard.
+
+The two existing consumers that *want* empty-effects-means-pure both solved it **locally**, at
+the point of consumption, without touching the parser (`verify.go:160-168`,
+`ai_check.go:231-232`). We do the same.
+
+### Why (a) alone is insufficient — and why the split is M1/M2, not one change
+
+- Strip the whole declaration and nothing else (M1 alone): `#548`'s named-test parse error is
+  gone, and the effectful/annotated variants (R1) are fixed. But AC9's `big` is deleted, so
+  `ExtractFunctionBinding` returns *"function 'big' not found"* — the trade the controller
+  predicted. And `c1_oneline`'s `undefined variable: big` (R2) is untouched.
+- Add the effectively-pure predicate (M2): `big` (`! {}`) is no longer classified non-pure, so
+  it survives the strip with its contracts attached, and AC9 clears. Independently, the
+  function *under test* is force-kept at the extraction call sites, so an effectful
+  function-under-test does not vanish either.
+
+Both halves are needed. M1 is nonetheless independently landable and independently valuable
+(§5), because it fixes a class M2 does not touch: genuinely effectful (`! {IO}`) multi-line
+declarations, which must stay stripped and today corrupt the file when they are.
+
+### Deliberately OUT of scope (recorded, not silently dropped)
+
+A named test that **calls** a genuinely effectful function still gets `undefined variable`,
+because M2 keeps effectful functions only at the *extraction* call sites, not in the named-test
+base source. That is a real defect with a verified repro, but it is neither `#548` nor AC9, and
+keeping `! {IO}` functions in a `ModeEval` temp module is an effect-checking risk this sprint
+should not absorb. **Deliverable: file it as a new issue during landing** (repro:
+`c1_oneline.ail`-shape with `! {IO}` instead of `! {}`). Do not fix it here.
+
+---
+
+## 4. Conflict surface / blast radius — the three call sites
+
+`stripNonPureFunctions` has three callers. They do **not** share a fate, because the pipeline
+routes on `Filename`, not `Code` (`internal/pipeline/pipeline.go:163-169`: any non-empty,
+non-`<repl>` `Filename` → `runModuleWithContext`, which loads the file from disk).
+
+| Site | Function | Temp file written? | Is the strip LIVE? | Affected by this sprint |
+|---|---|---|---|---|
+| `executor.go:197` | `EvaluateNamedTestBodyExprs` | **always** (`_namedtest_body_*.ail`) | **LIVE in all cases** | **YES** — `#548` lives here |
+| `executor.go:401` | `ExtractFunctionBinding` | only when `sourceFile.Module == nil` | **LIVE only module-less**; dead when a `module` header is present | **YES** — AC9 lives here |
+| `executor.go:682` | `ExtractPureClusterForFunction` | never (`Filename: e.modulePath`) | **DEAD in all cases** | M3 only |
+
+**Sharpening of premise 8 — it is a latent trap, and it also mis-reports telemetry.**
+In the module path, `src.Code` is referenced exactly once, and never lexed:
+
+```
+$ grep -n "src.Code" internal/pipeline/pipeline_module.go
+38:  attribute.Int("file.size_bytes", len(src.Code)),
+```
+
+(`src.Code` *is* lexed in `pipeline_single.go:88`, but that path is unreachable with a non-empty
+`Filename`.) So at site 682 the entire `stripNonPureFunctions` call is a no-op whose only
+observable effect is that the `file.size_bytes` trace attribute reports the **stripped** length
+instead of the file length. Verdict: **latent trap, not benign dead code** — a maintainer will
+reasonably assume the strip applies there. M3 disposes of it explicitly.
+
+**Also note premise 8's masking claim is site-specific**: it masks at site 401 only. It does
+*not* mask at site 197 — a module header does not save the named-test path:
+
+```
+$ /tmp/wt-iter127/bin/ailang test /tmp/iter127v/c4_mod_multiline.ail   # HAS module header
+      PAR_NO_PREFIX_PARSE at .../_namedtest_body_2122008266.ail:4:1: unexpected token in expression: }
+rc=1
+```
+
+**File-size conflict**: `internal/testing/executor.go` is **739 lines** against the 800-line CI
+cap (`make/code-health.mk:122`) — 61 lines of headroom. All new code goes in a **new file**
+`internal/testing/source_strip.go`, and `stripNonPureFunctions` **moves** there (dropping
+`executor.go` to ~670). `runner.go` (670) is untouched.
+
+---
+
+## 5. Milestones
+
+### M1 — Declaration-aware strip (mechanical; kills the corruption class)
+
+**Independently landable. Independently valuable.** After M1 alone, effectful multi-line
+declarations beside a named test stop producing parse errors in an invisible temp file.
+
+**Files**
+- NEW `internal/testing/source_strip.go` (~120 lines): `stripNonPureFunctions` moves here
+  verbatim, then is rewritten.
+- `internal/testing/executor.go`: delete the moved function (739 → ~670 lines).
+- NEW `internal/testing/testdata/strip/*.ail`: fixtures from §6.
+- NEW `internal/testing/source_strip_test.go` (~150 lines).
+
+**Change**
+1. For each `*ast.FuncDecl` selected for removal, delete the line range
+   `startLine .. f.Span.End.Line`, where
+   `startLine = min(f.Span.Start.Line, min over f.Annotations[i].Pos.Line)`.
+   `f.Span` is populated at `internal/parser/parser_func.go:229` (block form) and `:323`
+   (extern); `End` is the position of the closing `}` of the body.
+2. **Defensive fallback, mandatory**: if `f.Span.End.Line == 0` or `< f.Span.Start.Line`
+   (hand-built ASTs in unit tests; extern decls), fall back to deleting the single line
+   `f.Pos.Line`. This must be its own unit test, not an untested branch.
+3. Keep the existing `*ast.TestDecl` / `*ast.PropertyDecl` brace-depth `skipRanges` machinery
+   unchanged — it already works and is orthogonal.
+4. Delete the `containsPattern(line, "export func "+name)` substring matching entirely. It is
+   the source of the bug and is also a false-positive hazard (`func fooBar` contains `func foo`).
+
+**Acceptance criteria (runnable now, with the current flag set)**
+
+All from repo root in `/tmp/wt-iter127`, after `go build -o bin/ailang ./cmd/ailang`.
+
+| AC | Command | Expected |
+|---|---|---|
+| **AC1.1** | `./bin/ailang test internal/testing/testdata/strip/named_test_multiline.ail; echo rc=$?` | `rc=0`; output contains `1 passed` and `0 failed`; output does **not** contain `PAR_NO_PREFIX_PARSE`. *Pre-fix: rc=1, `PAR_NO_PREFIX_PARSE … unexpected token in expression: }`* |
+| **AC1.2** | `./bin/ailang test internal/testing/testdata/strip/named_test_effectful.ail; echo rc=$?` | `rc=0`; `1 passed`, `0 failed`; no `PAR_NO_PREFIX_PARSE`. Proves a genuinely `! {IO}` declaration is removed *whole*. *Pre-fix: rc=1, `unexpected token in expression: }`* |
+| **AC1.3** | `./bin/ailang test internal/testing/testdata/strip/named_test_annotated.ail; echo rc=$?` | `rc=0`; `1 passed`, `0 failed`; no `PAR_ATTR_REQUIRES_FUNC`. Proves leading annotations are removed with their declaration. *Pre-fix: rc=1, `PAR_ATTR_REQUIRES_FUNC … annotations must be followed by a function declaration`* |
+| **AC1.4** | `./bin/ailang test internal/testing/testdata/strip/named_test_contract.ail; echo rc=$?` | `rc=0`; `0 failed`; no `PAR_NO_PREFIX_PARSE`. This is `#548` verbatim. *Pre-fix: rc=1, `3 tests: 1 passed, 1 failed, 1 skipped`* |
+| **AC1.5** | `go test ./internal/testing/... 2>&1 \| tail -3` | `ok  github.com/sunholo-data/ailang/internal/testing`. Baseline at `858b067d4` is `ok` (measured) — no pre-existing red to explain away |
+| **AC1.6** | `make check-file-sizes` | exits 0; `internal/testing/executor.go` reported under 800 |
+| **AC1.7** | `./bin/ailang test tests/record_update_regression_test.ail && ./bin/ailang test internal/pkg/testdata/multi_module/src/core_test.ail` | both rc=0 — the two live in-repo named-test files, which pass today. Non-regression control |
+
+> **AC1.1–AC1.4 do not pin skip counts or case counts.** Property case counts are wall-clock
+> seeded (that is `#535`, still open); an AC that pinned them would be flaky by construction.
+> `0 failed` + absence of the parse-error string is the crisp, stable assertion.
+
+**Non-vacuity requirement (HARD)**: `source_strip_test.go` asserts absence of
+`PAR_NO_PREFIX_PARSE` in several places. Every such negative assertion must sit in a table that
+**also** contains `malformed_control.ail` (§6), asserting the string **is** present. If the
+detector ever stops seeing parse errors, that row goes red and the whole test fails loudly.
+A negative assertion without its positive control in the same test function is a review reject.
+
+**Est**: ~120 impl + ~150 test = 270 LOC · ~1 day
+
+---
+
+### M2 — Strip policy: effectively-pure + keep-set (unblocks AC9, closes `#548` end-to-end)
+
+**Depends on M1.**
+
+**Files**
+- `internal/testing/source_strip.go` (+~50 lines)
+- `internal/testing/executor.go` (call sites 401 and 682: pass the function under test as the
+  keep-set; ~6 lines)
+- NEW `internal/testing/testdata/strip/moduleless_contract.ail`,
+  `moduleless_contract_control.ail`
+- `internal/testing/source_strip_test.go` (+~80 lines)
+
+**Change**
+1. Add, in `source_strip.go`, mirroring `cmd/ailang/verify.go:160-168` (cite it in the comment):
+   ```go
+   // isEffectivelyPure mirrors the fixup at cmd/ailang/verify.go:160-168 and
+   // cmd/ailang/ai_check.go:231-232: a function with an EXPLICIT empty effect
+   // annotation (`! {}`) is semantically pure, but the parser sets IsPure only
+   // for the `pure` keyword (internal/parser/parser_func.go:22-24).
+   // Deliberately LOCAL: ast.FuncDecl.IsPure is read by internal/format/decl.go:57,
+   // where flipping it would make `ailang fmt` insert a `pure` keyword the author
+   // never wrote.
+   func isEffectivelyPure(f *ast.FuncDecl) bool {
+       return f.IsPure || (f.Effects != nil && len(f.Effects) == 0)
+   }
+   ```
+   Note the `f.Effects != nil` guard is load-bearing: a function with **no** effect annotation
+   at all (`Effects == nil`) is *not* claimed pure, matching both precedent sites exactly.
+2. Add a `keep map[string]bool` parameter (or variadic `keepFuncs ...string`) to the strip. A
+   function whose name is in the keep set is never removed, regardless of purity.
+3. `ExtractFunctionBinding` (`:401`) and `ExtractPureClusterForFunction` (`:682`) pass
+   `functionName` as the keep-set. Site `:197` (named test) passes an empty keep-set — see the
+   out-of-scope note in §3.
+
+**Acceptance criteria**
+
+| AC | Command | Expected |
+|---|---|---|
+| **AC2.1 (the AC9 blocker)** | `./bin/ailang test internal/testing/testdata/strip/moduleless_contract.ail; echo rc=$?` | `rc=0`; `0 failed`; output contains neither `failed to extract function binding` nor `PAR_NO_PREFIX_PARSE`; contains `big_property_2` with a `✓`. *Pre-fix: rc=1, `failed to extract function binding for big: … PAR_NO_PREFIX_PARSE … 3:1: requires`* |
+| **AC2.2 (control)** | `./bin/ailang test internal/testing/testdata/strip/moduleless_contract_control.ail; echo rc=$?` | `rc=0`, `0 failed`. The module-ful twin of AC2.1. Passes **today** (measured: `2 tests: 1 passed, 0 failed, 1 skipped`) and must still pass. If AC2.1 and AC2.2 ever disagree, the module-less path has diverged again |
+| **AC2.3** | `./bin/ailang test internal/testing/testdata/strip/named_test_contract.ail; echo rc=$?` | `rc=0`, `0 failed` — `#548` closed with the function actually present, not merely parseable |
+| **AC2.4** | `go test -run 'TestStrip' ./internal/testing/... -v 2>&1 \| grep -E '^(=== RUN\|--- (PASS\|FAIL))'` | every `TestStrip*` shows `--- PASS`; **at least one `--- PASS` line must appear** (a zero-test run is a FAIL, not a pass) |
+| **AC2.5** | `go test ./... 2>&1 \| grep -v '^ok\|no test files' \| head -20` | empty, **or** only `bind: operation not permitted` lines — which are **UNINFORMATIVE UNDER SANDBOX**, to be recorded verbatim and re-run by the controller outside |
+| **AC2.6** | `./bin/ailang test examples/runnable/contracts/basic.ail; echo rc=$?` | rc unchanged from the pre-M1 baseline the executor records in step 1 of the sprint. Regression guard on the real contract corpus |
+
+**Non-vacuity**: the AC9 unit test must assert `binding != nil` **and** that the returned binding
+is named `big` — not merely that `ExtractFunctionBinding` returned no error. Pair it with a
+negative control asserting `ExtractFunctionBinding("nonexistent", …)` still returns
+`function 'nonexistent' not found`, so a keep-set that accidentally keeps everything fails loudly.
+
+**Est**: ~50 impl + ~80 test = 130 LOC · ~0.5 day
+
+---
+
+### M3 — Dispose of the dead strip at call site 682 (small, honest)
+
+**Depends on M2.** Do not skip: an untouched no-op that *looks* live is how the next reader
+reintroduces this bug.
+
+**Change**: in `ExtractPureClusterForFunction` (`executor.go:682`), the pipeline is invoked with
+`Filename: e.modulePath`, so `strippedSource` is never lexed (§4). Choose ONE and state which in
+the commit message:
+- **(i) preferred** — stop computing it; pass `Code: string(sourceCode)` so the `file.size_bytes`
+  telemetry attribute is truthful, and add a comment recording that the module pipeline loads by
+  filename (`internal/pipeline/pipeline.go:163-169`) so a strip here would require a temp file.
+- (ii) — write a temp file as `ExtractFunctionBinding` does, making the strip actually live.
+  **Rejected as scope**: it changes cluster-extraction behaviour for every contract file in the
+  corpus and is not needed by `#548` or AC9. Only take (ii) if (i) turns out to break a test.
+
+**AC3.1**: `go test ./internal/testing/... ./internal/pipeline/...` → `ok` for both.
+**AC3.2**: `./bin/ailang test examples/runnable/contracts/cross_function.ail; echo rc=$?` →
+rc unchanged from the pre-M1 baseline (this file exercises the cluster path).
+
+**Est**: ~15 impl + ~0 test (covered by AC3.1/AC3.2) · ~0.25 day
+
+---
+
+## 6. Fixtures (verified to parse before being written down)
+
+Create under `internal/testing/testdata/strip/`. Each was written to disk and run through
+`ailang check` and `ailang test` in `/tmp/iter127fx` at `858b067d4`; the "pre-fix" column is
+measured, not predicted.
+
+| File | Purpose | `ailang check` today | `ailang test` today |
+|---|---|---|---|
+| `named_test_contract.ail` | `#548` verbatim | OK | rc=1, `PAR_NO_PREFIX_PARSE … requires` |
+| `named_test_multiline.ail` | R1: multi-line, **no** contract | OK | rc=1, `unexpected token: }` |
+| `named_test_effectful.ail` | R1: genuinely `! {IO}` | OK | rc=1, `unexpected token: }` |
+| `named_test_annotated.ail` | R1: leading `@verify` | OK | rc=1, `PAR_ATTR_REQUIRES_FUNC` |
+| `moduleless_contract.ail` | AC9 shape | `MOD014 no 'module' declaration` — **expected**, the fixture is module-less by design | rc=1, `failed to extract function binding for big` |
+| `moduleless_contract_control.ail` | module-ful twin, known-positive | OK | **rc=0**, `2 tests: 1 passed, 0 failed, 1 skipped` |
+| `malformed_control.ail` | **instrument control** — genuinely broken source that must keep producing `PAR_NO_PREFIX_PARSE` | FAIL (by design) | rc=1 (by design) |
+
+```ailang
+-- named_test_contract.ail
+module named_test_contract
+
+test "trivial" { true }
+
+export func guarded(x: int) -> bool ! {}
+requires { x > 0 }
+ensures { result == true } {
+  x > 0
+}
+```
+
+```ailang
+-- named_test_multiline.ail
+module named_test_multiline
+
+export func big(x: int) -> bool ! {} {
+  x > 10
+}
+
+test "big works" {
+  big(20) == true
+}
+```
+
+```ailang
+-- named_test_effectful.ail
+module named_test_effectful
+
+import std/io (println)
+
+export func shout(s: string) -> () ! {IO} {
+  println(s)
+}
+
+export pure func big(x: int) -> bool {
+  x > 10
+}
+
+test "big works" {
+  big(20) == true
+}
+```
+
+```ailang
+-- named_test_annotated.ail
+module named_test_annotated
+
+import std/io (println)
+
+@verify(depth: 3)
+export func shout(s: string) -> () ! {IO} {
+  println(s)
+}
+
+export pure func big(x: int) -> bool { x > 10 }
+
+test "big works" {
+  big(20) == true
+}
+```
+
+```ailang
+-- moduleless_contract.ail   (NO module header — that is the point)
+export func big(x: int) -> bool ! {}
+requires { x >= 0 }
+ensures { result == (x > 10) } {
+  x > 10
+}
+```
+
+```ailang
+-- moduleless_contract_control.ail
+module moduleless_contract_control
+
+export func big(x: int) -> bool ! {}
+requires { x >= 0 }
+ensures { result == (x > 10) } {
+  x > 10
+}
+```
+
+`malformed_control.ail` is authored by the executor; the only requirement is that
+`ailang test` on it emits `PAR_NO_PREFIX_PARSE`, verified before it is used as a control.
+
+---
+
+## 7. Execution order
+
+1. **Baseline capture (before any edit)** — run and save to the sprint notes:
+   `./bin/ailang test examples/runnable/contracts/basic.ail`,
+   `…/cross_function.ail`, `…/invoice.ail`, `…/finance.ail` (rc + summary line each), and
+   `go test ./internal/testing/... > /tmp/base_testing.txt`. AC2.6 and AC3.2 compare to this.
+   Without it, "unchanged" is unfalsifiable.
+2. M1: move + rewrite the strip; fixtures; tests; AC1.1–AC1.7.
+3. M2: purity predicate + keep-set; AC2.1–AC2.6.
+4. M3: dead-code disposition; AC3.1–AC3.2.
+5. `make fmt && make lint && make test` — record any `bind:` denial as UNINFORMATIVE.
+6. Leave the tree dirty; report to the controller.
+
+---
+
+## 8. Rollback
+
+Fully self-contained and cheap:
+
+- **M3 alone**: revert the ~15-line diff in `ExtractPureClusterForFunction`. Zero behavioural
+  coupling to M1/M2.
+- **M2 alone**: delete `isEffectivelyPure` and drop the keep-set argument (revert to
+  `!f.IsPure`). M1's span-aware strip is untouched and still correct — the tree lands in the
+  state described in §3 ("M1 alone"), i.e. `#548`'s parse error fixed, AC9 still blocked. This is
+  a *valid shippable state*, so M2 can be reverted under time pressure without a re-plan.
+- **M1+M2+M3**: `git revert` the sprint commit(s). `stripNonPureFunctions` returns to
+  `executor.go`, which returns to 739 lines — still under the cap. No schema, no data, no
+  on-disk format, no CLI surface is touched, so there is nothing to migrate back.
+- **Blast radius if it goes wrong in the field**: `stripNonPureFunctions` is reachable only from
+  `ailang test`. `make verify-examples` runs `ailang run`, never `ailang test`
+  (`scripts/verify_examples.go:108-115`, verified in iteration 126), so a regression here cannot
+  redden the examples gate — it would surface in `go test ./internal/testing/...` and in
+  `ailang test` on the contracts corpus, both of which are ACs above.
+
+---
+
+## 9. What this sprint explicitly does NOT do
+
+- **ZERO seed work.** No `--seed` flag, no change to `newRNG`'s wall-clock branch, no
+  `internal/testing/config.go`, no `TestConfig.WorkspaceRoot`. `#535` stays **OPEN**. M2/M3 of
+  `m-property-seed-determinism` remain date-gated to the 2026-08-03 07:00 re-arm.
+- No change to `internal/parser`, `internal/format`, or `ast.FuncDecl.IsPure` (§3).
+- No fix for "named test calls an effectful function" (§3, out-of-scope) — **file an issue**.
+- No change to how parse errors in generated temp modules are *attributed* to the originating
+  source file. `#548`'s secondary suggestion ("a user cannot act on a path that no longer
+  exists") is a genuine diagnostics defect but is a separate, larger change to pipeline error
+  reporting. **Record it in the landing comment as remaining open on `#548`'s thread**, or
+  `#548` gets closed with half its ask unaddressed.
+
+---
+
+## 10. Effect on the AC9 blocker
+
+After AC2.1 passes, `m-property-seed-determinism`'s §5.3 blocker is discharged in its **first**
+form — "produce a module-less contract fixture that survives `ExtractFunctionBinding`'s temp-file
+round-trip" — and `internal/testing/testdata/strip/moduleless_contract.ail` is that fixture. The
+re-arm session then does **not** need to restate AC9 over module-bearing files under two absolute
+roots (the weaker fallback), so AC9 keeps testing exactly what it was written to test: that the
+absolute checkout directory is absent from the hash identity.
+
+**Landing must update** `design_docs/planned/v0_31_0/m-property-seed-determinism-sprint-plan.md`
+§0.3 and §5.3 to record the discharge and name the fixture. If that edit is skipped, the 08-03
+session re-derives a blocker that no longer exists.
+
+---
+
+**SPRINT_PLAN_PATH**: `design_docs/planned/v0_31_0/m-strip-contract-awareness-sprint-plan.md`

--- a/internal/testing/executor.go
+++ b/internal/testing/executor.go
@@ -398,7 +398,7 @@ func (e *Executor) ExtractFunctionBinding(functionName string, sourceFile *ast.F
 	}
 
 	// Strip out non-pure functions
-	strippedSource := e.stripNonPureFunctions(string(sourceCode), sourceFile)
+	strippedSource := e.stripNonPureFunctions(string(sourceCode), sourceFile, functionName)
 
 	pipelineFilename := e.modulePath
 	if sourceFile.Module == nil {
@@ -465,92 +465,6 @@ func (e *Executor) ExtractFunctionBinding(functionName string, sourceFile *ast.F
 	}
 
 	return nil, fmt.Errorf("function '%s' not found in Core program", functionName)
-}
-
-// stripNonPureFunctions removes functions with effects and test/property
-// declaration blocks from source code.  Test blocks (test "name" { ... }) are
-// stripped because they are already collected into TestCase.Body and would
-// otherwise be re-elaborated as duplicate Core declarations — causing
-// evaluation of the wrong expression or type conflicts in EvalCoreProgram.
-func (e *Executor) stripNonPureFunctions(source string, file *ast.File) string {
-	var nonPureFunctions []string
-	for _, f := range file.Funcs {
-		if !f.IsPure {
-			nonPureFunctions = append(nonPureFunctions, f.Name)
-		}
-	}
-
-	// Collect line ranges occupied by test/property declarations.
-	// We use a brace-depth counter to find the closing } of each block.
-	type lineRange struct{ start, end int }
-	var skipRanges []lineRange
-
-	sourceLines := splitLines(source)
-	for _, decl := range file.Decls {
-		var startLine int
-		switch d := decl.(type) {
-		case *ast.TestDecl:
-			startLine = d.Pos.Line
-		case *ast.PropertyDecl:
-			startLine = d.Pos.Line
-		default:
-			continue
-		}
-
-		// Find the closing brace by scanning from startLine.
-		depth := 0
-		endLine := startLine
-		for i := startLine - 1; i < len(sourceLines); i++ {
-			for _, ch := range sourceLines[i] {
-				if ch == '{' {
-					depth++
-				} else if ch == '}' {
-					depth--
-					if depth == 0 {
-						endLine = i + 1 // 1-based
-						goto foundEnd
-					}
-				}
-			}
-		}
-	foundEnd:
-		skipRanges = append(skipRanges, lineRange{startLine, endLine})
-	}
-
-	inSkipRange := func(lineNum int) bool {
-		for _, r := range skipRanges {
-			if lineNum >= r.start && lineNum <= r.end {
-				return true
-			}
-		}
-		return false
-	}
-
-	lines := []string{}
-	for i, line := range sourceLines {
-		lineNum := i + 1 // 1-based
-		skip := false
-
-		// Skip lines inside test/property declaration blocks.
-		if inSkipRange(lineNum) {
-			skip = true
-		}
-
-		if !skip {
-			for _, funcName := range nonPureFunctions {
-				if containsPattern(line, "export func "+funcName) || containsPattern(line, "func "+funcName) {
-					skip = true
-					break
-				}
-			}
-		}
-
-		if !skip {
-			lines = append(lines, line)
-		}
-	}
-
-	return joinLines(lines)
 }
 
 // EvaluateLiteral converts an AST literal expression to an eval.Value.
@@ -679,13 +593,14 @@ func (e *Executor) ExtractPureClusterForFunction(
 		return nil, nil, fmt.Errorf("failed to read source file: %w", err)
 	}
 
-	strippedSource := e.stripNonPureFunctions(string(sourceCode), sourceFile)
-
 	cfg := pipeline.Config{
 		Mode: pipeline.ModeEval,
 	}
 	src := pipeline.Source{
-		Code:     strippedSource,
+		// With a filename, the module pipeline reloads source from disk
+		// (internal/pipeline/pipeline.go), so an in-memory strip here would be dead.
+		// Keep Code truthful for the file.size_bytes telemetry attribute.
+		Code:     string(sourceCode),
 		Filename: e.modulePath,
 		IsREPL:   false,
 	}

--- a/internal/testing/executor_helpers.go
+++ b/internal/testing/executor_helpers.go
@@ -238,11 +238,6 @@ func joinLines(lines []string) string {
 	return result
 }
 
-// Helper: check if line contains pattern
-func containsPattern(line, pattern string) bool {
-	return len(line) >= len(pattern) && findSubstring(line, pattern)
-}
-
 // Helper: find substring
 func findSubstring(s, substr string) bool {
 	if len(substr) == 0 {

--- a/internal/testing/source_strip.go
+++ b/internal/testing/source_strip.go
@@ -1,0 +1,108 @@
+package testing
+
+import "github.com/sunholo-data/ailang/internal/ast"
+
+type sourceLineRange struct {
+	start int
+	end   int
+}
+
+// stripNonPureFunctions removes non-pure function declarations and test/property
+// blocks from source code. keepFuncs names declarations that must survive even
+// when they are effectful, such as the function currently being extracted.
+func (e *Executor) stripNonPureFunctions(source string, file *ast.File, keepFuncs ...string) string {
+	keep := make(map[string]bool, len(keepFuncs))
+	for _, name := range keepFuncs {
+		keep[name] = true
+	}
+
+	sourceLines := splitLines(source)
+	skipRanges := functionSkipRanges(file, keep)
+	skipRanges = append(skipRanges, testAndPropertySkipRanges(sourceLines, file)...)
+
+	lines := make([]string, 0, len(sourceLines))
+	for i, line := range sourceLines {
+		if !lineInRanges(i+1, skipRanges) {
+			lines = append(lines, line)
+		}
+	}
+	return joinLines(lines)
+}
+
+func functionSkipRanges(file *ast.File, keep map[string]bool) []sourceLineRange {
+	var ranges []sourceLineRange
+	for _, f := range file.Funcs {
+		if keep[f.Name] || isEffectivelyPure(f) {
+			continue
+		}
+
+		startLine := f.Span.Start.Line
+		endLine := f.Span.End.Line
+		if endLine == 0 || endLine < startLine {
+			startLine = f.Pos.Line
+			endLine = f.Pos.Line
+		} else {
+			for _, annotation := range f.Annotations {
+				if annotation.Pos.Line > 0 && annotation.Pos.Line < startLine {
+					startLine = annotation.Pos.Line
+				}
+			}
+		}
+		ranges = append(ranges, sourceLineRange{start: startLine, end: endLine})
+	}
+	return ranges
+}
+
+// isEffectivelyPure mirrors the fixup at cmd/ailang/verify.go:160-168 and
+// cmd/ailang/ai_check.go:231-232: an explicit empty effect annotation (`! {}`)
+// is semantically pure, although the parser sets IsPure only for `pure`.
+// This stays local because internal/format/decl.go uses IsPure to emit source.
+func isEffectivelyPure(f *ast.FuncDecl) bool {
+	return f.IsPure || (f.Effects != nil && len(f.Effects) == 0)
+}
+
+// testAndPropertySkipRanges preserves the existing brace-depth treatment of
+// declarations already collected as test cases.
+func testAndPropertySkipRanges(sourceLines []string, file *ast.File) []sourceLineRange {
+	var ranges []sourceLineRange
+	for _, decl := range file.Decls {
+		var startLine int
+		switch d := decl.(type) {
+		case *ast.TestDecl:
+			startLine = d.Pos.Line
+		case *ast.PropertyDecl:
+			startLine = d.Pos.Line
+		default:
+			continue
+		}
+
+		depth := 0
+		endLine := startLine
+		for i := startLine - 1; i < len(sourceLines); i++ {
+			for _, ch := range sourceLines[i] {
+				switch ch {
+				case '{':
+					depth++
+				case '}':
+					depth--
+					if depth == 0 {
+						endLine = i + 1
+						goto foundEnd
+					}
+				}
+			}
+		}
+	foundEnd:
+		ranges = append(ranges, sourceLineRange{start: startLine, end: endLine})
+	}
+	return ranges
+}
+
+func lineInRanges(line int, ranges []sourceLineRange) bool {
+	for _, r := range ranges {
+		if line >= r.start && line <= r.end {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/testing/source_strip_test.go
+++ b/internal/testing/source_strip_test.go
@@ -1,0 +1,199 @@
+package testing
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/ast"
+	"github.com/sunholo-data/ailang/internal/lexer"
+	"github.com/sunholo-data/ailang/internal/parser"
+)
+
+func parseStripFixture(t *testing.T, name string) (string, string, *ast.File) {
+	t.Helper()
+	path := filepath.Join("testdata", "strip", name)
+	sourceBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	source := string(sourceBytes)
+	p := parser.New(lexer.New(source, path))
+	file := p.ParseFile()
+	if errs := p.Errors(); len(errs) > 0 {
+		t.Fatalf("parse %s: %v", path, errs)
+	}
+	return path, source, file
+}
+
+func TestStripNonPureFunctions_DeclarationRanges(t *testing.T) {
+	tests := []struct {
+		name    string
+		fixture string
+		absent  []string
+		present []string
+	}{
+		{
+			name:    "multiline body",
+			fixture: "named_test_multiline.ail",
+			absent:  []string{"export func big", "x > 10\n}"},
+			present: []string{"module named_test_multiline"},
+		},
+		{
+			name:    "contracts",
+			fixture: "named_test_contract.ail",
+			absent:  []string{"export func guarded", "requires {", "ensures {"},
+			present: []string{"module named_test_contract"},
+		},
+		{
+			name:    "leading annotation",
+			fixture: "named_test_annotated.ail",
+			absent:  []string{"@verify", "export func shout", "println(s)"},
+			present: []string{"export pure func big"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, source, file := parseStripFixture(t, tt.fixture)
+			// Exercise declaration-range deletion independently of the M2 policy:
+			// force the target declaration to be classified as effectful.
+			if tt.fixture != "named_test_annotated.ail" {
+				file.Funcs[0].Effects = []ast.EffectAnnotation{{Name: "IO"}}
+			}
+			got := new(Executor).stripNonPureFunctions(source, file)
+			for _, needle := range tt.absent {
+				if strings.Contains(got, needle) {
+					t.Errorf("stripped source unexpectedly contains %q:\n%s", needle, got)
+				}
+			}
+			for _, needle := range tt.present {
+				if !strings.Contains(got, needle) {
+					t.Errorf("stripped source does not contain control %q:\n%s", needle, got)
+				}
+			}
+		})
+	}
+}
+
+// Both disjuncts of the invalid-span guard (`endLine == 0 || endLine < startLine`)
+// must be exercised. Covering only the zero-value End lets the `< startLine`
+// disjunct be deleted with every test still green — a mutation that survived
+// the iteration-127 review and is the reason this is a table.
+func TestStripNonPureFunctions_InvalidSpanFallsBackToPosition(t *testing.T) {
+	source := "module fallback\nfunc remove() -> int { 1 }\nlet control = 2\n"
+
+	tests := []struct {
+		name string
+		span ast.Span
+	}{
+		{
+			// End is the zero value: hand-built ASTs, extern decls.
+			name: "unset end",
+			span: ast.Span{Start: ast.Pos{Line: 2}},
+		},
+		{
+			// End precedes Start. Without the `< startLine` disjunct this
+			// produces the inverted range {start:2,end:1}, which matches no
+			// line at all, so the declaration would survive uncut.
+			name: "end before start",
+			span: ast.Span{Start: ast.Pos{Line: 2}, End: ast.Pos{Line: 1}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file := &ast.File{Funcs: []*ast.FuncDecl{{
+				Name: "remove",
+				Pos:  ast.Pos{Line: 2},
+				Span: tt.span,
+			}}}
+			got := new(Executor).stripNonPureFunctions(source, file)
+			if strings.Contains(got, "func remove") {
+				t.Fatalf("fallback did not remove declaration line:\n%s", got)
+			}
+			if !strings.Contains(got, "let control = 2") {
+				t.Fatalf("fallback removed known-positive control:\n%s", got)
+			}
+		})
+	}
+}
+
+func TestStripNonPureFunctions_EffectivelyPureAndKeepSet(t *testing.T) {
+	source := strings.Join([]string{
+		"module policy",
+		"func implicit() -> int { 1 }",
+		"func explicit() -> int ! {} { 2 }",
+		"func effectful() -> int ! {IO} { 3 }",
+		"pure func keyword() -> int { 4 }",
+	}, "\n")
+	p := parser.New(lexer.New(source, "policy.ail"))
+	file := p.ParseFile()
+	if errs := p.Errors(); len(errs) > 0 {
+		t.Fatalf("parse policy source: %v", errs)
+	}
+	got := new(Executor).stripNonPureFunctions(source, file, "effectful")
+	for _, kept := range []string{"func explicit", "func effectful", "pure func keyword"} {
+		if !strings.Contains(got, kept) {
+			t.Errorf("expected %q to survive:\n%s", kept, got)
+		}
+	}
+	if strings.Contains(got, "func implicit") {
+		t.Errorf("implicit-effects function unexpectedly survived:\n%s", got)
+	}
+}
+
+func TestStripNonPureFunctions_ExtractFunctionBindingModuleless(t *testing.T) {
+	path, _, file := parseStripFixture(t, "moduleless_contract.ail")
+	executor := NewExecutor(path)
+	binding, err := executor.ExtractFunctionBinding("big", file)
+	if err != nil {
+		t.Fatalf("ExtractFunctionBinding(big): %v", err)
+	}
+	if binding == nil || binding.Name != "big" {
+		t.Fatalf("binding = %#v, want non-nil binding named big", binding)
+	}
+	if _, err := executor.ExtractFunctionBinding("nonexistent", file); err == nil || !strings.Contains(err.Error(), "function 'nonexistent' not found") {
+		t.Fatalf("negative control error = %v, want function-not-found", err)
+	}
+}
+
+func TestStripNonPureFunctions_ParseErrorDetectorHasPositiveControl(t *testing.T) {
+	tests := []struct {
+		fixture       string
+		strip         bool
+		wantParseCode bool
+	}{
+		{fixture: "named_test_multiline.ail", strip: true},
+		{fixture: "named_test_effectful.ail", strip: true},
+		{fixture: "named_test_annotated.ail", strip: true},
+		{fixture: "named_test_contract.ail", strip: true},
+		// Known-positive control: the detector must observe a genuine parse error.
+		{fixture: "malformed_control.ail", wantParseCode: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.fixture, func(t *testing.T) {
+			path := filepath.Join("testdata", "strip", tt.fixture)
+			sourceBytes, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			source := string(sourceBytes)
+			p := parser.New(lexer.New(source, path))
+			file := p.ParseFile()
+			if tt.strip {
+				if errs := p.Errors(); len(errs) > 0 {
+					t.Fatalf("parse fixture before strip: %v", errs)
+				}
+				source = new(Executor).stripNonPureFunctions(source, file)
+				p = parser.New(lexer.New(source, path))
+				p.ParseFile()
+			}
+			hasParseCode := strings.Contains(fmt.Sprint(p.Errors()), "PAR_NO_PREFIX_PARSE")
+			if hasParseCode != tt.wantParseCode {
+				t.Fatalf("PAR_NO_PREFIX_PARSE present = %v, want %v; errors: %v", hasParseCode, tt.wantParseCode, p.Errors())
+			}
+		})
+	}
+}

--- a/internal/testing/testdata/strip/malformed_control.ail
+++ b/internal/testing/testdata/strip/malformed_control.ail
@@ -1,0 +1,5 @@
+module malformed_control
+
+test "malformed" {
+  }
+}

--- a/internal/testing/testdata/strip/moduleless_contract.ail
+++ b/internal/testing/testdata/strip/moduleless_contract.ail
@@ -1,0 +1,5 @@
+export func big(x: int) -> bool ! {}
+requires { x >= 0 }
+ensures { result == (x > 10) } {
+  x > 10
+}

--- a/internal/testing/testdata/strip/moduleless_contract_control.ail
+++ b/internal/testing/testdata/strip/moduleless_contract_control.ail
@@ -1,0 +1,7 @@
+module moduleless_contract_control
+
+export func big(x: int) -> bool ! {}
+requires { x >= 0 }
+ensures { result == (x > 10) } {
+  x > 10
+}

--- a/internal/testing/testdata/strip/named_test_annotated.ail
+++ b/internal/testing/testdata/strip/named_test_annotated.ail
@@ -1,0 +1,14 @@
+module named_test_annotated
+
+import std/io (println)
+
+@verify(depth: 3)
+export func shout(s: string) -> () ! {IO} {
+  println(s)
+}
+
+export pure func big(x: int) -> bool { x > 10 }
+
+test "big works" {
+  big(20) == true
+}

--- a/internal/testing/testdata/strip/named_test_contract.ail
+++ b/internal/testing/testdata/strip/named_test_contract.ail
@@ -1,0 +1,9 @@
+module named_test_contract
+
+test "trivial" { true }
+
+export func guarded(x: int) -> bool ! {}
+requires { x > 0 }
+ensures { result == true } {
+  x > 0
+}

--- a/internal/testing/testdata/strip/named_test_effectful.ail
+++ b/internal/testing/testdata/strip/named_test_effectful.ail
@@ -1,0 +1,15 @@
+module named_test_effectful
+
+import std/io (println)
+
+export func shout(s: string) -> () ! {IO} {
+  println(s)
+}
+
+export pure func big(x: int) -> bool {
+  x > 10
+}
+
+test "big works" {
+  big(20) == true
+}

--- a/internal/testing/testdata/strip/named_test_multiline.ail
+++ b/internal/testing/testdata/strip/named_test_multiline.ail
@@ -1,0 +1,9 @@
+module named_test_multiline
+
+export func big(x: int) -> bool ! {} {
+  x > 10
+}
+
+test "big works" {
+  big(20) == true
+}


### PR DESCRIPTION
## What

`stripNonPureFunctions` deleted exactly **one line** of a function declaration that may span many, and treated any function not written with the `pure` keyword as effectful. Everything below that first line survived as orphaned top-level tokens, so the regenerated temp module failed to parse — and the error was reported against a `_namedtest_body_*.ail` the user never wrote and cannot inspect.

Four shapes reproduced at HEAD, all now `rc=0`:

| Shape | Pre-fix failure |
|---|---|
| multi-line function + named test | `unexpected token in expression: }` |
| contract-bearing function + named test | `unexpected token in expression: requires` |
| `@verify`-annotated function + named test | `PAR_ATTR_REQUIRES_FUNC` |
| module-less `export func` + `ensures` | extraction failed entirely |

**The defect is not contract-specific.** That was the first diagnosis; the planner refuted it and the refutation was confirmed first-party — a plain multi-line function with no contract at all corrupts identically. Contracts were just the loudest instance.

## How

New file `internal/testing/source_strip.go`, serving all three call sites (Critical Principle 3):

- delete whole AST declaration **spans**, extended upward over `@annotations` — annotations sit above `Span.Start`, so a span-only strip still breaks them
- `isEffectivelyPure`: an explicit empty effect annotation `! {}` counts as pure. Kept **local** to `internal/testing`, mirroring `cmd/ailang/ai_check.go:231`. Deriving it in the parser was rejected on measured blast radius — `internal/format/decl.go:57` emits `pure ` from that flag, so `ailang fmt` would begin inserting a keyword the author never typed
- a **keep-set**, so the function under extraction survives its own strip
- `ExtractPureClusterForFunction` no longer computes a stripped source the module pipeline never reads (it loads by filename); telemetry now reports truthful source bytes

`executor.go` 739 → 654 lines.

## Also unblocks the seed sprint

This discharges the **AC9 blocker** gating M2 of `m-property-seed-determinism`. AC9's original module-less fixture now passes **unmodified** — paired control: pre-fix `rc=1` with `PAR_NO_PREFIX_PARSE ... ensures`, post-fix `rc=0`. That plan's §0.3 / §5.3 / risk-row B3 are updated so the 2026-08-03 session does not re-derive a blocker that no longer exists.

**Zero seed work** — `#535` stays open by design, `newRNG` untouched.

## Verification

Gates re-run **outside** the codex sandbox (its `go test ./...` hit a loopback-bind denial, correctly labelled `UNINFORMATIVE UNDER SANDBOX`): `internal/testing` rc=0 · `gofmt` clean · `check-file-sizes` rc=0 · `make lint` rc=0.

Two failures confirmed **pre-existing** against a pristine `origin/dev`, not caused by this change:
- `cmd/wasm` build — a `GOOS=js` build-tag artifact
- `TestIsTempPath` — fails only when the worktree itself lives under `/tmp`; passes `rc=0` in a non-`/tmp` checkout

**Mutation testing:** four killed (purity policy, span collapse, annotation extension, `lineInRanges` off-by-one). The evaluator found a **fifth that survived** — the `endLine < startLine` disjunct of the invalid-span guard was untested — so the fallback test became a table covering both disjuncts, and that mutation is now demonstrably killed by the `end_before_start` subtest.

Planner opus · executor codex `gpt-5.6-sol` · evaluator sonnet **PASS 81/100 r1, zero blocking** (generator≠judge: OpenAI executor, Anthropic judge). All three non-blocking findings were acted on rather than filed.

Refs #535
Fixes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)