### PR TITLE
ci(ci-flake): M4 — poisoned-proxy egress boundary across all 6 default-lane legs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,13 +56,24 @@ jobs:
       uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
     - name: Get dependencies
-      run: go mod download
+      run: go mod download all
 
     - name: Install ailang binary for integration tests
       run: go install ./cmd/ailang
 
     - name: Run tests
-      run: go test -v $(go list ./... | grep -v /scripts | grep -v /examples/agents)
+      shell: bash
+      env:
+        HTTP_PROXY: http://127.0.0.1:9
+        HTTPS_PROXY: http://127.0.0.1:9
+        NO_PROXY: localhost,127.0.0.1
+        GOPROXY: off
+      run: |
+        [[ "$HTTP_PROXY" == "http://127.0.0.1:9" ]] || { echo "::error::HTTP_PROXY poison is not configured"; exit 1; }
+        [[ "$HTTPS_PROXY" == "http://127.0.0.1:9" ]] || { echo "::error::HTTPS_PROXY poison is not configured"; exit 1; }
+        [[ "$NO_PROXY" == "localhost,127.0.0.1" ]] || { echo "::error::NO_PROXY loopback bypass is not configured"; exit 1; }
+        [[ "$GOPROXY" == "off" ]] || { echo "::error::GOPROXY is not disabled"; exit 1; }
+        go test -v $(go list ./... | grep -v /scripts | grep -v /examples/agents)
 
     - name: Build binary
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,20 @@ jobs:
     - name: Install dependencies
       run: make deps
 
+    # Prefetch UNPOISONED so the poisoned `go test` step below cannot fail on a
+    # module-cache miss. This MUST run BEFORE the binaries are built: `go mod
+    # download all` writes new entries into the TRACKED go.sum, and the binary
+    # staleness detector (internal/testutil/ailangbin.go) compares binary mtime
+    # against the newest Go source file — so downloading afterwards makes every
+    # ailang binary look stale and silently SKIPS every binary-gated integration
+    # test. Measured on PR #599's first run: binaries built 21:21:03Z, go.sum
+    # touched 21:21:17Z, TestRunSmokeInTempDir_Pass / TestPromptCommand_Piping /
+    # TestZ3VerifyEndToEnd all skipped, and the no-silent-skip gate below
+    # correctly red-lighted the job. build.yml was unaffected precisely because
+    # its download already precedes `go install`.
+    - name: Download all Go modules (including test dependencies)
+      run: go mod download all
+
     - name: Build binaries
       run: make install
 
@@ -70,9 +84,6 @@ jobs:
     # 35-50s (CLI subprocess tests), so 60s was boundary-flaky on loaded
     # runners (red dev 2026-07-10: package panicked at exactly 1m0s).
     # 300s still catches genuine hangs (M-DX11's intent) without the flake.
-    - name: Download all Go modules (including test dependencies)
-      run: go mod download all
-
     - name: Run tests with timeout (M-DX11)
       env:
         HTTP_PROXY: http://127.0.0.1:9
@@ -290,6 +301,13 @@ jobs:
     - name: Set up uv (provides Python for eval-harness Python runner tests)
       uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
+    # Same ordering constraint as the Linux leg: prefetch BEFORE the binary is
+    # installed, because `go mod download all` touches the tracked go.sum and the
+    # staleness detector would then treat the freshly-installed ailang as stale,
+    # silently skipping every binary-gated test.
+    - name: Download all Go modules (including test dependencies)
+      run: go mod download all
+
     - name: Install ailang to PATH (mirrors `make install`)
       shell: pwsh
       # Use go install so the binary lands in $(go env GOPATH)/bin, which
@@ -320,9 +338,6 @@ jobs:
         if ($LASTEXITCODE -ne 0) { Write-Error "ailang exited $LASTEXITCODE"; exit 1 }
         if ($output -notcontains 'World') { Write-Error "expected 'World' in output, got: $output"; exit 1 }
         Write-Host "OK: -args-json - (stdin)"
-
-    - name: Download all Go modules (including test dependencies)
-      run: go mod download all
 
     - name: Run Go test suite
       shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,21 @@ jobs:
     # 35-50s (CLI subprocess tests), so 60s was boundary-flaky on loaded
     # runners (red dev 2026-07-10: package panicked at exactly 1m0s).
     # 300s still catches genuine hangs (M-DX11's intent) without the flake.
+    - name: Download all Go modules (including test dependencies)
+      run: go mod download all
+
     - name: Run tests with timeout (M-DX11)
-      run: go test -timeout 300s ./...
+      env:
+        HTTP_PROXY: http://127.0.0.1:9
+        HTTPS_PROXY: http://127.0.0.1:9
+        NO_PROXY: localhost,127.0.0.1
+        GOPROXY: off
+      run: |
+        [[ "$HTTP_PROXY" == "http://127.0.0.1:9" ]] || { echo "::error::HTTP_PROXY poison is not configured"; exit 1; }
+        [[ "$HTTPS_PROXY" == "http://127.0.0.1:9" ]] || { echo "::error::HTTPS_PROXY poison is not configured"; exit 1; }
+        [[ "$NO_PROXY" == "localhost,127.0.0.1" ]] || { echo "::error::NO_PROXY loopback bypass is not configured"; exit 1; }
+        [[ "$GOPROXY" == "off" ]] || { echo "::error::GOPROXY is not disabled"; exit 1; }
+        go test -timeout 300s ./...
 
     # `go test ./...` output is non-verbose: a t.Skip is invisible and CI
     # stays green while integration coverage silently evaporates (e.g. if
@@ -81,9 +94,9 @@ jobs:
     # verbosely and require an explicit PASS — a skip or rename fails here.
     - name: Assert binary-gated integration tests ran (no silent skips)
       run: |
-        go test -count=1 -v -run '^(TestRunSmokeInTempDir_Pass|TestPromptCommand_Piping|TestZ3VerifyEndToEnd|TestFormatAilHookSinkRoundTrip)$' \
-          ./internal/pkg ./cmd/ailang ./internal/bestof ./internal/eval_harness 2>&1 | tee gated_integration.log
-        for t in TestRunSmokeInTempDir_Pass TestPromptCommand_Piping TestZ3VerifyEndToEnd TestFormatAilHookSinkRoundTrip; do
+        go test -count=1 -v -run '^(TestRunSmokeInTempDir_Pass|TestPromptCommand_Piping|TestZ3VerifyEndToEnd|TestFormatAilHookSinkRoundTrip|TestGateLint_SelfTest)$' \
+          ./internal/pkg ./cmd/ailang ./internal/bestof ./internal/eval_harness ./internal/testutil/gatelint 2>&1 | tee gated_integration.log
+        for t in TestRunSmokeInTempDir_Pass TestPromptCommand_Piping TestZ3VerifyEndToEnd TestFormatAilHookSinkRoundTrip TestGateLint_SelfTest; do
           grep -q -- "--- PASS: $t" gated_integration.log || {
             echo "::error::$t did not PASS — a binary-gated integration test is being skipped (missing/stale ailang, z3, jq or bash?) or was renamed (then update this step)."
             exit 1
@@ -308,6 +321,9 @@ jobs:
         if ($output -notcontains 'World') { Write-Error "expected 'World' in output, got: $output"; exit 1 }
         Write-Host "OK: -args-json - (stdin)"
 
+    - name: Download all Go modules (including test dependencies)
+      run: go mod download all
+
     - name: Run Go test suite
       shell: pwsh
       # 5min timeout (vs 60s on Linux): windows-latest runners are noticeably
@@ -315,7 +331,17 @@ jobs:
       # still get caught — a 5min ceiling is well above any healthy test.
       # If a test is genuinely Windows-incompatible (not just slow), fix it or
       # skip it with a `// TODO(windows-ci): <reason>` + tracked GH issue.
-      run: go test -timeout 300s ./...
+      env:
+        HTTP_PROXY: http://127.0.0.1:9
+        HTTPS_PROXY: http://127.0.0.1:9
+        NO_PROXY: localhost,127.0.0.1
+        GOPROXY: off
+      run: |
+        if ($env:HTTP_PROXY -ne 'http://127.0.0.1:9') { Write-Error "HTTP_PROXY poison is not configured"; exit 1 }
+        if ($env:HTTPS_PROXY -ne 'http://127.0.0.1:9') { Write-Error "HTTPS_PROXY poison is not configured"; exit 1 }
+        if ($env:NO_PROXY -ne 'localhost,127.0.0.1') { Write-Error "NO_PROXY loopback bypass is not configured"; exit 1 }
+        if ($env:GOPROXY -ne 'off') { Write-Error "GOPROXY is not disabled"; exit 1 }
+        go test -timeout 300s ./...
 
     # Same anti-silent-skip gate as the Linux job (minus z3, which isn't
     # installed here): tests that shell out to ailang t.Skip when it's
@@ -324,8 +350,8 @@ jobs:
     - name: Assert binary-gated integration tests ran (no silent skips)
       shell: pwsh
       run: |
-        go test -count=1 -v -run '^(TestRunSmokeInTempDir_Pass|TestPromptCommand_Piping|TestFormatAilHookSinkRoundTrip)$' ./internal/pkg ./cmd/ailang ./internal/eval_harness 2>&1 | Tee-Object -FilePath gated_integration.log
-        foreach ($t in 'TestRunSmokeInTempDir_Pass','TestPromptCommand_Piping','TestFormatAilHookSinkRoundTrip') {
+        go test -count=1 -v -run '^(TestRunSmokeInTempDir_Pass|TestPromptCommand_Piping|TestFormatAilHookSinkRoundTrip|TestGateLint_SelfTest)$' ./internal/pkg ./cmd/ailang ./internal/eval_harness ./internal/testutil/gatelint 2>&1 | Tee-Object -FilePath gated_integration.log
+        foreach ($t in 'TestRunSmokeInTempDir_Pass','TestPromptCommand_Piping','TestFormatAilHookSinkRoundTrip','TestGateLint_SelfTest') {
           if (-not (Select-String -Path gated_integration.log -SimpleMatch "--- PASS: $t" -Quiet)) {
             Write-Error "$t did not PASS - a binary-gated integration test is being skipped (missing/stale ailang, jq or bash?) or was renamed (then update this step)."
             exit 1

--- a/make/test.mk
+++ b/make/test.mk
@@ -12,9 +12,22 @@
 # Core tests. Depends on build so integration tests that shell out to the
 # ailang binary never see a stale bin/ailang — a stale binary caused phantom
 # stdlib failures on 2026-07-10 (see internal/testutil/ailangbin.go).
+#
+# The prefetch below runs UNPOISONED so the poisoned test run cannot fail on a
+# module-cache miss. It is deliberately plain `download`, NOT `download all`:
+# `all` resolves the full transitive graph and writes checksums for modules this
+# repo never imports, adding ~394 lines to the TRACKED go.sum on every run —
+# which leaves the developer's tree dirty and stamps every later build `-dirty`
+# (Makefile:27 uses `git describe --dirty`). Measured 2026-08-05: plain
+# `download` into a cold GOMODCACHE followed by this poisoned run gives
+# rc=0 / 107 ok / zero module-resolution failures — indistinguishable from the
+# warm run, with go.sum untouched. The CI workflows keep `download all`: they
+# run on three OSes whose build constraints were not measured here, and their
+# checkout is ephemeral so the go.sum churn is harmless there.
 test: build ## Run all Go unit tests (builds bin/ailang first)
 	@echo "Running tests..."
-	@$(GOTEST) -v $$($(GOCMD) list ./... | grep -v /scripts | grep -v /examples/agents)
+	@$(GOCMD) mod download
+	@HTTP_PROXY=http://127.0.0.1:9 HTTPS_PROXY=http://127.0.0.1:9 NO_PROXY=localhost,127.0.0.1 GOPROXY=off $(GOTEST) -v $$($(GOCMD) list ./... | grep -v /scripts | grep -v /examples/agents)
 
 test-nightly-classifier: ## Run nightly variance-guard contract and replay tests
 	@python3 tools/test_nightly_classify.py -v


### PR DESCRIPTION
Milestone **M4** of the CI-flake systemic fix — the sprint's **only CI-touching commit**. Closes **AC9, AC11, AC12**.

Revert in isolation with `git revert --no-edit <squash-sha>` if dev goes red.

## What

**Six legs, not five.** The doc's own **V34** measured 6 while its AC prose still says "5 CI legs" in 6 places (M5 owes that cleanup). ci.yml `test` + `test-windows`, plus build.yml's 4-entry matrix (ubuntu, macos/amd64, macos/arm64, windows).

- **ci.yml, both legs** — unpoisoned `go mod download all`, then the poison env on the test step, with an in-step guard asserting all four vars **before** `go test`: bash on Linux, **PowerShell** on the `shell: pwsh` Windows leg (one guard body cannot serve both).
- **build.yml** — **`shell: bash` PINNED** on the matrix test step. build.yml declares no `defaults.run.shell` (exactly one `shell:` hit, at `:86`), so on `windows-latest` that step ran under the runner default pwsh; an unpinned bash-shaped guard was the single most likely way this milestone reds `dev`.
- **AC9** — `TestGateLint_SelfTest` and `./internal/testutil/gatelint` registered in the no-silent-skip `-run` regex, **package list** and assertion loop of **both** legs.

## `go mod download all` mutates a tracked file

It adds **394 lines** to `go.sum` — measured three ways that agree (`--stat` insertions, `grep -c '^+[^+]'`, and the actual `wc -l` delta). In `make test` that leaves every developer's tree dirty and stamps later builds `-dirty` (`Makefile:27` uses `git describe --dirty`).

Measured: plain `go mod download` into a **cold** `GOMODCACHE` followed by the poisoned suite gives **rc=0 / 107 ok / zero module-resolution failures** — indistinguishable from warm, `go.sum` untouched. So `make/test.mk` uses plain `download`; the **workflows keep `all`**, because they run on three OSes whose build constraints were not measured here and their checkout is ephemeral.

## ⚠ Correction — a false claim I made and then caught

An earlier revision of this PR and commit claimed the gate `actionlint -shellcheck='-e SC2086'` "keeps shellcheck on for everything else". **That was false.**

`actionlint`'s `-shellcheck` flag takes an **executable path**, so `-e SC2086` is a bogus command name and shellcheck **silently never runs**. Proven: a deliberately bogus executable, `-e SC2086`, and explicit `-shellcheck=` all give **rc=0 / 0 findings**, while `-shellcheck=$(which shellcheck)` gives **rc=1 / 3 SC2086**. My original mutation proof was real but exercised actionlint's **native** checker, and I over-generalised it to "the gate works".

The evaluator flagged the anomaly as unexpected; reproducing it first-party found the cause.

What actually holds, verified:
- The plan's gate `actionlint <files>` → rc=0 **cannot pass** — it is rc=1 on the unmodified base, with 5 pre-existing shellcheck findings (**3 SC2086, 1 SC2035, 1 SC2046** — not "all SC2086" as I first wrote).
- `actionlint -shellcheck=` (native workflow validation): **rc=0 on base and on M4**, mutation-proved non-vacuous — an undefined `github.*` context makes it rc=1 naming the property and line.
- Real shellcheck: **5 findings on base, 5 on M4** — identical, so M4's new guard bodies add **zero** new shellcheck findings.

`actionlint` **does not run in CI at all** (control: `golangci-lint` is found by the same search), so this is a controller-side pre-commit gate and shipped behaviour is unaffected. Making the unfiltered gate genuinely passable means fixing the 5 pre-existing findings — filed for M5.

## Verification — all run OUTSIDE the executor sandbox

| Gate | Result |
|---|---|
| poison counts ci / build / test.mk | 8 / 4 / 1 (pre-edit control: **0 / 0 / 0**) |
| AC9 registration | package path ×2, test name ×4; step body GREEN, all 5 PASS lines |
| AC11 lane-crossing | poisoned **rc=1** with the named message; **unpoisoned rc=0** in the same block |
| AC12 cold cache | negative (no prefetch) fails; positive (prefetch + poisoned full suite) **rc=0, 107 ok, 0 resolution failures** |
| `make test` | **rc=0, 107 ok, 0 FAIL**, `go.sum` dirty count **0** |

**Mutations**, each proven landed and reverted byte-identical: each of the four env vars removed individually reds the guard with its own message **before** `go test`; renaming `TestGateLint_SelfTest` removes the PASS line and reds the step (note `go test` itself stays rc=0 — the grep loop is what catches it, the safe direction the doc predicted).

**Evaluator** (sonnet, generator≠judge): **PASS 88/100 round 1, zero blocking.** Its NB-1 ("go.sum churn is 618 lines, not 394") was **refuted** on reproduction — 618 is `git diff | wc -l`, the diff's total output length including headers and context, not lines added.

## ⚠ Not verified locally

The **PowerShell guard**: `pwsh` is not installed on the rig, so the Windows leg is **CI-verifiable only**. M1 and M3 each shipped a Windows-only defect in this area — watch `test-windows` and `Build windows-latest` specifically.

## Unrelated

`#598` filed — `TestSolve_HardTimeout_FakeSolverIgnoringT` fataled once on a pid-file race during a full-suite run. Not caused by this change: isolated arms pass with and without the poison, and a second identical run was fully green.

Depends on `#569` (actions bump), merged first as `bc30912ea` to clear the ci.yml/build.yml collision — dev CI green on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)