### PR TITLE
docs(skills): fix iter-134's own Gate-4 control — a known-absent literal poisons itself in a self-describing file

### DIFF
--- a/.claude/skills/mission-control/SKILL.md
+++ b/.claude/skills/mission-control/SKILL.md
@@ -968,9 +968,19 @@ a charter that was byte-identical to origin. This is rule 3a's trap wearing THIS
 and it is the worst place for it: a broken tell and a genuinely stale charter produce the
 identical output, so the failure routes a healthy iteration down the stale-copy path — or, in the
 other direction, teaches you to distrust a tell you will need for real. Run it as
-`grep -c "ITERATION <N-1>"` **alongside two controls in the same breath**: a known-present one
-(`ITERATION <N-2>`, must be ≥1) and a known-absent one (`ITERATION 999`, must be 0). A `0` on the
-known-present control means your instrument is broken, not that the charter is stale.
+`grep -c "ITERATION <N-1>"` **alongside a known-present control in the same breath**
+(`ITERATION <N-2>`, must be ≥1). A `0` on the control means your instrument is broken, not that
+the charter is stale — that is the failure mode here, and the known-present control is the one
+that catches it.
+
+**Do NOT add a known-absent literal as a second control — in a file the loop WRITES ABOUT ITSELF,
+the absent token does not stay absent.** Iteration 134 shipped `ITERATION 999` as its
+known-absent control and then measured it coming back **1** within the same iteration: the STATUS
+stamp it had just written *documents the control*, so the literal is now in the charter forever.
+Any self-describing file poisons this class of control the moment a record mentions it. Where you
+want a structural second check, assert the rotation invariant instead —
+`grep -c "^## STATUS 2026"` must equal **3** — which is anchored to line-start and cannot be
+tripped by prose.
 
 **THE STATUS ROTATION IS THE MOST DANGEROUS EDIT THIS LOOP MAKES — SCRIPT IT WITH A LINE-COUNT
 ASSERTION, NEVER A BARE `## `-HEADER SCAN** (added 2026-08-01 iteration 127; third failure of this


### PR DESCRIPTION
Correction to the Gate-5 skill edit landed minutes ago in #570 — caught by running the check it added.

#570 told Gate 4 to pair the charter cheap tell with two controls: known-present `ITERATION <N-2>` and known-absent `ITERATION 999`. Verifying the landed record, the **known-absent control returned `1`, not `0`**.

Cause: the STATUS stamp #570 had just written *documents the control*, so `ITERATION 999` is now in the charter permanently. The charter is a file the loop **writes about itself**, so any literal named "known-absent" stops being absent the moment a record mentions it. And unlike the case-sensitivity bug it was added to fix, this one fails **silently in the safe-looking direction** — the control reads as firing while proving nothing.

**Fix:** keep the known-**present** control (the one that actually detects the failure mode: a broken instrument reads `0` on a healthy charter). Drop the known-absent literal. Where a structural second check is wanted, assert the rotation invariant `grep -c "^## STATUS 2026" == 3` — anchored to line-start, untrippable by prose.

Saved in the main checkout first (same inode via the `~/.claude` symlink, so it is live now) and mirrored here — no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)