### PR TITLE
docs(ci-flake): M5 — changelog, developer guide, and the doc/plan reconciliation

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -2,6 +2,19 @@
 
 > Current changelog (v0.18.0 onward). Earlier series: [v0.10–v0.17](v0.10-v0.17-bytecode-vm.md). Index: [CHANGELOG.md](../CHANGELOG.md).
 
+## [v0.33.1] - 2026-08-06
+
+### Changed
+
+- **Deterministic test gating and egress posture (#583, #494, #509, #587, #561).**
+  `go test -short ./...` no longer skips first-party tests: the `testing.Short()` convention has
+  been removed and live-internet tests now skip by default, running only when explicitly opted
+  in with `AILANG_LIVE_NET=1`. `make test` now uses a poisoned HTTP(S) proxy at
+  `127.0.0.1:9`, matching CI so accidental public-internet access fails locally as well.
+- Added the shared `internal/testutil` live-network gate, deadline-derived hang guards, and
+  bounded subprocess runner; `gatelint` prevents the banned gate idioms from returning, and an
+  egress-posture probe records both the proxy-covered routes and the deliberately open residuals.
+
 ## [v0.33.0] - 2026-08-04
 
 ### Added

--- a/design_docs/planned/v0_33_1/m-ci-flake-systemic-fix-sprint-plan.md
+++ b/design_docs/planned/v0_33_1/m-ci-flake-systemic-fix-sprint-plan.md
@@ -442,7 +442,10 @@ immediately before committing, and keep the M2→M3 gap short (a concurrent sess
    of `https://example.com` asserts `proxyconnect … 127.0.0.1:9 … connection refused`;
    (b) loopback `httptest` GET under the lane's poison succeeds, skipping with a **named** message
    outside a poisoned lane; (c) `AILANG_LIVE_NET=1` only: raw `net.Dial` to a public host:443
-   SUCCEEDS despite the poison — the honestly-asserted open route (V27, CONFIRMED).
+   SUCCEEDS despite the poison — the honestly-asserted open route (V27, CONFIRMED); and
+   (d) `AILANG_LIVE_NET=1` only: `effects_nil_proxy_remains_open` proves AILANG's hand-built
+   effects transport still bypasses the poison under D5=Option A, with a
+   `ProxyFromEnvironment` control half that remains denied.
 
 **Anti-vacuity**
 
@@ -454,12 +457,13 @@ immediately before committing, and keep the M2→M3 gap short (a concurrent sess
 | `TestGateLint_Repo` | **manual falsification drill (AC8)**: create `internal/pipeline/scratch_gatelint_test.go` containing `testing.Short()` → `TestGateLint_Repo` FAILs naming that path → delete the file → PASS | **`grep -c 'testing.Short()' internal/pipeline/scratch_gatelint_test.go` → 1 before the failing run, and `ls` → No such file after.** The drill's rc means nothing without both |
 | AC10(a) | point the probe transport at a live proxy instead of `127.0.0.1:9` | `git diff` on the sentinel constant |
 | AC10(b) | make the poison intercept loopback (add `127.0.0.1` removal from `NO_PROXY`) | `git diff` on the test's env setup |
+| AC10(d) | set the effects transport proxy to `http.ProxyFromEnvironment` | `git diff` on the effects client constructor; the residual half turns red while the control remains denied |
 
 **Acceptance (M3)**
 ```bash
 go test -count=1 -v ./internal/testutil/gatelint    # --- PASS: TestGateLint_SelfTest  AND  --- PASS: TestGateLint_Repo
 go test -count=1 -v ./internal/testutil -run TestEgressPosture           # AC10 (a)+(b)
-AILANG_LIVE_NET=1 go test -count=1 -v ./internal/testutil -run TestEgressPosture   # AC10 (c)
+AILANG_LIVE_NET=1 go test -count=1 -v ./internal/testutil -run TestEgressPosture   # AC10 (c)+(d), including effects_nil_proxy_remains_open
 go test -count=1 $(go list ./... | grep -v /scripts)                     # rc=0 — gatelint is green against the REAL tree
 golangci-lint run ./internal/testutil/...
 # falsification drill, with the mutation-landed proof:
@@ -477,7 +481,7 @@ git status --porcelain | grep scratch_gatelint || echo "drill file removed"
 Closes **AC8, AC10**.
 
 **UNINFORMATIVE UNDER SANDBOX**: AC10(b) binds a loopback listener (`httptest.NewServer`);
-AC10(c) needs live network. `TestGateLint_*` is pure file-reading and **is** sandbox-authoritative.
+AC10(c/d) need live network or socket behavior. `TestGateLint_*` is pure file-reading and **is** sandbox-authoritative.
 **Controller re-runs AC10 outside the sandbox.**
 
 ---
@@ -496,10 +500,26 @@ and is revertable in isolation.
 |---|---|---|---|
 | G-a | Rebase onto current `origin/dev` | `git fetch origin && git log --oneline HEAD..origin/dev \| wc -l` → 0 | workflow files are the most contended in the repo |
 | G-b | Re-check in-flight workflow PRs | `gh pr list --state open --json number,files --jq '.[] \| select(.files[].path \| test("workflows/")) \| .number'` | #532 and #569 both touch these files today |
-| G-c | **Workflow syntax** | `actionlint .github/workflows/ci.yml .github/workflows/build.yml` → rc=0 | `actionlint` is installed; catches the class that reds `dev` before push |
+| G-c | **Workflow syntax** | `actionlint .github/workflows/ci.yml .github/workflows/build.yml` → rc=0 — **BROKEN AS WRITTEN, see note below** | `actionlint` is installed; catches the class that reds `dev` before push |
 | G-d | Simulate each edited step locally | run the exact `run:` body of each edited step in a shell, with the poison + `GOPROXY=off`, after an unpoisoned `go mod download all` | proves the step's own guard fires and the prefetch is sufficient |
 | G-e | **AC12 cold-cache drill, negative direction FIRST** | see task 5 | a drill that has never been seen to fail is not a drill |
 | G-f | Post-push bounded CI poll | `gh run list --branch dev --limit 3` polled against a `date +%s` deadline ≤ 30 min | red must be caught and reverted in minutes, not at the next iteration |
+
+> **G-c IS UNPASSABLE AS WRITTEN, AND THE OBVIOUS "FIX" IS A VACUOUS GATE.** Recorded by
+> iteration 147, **re-measured first-party at iteration 148** on unmodified `dev`
+> (Gate 2 rule 3e: baseline every acceptance command before trusting it):
+> - `actionlint .github/workflows/{ci,build}.yml` → **rc=1** with **5 pre-existing shellcheck
+>   findings** (3 × SC2086, 1 × SC2035, 1 × SC2046). The gate is red at base, so it measures the
+>   repo, not the change — it can only be waved through or misattributed to the sprint.
+> - **Never "filter" it with `-shellcheck='-e SC2086'`.** That flag takes an **executable path**,
+>   so the string is a bogus command name and shellcheck **silently never runs**: measured
+>   **rc=0 with 0 findings**. A gate that passes because its checker was disabled is exactly the
+>   vacuous-pass class this sprint exists to close.
+> - Control proving the instrument works: `-shellcheck="$(which shellcheck)"` → **rc=1, 5
+>   findings** — same 5, so M4 introduced **zero** new ones.
+> - `actionlint` never runs in CI; it is a local pre-commit aid only.
+>
+> **Correct form of the gate:** assert *no NEW findings vs the base count*, not `rc=0`.
 
 **Tasks**
 1. **ci.yml — Linux leg** (`test` job): before the `go test` step at `:74`, add an *unpoisoned*
@@ -554,7 +574,10 @@ and is revertable in isolation.
 
 **Acceptance (M4)**
 ```bash
-actionlint .github/workflows/ci.yml .github/workflows/build.yml     # rc=0
+# NOT `rc=0` — that is red at base on 5 pre-existing findings (see the G-c note above).
+# Assert NO NEW findings instead; never disable shellcheck with `-shellcheck='-e SC2086'`.
+actionlint -shellcheck="$(which shellcheck)" .github/workflows/ci.yml .github/workflows/build.yml \
+  2>&1 | grep -c 'SC[0-9]'                            # → 5, i.e. unchanged from base
 grep -c '127.0.0.1:9' .github/workflows/ci.yml        # → ≥2
 grep -c '127.0.0.1:9' .github/workflows/build.yml     # → ≥1
 grep -c '127.0.0.1:9' make/test.mk                    # → ≥1
@@ -589,9 +612,13 @@ first `dev` CI run after this commit**, with a revert command staged:
 3. **Restate the boundary claim honestly (this is a correction, not a doc chore).** The doc's
    Goals paragraph says the default lanes deny HTTP(S) egress as a *boundary*. Per finding R-B
    that is true only for clients using Go's **default** transport, and for `git`. Every
-   first-party `http.Transport{…}` literal (**6 of them, in 4 files, 0 setting
+   first-party `http.Transport{…}` literal (**7 of them, across 4 files, 0 setting
    `ProxyFromEnvironment`**) bypasses it — including `internal/effects/net.go`, the `Net` effect
-   itself. The guide and the design doc must both say so, and the reviewer instruction becomes:
+   itself. **COUNT CORRECTED 2026-08-06 (iteration 148), measured first-party:** the "6 in 4
+   files" written here conflated two scopes. `internal/effects` holds **6** literals in **3**
+   files (`net.go:96,212,587`, `stream_ndjson.go:80`, `stream_sse.go:70,329`); the 4th file is
+   `internal/executor/managed_agents/client.go:141`, which builds a `Proxy`-nil transport too and
+   therefore **also bypasses the poison**. First-party total: **7 across 4 files**. The guide and the design doc must both say so, and the reviewer instruction becomes:
    *flag by hand any new test that (a) dials raw TCP/SSH, **or (b) constructs its own
    `http.Transport`**.*
 4. Run the full AC1–AC12 sweep (as corrected) and paste every output into the implementation

--- a/design_docs/planned/v0_33_1/m-ci-flake-systemic-fix.md
+++ b/design_docs/planned/v0_33_1/m-ci-flake-systemic-fix.md
@@ -1,11 +1,17 @@
 # M-CI-FLAKE-SYSTEMIC-FIX: One Gating Convention, Bounded Waits, a Default-Deny Egress Boundary, and a Known-Offender Lint for the Go Test Suite
 
-**Status**: Planned — **SPRINT-PLANNED 2026-08-04 (iteration 142); M1 LANDED 2026-08-05 (`c440a1628`); `D5` DECIDED 2026-08-05 = Option A (Mark), so M2/M3/M4 are UNBLOCKED**
+**Status**: **ALL MILESTONES LANDED** — SPRINT-PLANNED 2026-08-04 (iteration 142); M1 (`c440a1628`), M2 (`368f940cf`), M3 (`13c570063`), M4 (`4b47f8b0a`), **M5 (2026-08-06, iteration 148)**; `D5` DECIDED 2026-08-05 = Option A (Mark). **Full AC1–AC12 sweep re-run out-of-sandbox at M5 — all pass**; the one full-suite red observed was `#598` (an unrelated pid-file race, poison ruled out by a 3-arm negative control, and green on re-run: rc=0 / 107 ok). Ready to move to `design_docs/implemented/v0_33_1/` once the M5 merge is CI-green.
 **Target**: v0.33.1
 **Priority**: P0 (High) — flakes red-light `dev` CI, and a red `dev` outranks the mission queue every time it occurs
 **Estimated**: ~~3–4 days (4 milestones)~~ **26h ≈ 4.5 days, 5 milestones** (planner revision, iteration 142 — the doc's M3 bundled a 460-LOC pure-Go linter with the workflow edits; splitting them isolates the only CI-touching commit)
 **Sprint plan**: [`m-ci-flake-systemic-fix-sprint-plan.md`](./m-ci-flake-systemic-fix-sprint-plan.md)
 **Dependencies**: None. ⚠ **Collision — CONTROLLER DECISION TAKEN 2026-08-05 (iteration 145), plan §6.1 option (b), not the planner's recommended (a):** PR **#532** rewrites `buildAilang` in `cmd/ailang/main_test.go` and the body under the `testing.Short()` gate in `serve_api_mcp_surface_test.go`, and touches `ci.yml` — i.e. exactly M2's surface. **M2 proceeds first; #532 rebases onto it afterwards.** Reasons, measured not assumed: (1) #532 is authored by `sunholo-voight-kampff` — *this loop's own PR*, so there is no external author to coordinate with and no review latency; (2) it has been `CONFLICTING`/`DIRTY` against `dev` since **2026-07-29** and untouched for 7 days, so **M2 does not make it any more conflicted than it already is** — the "resolve #532 first" cost is a pre-existing debt, not one M2 creates; (3) resolving a week-old conflict is a separate piece of work that would consume the iteration that Mark's `D5` answer exists to unblock. The re-application cost is symmetric either way (#532 replaces `buildAilang` wholesale; M2 wraps it — whoever goes second re-applies), so ordering was chosen on *unblocking value*, not on merge cost. **Follow-up owed:** comment on #532 recording this, so its rebase re-applies `HangGuardContext` to the new `sync.Once` body. PR **#569** (dependabot actions bump) touches `ci.yml` + `build.yml` — M4's surface, re-check before M4.
+**BOTH COLLISIONS ARE NOW RESOLVED — this Dependencies block is retained for provenance only:**
+**#532 was CLOSED as SUPERSEDED** (iteration 145, verified *by purpose* rather than by state: its
+entire reason — one shared binary build instead of fourteen, to escape the Windows timeout — had
+already landed independently as `#564`/`3c28cc322`, so it sat `OPEN`/`CONFLICTING` *because* it was
+dead, not because it was blocking). **#569 was MERGED first** (`bc30912ea`, iteration 147) to clear
+the `ci.yml`/`build.yml` collision before M4 touched those files. No open collision remains.
 **Planner-Lane**: opus-required
 **Authorized**: Mark Edmondson, 2026-08-04 — "Yes sprint a CI flake fix"
 **Closes**: #583, #494, #509, #587 (CI flakes) · #561 (local-only network dependency — see Scope note)
@@ -84,12 +90,14 @@ This doc fixes it as part of unifying idiom 2 into idiom 3, but does not claim i
 
 ## Goals
 
-**Primary Goal:** After this sprint, the default lanes (all 5 CI `go test` legs and local
+**Primary Goal:** After this sprint, the default lanes (all 6 CI `go test` legs and local
 `make test`) run behind a **poisoned proxy** (`HTTP_PROXY=HTTPS_PROXY=http://127.0.0.1:9`) — a
-protocol-level **default-deny for HTTP(S) egress**, a boundary rather than an enumerated host
-list — so no first-party test can red a default lane due to third-party uptime over HTTP(S),
-runner cold-start, or an unbounded child process; and the boundary **fails loudly if it stops
-being wired**, unlike `testing.Short()` which degraded silently.
+protocol-level **default-deny for HTTP(S) egress only for clients that consult proxy environment
+variables**, notably Go's default transport and `git`, rather than an enumerated host list. It
+does not cover raw TCP/SSH or hand-built `http.Transport` values with a nil `Proxy`. Within that
+measured scope, third-party uptime cannot red a default lane; bounded child processes and
+fail-loud wiring address the other flake classes without repeating `testing.Short()`'s silent
+degradation.
 
 **Enforcement boundary vs. legibility check (scope stated plainly):** the poisoned lane is the
 anti-recurrence mechanism; gatelint is a *legibility check for known offenders*, NOT the
@@ -105,9 +113,10 @@ ambient network access in the default lane (measured open — V27); **(b) — AD
 `http.Transport{}`, so the instrument sees positives). A hand-built transport has `Proxy == nil`
 = no proxy consulted, so the poison is inert for the repo's principal HTTP client — which is the
 exact code path of `#561`. Measured V33. Closing (b) is a **production runtime change** with
-SSRF-guard interactions and is PARKED for human decision, not assumed. That residual is restated
-in Non-Goals, probed honestly by AC10(c), and mitigated only by review plus R3's extendable
-known-offender list — not mechanically.
+SSRF-guard interactions. Decision `D5` = Option A deliberately leaves it open in this sprint;
+AC10(d) asserts the residual, and the separate `m-net-effect-proxy-boundary` follow-up (Option B)
+will close it. AC10(d) is the tripwire that goes red when that follow-up lands. Reviewers must
+flag by hand any new test that dials raw TCP/SSH or constructs its own `http.Transport`.
 
 **Success Metrics:**
 - `testing.Short()` occurrences in first-party `*_test.go`: **7 files → 0** (enforced by gate)
@@ -133,9 +142,9 @@ known-offender list — not mechanically.
 |----------|-----------------|-----------|----------|-------------|
 | **Ban `testing.Short()` and env opt-out gating; standardize on explicit opt-in via one `internal/testutil` helper** (do NOT start passing `-short` in CI) | Passing `-short` would instead flip 7 inert gates to *silent mass-skipping* in CI — trading a flake for invisible coverage loss. Six of the 7 gated tests are proven CI-safe by months of green runs (V2, V3); only explicit opt-in is legible | human | design | med |
 | **Hang-guards are derived from `t.Deadline()` (minus grace), never hard-coded** — and are distinguished from *assertion* bounds, which must be relative, never absolute | Every hard-coded bound in the repo has already been raised at least once chasing runners (V10, V12, ci.yml comments). Derivation ends the class; it also guarantees a hung subtest fails *before* the package-wide panic that reds every test in the package (#494's amplification) | human | design | med |
-| **The lint gate (`gatelint`) = a plain Go test, not a shell script or workflow step** | A Go test runs automatically on all 5 CI legs that run `go test ./...` — ci.yml `test` + `test-windows` AND build.yml's 3-OS matrix (V8) — with zero workflow edits. Shell gates would need per-workflow wiring and can't run on the Windows legs uniformly (rig bash is 3.2; scripts/ has zero Windows coverage) | human | design | med |
+| **The lint gate (`gatelint`) = a plain Go test, not a shell script or workflow step** | A Go test runs automatically on all 6 CI legs that run `go test ./...` — ci.yml `test` + `test-windows` AND build.yml's 4-entry matrix (ubuntu, macOS amd64, macOS arm64, Windows; V34) — with zero workflow edits. Shell gates would need per-workflow wiring and can't run on the Windows legs uniformly (rig bash is 3.2; scripts/ has zero Windows coverage) | human | design | med |
 | **Anti-vacuity floor**: gatelint self-tests against known-positive fixtures every run, and its PASS is asserted by name in ci.yml's existing "no silent skips" step | Without this, gatelint is the next `testing.Short()` — an assertion nobody notices has stopped firing. The repo already invented this pattern once (ci.yml:76-90 asserts `--- PASS:` per gated integration test — V9); reuse it, don't reinvent | human | design | low |
-| **The enforcement boundary is a poisoned proxy in every default lane** (`HTTP_PROXY=HTTPS_PROXY=http://127.0.0.1:9` on the 5 CI `go test` steps + `make test`'s `$(GOTEST)` line); gatelint R3 is thereby demoted to a legibility/known-offender lint | An enumerated denylist cannot be complete (quorum objection, upheld): a test using a new hostname would pass R3 and every prior AC. The poison is a *boundary* for the protocols behind all five issues: any-host HTTP(S) via Go's default transport (V25) and `git` https clones (V26) fail in ~0ms with no listener on port 9; loopback is bypassed so httptest/local-daemon tests are untouched (V28); the full poisoned suite pre-sprint fails in exactly the 2 known packages and no others (V30). Measured NOT closed: raw TCP (V27) — documented residual, never claimed | human | design | med |
+| **The enforcement boundary is a poisoned proxy in every default lane** (`HTTP_PROXY=HTTPS_PROXY=http://127.0.0.1:9` on the 6 CI `go test` legs + `make test`'s `$(GOTEST)` line); gatelint R3 is thereby demoted to a legibility/known-offender lint | An enumerated denylist cannot be complete (quorum objection, upheld). The poison is a boundary for HTTP(S) through Go's default transport (V25) and `git` HTTPS clones (V26). Measured, deliberately open residuals are raw TCP/SSH and hand-built transports with nil `Proxy`, including AILANG's `Net` effect (V27, V33, D5=A); AC10(c/d) keep them visible and reviewers flag new instances by hand | human | design | med |
 | **gatelint R3 (legibility lint, not the boundary): narrow host list + checked-in allowlist, scoped to `*_test.go` only** | Measured FP surface: `https://github.com/` appears in **14** first-party test files, nearly all inert string fixtures (V16). A generic rule would either drown in false positives or grow escape hatches until vacuous. Narrow list ({`httpbin.org`, `ailang-packages`}) + allowlist = zero current FPs in test scope. Scoping to `*_test.go` is measured-necessary, not stylistic: R3's tokens appear in **6 production `.go` files** plus gatelint's own source once written (V23) — an unrestricted rule would red CI on the commit introducing it | human | design | low |
 | Subprocess bounding uses `exec.CommandContext` + `cmd.WaitDelay` (Go 1.26.5 — V17) | `WaitDelay` is precisely the fix for #494's observed goroutine profile (`Cmd.Wait` + `watchCtx` both blocked); without it, ctx cancellation can still leave `Wait` blocked on I/O pipes | agent | implementation | low |
 
@@ -278,7 +287,7 @@ cannot silently rot the way `testing.Short()` did.
      (component 5).
 
 5. **Default-lane poison wiring** — the enforcement boundary itself:
-   - ci.yml's two `go test` steps (Linux ~:74, Windows ~:318), build.yml's 3-OS `go test` step,
+   - ci.yml's two `go test` steps (Linux ~:74, Windows ~:318), build.yml's **4-entry matrix** `go test` step (one step, 4 legs),
      and the `$(GOTEST)` invocation line of `make test` (make/test.mk:15-17) all gain
      `HTTP_PROXY=http://127.0.0.1:9 HTTPS_PROXY=http://127.0.0.1:9 NO_PROXY=localhost,127.0.0.1`.
      Port 9 (discard) has no listener: any proxied egress fails in ~0ms (V25, V26). `NO_PROXY`
@@ -376,25 +385,31 @@ changes; a human habit of `-short` for speed should become package selection.
       the whole migration surface
 - [ ] Commit
 
-**M3: gatelint + default-lane poison wiring** (~1 day)
+**M3: gatelint + egress-posture probe (pure Go, no workflow edits)** (~1 day)
 - [ ] `internal/testutil/gatelint/{scan.go,allowlist.go}` + `testdata/fixtures/` (walker:
       `*_test.go` only, own package excluded; 5-entry seed allowlist per V16+V24)
 - [ ] `gatelint_test.go`: `TestGateLint_SelfTest` (fixtures incl. the non-test R3-token fixture,
       exact-set assertion) + `TestGateLint_Repo` (real tree, zero violations)
-- [ ] Poison env + in-step guard on ci.yml's two `go test` steps and build.yml's matrix step
-- [ ] make/test.mk: poison env on the `$(GOTEST)` line only (`build` prerequisite stays
-      unpoisoned — module fetch, V31)
-- [ ] `internal/testutil/egress_posture_test.go` (AC10 a/b/c)
+- [ ] `internal/testutil/egress_posture_test.go` (AC10 a/b/c/d), including the deliberately-open
+      `effects_nil_proxy_remains_open` subtest for D5=A
+- [ ] Run AC10(c) and AC10(d) in the `AILANG_LIVE_NET=1` acceptance leg
+- [ ] Commit (landed as `13c570063`)
+
+**M4: default-lane poison wiring — the only CI-touching commit** (~1 day)
+- [ ] Poison env + in-step guard on ci.yml's two `go test` steps and build.yml's 4-entry matrix step
+- [ ] make/test.mk: poison env on the `$(GOTEST)` line only; prefetch modules unpoisoned and use
+      `GOPROXY=off` during the poisoned test step
 - [ ] ci.yml: add `TestGateLint_SelfTest` + package path to BOTH no-silent-skip steps
       (Linux ~line 84, PowerShell ~line 327)
-- [ ] Commit
+- [ ] Run the AC12 cold-cache drill and verify all 6 CI legs
+- [ ] Commit (landed as `4b47f8b0a`)
 
-**M4: docs + verification sweep** (~0.5 day)
+**M5: docs + verification sweep** (~0.5 day)
 - [ ] `changelogs/` entry (v0.33.1); note the `-short` local behavior change
 - [ ] `docs/docs/guides/development-workflow.md` (or debugging.md): the one-idiom convention,
       `AILANG_LIVE_NET`, how to write a live test, how to satisfy/extend gatelint, the poisoned
-      default lanes and their **named residual** (raw TCP/SSH/proxy-ignoring subprocesses are
-      not blocked — reviewers should flag them by hand)
+      default lanes and their **named residual** (raw TCP/SSH and hand-built transports are not
+      blocked — reviewers should flag them by hand)
 - [ ] Run every AC command below; paste outputs into the implementation report
 - [ ] Comment-and-close #583/#494/#509/#587/#561 referencing the ACs (controller commits/closes)
 - [ ] Commit
@@ -427,7 +442,7 @@ changes; a human habit of `-short` for speed should become package selection.
 - `internal/coordinator/provider_script_test.go` (audit; migrate or allowlist)
 - `.github/workflows/ci.yml` (+10/−2) — register `TestGateLint_SelfTest` in both no-silent-skip
   steps; poison env + in-step guard on both `go test` steps
-- `.github/workflows/build.yml` (+5) — poison env + in-step guard on the 3-OS `go test` step
+- `.github/workflows/build.yml` (+5) — poison env + in-step guard on the **4-entry matrix** `go test` step (one step, 4 legs)
 - `make/test.mk` (+1/−1) — poison env on the `$(GOTEST)` line of `test:` only
 
 ## Examples
@@ -487,8 +502,11 @@ false?* Scope note per V19: every grep is scoped to first-party dirs; `.claude/`
   → only `internal/testutil/gatelint/testdata/` fixture path(s).
   *Falsifiable?* Yes — any surviving or new gate adds a path. Instrument control: pre-sprint the
   same command returns 7 files (V2).
-- [ ] **AC2 (opt-out idiom eliminated):** same grep for `Getenv("CI")\|Getenv("GITHUB_ACTIONS")`
-  → only fixture path(s). Pre-sprint control: 2 files (V5).
+- [ ] **AC2 (opt-out idiom eliminated except the reviewed escape hatch):** same grep for
+  `Getenv("CI")\|Getenv("GITHUB_ACTIONS")` → only
+  `internal/coordinator/provider_script_test.go`, the allowlisted-with-reason Unix
+  shell/grandchild signal-semantics exception recorded by M2; no live-network gate may use the
+  idiom. Pre-sprint control: 2 files (V5).
 - [ ] ~~**AC3**~~ — **SUPERSEDED. The original single command was VACUOUS; `D5` is now DECIDED
   (Option A), so AC3 is replaced by AC3′(a/b/c) below.**
   ~~`HTTPS_PROXY=… HTTP_PROXY=… go test ./internal/pkg/ ./internal/effects/` → PASS~~
@@ -580,6 +598,17 @@ false?* Scope note per V19: every grep is scoped to first-party dirs; `.claude/`
   *Provenance:* the residual it measures is **V33** — 6 hand-built `http.Transport{}` in
   `internal/effects` (`net.go:96,212,587`, `stream_ndjson.go:80`, `stream_sse.go:70,329`), none
   setting `Proxy`; `ProxyFromEnvironment` in **0** first-party files.
+  **WIDENED 2026-08-06 (iteration 148), measured first-party — the residual is larger than V33
+  recorded.** V33's scope is `internal/effects`; a repo-wide sweep
+  (`grep -rn 'http\.Transport{' --include='*.go' ./internal ./cmd ./runtime`, 11 hits, control
+  firing) finds a **7th** proxy-ignoring literal outside it:
+  `internal/executor/managed_agents/client.go:141`, which sets only `ResponseHeaderTimeout` and
+  `IdleConnTimeout` and therefore bypasses the poison identically. First-party total: **7
+  literals across 4 files** (`internal/effects` contributes 6 across **3** files — the doc and
+  plan previously said "6 in 4 files", conflating the two scopes). AC10(d) is unaffected: it
+  asserts the *mechanism* (a `Proxy`-nil transport bypasses the poison), which is
+  file-independent, so it remains the correct Option-B tripwire. What changes is the documented
+  EXTENT of the residual, which Option B must therefore close in 4 files, not 3.
 - [ ] **AC11 (boundary cannot be silently dropped, and the lanes cannot cross):**
   `grep -c '127.0.0.1:9' .github/workflows/ci.yml` → ≥2 (both legs);
   `grep -c '127.0.0.1:9' .github/workflows/build.yml` → ≥1;
@@ -605,8 +634,8 @@ false?* Scope note per V19: every grep is scoped to first-party dirs; `.claude/`
       this AC fails. Pre-sprint, the equivalent run without the prefetch is expected to FAIL —
       run it once in that form first and record it, so the AC is demonstrated non-vacuous
       against a known-positive rather than assumed.
-- [ ] All tests passing on all 5 CI legs (ci.yml test, test-windows; build.yml ubuntu/macos/windows)
-- [ ] Documentation updated (M4); CHANGELOG entry
+- [ ] All tests passing on all 6 CI legs (ci.yml test, test-windows; build.yml ubuntu, macOS amd64, macOS arm64, Windows)
+- [ ] Documentation updated (M5); CHANGELOG entry
 
 ## Testing Strategy
 
@@ -615,7 +644,7 @@ math edge cases: no deadline, deadline < grace), `subproc.go` (normal exit codes
 capture, hung-child kill), `gatelint` (fixture exact-set, clean-file zero, allowlist honored,
 dot-dir exclusion — fixture under a fake `.hidden/` must NOT be flagged — and non-test-file
 exclusion — the R3-token non-test fixture must NOT be flagged), `egress_posture_test.go`
-(AC10 a/b always, c in the live lane).
+(AC10 a/b always, c/d in the live lane).
 
 **Integration:** the migrated tests themselves on all CI legs — every leg now runs *behind the
 boundary*, so the poisoned posture is exercised on every CI run, not just in a drill; AC3's
@@ -675,13 +704,14 @@ The following are intentionally left open for the implementer:
   contain `https://github.com/` innocently). R3's narrow-list+allowlist is the honest bounded
   version; the bound is documented, not silent — and R3 is a legibility lint, NOT the
   enforcement boundary (the poisoned lane is; component 5).
-- **Blocking non-HTTP egress (raw TCP, SSH, proxy-ignoring subprocesses)** — the poisoned proxy
-  denies HTTP(S) and git-https only; a raw TCP dial connects fine underneath it (measured —
-  V27). OS-level egress blocking (packet filters, network namespaces) across 5 CI legs
+- **Blocking proxy-bypassing egress (raw TCP, SSH, proxy-ignoring subprocesses, and hand-built
+  `http.Transport` values)** — the poisoned proxy denies HTTP(S) only when the client consults
+  proxy environment variables; raw TCP connects and a nil-`Proxy` transport bypasses it
+  (measured V27/V33). OS-level egress blocking (packet filters, network namespaces) across 6 CI legs
   including macOS and Windows runners would be its own design and is out of scope this sprint.
-  **This is the doc's one deliberate enforcement gap**: it is stated in Goals, kept visible by
-  AC10(c)'s live-lane probe, and mitigated only by review plus R3's extendable known-offender
-  list. A future test that dials raw TCP is *not* mechanically prevented.
+  **These are deliberately open residual routes under D5=Option A**, stated in Goals and kept
+  visible by AC10(c/d). Reviewers must flag any new test that dials raw TCP/SSH or constructs its
+  own `http.Transport`. AC10(d) will turn red when `m-net-effect-proxy-boundary` adopts Option B.
 - **Process-group (grandchild) cleanup on Windows** — #494's observed failure is the direct
   child; `WaitDelay` addresses it. Unix procgroup precedent exists if ever needed.
 - **Unifying `buildAilang` with `testutil.FindAilangBinary`** — real overlap (V14), but
@@ -697,12 +727,18 @@ The following are intentionally left open for the implementer:
 
 ## Timeline
 
-**Day 1:** M1 (helpers + unit tests) — commit
-**Day 2 → 2.5:** M2 (migrations, poisoned-proxy green) — commit
-**Day 3:** M3 (gatelint + poison wiring: ci.yml, build.yml, make/test.mk, posture test) — commit
-**Day 3.5–4:** M4 (docs, AC sweep, issue closes) — commit
+**CORRECTED 2026-08-06 (iteration 148)** to the 5-milestone split that actually shipped — this
+section previously carried the stale 4-milestone structure and contradicted the Implementation
+Plan above (found by the M5 evaluator, reproduced first-party before the fix).
 
-**Total: 3–4 days** (matches sprint authorization)
+**Day 1:** M1 (helpers + unit tests) — landed `c440a1628`
+**Day 2 → 2.5:** M2 (migrations, poisoned-proxy green) — landed `368f940cf`
+**Day 3:** M3 (gatelint + egress posture probe — **pure Go, zero workflow edits**) — landed `13c570063`
+**Day 3.5–4:** M4 (default-lane poison wiring — **the ONLY CI-touching commit**) — landed `4b47f8b0a`
+**Day 4.5:** M5 (docs, CHANGELOG, AC sweep, issue closes) — landed 2026-08-06
+
+**Total: planner-revised 26h ≈ 4.5 days, 5 milestones** (the original "3–4 days, 4 milestones"
+estimate is superseded — see the Estimated field in the header).
 
 ## Risks & Mitigations
 
@@ -715,7 +751,7 @@ The following are intentionally left open for the implementer:
 | Warm-up run masks a *real* interpreter-startup regression | Low | Warm-up is unasserted by design — startup performance was never what this test asserts (V12); eval-harness benchmarks (`make/eval.mk:169`) remain the perf instrument |
 | `provider_script_test.go` (R2's second match) turns out to genuinely need CI detection | Low | M2 audits it; allowlist-with-reason is the sanctioned escape, so the sprint cannot wedge on it |
 | Poisoned lane breaks a test that legitimately talks HTTP to a non-loopback local service | Low | Loopback is bypassed (V28) and the full poisoned suite already passes everywhere except the 2 known migration packages (V30); `NO_PROXY` is extendable per-lane if a LAN-daemon case ever appears |
-| A future test dials raw TCP/SSH and reintroduces class C1 outside the boundary | Med | The named residual (Goals, Non-Goals); AC10(c) keeps the hole visible on every live-lane run; R3's host list extends in one line; workflow doc (M4) tells reviewers to flag non-HTTP egress by hand |
+| A future test dials raw TCP/SSH or constructs a proxy-bypassing `http.Transport` and reintroduces class C1 outside the boundary | Med | The named residual (Goals, Non-Goals); AC10(c/d) keep both holes visible on every live-lane run; R3's host list extends in one line; the workflow doc tells reviewers to flag both forms by hand |
 
 ## Conflict Surface
 
@@ -735,7 +771,7 @@ concretely (G4):
    dependency-light: `gate.go`/`subproc.go` import only stdlib + `testing`, so no
    `check-boundaries` (make/code-health.mk:139) implication. gatelint's walker likewise reads
    files as bytes — it imports no compiler packages.
-4. **`go test ./...` runs in 5 CI legs and `make test`** (V8). gatelint adds one fast package
+4. **`go test ./...` runs in 6 CI legs and `make test`** (V34). gatelint adds one fast package
    (~ms — it reads ~937 test files' bytes once); no timeout budget concern. Anything gatelint
    flags blocks ALL of those legs at once — which is the point, but means an FP is
    maximum-visibility; hence the allowlist escape and reason strings.
@@ -772,7 +808,7 @@ excluded everywhere per V19. Shell: zsh; glob-shaped flag values quoted througho
 | V5 | Exactly 2 first-party test files use env opt-out gating; net_test already skips in CI (so #561 is local-only) | `grep -rln 'Getenv("CI")\|Getenv("GITHUB_ACTIONS")' --include='*_test.go' <first-party scope>` + read `internal/effects/net_test.go:361-401` | 2 files: `internal/coordinator/provider_script_test.go`, `internal/effects/net_test.go`. net_test lines 363-365: skip when `SKIP_NET_TESTS`/`CI`/`GITHUB_ACTIONS` set — GitHub Actions always sets `GITHUB_ACTIONS` |
 | V6 | 6 first-party `*_live_test.go` files use the reliable opt-in idiom | `find ./internal ./cmd ./runtime ./std ./tests -name '*_live_test.go'` | 6 files (notify/discord, ai/anthropic/cache, 3× executor/managed_agents, cmd/ailang/chains) |
 | V7 | Build tags are a near-unused gating convention; `integration` tag has a make entry | `grep -rn '//go:build' --include='*_test.go' <first-party scope>` ; `grep -n 'tags integration' Makefile` | 11 lines total; exactly 2 are `integration` (`internal/feedback/integration_test.go:1`, `internal/telemetry/gcp_integration_test.go:1`); rest are `!js`/`!windows`/`darwin` (+2 string-content matches in `debug_test.go`). `Makefile:264` runs `go test -tags integration ./internal/feedback/` |
-| V8 | `go test` runs in 5 CI legs + make test; build.yml (the workflow #583/#587/#509 red-lit) is one of them | `grep -rn 'go test' .github/workflows/ make/ Makefile` ; read `build.yml:15-26,65` | ci.yml:74 & :318 (`go test -timeout 300s ./...`, Linux + Windows jobs); ci.yml:84 & :327 (gated re-runs); build.yml:65 (`go test -v $(go list ./... \| grep -v /scripts …)`) under a 3-OS matrix (ubuntu/macos/windows); make/test.mk:15-17 |
+| V8 | `go test` runs in 6 CI legs + make test; build.yml (the workflow #583/#587/#509 red-lit) is one of them | `grep -rn 'go test' .github/workflows/ make/ Makefile` ; read `build.yml:15-39,65` | ci.yml:74 & :318 (`go test -timeout 300s ./...`, Linux + Windows jobs); ci.yml:84 & :327 (gated re-runs); build.yml's 4-entry matrix runs ubuntu, macOS amd64, macOS arm64, and Windows; make/test.mk:15-17 |
 | V9 | An anti-silent-skip CI gate pattern already exists to reuse | Read ci.yml:76-91 and :320-331 | Both jobs re-run named tests `-v` and `grep -q -- "--- PASS: $t"`, failing with `::error::` if absent — the exact anti-vacuity mechanism gatelint plugs into |
 | V10 | #509's failing check is self-described as redundant; the load-bearing assertion is relative; a correct bounded-subprocess pattern already exists in the same file | Read `cmd/ailang/main_run_pipe_test.go:55-168` | Lines 148-149: "The load-bearing assertion is the gap check above (EVENT_1 → EVENT_2 ≥ 200ms); this check is redundant guardrail." Absolute check lines 150-159 (`eventOneBudget` 1500ms/3500ms). Free-standing `time.After(4 * time.Second)` line 108; 10s ctx line 67; `exec.CommandContext` + deferred `Process.Kill()` lines 69, 78-81 |
 | V11 | #494's helpers are unbounded | Read `cmd/ailang/main_test.go:427-499` | `buildAilang` (line 445): `exec.Command("go","build",…)` no ctx; `runAilangBin` (line 477): `exec.Command(binPath, args...)` + `cmd.Run()` no ctx; `TestCLI_Exit_Code42` at line 531 uses it (line 542) |

--- a/docs/docs/guides/development-workflow.md
+++ b/docs/docs/guides/development-workflow.md
@@ -266,6 +266,76 @@ Fixes #42"
 - Include test writing in timeline estimates
 - Never skip tests to save time
 
+### Deterministic Test Boundaries
+
+First-party tests use one live-network gate: call `testutil.RequiresLiveNetwork(t)` and run the
+test explicitly with `AILANG_LIVE_NET=1`. The default test must be deterministic: cover the HTTP
+behavior with `httptest` first, then keep any call to the public internet as optional extra
+coverage. `testing.Short()` and gates based on `os.Getenv("CI")` or
+`os.Getenv("GITHUB_ACTIONS")` are banned; `gatelint` fails the build if they reappear.
+
+Writing one looks like this — the deterministic `httptest` case is the default, and the live call
+is the opt-in extra:
+
+```go
+func TestFetchUser(t *testing.T) {
+    // Default lane: deterministic, always runs, no egress.
+    t.Run("local_success_response", func(t *testing.T) {
+        srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+            w.Write([]byte(`{"id":1}`))
+        }))
+        defer srv.Close()
+        // ... assert against srv.URL
+    })
+
+    // Live lane: SKIPs unless AILANG_LIVE_NET=1 is set.
+    t.Run("against_real_api", func(t *testing.T) {
+        testutil.RequiresLiveNetwork(t)
+        // ... assert against the real endpoint
+    })
+}
+```
+
+Run the live lane explicitly, and never together with the poison — the lanes are mutually
+exclusive and crossing them hard-fails with a named error rather than silently skipping:
+
+```bash
+go test ./internal/yourpkg                        # default: live subtest SKIPs
+AILANG_LIVE_NET=1 go test ./internal/yourpkg      # live lane: it RUNS
+```
+
+When a legitimate fixture resembles a banned pattern, either rewrite it so its intent is clear
+or add its path to the allowlist in `internal/testutil/gatelint/allowlist.go`, keyed by rule
+(`RuleR1` = `testing.Short()`, `RuleR2` = `Getenv("CI")`/`Getenv("GITHUB_ACTIONS")`,
+`RuleR3` = known third-party hosts) with a non-empty reason — `mustReason` panics on an empty
+one, so an unexplained entry cannot exist. When adding a new *rule*, extend `scan.go`, add a
+deliberately-positive fixture under `testdata/`, and update the exact-set assertion in
+`TestGateLint_SelfTest` together, so the scanner cannot regress into finding nothing. Do not
+weaken a rule merely to accommodate one explained fixture.
+
+Default `make test` and CI test lanes set `HTTP_PROXY` and `HTTPS_PROXY` to
+`http://127.0.0.1:9`. Port 9 is an intentionally unused loopback sentinel, so an error such as
+`proxyconnect ... 127.0.0.1:9 ... connection refused` means the egress boundary caught an HTTP(S)
+request; it does not mean the developer's machine is misconfigured. Loopback remains available
+for `httptest` and local daemons.
+
+The boundary is deliberately scoped. It governs clients using Go's default transport and `git`
+HTTPS operations. It does not govern raw TCP/SSH or a client that constructs its own
+`http.Transport` without `Proxy: http.ProxyFromEnvironment`. The measured residual is currently
+**seven such transports across four first-party files**: six in `internal/effects`
+(`net.go`, `stream_ndjson.go`, `stream_sse.go` — including AILANG's `Net` effect) and one in
+`internal/executor/managed_agents/client.go`. No first-party file sets
+`Proxy: http.ProxyFromEnvironment`.
+Decision D5 deliberately leaves this route open; AC10(d),
+`effects_nil_proxy_remains_open`, is the tripwire that will turn red when the separate
+`m-net-effect-proxy-boundary` follow-up adopts Option B. Reviewers must flag any new test that
+dials raw TCP/SSH or constructs its own `http.Transport`.
+
+Subprocesses and waits must also be bounded by the test deadline. Use `testutil.RunBounded` for
+commands and `testutil.HangGuard` or `testutil.HangGuardContext` for other waits. Absolute
+wall-clock timeouts are the anti-pattern these helpers replace: they become flaky on cold
+runners and do not derive from Go's package-level test deadline.
+
 ### Documentation
 
 - Update CHANGELOG.md at each milestone


### PR DESCRIPTION
Final milestone of **M-CI-FLAKE-SYSTEMIC-FIX**. **Docs-only** — zero `.go`, zero `.github/workflows` edits.

Closes the sprint that fixes #583, #494, #509, #587, #561.

## What landed

- **`changelogs/v0.18-current.md`** — `[v0.33.1]` section stating the two **local** behaviour changes: `go test -short ./...` no longer skips anything, and `make test` now runs behind the `127.0.0.1:9` poisoned proxy.
- **`docs/docs/guides/development-workflow.md`** — new *Deterministic Test Boundaries* section: the one gating idiom (`AILANG_LIVE_NET`) with a worked httptest-default / live-opt-in example, gatelint and its allowlist-with-reason escape, the poisoned lanes, and the bounded-wait helpers.

## The residual is larger than the design doc recorded

The honest-boundary restatement was itself understating the residual. Measured first-party:

| Scope | Proxy-ignoring `http.Transport{}` | Files |
|---|---|---|
| `internal/effects` | 6 | **3** (not 4) |
| `internal/executor/managed_agents/client.go:141` | 1 | 1 |
| **First-party total** | **7** | **4** |

The doc and plan said "6 in 4 files", conflating the two scopes. The 7th transport sets only `ResponseHeaderTimeout`/`IdleConnTimeout`, so it bypasses the poison identically.

**AC10(d) is unaffected** — it asserts the *mechanism* (a `Proxy`-nil transport bypasses), which is file-independent, so it remains the correct Option-B tripwire. What changes is the documented **extent**: Option B must close 4 files, not 3.

## Doc/plan drift reconciled

- **D-1** "5 CI legs" → 6, plus the two `3-OS go test step` sites naming the same miscount. Re-derived: build.yml's matrix has 4 entries + ci.yml `test`/`test-windows` = 6. Row **V34** is deliberately left intact — it already said 6 and quotes the historical phrases.
- **D-2** plan's M3 section gains AC10(d); doc corrected to a/b/c/d. The subtest was already implemented in M3 — the plan text was stale.
- **D-3** doc's Implementation Plan **and Timeline** rewritten from the stale 4-milestone split to the 5-milestone split that shipped.
- Dependencies block now records **#532 as CLOSED/SUPERSEDED** and **#569 as MERGED**, so the doc no longer describes dead collisions as live.

## Verification

Full **AC1–AC12** sweep re-run **outside the executor sandbox**; all pass. AC10's four subtests all PASS in the poisoned live lane, including `effects_nil_proxy_remains_open`.

The one full-suite red was **#598** (`TestSolve_HardTimeout_FakeSolverIgnoringT`, a pid-file race). Ruled out as unrelated by a 3-arm negative control — poison ON and poison OFF are outcome-identical — and the re-run was rc=0 / 107 ok / 0 FAIL / **0 egress errors**. A second observation was added to #598: both failures needed *concurrent load*, which is why an idle stress loop measured 0/12.

Also recorded: the plan's `actionlint … → rc=0` gate is **unpassable at base** (rc=1 on 5 pre-existing shellcheck findings), and `-shellcheck='-e SC2086'` is a **vacuous** fix — that flag takes an executable path, so shellcheck silently never runs (rc=0 / 0 findings, vs a control of rc=1 / 5).

Evaluator sonnet **PASS 88/100 round 1, zero blocking**; its three non-blocking findings were reproduced first-party and fixed in this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)