### PR TITLE
fix(test): build the ailang test binary ONCE per cmd/ailang run — unblocks red dev CI (test-windows 5m timeout)

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -6,6 +6,17 @@
 
 ### Fixed
 
+- **`cmd/ailang` tests build the `ailang` binary once per run instead of ~16 times
+  (#564).** `buildAilang`'s doc comment claimed it built "once per test run", but it
+  had no memoization — each of its 14 call sites re-linked the ~93 MB binary into a
+  fresh `t.TempDir()`, and two further call paths linked their own copies. The
+  redundant linking was 86% of the package's test runtime and pushed it past the 300s
+  CI ceiling, turning `test-windows` red on a docs-only commit. All three paths now
+  share one `sync.Once` builder (the pattern `budget_scoping_e2e_test.go` already
+  used): `cmd/ailang` drops from 110.8s to 15.5s. Test-infrastructure only — no
+  runtime, CLI, or language behaviour changes, and the 300s timeout is deliberately
+  unchanged since it is a real hang-detector.
+
 - **`ailang test` no longer corrupts the temp modules it generates (#548).**
   The internal strip that removes effectful functions before re-elaboration
   deleted only the *first line* of a declaration and treated any function not

--- a/cmd/ailang/budget_scoping_e2e_test.go
+++ b/cmd/ailang/budget_scoping_e2e_test.go
@@ -12,52 +12,15 @@ package main
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
-	"sync"
 	"testing"
 )
 
-var (
-	budgetBinOnce sync.Once
-	budgetBinPath string
-	budgetBinErr  error
-)
-
-// budgetBin builds the ailang binary once for the whole matrix into a temp dir
-// that survives across all tests (NOT a per-test t.TempDir, which is removed
-// when the first test returns and would delete the shared binary).
+// budgetBin returns the package-wide shared ailang test binary.
 func budgetBin(t *testing.T) string {
 	t.Helper()
-	budgetBinOnce.Do(func() {
-		projectRoot, err := filepath.Abs(filepath.Join("..", ".."))
-		if err != nil {
-			budgetBinErr = err
-			return
-		}
-		binName := "ailang-budget-e2e"
-		if runtime.GOOS == "windows" {
-			binName += ".exe"
-		}
-		dir, err := os.MkdirTemp("", "ailang-budget-e2e")
-		if err != nil {
-			budgetBinErr = err
-			return
-		}
-		budgetBinPath = filepath.Join(dir, binName)
-		cmd := exec.Command("go", "build", "-o", budgetBinPath, "./cmd/ailang")
-		cmd.Dir = projectRoot
-		if out, err := cmd.CombinedOutput(); err != nil {
-			budgetBinErr = err
-			t.Logf("build output:\n%s", out)
-		}
-	})
-	if budgetBinErr != nil {
-		t.Fatalf("ailang binary build failed: %v", budgetBinErr)
-	}
-	return budgetBinPath
+	return buildAilang(t)
 }
 
 // runBudget writes src to a temp module and runs `main` with --caps IO.

--- a/cmd/ailang/main_test.go
+++ b/cmd/ailang/main_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/sunholo-data/ailang/internal/effects"
@@ -423,28 +424,53 @@ func TestSetupNetHandler(t *testing.T) {
 	}
 }
 
-// TestCLI_NetAllowHTTPFlag_Exists is a regression test ensuring the
-// --net-allow-http flag is recognized by the CLI (not just documented).
+var (
+	ailangBinOnce   sync.Once
+	ailangBinPath   string
+	ailangBinErr    error
+	ailangBinOutput []byte
+)
+
 // buildAilang builds the ailang binary once per test run and returns its path.
+// It is the package's single builder: every test that needs a real ailang
+// executable goes through here. Linking this binary costs ~5s warm, and the
+// package used to link it 16 times, which is what pushed cmd/ailang past the
+// 300s CI ceiling on the (slower) windows-latest runner.
+//
+// The shared binary lives in an os.MkdirTemp directory, not a per-test
+// t.TempDir: t.TempDir is removed when the first caller returns and would
+// delete the binary before later tests can use it. TestMain removes it after
+// m.Run() returns.
 // Uses a compiled binary instead of "go run" so exit codes propagate correctly.
 func buildAilang(t *testing.T) string {
 	t.Helper()
-	projectRoot, err := filepath.Abs(filepath.Join("..", ".."))
-	if err != nil {
-		t.Fatalf("Failed to get project root: %v", err)
+	ailangBinOnce.Do(func() {
+		projectRoot, err := filepath.Abs(filepath.Join("..", ".."))
+		if err != nil {
+			ailangBinErr = err
+			return
+		}
+		// Windows refuses to exec a file without the .exe suffix, failing with
+		// "executable file not found in %PATH%" — which reads like a missing
+		// toolchain rather than the naming bug it actually is.
+		binName := "ailang"
+		if runtime.GOOS == "windows" {
+			binName = "ailang.exe"
+		}
+		dir, err := os.MkdirTemp("", "ailang-test-bin")
+		if err != nil {
+			ailangBinErr = err
+			return
+		}
+		ailangBinPath = filepath.Join(dir, binName)
+		cmd := exec.Command("go", "build", "-o", ailangBinPath, "./cmd/ailang")
+		cmd.Dir = projectRoot
+		ailangBinOutput, ailangBinErr = cmd.CombinedOutput()
+	})
+	if ailangBinErr != nil {
+		t.Fatalf("Failed to build ailang: %v\n%s", ailangBinErr, ailangBinOutput)
 	}
-	binName := "ailang"
-	if runtime.GOOS == "windows" {
-		binName = "ailang.exe"
-	}
-	binPath := filepath.Join(t.TempDir(), binName)
-	cmd := exec.Command("go", "build", "-o", binPath, "./cmd/ailang")
-	cmd.Dir = projectRoot
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to build ailang: %v\n%s", err, out)
-	}
-	return binPath
+	return ailangBinPath
 }
 
 // runAilangBin runs a pre-built ailang binary and returns stdout, stderr, exit code.

--- a/cmd/ailang/prompt_test.go
+++ b/cmd/ailang/prompt_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -297,5 +298,9 @@ func TestMain(m *testing.M) {
 		}
 	}
 
-	os.Exit(m.Run())
+	code := m.Run()
+	if ailangBinPath != "" {
+		_ = os.RemoveAll(filepath.Dir(ailangBinPath))
+	}
+	os.Exit(code)
 }

--- a/cmd/ailang/serve_api_mcp_surface_test.go
+++ b/cmd/ailang/serve_api_mcp_surface_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 )
@@ -18,18 +17,7 @@ func TestServeAPI_MCPToolSurface(t *testing.T) {
 	if testing.Short() {
 		t.Skip("builds and drives the serve-api stdio MCP binary")
 	}
-	// Windows refuses to exec a file without the .exe suffix, failing with
-	// "executable file not found in %PATH%" — which reads like a missing
-	// toolchain rather than the naming bug it actually is.
-	binaryName := "ailang"
-	if runtime.GOOS == "windows" {
-		binaryName += ".exe"
-	}
-	binary := filepath.Join(t.TempDir(), binaryName)
-	build := exec.Command("go", "build", "-o", binary, ".")
-	if output, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("go build: %v\n%s", err, output)
-	}
+	binary := buildAilang(t)
 
 	moduleRoot := t.TempDir()
 	modulePath := filepath.Join(moduleRoot, "api", "surface.ail")


### PR DESCRIPTION
## Why

`test-windows` went **RED on dev HEAD `773894d87`**:

```
panic: test timed out after 5m0s
  running tests:
    TestTestCommand_JSONStdoutPackage (4s)
...
  cmd/ailang.buildAilang(...) cmd/ailang/main_test.go:443
FAIL github.com/sunholo-data/ailang/cmd/ailang  300.527s
```

`773894d87` is a **docs-only** commit and 11 of the previous 12 dev runs were green — this is not a code regression. The `cmd/ailang` package had been sitting just under its 300s ceiling (`ci.yml:74` linux, `:318` windows) and finally tipped over on the slower `windows-latest` runner.

## Root cause

`buildAilang` (`main_test.go:430`) carried the comment *"builds the ailang binary once per test run"* — **the comment was false**. There was no memoization: every call ran a full `go build` into a fresh `t.TempDir()`, re-linking the ~93 MB binary. **14 call sites**, plus two more independent full links of the same binary in the same package:

- `budget_scoping_e2e_test.go` — **already correct** (`sync.Once` + persistent temp dir). This is the pattern that was copied.
- `serve_api_mcp_surface_test.go` — its own `go build -o ... "."`.

≈**16 links of one identical binary inside a 300s budget.**

## Fix

One systemic fix rather than three patches (CLAUDE.md Principle 3): package-level `sync.Once` + a persistent `os.MkdirTemp` dir (**not** `t.TempDir`, which is torn down when the *first* caller returns and would delete the shared binary), all three call paths routed through it, `TestMain` removing the dir after `m.Run()`. `buildAilang`'s signature is unchanged, so **no call site moved**.

**The 300s timeout is not raised and nothing is skipped** — it is a real hang-detector and stays.

## Measured (controller, outside the codex sandbox, same machine + worktree)

| | `cmd/ailang` |
|---|---|
| before | `ok 110.833s` (rc=0) |
| after | `ok  15.487s` (rc=0) |

**7.2×, 95s saved — 86% of the package's runtime was redundant re-linking.** Executor instrumentation: 18 test runs → **1** physical build marker (probe reverted, `git diff` confirmed clean of it).

## Two `go test ./...` failures investigated — neither is from this diff

- `internal/effects` `TestNetHttpPost` — reproduces **identically on unmodified `origin/dev`** (httpbin.org 503). Pre-existing, #561.
- `internal/smt` `TestSolve_HardTimeout_FakeSolverIgnoringT` — passes **3/3 alone** in this worktree, and the diff touches **zero files outside `cmd/ailang`**. A 3s hard-timeout test flaking under full-suite parallelism.

CI's anti-silent-skip gate re-verified: all three required tests PASS once the environment matches CI. The two local skips were `internal/testutil`'s staleness guard doing its job (no `bin/ailang`; on-PATH binary older than the just-edited sources).

`gofmt` clean · `go vet ./cmd/ailang` rc=0.

Mission-control iteration 134 · executor `codex:gpt-5.6-sol`, controller Opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)