### PR TITLE
feat(serveapi): #498 Lane B M1 — public embeddable contract, authorized surface, bounded callback runner

### DIFF
--- a/design_docs/planned/v1_0_0/m-mcp-exact-tool-surface-lane-b-sprint-plan.md
+++ b/design_docs/planned/v1_0_0/m-mcp-exact-tool-surface-lane-b-sprint-plan.md
@@ -96,6 +96,24 @@ name → `validateMCPName` (AILANG's stricter `^[a-zA-Z0-9_-]{1,64}$`, not the S
 The doc's M1 AC only tests "a scalar input schema"; **a nil-schema case is added**, and M2 gains a
 panic-safety AC.
 
+> **UPDATE (iteration 139, after M1 landed) — a FIFTH panic case is NOT covered by M1, and it is an
+> M2 prerequisite.** M1's `validateToolDescriptor` covers nil / non-object / unmarshalable input
+> schema, unmarshalable output schema, and the name rule. It does **not** cover
+> `validateParamHeaderAnnotations`, which the SDK reaches at `mcp/server.go:312-313` and which
+> **panics** (`AddTool %q: invalid parameter header annotations`) — controller-reproduced
+> first-party, with the already-confirmed `missing input schema` panic as the known-positive
+> control in the same call. It fires on an `x-mcp-header` property annotation that is not a valid
+> HTTP header name, is applied to a non-primitive type, or is duplicated. This is invisible today
+> because M1 never calls `AddTool` (both handlers return `NotFoundHandler`); it goes live the
+> moment M2 registers per request from caller-supplied descriptors.
+> **M2 AC5 is therefore NOT sound as written unless it does both:** (a) extend
+> `validateToolDescriptor` with the same annotation check, so an invalid descriptor is rejected
+> loudly like every other invalid class, **and** (b) wrap the per-request `AddTool` in `recover()`
+> mapped to the already-frozen `-32603` envelope, as the backstop for any panic case the SDK adds
+> later. (b) alone would silently accept a descriptor class the contract calls invalid — the
+> CLAUDE.md §2 failure mode. Raised by the M1 sonnet evaluator (NB-1); reproduced by the controller
+> before adoption, per the rule that a judge's finding is a claim until measured.
+
 ### 0.6 NEW — the doc contradicts itself on WHERE resolution happens, and only one of the two options can emit the frozen envelope.
 
 Two statements cannot both hold:

--- a/internal/apiserver/authorized_surface.go
+++ b/internal/apiserver/authorized_surface.go
@@ -1,0 +1,96 @@
+package apiserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// ToolDescriptor is the internal, protocol-neutral form of a host tool.
+// The public serveapi facade converts its descriptors to this type.
+type ToolDescriptor struct {
+	Name         string
+	Description  string
+	InputSchema  json.RawMessage
+	OutputSchema json.RawMessage
+	Tags         []string
+	Examples     []string
+}
+
+// AuthorizedSurface is a validated, sorted, request-local tool surface.
+// Its contents are detached from all caller-owned storage.
+type AuthorizedSurface struct {
+	tools  []ToolDescriptor
+	byName map[string]int
+}
+
+// callerSurface copies and validates descriptors supplied by an embedding host.
+func callerSurface(descriptors []ToolDescriptor) (*AuthorizedSurface, error) {
+	tools := make([]ToolDescriptor, len(descriptors))
+	for i, descriptor := range descriptors {
+		tool := cloneToolDescriptor(descriptor)
+		if err := validateToolDescriptor(tool); err != nil {
+			return nil, fmt.Errorf("tool descriptor %d: %w", i, err)
+		}
+		tools[i] = tool
+	}
+
+	sort.Slice(tools, func(i, j int) bool { return tools[i].Name < tools[j].Name })
+	byName := make(map[string]int, len(tools))
+	for i, tool := range tools {
+		if _, exists := byName[tool.Name]; exists {
+			return nil, fmt.Errorf("duplicate tool name %q", tool.Name)
+		}
+		byName[tool.Name] = i
+	}
+	return &AuthorizedSurface{tools: tools, byName: byName}, nil
+}
+
+func validateToolDescriptor(tool ToolDescriptor) error {
+	if err := validateMCPName(tool.Name); err != nil {
+		return err
+	}
+	if tool.InputSchema == nil {
+		return fmt.Errorf("tool %q: input schema is required", tool.Name)
+	}
+	var input map[string]any
+	if err := json.Unmarshal(tool.InputSchema, &input); err != nil {
+		return fmt.Errorf("tool %q: invalid input schema: %w", tool.Name, err)
+	}
+	if input == nil || input["type"] != "object" {
+		return fmt.Errorf("tool %q: input schema must have type object", tool.Name)
+	}
+	if tool.OutputSchema != nil {
+		var output any
+		if err := json.Unmarshal(tool.OutputSchema, &output); err != nil {
+			return fmt.Errorf("tool %q: invalid output schema: %w", tool.Name, err)
+		}
+	}
+	return nil
+}
+
+func cloneToolDescriptor(tool ToolDescriptor) ToolDescriptor {
+	tool.InputSchema = append(json.RawMessage(nil), tool.InputSchema...)
+	tool.OutputSchema = append(json.RawMessage(nil), tool.OutputSchema...)
+	tool.Tags = append([]string(nil), tool.Tags...)
+	tool.Examples = append([]string(nil), tool.Examples...)
+	return tool
+}
+
+// Lookup returns a detached descriptor for name.
+func (s *AuthorizedSurface) Lookup(name string) (ToolDescriptor, bool) {
+	i, ok := s.byName[name]
+	if !ok {
+		return ToolDescriptor{}, false
+	}
+	return cloneToolDescriptor(s.tools[i]), true
+}
+
+// All returns a detached, sorted descriptor slice.
+func (s *AuthorizedSurface) All() []ToolDescriptor {
+	result := make([]ToolDescriptor, len(s.tools))
+	for i, tool := range s.tools {
+		result[i] = cloneToolDescriptor(tool)
+	}
+	return result
+}

--- a/internal/apiserver/authorized_surface_test.go
+++ b/internal/apiserver/authorized_surface_test.go
@@ -1,0 +1,91 @@
+package apiserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func validDescriptor(name string) ToolDescriptor {
+	return ToolDescriptor{
+		Name:         name,
+		Description:  "description-" + name,
+		InputSchema:  json.RawMessage(`{"type":"object","properties":{"x":{"type":"string"}}}`),
+		OutputSchema: json.RawMessage(`{"type":"string"}`),
+		Tags:         []string{"tag-" + name},
+		Examples:     []string{"example-" + name},
+	}
+}
+
+func TestCallerSurfaceSortLookupAndDeepCopy(t *testing.T) {
+	zeta := validDescriptor("zeta")
+	alpha := validDescriptor("alpha")
+	input := []ToolDescriptor{zeta, alpha}
+	surface, err := callerSurface(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := surface.All()
+	if len(want) != 2 {
+		t.Fatal("instrument failure: expected non-empty surface")
+	}
+	if want[0].Name != "alpha" || want[1].Name != "zeta" {
+		t.Fatalf("surface order = [%s, %s]", want[0].Name, want[1].Name)
+	}
+
+	// Materialize the pre-mutation surface into bytes. Comparing two All() results
+	// would be VACUOUS: under a shallow clone both alias the caller's storage, so
+	// both change together and the comparison holds however broken the copy is
+	// (measured — that exact mutation survived this test in its original form).
+	wantJSON, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	input[0].Name = "mutated"
+	input[1].InputSchema[2] = 'X'
+	input[1].OutputSchema[2] = 'X'
+	input[1].Tags[0] = "mutated"
+	input[1].Examples[0] = "mutated"
+	gotJSON, err := json.Marshal(surface.All())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(gotJSON, wantJSON) {
+		t.Fatalf("surface changed after caller mutation:\n got %s\nwant %s", gotJSON, wantJSON)
+	}
+
+	// Mutating a returned slice must not reach the surface either. Compared against
+	// a literal, not against another All() result, for the same reason.
+	result := surface.All()
+	result[0].Tags[0] = "result mutation"
+	again, ok := surface.Lookup("alpha")
+	if !ok || again.Tags[0] != "tag-alpha" {
+		t.Fatalf("returned storage aliases surface: %#v", again)
+	}
+}
+
+func TestCallerSurfaceRejectsUnsafeDescriptors(t *testing.T) {
+	tests := []struct {
+		name  string
+		tools []ToolDescriptor
+		want  string
+	}{
+		{"duplicate", []ToolDescriptor{validDescriptor("alpha"), validDescriptor("alpha")}, "duplicate"},
+		{"nil input", []ToolDescriptor{{Name: "alpha"}}, "required"},
+		{"scalar input", []ToolDescriptor{{Name: "alpha", InputSchema: json.RawMessage(`"scalar"`)}}, "invalid input"},
+		{"non-object input", []ToolDescriptor{{Name: "alpha", InputSchema: json.RawMessage(`{"type":"array"}`)}}, "type object"},
+		{"invalid input JSON", []ToolDescriptor{{Name: "alpha", InputSchema: json.RawMessage(`{`)}}, "invalid input"},
+		{"invalid output JSON", []ToolDescriptor{{Name: "alpha", InputSchema: json.RawMessage(`{"type":"object"}`), OutputSchema: json.RawMessage(`{`)}}, "invalid output"},
+		{"bad name", []ToolDescriptor{{Name: "bad name", InputSchema: json.RawMessage(`{"type":"object"}`)}}, "invalid"},
+		{"long name", []ToolDescriptor{{Name: strings.Repeat("a", 65), InputSchema: json.RawMessage(`{"type":"object"}`)}}, "invalid"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := callerSurface(test.tools); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("callerSurface() error = %v, want containing %q", err, test.want)
+			}
+		})
+	}
+}

--- a/internal/apiserver/callbacks.go
+++ b/internal/apiserver/callbacks.go
@@ -1,0 +1,66 @@
+package apiserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrCallbackCapacity is returned when no host-callback slot becomes available
+// before the bounded callback context ends.
+var ErrCallbackCapacity = errors.New("host callback capacity exceeded")
+
+// CallbackRunner bounds handler wait time and concurrently started host calls.
+// A slot remains occupied until host code actually returns, even after timeout.
+type CallbackRunner struct {
+	timeout time.Duration
+	slots   chan struct{}
+}
+
+// NewCallbackRunner constructs a callback runner from effective positive limits.
+func NewCallbackRunner(timeout time.Duration, maxConcurrent int) (*CallbackRunner, error) {
+	if timeout <= 0 {
+		return nil, fmt.Errorf("callback timeout must be positive")
+	}
+	if maxConcurrent <= 0 {
+		return nil, fmt.Errorf("maximum concurrent callbacks must be positive")
+	}
+	return &CallbackRunner{timeout: timeout, slots: make(chan struct{}, maxConcurrent)}, nil
+}
+
+type callbackResult[T any] struct {
+	value T
+	err   error
+}
+
+// RunCallback executes callback with a bounded context. In-process callbacks
+// cannot be forcibly terminated; a non-cooperative callback keeps its slot.
+func RunCallback[T any](ctx context.Context, runner *CallbackRunner, callback func(context.Context) (T, error)) (T, error) {
+	var zero T
+	callCtx, cancel := context.WithTimeout(ctx, runner.timeout)
+	defer cancel()
+
+	select {
+	case runner.slots <- struct{}{}:
+	case <-callCtx.Done():
+		if ctx.Err() != nil {
+			return zero, ctx.Err()
+		}
+		return zero, ErrCallbackCapacity
+	}
+
+	result := make(chan callbackResult[T], 1)
+	go func() {
+		defer func() { <-runner.slots }()
+		value, err := callback(callCtx)
+		result <- callbackResult[T]{value: value, err: err}
+	}()
+
+	select {
+	case completed := <-result:
+		return completed.value, completed.err
+	case <-callCtx.Done():
+		return zero, callCtx.Err()
+	}
+}

--- a/internal/apiserver/callbacks_test.go
+++ b/internal/apiserver/callbacks_test.go
@@ -1,0 +1,145 @@
+package apiserver
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestCallbackRunnerTimeoutAndStopsChain(t *testing.T) {
+	runner, err := NewCallbackRunner(20*time.Millisecond, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	release := make(chan struct{})
+	defer close(release)
+	start := time.Now()
+	_, err = RunCallback(context.Background(), runner, func(context.Context) (int, error) {
+		<-release
+		return 1, nil
+	})
+	elapsed := time.Since(start)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want deadline exceeded", err)
+	}
+	if elapsed < 20*time.Millisecond || elapsed >= 250*time.Millisecond {
+		t.Fatalf("elapsed = %v, want [20ms, 250ms)", elapsed)
+	}
+	// The chain-level "stop after a timeout" clause needs a chain, which arrives
+	// with the M2 wrapper; guarding a follow-up call on `err == nil` here would be
+	// dead code and the counter assertion would hold under any implementation.
+	// What IS provable at the runner level is the stronger half of the same claim:
+	// a timed-out callback keeps its slot until it actually RETURNS, so the next
+	// call on a saturated runner is rejected without host code ever being entered.
+	// This fails if the token is released when the handler stops waiting.
+	var next atomic.Int32
+	_, nextErr := RunCallback(context.Background(), runner, func(context.Context) (int, error) {
+		next.Add(1)
+		return 0, nil
+	})
+	if !errors.Is(nextErr, ErrCallbackCapacity) {
+		t.Fatalf("follow-up call error = %v, want capacity exceeded", nextErr)
+	}
+	if next.Load() != 0 {
+		t.Fatalf("next callback entered %d times", next.Load())
+	}
+}
+
+func TestCallbackRunnerObservedDeadlineAndFastCall(t *testing.T) {
+	runner, err := NewCallbackRunner(5*time.Second, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	deadline, err := RunCallback(context.Background(), runner, func(ctx context.Context) (time.Time, error) {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("callback context has no deadline")
+		}
+		return deadline, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deadline.Before(now.Add(4*time.Second)) || deadline.After(now.Add(6*time.Second)) {
+		t.Fatalf("observed deadline %v outside expected window from %v", deadline, now)
+	}
+	value, err := RunCallback(context.Background(), runner, func(context.Context) (int, error) { return 137, nil })
+	if err != nil || value != 137 {
+		t.Fatalf("fast callback = (%d, %v)", value, err)
+	}
+}
+
+func TestCallbackRunnerBoundsConcurrencyAndRecovers(t *testing.T) {
+	runner, err := NewCallbackRunner(30*time.Millisecond, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	release := make(chan struct{})
+	var starts atomic.Int32
+	runBurst := func(count int) int {
+		var overloads atomic.Int32
+		var wg sync.WaitGroup
+		for range count {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, callErr := RunCallback(context.Background(), runner, func(context.Context) (int, error) {
+					starts.Add(1)
+					<-release
+					return 0, nil
+				})
+				if errors.Is(callErr, ErrCallbackCapacity) {
+					overloads.Add(1)
+				}
+			}()
+		}
+		wg.Wait()
+		return int(overloads.Load())
+	}
+	baseline := runtime.NumGoroutine()
+	if overloads := runBurst(40); overloads != 36 {
+		t.Fatalf("40-call overloads = %d, want 36", overloads)
+	}
+	if starts.Load() != 4 {
+		t.Fatalf("callback starts = %d, want 4", starts.Load())
+	}
+	after40 := runtime.NumGoroutine()
+	if overloads := runBurst(80); overloads != 80 {
+		t.Fatalf("80-call overloads = %d, want 80", overloads)
+	}
+	after80 := runtime.NumGoroutine()
+	if growth := after80 - after40; growth > 4 {
+		t.Fatalf("goroutines grew with rejected call count: baseline=%d after40=%d after80=%d", baseline, after40, after80)
+	}
+	close(release)
+	deadline := time.Now().Add(time.Second)
+	for len(runner.slots) != 0 && time.Now().Before(deadline) {
+		runtime.Gosched()
+	}
+	if len(runner.slots) != 0 {
+		t.Fatal("capacity did not recover after callbacks returned")
+	}
+
+	fastRunner, _ := NewCallbackRunner(time.Second, 4)
+	var fastOverloads atomic.Int32
+	var wg sync.WaitGroup
+	for range 40 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, callErr := RunCallback(context.Background(), fastRunner, func(context.Context) (int, error) { return 1, nil })
+			if errors.Is(callErr, ErrCallbackCapacity) {
+				fastOverloads.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	if fastOverloads.Load() != 0 {
+		t.Fatalf("fast callbacks overloaded %d times", fastOverloads.Load())
+	}
+}

--- a/serveapi/serveapi.go
+++ b/serveapi/serveapi.go
@@ -1,0 +1,139 @@
+// Package serveapi exposes AILANG-owned protocol handlers while leaving
+// identity, session, capability, and execution policy to the embedding host.
+package serveapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/sunholo-data/ailang/internal/apiserver"
+)
+
+const (
+	DefaultCallbackTimeout        = 5 * time.Second
+	DefaultMaxConcurrentCallbacks = 64
+)
+
+type Session any
+
+type SessionResolver interface {
+	ResolveSession(context.Context, *http.Request) (Session, error)
+}
+
+type ToolSource interface {
+	Tools(context.Context, Session) ([]ToolDescriptor, error)
+}
+
+type Invoker interface {
+	Invoke(context.Context, Session, Invocation) (InvocationResult, error)
+}
+
+type ToolDescriptor struct {
+	Name         string
+	Description  string
+	InputSchema  json.RawMessage
+	OutputSchema json.RawMessage
+	Tags         []string
+	Examples     []string
+}
+
+type Invocation struct {
+	Name      string
+	Arguments json.RawMessage
+}
+
+type InvocationResult struct {
+	Value json.RawMessage
+}
+
+type AgentInfo struct {
+	Name        string
+	Description string
+	Version     string
+}
+
+type Config struct {
+	Resolver               SessionResolver
+	Tools                  ToolSource
+	Invoker                Invoker
+	Agent                  AgentInfo
+	CallbackTimeout        time.Duration
+	MaxConcurrentCallbacks int
+}
+
+// Server is an embeddable protocol surface. Wire adapters are completed in
+// later milestones; M1 establishes and validates the host contract.
+type Server struct {
+	config Config
+	runner *apiserver.CallbackRunner
+}
+
+func New(cfg Config) (*Server, error) {
+	if isNilInterface(cfg.Resolver) {
+		return nil, errors.New("session resolver is required")
+	}
+	if isNilInterface(cfg.Tools) {
+		return nil, errors.New("tool source is required")
+	}
+	if isNilInterface(cfg.Invoker) {
+		return nil, errors.New("invoker is required")
+	}
+	if strings.TrimSpace(cfg.Agent.Name) == "" {
+		return nil, errors.New("agent name is required")
+	}
+	if strings.TrimSpace(cfg.Agent.Version) == "" {
+		return nil, errors.New("agent version is required")
+	}
+	if cfg.CallbackTimeout < 0 {
+		return nil, errors.New("callback timeout must not be negative")
+	}
+	if cfg.MaxConcurrentCallbacks < 0 {
+		return nil, errors.New("maximum concurrent callbacks must not be negative")
+	}
+	if cfg.CallbackTimeout == 0 {
+		cfg.CallbackTimeout = DefaultCallbackTimeout
+	}
+	if cfg.MaxConcurrentCallbacks == 0 {
+		cfg.MaxConcurrentCallbacks = DefaultMaxConcurrentCallbacks
+	}
+	runner, err := apiserver.NewCallbackRunner(cfg.CallbackTimeout, cfg.MaxConcurrentCallbacks)
+	if err != nil {
+		return nil, fmt.Errorf("configure callback runner: %w", err)
+	}
+	return &Server{config: cfg, runner: runner}, nil
+}
+
+// MCPHandler returns the MCP endpoint handler. Wire behavior lands in M2.
+func (s *Server) MCPHandler() http.Handler { return http.NotFoundHandler() }
+
+// A2AHandler returns the A2A endpoint handler. Wire behavior lands in M3.
+func (s *Server) A2AHandler() http.Handler { return http.NotFoundHandler() }
+
+// Mount reserves the public protocol routes. Full routing lands in M3.
+func (s *Server) Mount(mux *http.ServeMux) {
+	if mux == nil {
+		return
+	}
+	mux.Handle("/mcp/", s.MCPHandler())
+	mux.Handle("/.well-known/agent.json", s.A2AHandler())
+	mux.Handle("/a2a/", s.A2AHandler())
+}
+
+func isNilInterface(value any) bool {
+	if value == nil {
+		return true
+	}
+	v := reflect.ValueOf(value)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
+}

--- a/serveapi/serveapi_external_test.go
+++ b/serveapi/serveapi_external_test.go
@@ -1,0 +1,154 @@
+package serveapi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sunholo-data/ailang/internal/apiserver"
+)
+
+type fixtureHost struct{}
+
+func (fixtureHost) ResolveSession(context.Context, *http.Request) (Session, error) {
+	return "session", nil
+}
+func (fixtureHost) Tools(context.Context, Session) ([]ToolDescriptor, error) { return nil, nil }
+func (fixtureHost) Invoke(context.Context, Session, Invocation) (InvocationResult, error) {
+	return InvocationResult{}, nil
+}
+
+func validConfig() Config {
+	host := fixtureHost{}
+	return Config{
+		Resolver: host,
+		Tools:    host,
+		Invoker:  host,
+		Agent:    AgentInfo{Name: "fixture", Version: "1.0.0"},
+	}
+}
+
+func TestNewValidationAndEffectiveDefaultDeadline(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Config)
+	}{
+		{"nil resolver", func(c *Config) { c.Resolver = nil }},
+		{"nil tools", func(c *Config) { c.Tools = nil }},
+		{"nil invoker", func(c *Config) { c.Invoker = nil }},
+		{"empty agent name", func(c *Config) { c.Agent.Name = " " }},
+		{"empty agent version", func(c *Config) { c.Agent.Version = "" }},
+		{"negative timeout", func(c *Config) { c.CallbackTimeout = -time.Second }},
+		{"negative concurrency", func(c *Config) { c.MaxConcurrentCallbacks = -1 }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := validConfig()
+			test.mutate(&cfg)
+			if _, err := New(cfg); err == nil {
+				t.Fatal("New() succeeded, want validation error")
+			}
+		})
+	}
+
+	server, err := New(validConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	deadline, err := apiserver.RunCallback(context.Background(), server.runner, func(ctx context.Context) (time.Time, error) {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("callback context has no deadline")
+		}
+		return deadline, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deadline.Before(now.Add(4*time.Second)) || deadline.After(now.Add(6*time.Second)) {
+		t.Fatalf("default deadline %v outside observed window from %v", deadline, now)
+	}
+	value, err := apiserver.RunCallback(context.Background(), server.runner, func(context.Context) (int, error) { return 137, nil })
+	if err != nil || value != 137 {
+		t.Fatalf("fast callback = (%d, %v)", value, err)
+	}
+}
+
+func TestExternalModuleCanImportFacadeButNotInternal(t *testing.T) {
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("instrument failure: runtime.Caller failed")
+	}
+	root := filepath.Dir(filepath.Dir(currentFile))
+	dir := t.TempDir()
+	t.Logf("external fixture directory: %s", dir)
+	goMod := fmt.Sprintf("module externalfixture\n\ngo 1.26.5\n\nrequire github.com/sunholo-data/ailang v0.0.0\nreplace github.com/sunholo-data/ailang => %s\n", root)
+	writeFixtureFile(t, filepath.Join(dir, "go.mod"), []byte(goMod))
+	sum, err := os.ReadFile(filepath.Join(root, "go.sum"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFixtureFile(t, filepath.Join(dir, "go.sum"), sum)
+	writeFixtureFile(t, filepath.Join(dir, "main.go"), []byte(externalFixtureSource))
+	writeFixtureFile(t, filepath.Join(dir, "denied.go"), []byte(deniedFixtureSource))
+
+	cmd := exec.Command("go", "build", "./...")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOFLAGS=-mod=mod", "GOPROXY=off")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("external facade build failed: %v\n%s", err, output)
+	}
+	t.Log("external facade build: rc=0")
+
+	cmd = exec.Command("go", "build", "-tags=denied", "./...")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOFLAGS=-mod=mod", "GOPROXY=off")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("internal import unexpectedly built")
+	}
+	want := "use of internal package github.com/sunholo-data/ailang/internal/apiserver not allowed"
+	if !strings.Contains(string(output), want) {
+		t.Fatalf("denied build error did not contain %q:\n%s", want, output)
+	}
+	t.Logf("denied internal import: nonzero rc, matched %q", want)
+}
+
+func writeFixtureFile(t *testing.T, path string, contents []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, contents, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const externalFixtureSource = `package main
+import (
+ "context"
+ "net/http"
+ "github.com/sunholo-data/ailang/serveapi"
+)
+type host struct{}
+func (host) ResolveSession(context.Context, *http.Request) (serveapi.Session, error) { return "s", nil }
+func (host) Tools(context.Context, serveapi.Session) ([]serveapi.ToolDescriptor, error) { return nil, nil }
+func (host) Invoke(context.Context, serveapi.Session, serveapi.Invocation) (serveapi.InvocationResult, error) { return serveapi.InvocationResult{}, nil }
+func main() {
+ h := host{}
+ api, err := serveapi.New(serveapi.Config{Resolver:h, Tools:h, Invoker:h, Agent:serveapi.AgentInfo{Name:"fixture", Version:"1"}})
+ if err != nil { panic(err) }
+ _ = api.MCPHandler(); _ = api.A2AHandler()
+ api.Mount(http.NewServeMux())
+}
+`
+
+const deniedFixtureSource = `//go:build denied
+package main
+import _ "github.com/sunholo-data/ailang/internal/apiserver"
+`


### PR DESCRIPTION
Milestone **M1 of 3** for `m-mcp-exact-tool-surface-lane-b` (`#498`, world-DEMAND — World's sole clause-6 blocker). Mission iteration 139.

Establishes the host-owned contract that M2 (MCP) and M3 (A2A) project onto the wire. **No wire behaviour changes and no existing call site is touched** — `MCPHandler()`/`A2AHandler()` are declared so the external compile fixture is real, and return `NotFoundHandler` until M2/M3.

## What lands

- **`serveapi/`** — new public package, stdlib types only. `Config`/`New` validation, `ToolDescriptor`, `SessionResolver`/`ToolSource`/`Invoker`, `MCPHandler`/`A2AHandler`/`Mount`.
- **`internal/apiserver/authorized_surface.go`** — `callerSurface()` deep-copies, validates and sorts host descriptors into a request-local `AuthorizedSurface`.
- **`internal/apiserver/callbacks.go`** — bounded callback runner: deadline + a capacity token **held until the callback goroutine actually exits**, not until the handler stops waiting.

Validation is fail-loud (CLAUDE.md §2): a nil `InputSchema` is an error, never a silent `{"type":"object"}` default. Load-bearing — `mcp.Server.AddTool` **panics** on nil/non-object schemas, and on the embedded path those values come from arbitrary host code inside an HTTP handler goroutine.

## Verification (controller-run, outside the codex sandbox)

| Check | Result |
|---|---|
| `go test ./internal/apiserver ./serveapi` | rc=0 |
| `go vet`, `gofmt -l` | rc=0, empty |
| `go test -race -run 'TestCallerSurface\|TestCallbackRunner'` | rc=0 |
| Import direction, two-sided + controls | serveapi → **0** compiler-core, **1** internal/apiserver; reverse **0** |
| `make check-file-sizes` / `check-boundaries` | rc=0 — **regression only**, neither can see a top-level package (`#584`) |
| `go test ./...` | 1 pre-existing failure: `TestNetHttpPost` on an httpbin.org 504 — reproduced at the untouched base commit, tracked as **`#561`**, skipped under `CI=true` (proven both ways) |

## Two vacuous assertions found by controller mutation testing and fixed

Both would have passed under a broken implementation:

1. **`callbacks_test.go`** — the "next callback not entered" branch was guarded on `err == nil`, provably false at that point. Dead code, so the counter assertion was a tautology (proven: an instrumented marker never printed while the test itself ran). Replaced with a saturated-runner assertion that fails if the token is released early.
2. **`authorized_surface_test.go`** — the deep-copy proof compared two `All()` results, but under a shallow clone **both alias caller storage and change together**. The shallow-clone mutation **survived**. Now compares against a materialized JSON snapshot and a literal; the same mutation dies.

Mutations run: 4 total, all reverted byte-identical (`cmp` verified).

Executor `codex:gpt-5.6-sol` under `codex exec --sandbox workspace-write`; controller re-ran every gate outside the sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)