### PR TITLE
fix(testing): make `test "name" { assert ... }` execute — lower assert in the fold (#590)

### DIFF
--- a/.ailang/state/sprints/sprint_M-NAMED-TEST-ASSERT-LOWERING.json
+++ b/.ailang/state/sprints/sprint_M-NAMED-TEST-ASSERT-LOWERING.json
@@ -1,0 +1,63 @@
+{
+  "sprint_id": "M-NAMED-TEST-ASSERT-LOWERING",
+  "design_doc": null,
+  "sprint_plan": "design_docs/planned/v0_33_1/m-named-test-assert-lowering-sprint-plan.md",
+  "status": "completed",
+  "created": "2026-08-06T00:00:00+01:00",
+  "github_issues": [590],
+  "features": [
+    {
+      "id": "M1",
+      "description": "Assert-aware test-body lowering: new internal/testing/test_body_lowering.go holding the moved FoldBodyExprs plus FoldTestBody, which lowers top-level AssertStmt into a short-circuiting if-chain over an int sentinel; EvaluateNamedTestBodyExprs decodes the sentinel.",
+      "estimated_loc": 260,
+      "dependencies": [],
+      "acceptance_criteria": [
+        "AC-1 (TDD): internal/testing/named_test_assert_test.go exists; the pre-fix run of `go test ./internal/testing/ -run TestNamedTest_Assert` was recorded RED",
+        "AC-2: `ailang test` on a single-assert module -> rc=0, output contains `1 passed` (base rc=1)",
+        "AC-3: `ailang test` on a false-only-assert module -> rc=1 and output does NOT contain PAR_NO_PREFIX_PARSE",
+        "AC-4: `test \"x\" { assert <false>; assert <true> }` -> rc=1 (short-circuit / anti-vacuous-green)",
+        "AC-5: `go test ./internal/testing/...` -> rc=0",
+        "AC-6: `make check-file-sizes` -> rc=0"
+      ],
+      "passes": true,
+      "started": "2026-08-06T00:00:00+01:00",
+      "completed": "2026-08-06T00:00:00+01:00",
+      "notes": "AC-1 RED recorded before the fix: `go test ./internal/testing/ -run TestNamedTest_Assert -v` rc=1, 7 FAIL / 1 PASS. Every failure was `pipeline error: ... PAR_NO_PREFIX_PARSE at _namedtest_body_*.ail:6:3: unexpected token in expression: assert`; the one PASS was TestNamedTest_AssertFree_LegacyPathUnchanged, confirming only assert bodies were broken. After the fix all 9 tests pass. AC-2 rc=0 `1 passed` (base rc=1); AC-3 rc=1 with zero PAR_NO_PREFIX_PARSE occurrences; AC-4 rc=1; AC-5 rc=0; AC-6 rc=0 (executor_helpers.go 717 -> 665 lines, new test_body_lowering.go 263 lines). Assert-free bodies return the byte-identical legacy FoldBodyExprs result and an empty []CheckInfo, so no currently-passing named test changes code path."
+    },
+    {
+      "id": "M2",
+      "description": "Report which check failed (sentinel k -> `assertion k failed: `assert <src>` (at pos)`) and add a printer tripwire so an AssertStmt reaching PrintAILANGSource is a self-describing error instead of unparseable source.",
+      "estimated_loc": 160,
+      "dependencies": ["M1"],
+      "acceptance_criteria": [
+        "AC-7: `go test ./internal/testing/ -run TestNamedTest_Assert_ReportsWhichAssertion` -> rc=0, result.Error contains `assertion 2 failed` when the SECOND assert is false",
+        "AC-8: PrintAILANGSource(&ast.AssertStmt{...}) contains `printer-error` and no longer emits verbatim `assert ...` (two-directional guard)",
+        "AC-9: `go test ./internal/parser/... ./internal/format/... ./internal/ast/...` -> rc=0 (parser untouched)",
+        "AC-10: `go vet ./internal/testing/...` -> rc=0 and `go build ./internal/... ./cmd/ailang` -> rc=0"
+      ],
+      "passes": true,
+      "started": "2026-08-06T00:00:00+01:00",
+      "completed": "2026-08-06T00:00:00+01:00",
+      "notes": "AC-7/AC-8 RED recorded before M2: rc=1, error text was `expected true, got false` and the printer returned `assert (x == 1)` — exactly the state the plan predicted. All three AC-8 clauses fired in the red (printer-error absent, FoldTestBody absent, verbatim `assert ` prefix present), proving both directions. After M2: AC-7 rc=0, AC-8 rc=0, AC-9 rc=0 (internal/format's own node_coverage_test.go still expects `assert x` from the FORMATTER's separate printer and stays green), AC-10 vet rc=0 / build rc=0. End-to-end CLI: `assertion 1 failed: `assert (add_one(1) == 99)` (at false_assert.ail:6:3)` — original source position, not the round-trip temp file."
+    },
+    {
+      "id": "M3",
+      "description": "On-disk .ail fixture corpus under internal/testing/testdata/assert/ driven by a table test through RunTestsFromFile (the same entry point `ailang test` uses), plus a CHANGELOG entry.",
+      "estimated_loc": 60,
+      "dependencies": ["M1", "M2"],
+      "acceptance_criteria": [
+        "AC-11: `ailang test` over each fixture produces the expected rc, driven by a table test; `go test ./internal/testing/...` -> rc=0",
+        "AC-12: `rg -n \"590\" CHANGELOG.md` returns a hit"
+      ],
+      "passes": true,
+      "started": "2026-08-06T00:00:00+01:00",
+      "completed": "2026-08-06T00:00:00+01:00",
+      "notes": "7 fixtures: single_pass, single_fail, second_fails, first_fails_short_circuit, let_then_assert, assert_let_assert, assert_free_control. TestNamedTest_AssertFixtures rc=0 (7/7 subtests pass); each fixture is copied into a temp dir first so the evaluator's round-trip temp file never lands in testdata/ (verified pristine afterwards). Independently confirmed with the worktree-built CLI: rc=0/1/1/1/0/0/0 respectively, with ordinals 1/2/1 on the three failures. AC-12 hit at CHANGELOG.md:19. Per plan section 6, examples/experimental was deliberately LEFT ALONE (already labelled non-working; verify-examples runs `ailang run`, never `ailang test`, so a gated example could not guard this bug anyway)."
+    }
+  ],
+  "velocity": {
+    "target_loc_per_day": 400,
+    "estimated_total_loc": 480,
+    "estimated_days": 2
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ For the latest version, see [changelogs/v0.18-current.md](changelogs/v0.18-curre
 
 ## v0.32.0 (Unreleased)
 
+### Fixed
+
+- `test "name" { assert <cond> }` now executes instead of failing 100% of the time
+  with `PAR_NO_PREFIX_PARSE`. Named test bodies are printed back to AILANG source and
+  re-run through the general pipeline, which has no `assert` prefix parselet, so the
+  keyword could never survive that round-trip. Top-level `assert` statements are now
+  lowered in `FoldTestBody` (`internal/testing/test_body_lowering.go`) into a
+  short-circuiting `if` chain over an int sentinel, so a failing assert stops the body
+  and reports **which** assertion failed, with its source text and its original
+  position — e.g. ``assertion 2 failed: `assert (add_one(3) == 99)` (at m.ail:9:3)``.
+  A non-final false assert now fails the test instead of being silently discarded.
+  Bodies containing no `assert` keep the previous code path unchanged.
+  Fixes [#590](https://github.com/sunholo-data/ailang/issues/590).
+
 - Added experimental `std/ai.stepWithStreamRecorded`, originally authored by
   [@arniwesth](https://github.com/arniwesth). It preserves immediate stream
   callbacks while returning the exact ordered adapter-emitted chunk log and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,6 @@ For the latest version, see [changelogs/v0.18-current.md](changelogs/v0.18-curre
 
 ## v0.32.0 (Unreleased)
 
-### Fixed
-
-- `test "name" { assert <cond> }` now executes instead of failing 100% of the time
-  with `PAR_NO_PREFIX_PARSE`. Named test bodies are printed back to AILANG source and
-  re-run through the general pipeline, which has no `assert` prefix parselet, so the
-  keyword could never survive that round-trip. Top-level `assert` statements are now
-  lowered in `FoldTestBody` (`internal/testing/test_body_lowering.go`) into a
-  short-circuiting `if` chain over an int sentinel, so a failing assert stops the body
-  and reports **which** assertion failed, with its source text and its original
-  position — e.g. ``assertion 2 failed: `assert (add_one(3) == 99)` (at m.ail:9:3)``.
-  A non-final false assert now fails the test instead of being silently discarded.
-  Bodies containing no `assert` keep the previous code path unchanged.
-  Fixes [#590](https://github.com/sunholo-data/ailang/issues/590).
-
 - Added experimental `std/ai.stepWithStreamRecorded`, originally authored by
   [@arniwesth](https://github.com/arniwesth). It preserves immediate stream
   callbacks while returning the exact ordered adapter-emitted chunk log and

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,21 @@
 
 ## [v0.33.1] - 2026-08-06
 
+### Fixed
+
+- **`test "name" { assert <cond> }` now executes instead of failing 100% of the time**
+  with `PAR_NO_PREFIX_PARSE` (#590). Named test bodies are printed back to AILANG source
+  and re-run through the general pipeline, which has no `assert` prefix parselet, so the
+  keyword could never survive that round-trip — leaving `assert` a reserved word with no
+  working call site anywhere in the language. Top-level `assert` statements are now lowered
+  in `FoldTestBody` (`internal/testing/test_body_lowering.go`) into a short-circuiting `if`
+  chain over an int sentinel, so a failing assert stops the body and reports **which** check
+  failed, with its source text and its original position — e.g.
+  ``assertion 2 failed: `assert (add_one(3) == 99)` (at m.ail:9:3)``. A non-final false
+  assert now fails the test instead of being silently discarded. A trailing bare expression
+  is reported as ``check N failed`` rather than being quoted back as an `assert` the user
+  never wrote. Bodies containing no `assert` keep the previous code path unchanged.
+
 ### Added
 
 - **Embeddable serve-api surface complete — #498 Lane B M3 (final milestone).** The public

--- a/design_docs/planned/v0_33_1/m-named-test-assert-lowering-sprint-plan.md
+++ b/design_docs/planned/v0_33_1/m-named-test-assert-lowering-sprint-plan.md
@@ -1,0 +1,442 @@
+# Sprint Plan — `m-named-test-assert-lowering` (make `test "…" { assert … }` execute)
+
+**Sprint ID**: `M-NAMED-TEST-ASSERT-LOWERING`
+**Mission**: V1 outer loop, iteration 152
+**Planner**: Opus (sprint-planner role)
+**Planner-Lane**: opus
+**Date**: 2026-08-06
+**Base**: `dev` @ `64970c118` (`v0.33.0-39-g64970c118`), main checkout — executor works in a worktree
+**GitHub issues**: `#590` (closes)
+**Design doc**: **NONE — bug-fix lane** (judgement in §1)
+**Risk**: low
+**Estimated**: ~480 LOC (impl ~180, tests ~240, testdata/docs ~60), **~1.5–2 executor-days**
+
+---
+
+## 0. Verification posture
+
+Every claim in §2–§5 was measured first-party in this checkout with
+`/Users/voightkampff/go/bin/ailang`, whose `--version` (`v0.33.0-39-g64970c118-dirty`) matches
+`git describe` at `64970c118`. The `-dirty` is the two rig-synced benchmark JSON files
+(`docs/static/benchmarks/os/*.json`) — no Go source is modified.
+
+**Every lowering shape in §4 was validated as real AILANG source with `ailang test` before being
+written down.** They are not sketches; they parse, typecheck, elaborate and evaluate through the
+exact round-trip pipeline this sprint touches. Commands are recorded inline.
+
+**Commit posture**: the main checkout is shared and carries uncommitted benchmark JSON. Do not
+commit, branch, or stash in it. Work in a worktree; the controller finalizes.
+
+---
+
+## 1. JUDGEMENT: no design doc, no quorum — bug-fix lane
+
+**Recommendation: proceed straight to execution.**
+
+1. **No new syntax, no new flag, no new user-visible semantics.** `assert` is already a reserved
+   lexer keyword (`internal/lexer/token.go`), already has a parser production
+   (`parseAssertStmt`, `internal/parser/parser_test_decl.go:139`), already has an AST node that
+   implements `exprNode()` (`internal/ast/ast_decl.go:167-176`), and is already handled by the
+   formatter (`internal/format/expr.go:562`). Every layer exists **except the one that turns it
+   into something executable.** This sprint supplies that layer and nothing else.
+2. **Precedent is direct**: `#548` / `m-strip-decl-aware` ran doc-less as a bug fix inside
+   `internal/testing`; so did `#524` and `#541`. This is the same package and the same shape —
+   in fact it is the *sibling* of `#548`: both are defects in the AST→source→pipeline round-trip
+   that `EvaluateNamedTestBodyExprs` performs.
+3. **The chosen fix (§3) touches exactly one package, `internal/testing`.** No parser change, no
+   lexer change, no elaborator change, no Conflict Surface obligation. The two options that
+   *would* have triggered one are rejected on measured grounds in §3.
+
+---
+
+## 2. Premises: 6 confirmed, 1 partially refuted, 3 new findings
+
+The controller supplied 7 measured premises. Six reproduce exactly. One is literally true but
+its stated *inference* overstates the evidence. Three findings are new.
+
+### Confirmed
+
+| # | Premise | My re-measurement |
+|---|---------|-------------------|
+| 1 | `test "n" { assert … }` → rc=1 `PAR_NO_PREFIX_PARSE … assert`; true and false assertions fail identically; assert-free control rc=0 | **Confirmed.** `ailang test` on 3 fresh modules: assert-true rc=1, assert-false rc=1, no-assert control rc=0 `1 tests: 1 passed`. Two-assert body also rc=1, failing at col 14 not col 3 — because `FoldBodyExprs` wraps the first assert in `let _seq = … in …`, so `{ let _seq = ` (13 chars) precedes it. The column shift is itself proof the fold, not the parser, chooses the shape. |
+| 2 | `registerPrefix(lexer.ASSERT` = 0 of 26; `parseAssertStmt` reachable from one gated site | **Confirmed.** `rg -n "lexer.ASSERT" internal/` → 2 hits, both in `parser_test_decl.go` (:124 dispatch, :142 self-check). 26 `registerPrefix` calls total. |
+| 3 | Mechanism is `EvaluateNamedTestBodyExprs` → `FoldBodyExprs` → `PrintAILANGSource` → temp file → general pipeline; printer emits `assert %s` at `executor_helpers.go:487-488` | **Confirmed by reading all four sites.** |
+| 4 | `assert` in a plain function body also fails `PAR_NO_PREFIX_PARSE`; the keyword has no working call site in the language | **Confirmed.** `ailang check` on `export func main() -> () { assert 1 == 1 }` → rc=1, `PAR_NO_PREFIX_PARSE at …:2:28`. |
+| 6 | `verify-examples` gates `examples/runnable/` only; `examples/experimental` appears nowhere in make's database | **Confirmed with the same control.** `make -pn \| grep -c examples/experimental` = **0**; `examples/runnable` = **9**. `make/examples.mk:18-28` is the gate. |
+| 7 | `internal/testing` and `internal/format` both know `ast.AssertStmt`; it implements `exprNode()` | **Confirmed.** |
+
+### Partially refuted
+
+**P5 — literally true, inference overstated.** `ailang prompt --source=embedded` line 2269 does
+list `assert`. But the surrounding block (lines 2258-2260) is headed:
+
+> `## Reserved Keywords` — *"AILANG reserves 43 keywords. You **cannot** use these as variable or
+> function names."*
+
+So the prompt is **warning models off using `assert` as an identifier**, not advertising it as a
+usable construct. `assert` appears exactly twice in the whole embedded prompt (line 2269, and
+line 2323 in an unrelated package blurb) and is **never demonstrated in a worked example**. The
+demand evidence is therefore *weaker* than "every eval model is told this keyword exists [and can
+be used]" — it is "models are told the word is part of the language and then never shown what it
+does." That is still real demand (models reach for keywords they are told exist), but it is
+second-hand, and it changes a scope decision: see §6, M3.
+
+Corroborating: the issue says `assert` is "the form shown in the language's own test
+examples/docs". I could not confirm that — `rg` over `docs/docs/` found no `test "…" { assert … }`
+worked example. The only in-repo uses are the two ungated `examples/experimental` files and
+`internal/testing`'s own Go-string fixtures.
+
+### New findings (mine, iteration 152)
+
+**F1 — The elaborator has ZERO `AssertStmt` handling.** `rg "AssertStmt" -g '*.go'` over the whole
+repo returns 8 files: `ast`, `parser`, `format`, `testing`, and their tests. **`internal/elaborate`
+is not among them**, and `internal/elaborate/expressions.go:116-121` ends its `normalize` switch
+with `return nil, fmt.Errorf("normalization not implemented for %T", expr)`.
+
+This is decisive for §3: it means options (a) and (b) as the reporter phrased them **do not fix the
+bug on their own** — they relocate the failure from the parser to the elaborator.
+
+**F2 — Non-final expressions in a named test body are silently discarded, so a false one passes.**
+This is a *second, unfiled* vacuous-green bug in the same function:
+
+```ailang
+test "first expr false, last true" {
+  add_one(1) == 99;    -- FALSE
+  add_one(1) == 2      -- true
+}
+```
+→ **`✓ ... All tests passed!` rc=0.**
+
+Root cause: `FoldBodyExprs` (`executor_helpers.go:300-311`) wraps every non-final, non-`let`
+expression as `let _seq = expr in rest` — the value is bound to a dead name and thrown away.
+`runner.go:156-158` documents this as intentional ("evaluated for side-effects only … named test
+bodies are pure by contract"), which is precisely why it is wrong: a *pure* body's non-final
+expressions have no side effects, so discarding a `bool` can only ever hide a failure.
+
+**This directly constrains the fix.** The obvious lowering — print `assert c` as plain `c` — would
+make `test { assert false; assert true }` **PASS**. Any accepted design must short-circuit. §4 does.
+
+**F3 — Numeric literals in a comparison mis-infer on the named-test path only.**
+```
+test "x" { (if true then 0 else 2) == 0 }   →  type error: No instance for Num[bool]
+export pure func f() -> bool { (if true then 0 else 2) == 0 }   →  ailang check: ✓ No errors found
+```
+Byte-identical expression; typechecks in a function body, fails as a named-test body. This is a
+third bug, unrelated to `assert`, surfaced while validating §4's shapes. **Not in scope** — it does
+not block this sprint, because the chosen design never emits an in-AILANG comparison of the
+sentinel (the executor reads the `IntValue` in Go). Recommend the controller file it separately.
+
+---
+
+## 3. THE DESIGN DECISION — option (c), as an assert-aware *fold*, not a printer hack
+
+**Chosen: (c) — lower `AssertStmt` to general AILANG syntax before printing. Confined to
+`internal/testing`. No parser, lexer, or elaborator change.**
+
+### Why (b) is rejected
+
+Option (b) — "register `assert` as a general-expression prefix parselet" — **does not fix the bug.**
+By F1, the elaborator has no `AssertStmt` case. Registering the parselet moves the failure from
+`PAR_NO_PREFIX_PARSE` to `normalization not implemented for *ast.AssertStmt`. To actually work it
+needs: parser (parselet + precedence), elaborate (new Core form or a desugaring), types (what type
+does `assert e` have?), and eval (what does it *do* when false — there is no pure abort primitive;
+`_debug_check` is an **effect** builtin requiring the `Debug` capability, `internal/builtins/debug.go:62-107`,
+so it is unusable in a pure test body). That is **4 core packages plus a new pure-abort semantics**.
+
+It is also a **language change, not a bug fix**: making `assert` legal in ordinary expression
+position decides that AILANG has an assertion expression everywhere, with a defined value, a
+defined type, and a defined failure behaviour — in a language whose north star is "everything is an
+expression" and "all non-determinism explicit". Blast radius: every expression position in the
+grammar; it needs a Conflict Surface, a design doc, and a quorum. **If the mission wants that, it is
+a separate FEATURE item, not iteration 152's bug fix.**
+
+### Why (a) is rejected
+
+Option (a) — "evaluate the parsed AST directly instead of print-and-reparse" — also needs F1's
+missing elaborator support, *plus* it must reproduce what the round-trip buys. The comment at
+`executor.go:169-182` claims the round-trip exists so OpLowering and module-scope bindings work.
+I measured what that means concretely: **`TestDecl` is never elaborated by the pipeline at all** —
+`rg "TestDecl" internal/elaborate/ internal/pipeline/ internal/link/ internal/iface/` returns
+**zero non-coincidental hits** (the one hit is a Go test named `TestDeclaredRows…`). Contrast the
+contract path, which *does* get Core for free from `result.Artifacts.Core.Meta[fn].Contracts[i].Expr`
+(`EvaluateEnsuresHarnessFromCore`, `executor.go:128`) precisely because contracts live on function
+declarations the pipeline compiles.
+
+So option (a) is not "delete the round-trip"; it is "build a new AST→lowered-Core-in-module-scope
+entry point that does not exist today". That is a real piece of compiler plumbing, not a bug fix,
+and it would still need the elaborator to learn `AssertStmt`. **Rejected on size, not on principle**
+— it may well be the right long-term shape, and §9 records it as future work.
+
+### Why (c), and specifically why in the *fold*
+
+The reporter framed (c) as "have `PrintAILANGSource` lower `AssertStmt` when printing outside a
+test-decl body". Doing it in the printer is **wrong**, for a measured reason: the printer sees one
+node at a time and cannot see F2's sequencing problem. `assert c` printed as `c` in a non-final
+position is *swallowed by the surrounding* `let _seq = … in …` and the test goes vacuously green.
+Short-circuiting is a property of the **sequence**, so the lowering belongs where the sequence is
+built: `FoldBodyExprs`.
+
+Three further properties make this the small option:
+
+- **`AssertStmt` can only occur at the top level of a test body.** Verified: `parseStatement`
+  (`parser_test_decl.go:122-136`) dispatches on `ASSERT` only at statement start, and
+  `test "x" { let y = assert true; y }` is a parse error (rc=1, reporter shows `✗ parse`). So the
+  lowering is a **flat walk over `[]ast.Expr`**, not a recursive AST rewrite.
+- **`FoldBodyExprs` has exactly one caller** (`executor.go:206`). `rg "FoldBodyExprs" -g '*.go'`
+  → 4 hits: the definition, its doc comment, one mention in another comment, and the single call.
+- **The printer already emits everything the lowering needs.** `case *ast.If`
+  (`executor_helpers.go:411-415`) prints `if c then a else b`; literals and `let … in …` are
+  already covered. **No printer change is required for the lowering itself.**
+
+---
+
+## 4. The lowering, validated as source
+
+### Semantics (this is the part the controller asked to be pinned down)
+
+Define the body's **checks**, left to right, 1-based:
+- every top-level `*ast.AssertStmt` is a check;
+- the **final** expression is a check (it already is one under today's bool contract — if it is an
+  `AssertStmt` it is the same check, counted once).
+
+The body lowers to an **`int` sentinel**:
+- **`0`** — every check passed.
+- **`k ≥ 1`** — check `k` was the **first** to evaluate false; checks after `k` are **not evaluated**.
+
+**All sentinels are positive or zero** — deliberately, so the lowering never needs a unary-minus
+literal in `else` position.
+
+**Only bodies that contain at least one `AssertStmt` take the sentinel path.** An assert-free body
+keeps today's exact bool path, byte for byte. This is what makes the regression risk ~zero: every
+currently-passing named test is assert-free (they must be — assert bodies are 100% broken), so
+none of them change code path.
+
+`EvaluateNamedTestBodyExprs` decodes in Go and preserves the runner's contract:
+
+| sentinel | returned to `runner.go:191-211` |
+|---|---|
+| `0` | `*eval.BoolValue{true}` → `StatusPass` |
+| `k ≥ 1` | `error`: `` assertion 1 failed: `assert add_one(1) == 2` (at a.ail:6:3) `` → `StatusFail` with that text |
+
+So a failing assert reports **which** assertion failed, with its source text and its original
+position — not a bare `false`. (`ast.AssertStmt.Pos` is populated at
+`parser_test_decl.go:159`; the condition's source text comes from `PrintAILANGSource(e.Condition)`.)
+
+### Transformation
+
+Walk `exprs` right-to-left, exactly as today, with two changed cases:
+
+| element | today | after |
+|---|---|---|
+| `*ast.Let` / `*ast.LetRec` (non-final) | thread `Body: result` | **unchanged** |
+| `*ast.AssertStmt` (non-final) | `let _seq = <AssertStmt> in result` | `&ast.If{Cond: e.Condition, Then: result, Else: IntLit(k)}` |
+| `*ast.AssertStmt` (final) | `<AssertStmt>` | `&ast.If{Cond: e.Condition, Then: IntLit(0), Else: IntLit(k)}` |
+| other (non-final) | `let _seq = expr in result` | **unchanged** (see F2 disposition, §6) |
+| other (final), assert-bearing body | itself | `&ast.If{Cond: expr, Then: IntLit(0), Else: IntLit(k)}` |
+
+`IntLit` is `int64` — `internal/ast` `IntLit` takes `int64`, not `int` (`.claude/rules/parser.md`:
+"IntLit is `int64`, not `int` (will panic!)").
+
+### Validated shapes — every one of these was run
+
+| shape | source fed to `ailang test` | result |
+|---|---|---|
+| single assert | `{ if add_one(1) == 2 then 0 else 1 }` | evaluates, `*eval.IntValue` |
+| two asserts | `{ if add_one(1) == 2 then (if add_one(3) == 4 then 0 else 2) else 1 }` | evaluates, `*eval.IntValue` |
+| let then assert | `{ let x = add_one(1) in if x == 2 then 0 else 1 }` | evaluates, `*eval.IntValue` |
+| assert, let, assert | `{ if add_one(1) == 2 then (let x = 1 in if x == 1 then 0 else 2) else 1 }` | evaluates, `*eval.IntValue` |
+| plain non-final + sentinel final | `{ let _seq = (1 == 1) in if add_one(1) == 2 then 0 else 1 }` | evaluates, `*eval.IntValue` |
+
+**Sentinel values confirmed exactly**, by wrapping in module-level `isZero`/`isOne`/`isTwo` helpers
+so the result becomes a bool the runner can pass on:
+- all checks pass → `isZero(…)` → **`✓ 1 passed`** (sentinel is `0`)
+- first check false → `isOne(…)` → **`✓ passed`** (sentinel is `1`)
+- second check false → `isTwo(…)` → **`✓ passed`** (sentinel is `2`)
+  (`2 passed, 0 failed` for the latter two in one module.)
+
+**Dangling-else checked, and it is safe.** `PrintAILANGSource` emits `if` **without parentheses**.
+I ran the unparenthesized nested form — `isZero(if c1 then if c2 then 0 else 2 else 1)` and both
+failing variants — and got **`3 passed, 0 failed`**. Nested `if` in `then` position associates
+correctly. **No printer paren change is needed.** (Recorded because this is exactly the class of
+thing that mis-associates silently.)
+
+### File-size constraint (measured, and it dictates the file layout)
+
+`internal/testing/executor_helpers.go` is **717 lines**; `make check-file-sizes` fails at **>800**
+and is **green at base**. Adding ~180 LOC of lowering there would breach the gate. **M1 therefore
+creates a new file** `internal/testing/test_body_lowering.go` and moves `FoldBodyExprs` into it —
+the same move `#548`/`M-STRIP-DECL-AWARE` made when it created `internal/testing/source_strip.go`.
+
+---
+
+## 5. Baselines — every acceptance command, run on the pristine tree first
+
+Mission rule 3e. `RED` = fails today (so passing it proves the fix); `GREEN` = passes today (so it
+is a *stays-green* guard and is only non-vacuous alongside a RED criterion).
+
+| # | Command | Base result |
+|---|---------|-------------|
+| B1 | `ailang test <single-assert module>` | **rc=1** `PAR_NO_PREFIX_PARSE … unexpected token in expression: assert` — **RED** |
+| B2 | `ailang test <two-assert module>` | **rc=1**, same error at col 14 — **RED** |
+| B3 | `ailang test <assert-free control module>` | **rc=0**, `1 tests: 1 passed` — **GREEN (must stay)** |
+| B4 | `ailang test <non-final false, no assert>` | **rc=0, PASSES** — the F2 vacuous green |
+| B5 | `go test ./internal/testing/...` | **rc=0** `ok … 1.089s` — **GREEN (must stay)** |
+| B6 | `go test ./internal/parser/... ./internal/format/... ./internal/ast/...` | **rc=0** — **GREEN (must stay; proves the parser was not touched)** |
+| B7 | `go build ./internal/... ./cmd/ailang` | **rc=0** — usable gate |
+| B8 | `go build ./...` | **rc=1** at base (`cmd/wasm`, `gen/main` have no native `main`) — **NOT A GATE, do not use** |
+| B9 | `go vet ./internal/testing/...` | **rc=0** — **GREEN (must stay)** |
+| B10 | `make check-file-sizes` | **rc=0**, `✓ All files within 800 line limit` — **GREEN (must stay)** |
+| B11 | `go test ./...` | **rc=1** at base (`internal/smt TestSolve_HardTimeout_FakeSolverIgnoringT` under full-suite load, `#602`) — **NOT A GATE, do not use** |
+
+**Note on `go test -run`:** a `-run` pattern that matches nothing **exits 0**. So "run the new test"
+is vacuous until the test exists. AC-1 below is therefore worded as a TDD obligation with a
+recorded red output, not as an exit code.
+
+---
+
+## 6. Milestones
+
+### M1 — Assert-aware test-body lowering (the fix)
+**Size**: impl ~130 LOC, tests ~130 LOC · **~0.75 day** · depends on: nothing
+
+- Create `internal/testing/test_body_lowering.go`; **move** `FoldBodyExprs` there from
+  `executor_helpers.go` (file-size constraint, §4) with its doc comment.
+- Add `FoldTestBody(exprs []ast.Expr) (ast.Expr, []CheckInfo)` implementing §4. `CheckInfo` carries
+  `{Ordinal int, Source string, Pos ast.Pos}` for each check, in order.
+- When `exprs` contains **no** `*ast.AssertStmt`, `FoldTestBody` returns exactly what
+  `FoldBodyExprs` returns today and an empty `[]CheckInfo` — the byte-identical legacy path.
+- `EvaluateNamedTestBodyExprs` (`executor.go:184`) calls `FoldTestBody`, and when
+  `len(checks) > 0` decodes the resulting `*eval.IntValue` per the §4 table.
+
+**Acceptance (each a command; RED/GREEN per §5):**
+1. **AC-1 (TDD, records the red)**: a new `internal/testing/named_test_assert_test.go` exists with
+   `TestNamedTest_Assert_Passes` built on the existing `runInlineTestsOnSource` helper
+   (`executor_regression_test.go:14`). The executor **must** commit/record the run of
+   `go test ./internal/testing/ -run TestNamedTest_Assert` **before** the fix and paste its
+   failing output into the sprint JSON `notes`. Vacuous otherwise (see §5 note).
+2. **AC-2**: `ailang test` on a single-assert module → **rc=0**, output contains `1 passed`.
+   *(B1: rc=1 at base.)*
+3. **AC-3**: `ailang test` on a module whose **only** assert is false → **rc=1**, and the output
+   does **not** contain `PAR_NO_PREFIX_PARSE`. *(Both halves red at base: base rc=1 is for the
+   wrong reason and the string IS present.)*
+4. **AC-4 (short-circuit / anti-F2)**: `test "x" { assert <false>; assert <true> }` → **rc=1**.
+   Paired with AC-3's no-`PAR_NO_PREFIX_PARSE` clause so the rc is not inherited from the parse
+   error. *(B2 red at base.)*
+5. **AC-5**: `go test ./internal/testing/...` → rc=0. *(B5 green; stays green.)*
+6. **AC-6**: `make check-file-sizes` → rc=0. *(B10 green; this is why the new file exists.)*
+
+### M2 — Which check failed, and a tripwire that goes red on reintroduction
+**Size**: impl ~50 LOC, tests ~110 LOC · **~0.5 day** · depends on: M1
+
+- Executor maps sentinel `k` to `fmt.Errorf("assertion %d failed: `assert %s` (at %s)", …)` using
+  `CheckInfo`. Runner needs **no change** — `runner.go:191-196` already surfaces
+  `err.Error()` as `result.Error`.
+- **Tripwire**: change `PrintAILANGSource`'s `case *ast.AssertStmt`
+  (`executor_helpers.go:487-488`) from emitting `assert %s` to returning
+  `<printer-error: AssertStmt reached the printer; FoldTestBody must lower it first>`. This matches
+  the file's existing convention for unrepresentable nodes (`*ast.Error` at :486 and `default:` at
+  :501 already return `<printer-error: …>` strings). Reaching the printer with an `AssertStmt` is
+  now a *self-describing* failure instead of a `PAR_NO_PREFIX_PARSE` 200 lines away.
+
+**Acceptance:**
+7. **AC-7**: `go test ./internal/testing/ -run TestNamedTest_Assert_ReportsWhichAssertion` → rc=0,
+   asserting `result.Error` matches `assertion 2 failed` for a body whose **second** assert is
+   false. Red before M2 (the message would be `expected true, got false`).
+8. **AC-8 (regression guard, both directions)**: a unit test asserting
+   `PrintAILANGSource(&ast.AssertStmt{Condition: …})` contains `printer-error`. Goes **red** if
+   someone restores the verbatim `assert %s` printing. Combined with AC-2/AC-4, which go red if
+   someone reverts the fold, **#590 cannot be reintroduced without a red test.**
+9. **AC-9**: `go test ./internal/parser/... ./internal/format/... ./internal/ast/...` → rc=0.
+   *(B6 green; this is the "we did not touch the parser" proof. `internal/format`'s own
+   `node_coverage_test.go:100` still expects `"assert x"` from the **formatter's** printer — a
+   different printer — and must stay green.)*
+10. **AC-10**: `go vet ./internal/testing/...` → rc=0 and `go build ./internal/... ./cmd/ailang`
+    → rc=0. *(B9/B7 green. **Do not use `go build ./...`** — B8.)*
+
+### M3 — Fixtures, CHANGELOG, and explicit dispositions
+**Size**: ~40 LOC testdata + ~20 lines docs · **~0.25 day** · depends on: M1, M2
+
+- Add `.ail` fixtures under `internal/testing/testdata/assert/` (alongside the existing
+  `testdata/strip/` corpus) covering: single passing assert · single failing assert · two asserts
+  with the second false · `let` + assert · assert + `let` + assert. Drive them from the Go tests.
+- `CHANGELOG.md` entry under the unreleased heading, `Fixes #590`.
+
+**Acceptance:**
+11. **AC-11**: `ailang test` over each fixture produces the expected rc, driven by a table test;
+    `go test ./internal/testing/...` rc=0.
+12. **AC-12**: `rg -n "590" CHANGELOG.md` returns a hit.
+
+**Explicit disposition — the two ungated `examples/experimental` files: LEAVE THEM. Do not convert
+them to fixtures and do not gate them.** Grounds, measured:
+- All three experimental files I checked fail `ailang check` **rc=1 with parse errors** *today, for
+  reasons that have nothing to do with `assert`* — `web_api.ail` and `concurrent_pipeline.ail` use
+  `spawn { … }`, `channel[T]()`, `ch <- v`, `let x <- ch` and `withMockDB { db => … }`; none of
+  that parses. Gating them would mean implementing unrelated language features.
+- `examples/experimental/README.md` **already** opens with *"**These examples DO NOT currently
+  work!** They require features that are: on the roadmap / partially implemented / planned for
+  future releases."* The directory is correctly and explicitly labelled as aspirational design
+  documentation. Nothing is being hidden; adding a second warning would be noise.
+- **And a gated example would not guard this bug anyway**: `verify-examples` runs
+  `ailang run` (`scripts/verify_examples.go:108-115`) and **never** `ailang test`. Nothing in the
+  repo gates `ailang test` on `.ail` files — `tests/record_update_regression_test.ail` is
+  referenced by no Makefile target and no workflow (`rg` over `.github/workflows/`, `make/`,
+  `scripts/`, `tools/` → zero hits). **The only instrument that can guard this is a Go test in
+  `internal/testing`**, which is what M1–M3 build.
+
+---
+
+## 7. Non-goals (each with its reason)
+
+- **Making `assert` legal in general expression position.** That is option (b) — a language change
+  across 4 core packages needing a Conflict Surface, a design doc, and a quorum. §3.
+- **Removing the print-and-reparse round-trip** (option (a)). Needs a new
+  AST→lowered-Core-in-module-scope entry point that does not exist; `TestDecl` is never elaborated
+  by the pipeline. §3, F1. Recorded as future work, §9.
+- **Fixing F2 for non-assert expressions** (`test { false_expr; true_expr }` passes). Same function,
+  genuinely the same family, and Critical Principle 3 says to look — I did, and I am **deliberately
+  scoping it out**: making non-final plain expressions short-circuit changes the *type* obligation
+  on every existing multi-expression named test body (a non-bool non-final expression would become
+  a type error instead of being discarded), which is a semantics change to *currently-passing*
+  tests. That is a behaviour decision, not a bug fix, and it deserves its own item. Asserts are
+  safe to short-circuit precisely because they are bool by construction and 100% broken today, so
+  no passing test can regress. **Recommend the controller file F2 as a separate issue** and note
+  that this sprint's design is chosen so that fixing F2 later is a two-line extension of
+  `FoldTestBody` (add the `default:` case to the sentinel walk).
+- **Filing/fixing F3** (`Num[bool]` on the named-test path). Separate defect; does not block.
+- **Touching the canonical prompt or `docs/`.** Per the P5 refutation the prompt never demonstrates
+  `assert`, so there *is* a real teaching gap — but the canonical prompt is the eval harness's
+  system prompt, and editing it mid-mission perturbs benchmark comparability across the very
+  baselines this mission reads. **A worked `assert` example belongs in a prompt-manager item with
+  its own A/B**, not smuggled into a bug fix. Flagged, not done.
+
+---
+
+## 8. Risks
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Sentinel `int` collides with a body that legitimately returns `int` | Low | Impossible: the sentinel path is entered **only** when the body contains an `AssertStmt`, and every such body is 100% broken today. Assert-free bodies keep the byte-identical bool path (AC-5, B3). |
+| Nested `if` mis-associates when printed without parens | Medium if real | **Measured and refuted**: unparenthesized nested form ran `3 passed, 0 failed` across all-pass/first-fail/second-fail. §4. |
+| `executor_helpers.go` breaches the 800-line gate | Medium | New file `test_body_lowering.go`; AC-6 gates it. |
+| `AssertStmt` appears somewhere the flat walk misses | Low | **Measured**: `parseStatement` dispatches on `ASSERT` only at statement start, and a nested `assert` is a parse error. A flat walk is exhaustive. |
+| A failing assert's message loses which one | — | AC-7 is exactly this criterion, and it is red before M2. |
+| Executor "fixes" F2 opportunistically and regresses a passing test | Medium | §7 makes it an explicit non-goal with the reason. AC-5 catches it. |
+
+---
+
+## 9. Future work
+
+- **Elaborate `ast.AssertStmt` directly** (F1) and give named-test bodies a real
+  AST→Core-in-module-scope path, retiring the print-and-reparse round-trip for **all** node kinds,
+  not just `assert`. This is the principled version of option (a) and would also retire the
+  `<printer-error: …>` family in `PrintAILANGSource`.
+- **F2** — non-final expression results discarded in named test bodies.
+- **F3** — `Num[bool]` mis-inference on the named-test top-level-bare-expression path.
+- A gate that runs `ailang test` over `.ail` fixtures (today **nothing** does).
+
+---
+
+**Document created**: 2026-08-06
+**Base**: `dev` @ `64970c118`
+</content>
+</invoke>

--- a/internal/testing/executor.go
+++ b/internal/testing/executor.go
@@ -203,9 +203,15 @@ func (e *Executor) EvaluateNamedTestBodyExprs(bodyExprs []ast.Expr) (eval.Value,
 	// Named test blocks use semicolons to separate bindings (let x = ...; let y = ...)
 	// which the parser emits as separate ast.Let nodes with Body==nil.  We must
 	// chain them before printing so we produce valid AILANG ("let x = ... in ...").
-	folded := FoldBodyExprs(bodyExprs)
+	//
+	// FoldTestBody additionally lowers top-level `assert` statements into a
+	// short-circuiting `if` chain over an int sentinel (#590) — `assert` has no
+	// prefix parselet in the general grammar, so it cannot survive the round-trip
+	// verbatim. `checks` is empty for assert-free bodies, which keep the legacy
+	// bool path unchanged.
+	folded, checks := FoldTestBody(bodyExprs)
 	if folded == nil {
-		return nil, fmt.Errorf("named test block: FoldBodyExprs returned nil")
+		return nil, fmt.Errorf("named test block: FoldTestBody returned nil")
 	}
 
 	// Append the folded body expression.
@@ -325,7 +331,29 @@ func (e *Executor) EvaluateNamedTestBodyExprs(bodyExprs []ast.Expr) (eval.Value,
 	if err != nil {
 		return nil, fmt.Errorf("evaluation error: %w", err)
 	}
+
+	// Assert-bearing bodies evaluate to an int sentinel rather than a bool;
+	// translate it back into the runner's bool pass/fail contract.
+	if len(checks) > 0 {
+		return decodeCheckSentinel(val, checks)
+	}
 	return val, nil
+}
+
+// decodeCheckSentinel converts the int sentinel produced by FoldTestBody's
+// assert lowering back into the value the runner expects (#590).
+//
+//	0     → *eval.BoolValue{true}  — every check passed
+//	k ≥ 1 → *eval.BoolValue{false} — check k was the first to evaluate false
+func decodeCheckSentinel(val eval.Value, checks []CheckInfo) (eval.Value, error) {
+	intVal, ok := val.(*eval.IntValue)
+	if !ok {
+		return nil, fmt.Errorf("named test assert lowering: expected int sentinel, got %T", val)
+	}
+	if intVal.Value == 0 {
+		return &eval.BoolValue{Value: true}, nil
+	}
+	return &eval.BoolValue{Value: false}, nil
 }
 
 // EvaluateInlineTestsWithHarness evaluates inline tests using the test harness builder.

--- a/internal/testing/executor.go
+++ b/internal/testing/executor.go
@@ -341,10 +341,15 @@ func (e *Executor) EvaluateNamedTestBodyExprs(bodyExprs []ast.Expr) (eval.Value,
 }
 
 // decodeCheckSentinel converts the int sentinel produced by FoldTestBody's
-// assert lowering back into the value the runner expects (#590).
+// assert lowering back into the runner's pass/fail contract (#590).
 //
-//	0     → *eval.BoolValue{true}  — every check passed
-//	k ≥ 1 → *eval.BoolValue{false} — check k was the first to evaluate false
+//	0     → *eval.BoolValue{true} — every check passed
+//	k ≥ 1 → error naming check k, the FIRST check to evaluate false
+//
+// The runner surfaces the returned error text verbatim as result.Error
+// (runner.go, runNamedTest), so a failing assert reports which assertion failed,
+// its source text and its ORIGINAL position — not a bare "expected true, got
+// false", and not a position inside the internal round-trip temp file.
 func decodeCheckSentinel(val eval.Value, checks []CheckInfo) (eval.Value, error) {
 	intVal, ok := val.(*eval.IntValue)
 	if !ok {
@@ -353,7 +358,16 @@ func decodeCheckSentinel(val eval.Value, checks []CheckInfo) (eval.Value, error)
 	if intVal.Value == 0 {
 		return &eval.BoolValue{Value: true}, nil
 	}
-	return &eval.BoolValue{Value: false}, nil
+	for _, c := range checks {
+		if c.Ordinal == intVal.Value {
+			return nil, fmt.Errorf("assertion %d failed: `assert %s` (at %s)",
+				c.Ordinal, c.Source, c.Pos.String())
+		}
+	}
+	// Unreachable unless the sentinel and the CheckInfo table disagree — report
+	// loudly rather than silently passing the test.
+	return nil, fmt.Errorf("assertion %d failed (no source recorded for check %d of %d)",
+		intVal.Value, intVal.Value, len(checks))
 }
 
 // EvaluateInlineTestsWithHarness evaluates inline tests using the test harness builder.

--- a/internal/testing/executor.go
+++ b/internal/testing/executor.go
@@ -360,7 +360,14 @@ func decodeCheckSentinel(val eval.Value, checks []CheckInfo) (eval.Value, error)
 	}
 	for _, c := range checks {
 		if c.Ordinal == intVal.Value {
-			return nil, fmt.Errorf("assertion %d failed: `assert %s` (at %s)",
+			// Quote back exactly what the user wrote.  A trailing bare expression in
+			// an assert-bearing body is a check too, but it is not an `assert`, and
+			// showing it as one puts source in the diagnostic that is not in the file.
+			if c.IsAssert {
+				return nil, fmt.Errorf("assertion %d failed: `assert %s` (at %s)",
+					c.Ordinal, c.Source, c.Pos.String())
+			}
+			return nil, fmt.Errorf("check %d failed: `%s` (at %s)",
 				c.Ordinal, c.Source, c.Pos.String())
 		}
 	}

--- a/internal/testing/executor_helpers.go
+++ b/internal/testing/executor_helpers.go
@@ -433,7 +433,15 @@ func PrintAILANGSource(expr ast.Expr) string {
 	case *ast.Error:
 		return fmt.Sprintf("<printer-error: unrepresentable *ast.Error node: %s>", e.Msg)
 	case *ast.AssertStmt:
-		return fmt.Sprintf("assert %s", PrintAILANGSource(e.Condition))
+		// TRIPWIRE (#590): `assert` has no prefix parselet in the general
+		// expression grammar, so printing it verbatim produced source that could
+		// never parse — surfacing as PAR_NO_PREFIX_PARSE from the pipeline, far
+		// from the actual cause. FoldTestBody lowers every top-level AssertStmt
+		// before printing, so reaching here means the lowering was bypassed.
+		// Say so, in the same self-describing form this file uses for other
+		// unrepresentable nodes.
+		return fmt.Sprintf("<printer-error: AssertStmt reached the printer; FoldTestBody must lower it first (condition: %s)>",
+			PrintAILANGSource(e.Condition))
 	case *ast.Send:
 		return fmt.Sprintf("%s <- %s", PrintAILANGSource(e.Channel), PrintAILANGSource(e.Value))
 	case *ast.Recv:

--- a/internal/testing/executor_helpers.go
+++ b/internal/testing/executor_helpers.go
@@ -261,58 +261,6 @@ func findSubstring(s, substr string) bool {
 	return false
 }
 
-// FoldBodyExprs collapses a slice of AST expressions — as produced by parsing a
-// named test block where semicolons separate statements — into a single nested
-// expression.  The parser emits standalone `let x = val` nodes (Body == nil)
-// for each binding; this function re-chains them:
-//
-//	[let x = val, let y = ..., finalExpr]
-//	  → let x = val in (let y = ... in finalExpr)
-//
-// Non-let expressions that are not the last item are dropped (they were
-// evaluated for side-effects in the original source, which is meaningless for
-// pure bodies, so stripping them is safe).
-func FoldBodyExprs(exprs []ast.Expr) ast.Expr {
-	if len(exprs) == 0 {
-		return nil
-	}
-	// Walk in reverse, threading each let-binding around the accumulated tail.
-	result := exprs[len(exprs)-1]
-	for i := len(exprs) - 2; i >= 0; i-- {
-		switch e := exprs[i].(type) {
-		case *ast.Let:
-			// Clone to avoid mutating the parser's AST in place.
-			result = &ast.Let{
-				Name:  e.Name,
-				Type:  e.Type,
-				Value: e.Value,
-				Body:  result,
-				Pos:   e.Pos,
-			}
-		case *ast.LetRec:
-			result = &ast.LetRec{
-				Name:  e.Name,
-				Type:  e.Type,
-				Value: e.Value,
-				Body:  result,
-				Pos:   e.Pos,
-			}
-		default:
-			// Side-effect expression before the final value — wrap in a let_ binding.
-			// AILANG has no sequencing operator, so we emit "let _ = expr in rest".
-			// This is the closest approximation; pure bodies shouldn't have real side
-			// effects anyway, so semantics are preserved.
-			result = &ast.Let{
-				Name:  "_seq",
-				Value: exprs[i],
-				Body:  result,
-				Pos:   exprs[i].Position(),
-			}
-		}
-	}
-	return result
-}
-
 // PrintAILANGSource converts an AST expression to valid AILANG source text.
 //
 // This is needed because ast.FuncCall.String() uses prefix notation

--- a/internal/testing/named_test_assert_test.go
+++ b/internal/testing/named_test_assert_test.go
@@ -1,6 +1,8 @@
 package testing
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -174,6 +176,60 @@ func TestNamedTest_AssertFree_LegacyPathUnchanged(t *testing.T) {
 	legacy := FoldBodyExprs(exprs)
 	if got, want := PrintAILANGSource(folded), PrintAILANGSource(legacy); got != want {
 		t.Errorf("assert-free fold diverged from legacy path:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// TestNamedTest_AssertFixtures drives the on-disk corpus in
+// testdata/assert/ through RunTestsFromFile — the exact entry point the
+// `ailang test` CLI uses (cmd/ailang/test.go). Each fixture is copied into a
+// temp dir first, because the named-test evaluator writes its round-trip temp
+// file alongside the source; that keeps testdata/ pristine.
+//
+// Nothing in the repo runs `ailang test` over .ail files as a gate, so this
+// table IS the gate for #590.
+func TestNamedTest_AssertFixtures(t *testing.T) {
+	tests := []struct {
+		fixture    string
+		wantPassed int
+		wantFailed int
+		wantErr    string // substring required in the failure text ("" = no failure expected)
+	}{
+		{fixture: "single_pass.ail", wantPassed: 1, wantFailed: 0},
+		{fixture: "single_fail.ail", wantPassed: 0, wantFailed: 1,
+			wantErr: "assertion 1 failed: `assert (add_one(1) == 99)`"},
+		{fixture: "second_fails.ail", wantPassed: 0, wantFailed: 1,
+			wantErr: "assertion 2 failed: `assert (add_one(3) == 99)`"},
+		{fixture: "first_fails_short_circuit.ail", wantPassed: 0, wantFailed: 1,
+			wantErr: "assertion 1 failed: `assert (add_one(1) == 99)`"},
+		{fixture: "let_then_assert.ail", wantPassed: 1, wantFailed: 0},
+		{fixture: "assert_let_assert.ail", wantPassed: 1, wantFailed: 0},
+		{fixture: "assert_free_control.ail", wantPassed: 1, wantFailed: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.fixture, func(t *testing.T) {
+			path := filepath.Join("testdata", "assert", tt.fixture)
+			src, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+
+			result := runInlineTestsOnSource(t, string(src))
+			errText := firstFailureError(result)
+
+			if result.PassedTests != tt.wantPassed || result.FailedTests != tt.wantFailed {
+				t.Errorf("%s: expected %d passed/%d failed, got %d/%d; error: %s",
+					tt.fixture, tt.wantPassed, tt.wantFailed,
+					result.PassedTests, result.FailedTests, errText)
+			}
+			// No fixture may fail because the round-tripped source did not parse.
+			if strings.Contains(errText, "PAR_NO_PREFIX_PARSE") {
+				t.Errorf("%s: failed with a parse error, not a test outcome: %s", tt.fixture, errText)
+			}
+			if tt.wantErr != "" && !strings.Contains(errText, tt.wantErr) {
+				t.Errorf("%s: expected failure text to contain %q, got: %s", tt.fixture, tt.wantErr, errText)
+			}
+		})
 	}
 }
 

--- a/internal/testing/named_test_assert_test.go
+++ b/internal/testing/named_test_assert_test.go
@@ -1,0 +1,211 @@
+package testing
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/ast"
+)
+
+// Regression suite for #590: `test "name" { assert <cond> }` failed 100% of the
+// time with PAR_NO_PREFIX_PARSE, because EvaluateNamedTestBodyExprs prints the
+// body back to AILANG source and re-runs the general pipeline, which has no
+// `assert` prefix parselet.
+//
+// The fix lowers AssertStmt in FoldTestBody (internal/testing/test_body_lowering.go)
+// to a short-circuiting `if` chain over an int sentinel — see the sprint plan
+// design_docs/planned/v0_33_1/m-named-test-assert-lowering-sprint-plan.md §4.
+
+// assertFixtureSource builds a minimal module with a single named test body.
+func assertFixtureSource(body string) string {
+	return `module assert_fixture
+
+export pure func add_one(x: int) -> int { x + 1 }
+
+test "assert fixture" {
+` + body + `
+}
+`
+}
+
+// TestNamedTest_Assert_Passes is AC-2: a body whose only check is a passing
+// assert must run and pass. RED before the fix (PAR_NO_PREFIX_PARSE).
+func TestNamedTest_Assert_Passes(t *testing.T) {
+	result := runInlineTestsOnSource(t, assertFixtureSource(`  assert add_one(1) == 2`))
+
+	if result.FailedTests != 0 {
+		t.Errorf("expected 0 failures, got %d; first error: %s",
+			result.FailedTests, firstFailureError(result))
+	}
+	if result.PassedTests != 1 {
+		t.Errorf("expected 1 passing test, got %d", result.PassedTests)
+	}
+}
+
+// TestNamedTest_Assert_FalseFails is AC-3: a body whose only check is a FALSE
+// assert must fail — and must fail for the right reason, i.e. not because the
+// printed source failed to parse.
+func TestNamedTest_Assert_FalseFails(t *testing.T) {
+	result := runInlineTestsOnSource(t, assertFixtureSource(`  assert add_one(1) == 99`))
+
+	if result.FailedTests != 1 {
+		t.Errorf("expected 1 failure, got %d (passed=%d)", result.FailedTests, result.PassedTests)
+	}
+	errText := firstFailureError(result)
+	if strings.Contains(errText, "PAR_NO_PREFIX_PARSE") {
+		t.Errorf("failure is a parse error, not an assertion failure: %s", errText)
+	}
+	if strings.Contains(errText, "assert") && strings.Contains(errText, "unexpected token") {
+		t.Errorf("failure mentions an unexpected `assert` token: %s", errText)
+	}
+}
+
+// TestNamedTest_Assert_ShortCircuitsOnFirstFalse is AC-4, the anti-F2 guard.
+// A non-final FALSE assert must fail the test. Under the legacy fold every
+// non-final expression was bound to a dead `_seq` and discarded, so this body
+// would report a vacuous green if the lowering were done per-node instead of
+// across the sequence.
+func TestNamedTest_Assert_ShortCircuitsOnFirstFalse(t *testing.T) {
+	result := runInlineTestsOnSource(t, assertFixtureSource(
+		`  assert add_one(1) == 99;
+  assert add_one(1) == 2`))
+
+	if result.FailedTests != 1 {
+		t.Errorf("expected 1 failure (non-final false assert must not be discarded), got %d (passed=%d); error: %s",
+			result.FailedTests, result.PassedTests, firstFailureError(result))
+	}
+	errText := firstFailureError(result)
+	if strings.Contains(errText, "PAR_NO_PREFIX_PARSE") {
+		t.Errorf("failure is a parse error, not an assertion failure: %s", errText)
+	}
+}
+
+// TestNamedTest_Assert_AllTrueMultiple checks that a multi-assert body where
+// every check holds passes (sentinel 0).
+func TestNamedTest_Assert_AllTrueMultiple(t *testing.T) {
+	result := runInlineTestsOnSource(t, assertFixtureSource(
+		`  assert add_one(1) == 2;
+  assert add_one(3) == 4`))
+
+	if result.FailedTests != 0 {
+		t.Errorf("expected 0 failures, got %d; first error: %s",
+			result.FailedTests, firstFailureError(result))
+	}
+	if result.PassedTests != 1 {
+		t.Errorf("expected 1 passing test, got %d", result.PassedTests)
+	}
+}
+
+// TestNamedTest_Assert_WithLetBinding checks that `let` bindings still thread
+// correctly around the sentinel chain.
+func TestNamedTest_Assert_WithLetBinding(t *testing.T) {
+	result := runInlineTestsOnSource(t, assertFixtureSource(
+		`  let x = add_one(1);
+  assert x == 2`))
+
+	if result.FailedTests != 0 {
+		t.Errorf("expected 0 failures, got %d; first error: %s",
+			result.FailedTests, firstFailureError(result))
+	}
+	if result.PassedTests != 1 {
+		t.Errorf("expected 1 passing test, got %d", result.PassedTests)
+	}
+}
+
+// TestNamedTest_Assert_LetBetweenAsserts checks assert / let / assert ordering.
+func TestNamedTest_Assert_LetBetweenAsserts(t *testing.T) {
+	result := runInlineTestsOnSource(t, assertFixtureSource(
+		`  assert add_one(1) == 2;
+  let x = add_one(3);
+  assert x == 4`))
+
+	if result.FailedTests != 0 {
+		t.Errorf("expected 0 failures, got %d; first error: %s",
+			result.FailedTests, firstFailureError(result))
+	}
+	if result.PassedTests != 1 {
+		t.Errorf("expected 1 passing test, got %d", result.PassedTests)
+	}
+}
+
+// TestNamedTest_Assert_FinalBareExprInAssertBody covers the mixed shape: a
+// trailing bare bool expression in a body that also contains an assert. It is a
+// check too, so a false one must fail.
+func TestNamedTest_Assert_FinalBareExprInAssertBody(t *testing.T) {
+	pass := runInlineTestsOnSource(t, assertFixtureSource(
+		`  assert add_one(1) == 2;
+  add_one(3) == 4`))
+	if pass.PassedTests != 1 || pass.FailedTests != 0 {
+		t.Errorf("all-true mixed body: expected 1 passed/0 failed, got %d/%d; error: %s",
+			pass.PassedTests, pass.FailedTests, firstFailureError(pass))
+	}
+
+	fail := runInlineTestsOnSource(t, assertFixtureSource(
+		`  assert add_one(1) == 2;
+  add_one(3) == 99`))
+	if fail.FailedTests != 1 {
+		t.Errorf("false final bare expr: expected 1 failure, got %d (passed=%d)",
+			fail.FailedTests, fail.PassedTests)
+	}
+}
+
+// TestNamedTest_AssertFree_LegacyPathUnchanged is the stays-green guard (B3):
+// an assert-free body must keep the byte-identical legacy bool path.
+func TestNamedTest_AssertFree_LegacyPathUnchanged(t *testing.T) {
+	result := runInlineTestsOnSource(t, assertFixtureSource(`  add_one(1) == 2`))
+	if result.PassedTests != 1 || result.FailedTests != 0 {
+		t.Errorf("assert-free control: expected 1 passed/0 failed, got %d/%d; error: %s",
+			result.PassedTests, result.FailedTests, firstFailureError(result))
+	}
+
+	// And the fold must be byte-identical to the legacy FoldBodyExprs output.
+	exprs := []ast.Expr{
+		&ast.Let{Name: "x", Value: &ast.Literal{Kind: ast.IntLit, Value: int64(1)}},
+		&ast.BinaryOp{
+			Op:    "==",
+			Left:  &ast.Identifier{Name: "x"},
+			Right: &ast.Literal{Kind: ast.IntLit, Value: int64(1)},
+		},
+	}
+	folded, checks := FoldTestBody(exprs)
+	if len(checks) != 0 {
+		t.Errorf("assert-free body should produce no CheckInfo, got %d", len(checks))
+	}
+	legacy := FoldBodyExprs(exprs)
+	if got, want := PrintAILANGSource(folded), PrintAILANGSource(legacy); got != want {
+		t.Errorf("assert-free fold diverged from legacy path:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// TestFoldTestBody_SentinelShape pins the exact lowered source for a two-assert
+// body. It is the unit-level counterpart to the end-to-end tests above: if the
+// short-circuit structure regresses to a per-node lowering (each assert lowered
+// in isolation, non-final ones swallowed by `let _seq = ... in ...`), this goes
+// red immediately and names the shape that changed.
+func TestFoldTestBody_SentinelShape(t *testing.T) {
+	mkAssert := func(name string) ast.Expr {
+		return &ast.AssertStmt{Condition: &ast.Identifier{Name: name}}
+	}
+	exprs := []ast.Expr{mkAssert("a"), mkAssert("b")}
+
+	folded, checks := FoldTestBody(exprs)
+	got := PrintAILANGSource(folded)
+	want := "if a then if b then 0 else 2 else 1"
+	if got != want {
+		t.Errorf("lowered shape mismatch:\n got: %s\nwant: %s", got, want)
+	}
+	if len(checks) != 2 {
+		t.Fatalf("expected 2 checks, got %d", len(checks))
+	}
+	if checks[0].Ordinal != 1 || checks[1].Ordinal != 2 {
+		t.Errorf("expected ordinals 1,2; got %d,%d", checks[0].Ordinal, checks[1].Ordinal)
+	}
+	if checks[0].Source != "a" || checks[1].Source != "b" {
+		t.Errorf("expected check sources a,b; got %q,%q", checks[0].Source, checks[1].Source)
+	}
+	// The sentinel must never be negative — negative literals would need a unary
+	// minus in `else` position, which the printer does not bracket.
+	if strings.Contains(got, "-") {
+		t.Errorf("lowered sentinel contains a negative literal: %s", got)
+	}
+}

--- a/internal/testing/named_test_assert_test.go
+++ b/internal/testing/named_test_assert_test.go
@@ -177,6 +177,94 @@ func TestNamedTest_AssertFree_LegacyPathUnchanged(t *testing.T) {
 	}
 }
 
+// TestNamedTest_Assert_ReportsWhichAssertion is AC-7: a failing assert must say
+// WHICH assert failed, with its source text and its original position — not a
+// bare "expected true, got false".
+func TestNamedTest_Assert_ReportsWhichAssertion(t *testing.T) {
+	result := runInlineTestsOnSource(t, assertFixtureSource(
+		`  assert add_one(1) == 2;
+  assert add_one(3) == 99`))
+
+	if result.FailedTests != 1 {
+		t.Fatalf("expected 1 failure, got %d (passed=%d)", result.FailedTests, result.PassedTests)
+	}
+	errText := firstFailureError(result)
+
+	if !strings.Contains(errText, "assertion 2 failed") {
+		t.Errorf("error should name the SECOND assertion as the failing one, got: %s", errText)
+	}
+	if strings.Contains(errText, "assertion 1 failed") {
+		t.Errorf("error names the wrong assertion (1 passed), got: %s", errText)
+	}
+	// The condition's source text should be quoted back to the user.
+	if !strings.Contains(errText, "add_one(3) == 99") {
+		t.Errorf("error should quote the failing condition's source, got: %s", errText)
+	}
+	// And the original source position, not the temp round-trip file.
+	if !strings.Contains(errText, "test_input.ail") {
+		t.Errorf("error should cite the original source position, got: %s", errText)
+	}
+	if strings.Contains(errText, "_namedtest_body_") {
+		t.Errorf("error cites the internal round-trip temp file, got: %s", errText)
+	}
+}
+
+// TestNamedTest_Assert_ReportsFirstAssertion is the companion direction: when
+// the FIRST assert is the failing one, the ordinal must be 1 and the later
+// assert must not be evaluated.
+func TestNamedTest_Assert_ReportsFirstAssertion(t *testing.T) {
+	result := runInlineTestsOnSource(t, assertFixtureSource(
+		`  assert add_one(1) == 99;
+  assert add_one(3) == 4`))
+
+	if result.FailedTests != 1 {
+		t.Fatalf("expected 1 failure, got %d (passed=%d)", result.FailedTests, result.PassedTests)
+	}
+	errText := firstFailureError(result)
+	if !strings.Contains(errText, "assertion 1 failed") {
+		t.Errorf("error should name the FIRST assertion, got: %s", errText)
+	}
+	if !strings.Contains(errText, "add_one(1) == 99") {
+		t.Errorf("error should quote the failing condition's source, got: %s", errText)
+	}
+}
+
+// TestPrintAILANGSource_AssertStmtIsTripwire is AC-8, a two-directional
+// regression guard.
+//
+// Direction 1: an *ast.AssertStmt reaching PrintAILANGSource is now a
+// self-describing printer error. Before the fix it printed `assert <cond>`
+// verbatim, which parses nowhere and surfaced 200 lines away as
+// PAR_NO_PREFIX_PARSE.
+//
+// Direction 2: it must NOT emit the old verbatim form. If someone restores
+// `assert %s` printing, this goes red — so #590 cannot be reintroduced silently.
+//
+// Note this is the *executor's* source printer, not internal/format's formatter,
+// which legitimately still renders `assert x` (see internal/format's
+// node_coverage_test.go).
+func TestPrintAILANGSource_AssertStmtIsTripwire(t *testing.T) {
+	node := &ast.AssertStmt{
+		Condition: &ast.BinaryOp{
+			Op:    "==",
+			Left:  &ast.Identifier{Name: "x"},
+			Right: &ast.Literal{Kind: ast.IntLit, Value: int64(1)},
+		},
+	}
+	got := PrintAILANGSource(node)
+
+	if !strings.Contains(got, "printer-error") {
+		t.Errorf("AssertStmt reaching the printer must yield a printer-error marker, got: %q", got)
+	}
+	if !strings.Contains(got, "FoldTestBody") {
+		t.Errorf("printer error should name the function responsible for lowering, got: %q", got)
+	}
+	// Direction 2: the old verbatim rendering must not come back.
+	if got == "assert (x == 1)" || strings.HasPrefix(got, "assert ") {
+		t.Errorf("printer emitted verbatim `assert ...` again — #590 is reintroduced: %q", got)
+	}
+}
+
 // TestFoldTestBody_SentinelShape pins the exact lowered source for a two-assert
 // body. It is the unit-level counterpart to the end-to-end tests above: if the
 // short-circuit structure regresses to a per-node lowering (each assert lowered

--- a/internal/testing/named_test_assert_test.go
+++ b/internal/testing/named_test_assert_test.go
@@ -149,6 +149,21 @@ func TestNamedTest_Assert_FinalBareExprInAssertBody(t *testing.T) {
 		t.Errorf("false final bare expr: expected 1 failure, got %d (passed=%d)",
 			fail.FailedTests, fail.PassedTests)
 	}
+
+	// The diagnostic must quote what the user WROTE.  This check is a bare
+	// expression, not an `assert`, so reporting it as `assert (add_one(3) == 99)`
+	// would put source into the error that appears nowhere in the file.
+	// Evaluator finding NB-1, iteration 152.
+	got := firstFailureError(fail)
+	if strings.Contains(got, "assert (add_one(3) == 99)") {
+		t.Errorf("bare-expression check must not be quoted back as an `assert` — "+
+			"the user never wrote that word here; got: %s", got)
+	}
+	// Parens are the printer's (PrintAILANGSource parenthesizes binary ops), the
+	// same way the assert case reports `assert (add_one(1) == 99)`.
+	if !strings.Contains(got, "check 2 failed: `(add_one(3) == 99)`") {
+		t.Errorf("expected the bare check reported verbatim as check 2, got: %s", got)
+	}
 }
 
 // TestNamedTest_AssertFree_LegacyPathUnchanged is the stays-green guard (B3):

--- a/internal/testing/test_body_lowering.go
+++ b/internal/testing/test_body_lowering.go
@@ -75,6 +75,10 @@ type CheckInfo struct {
 	Ordinal int     // 1-based position among the body's checks
 	Source  string  // AILANG source text of the condition, for the failure message
 	Pos     ast.Pos // original position of the check in the user's source
+	// IsAssert records whether the user actually wrote `assert`.  A trailing bare
+	// expression in an assert-bearing body is also a check, but quoting it back as
+	// `assert <expr>` would show the user source they never wrote.
+	IsAssert bool
 }
 
 // FoldTestBody folds a named test body into a single expression, lowering any
@@ -151,10 +155,12 @@ func FoldTestBody(exprs []ast.Expr) (ast.Expr, []CheckInfo) {
 		if ordinals[i] == 0 {
 			continue
 		}
+		_, isAssert := e.(*ast.AssertStmt)
 		checks = append(checks, CheckInfo{
-			Ordinal: ordinals[i],
-			Source:  PrintAILANGSource(checkCondition(e)),
-			Pos:     e.Position(),
+			Ordinal:  ordinals[i],
+			Source:   PrintAILANGSource(checkCondition(e)),
+			Pos:      e.Position(),
+			IsAssert: isAssert,
 		})
 	}
 

--- a/internal/testing/test_body_lowering.go
+++ b/internal/testing/test_body_lowering.go
@@ -1,0 +1,263 @@
+package testing
+
+import (
+	"github.com/sunholo-data/ailang/internal/ast"
+)
+
+// This file owns the AST-level lowering of named test bodies — the transform
+// that runs between parsing `test "name" { ... }` and printing the body back to
+// AILANG source for re-elaboration through the general pipeline
+// (EvaluateNamedTestBodyExprs, executor.go).
+//
+// It lives apart from executor_helpers.go for a mundane reason: that file is
+// already 717 lines and `make check-file-sizes` fails at 800.
+
+// FoldBodyExprs collapses a slice of AST expressions — as produced by parsing a
+// named test block where semicolons separate statements — into a single nested
+// expression.  The parser emits standalone `let x = val` nodes (Body == nil)
+// for each binding; this function re-chains them:
+//
+//	[let x = val, let y = ..., finalExpr]
+//	  → let x = val in (let y = ... in finalExpr)
+//
+// Non-let expressions that are not the last item are dropped (they were
+// evaluated for side-effects in the original source, which is meaningless for
+// pure bodies, so stripping them is safe).
+//
+// This is the LEGACY path, retained verbatim: it is what FoldTestBody returns
+// for any body that contains no `assert`, so assert-free named tests are
+// byte-for-byte unchanged by #590's fix.
+func FoldBodyExprs(exprs []ast.Expr) ast.Expr {
+	if len(exprs) == 0 {
+		return nil
+	}
+	// Walk in reverse, threading each let-binding around the accumulated tail.
+	result := exprs[len(exprs)-1]
+	for i := len(exprs) - 2; i >= 0; i-- {
+		switch e := exprs[i].(type) {
+		case *ast.Let:
+			// Clone to avoid mutating the parser's AST in place.
+			result = &ast.Let{
+				Name:  e.Name,
+				Type:  e.Type,
+				Value: e.Value,
+				Body:  result,
+				Pos:   e.Pos,
+			}
+		case *ast.LetRec:
+			result = &ast.LetRec{
+				Name:  e.Name,
+				Type:  e.Type,
+				Value: e.Value,
+				Body:  result,
+				Pos:   e.Pos,
+			}
+		default:
+			// Side-effect expression before the final value — wrap in a let_ binding.
+			// AILANG has no sequencing operator, so we emit "let _ = expr in rest".
+			// This is the closest approximation; pure bodies shouldn't have real side
+			// effects anyway, so semantics are preserved.
+			result = &ast.Let{
+				Name:  "_seq",
+				Value: exprs[i],
+				Body:  result,
+				Pos:   exprs[i].Position(),
+			}
+		}
+	}
+	return result
+}
+
+// CheckInfo describes one check in a named test body that took the assert
+// lowering path.  Checks are numbered left-to-right starting at 1, and the
+// ordinal doubles as the failure sentinel the lowered expression evaluates to.
+type CheckInfo struct {
+	Ordinal int     // 1-based position among the body's checks
+	Source  string  // AILANG source text of the condition, for the failure message
+	Pos     ast.Pos // original position of the check in the user's source
+}
+
+// FoldTestBody folds a named test body into a single expression, lowering any
+// top-level `assert` statements on the way.
+//
+// # Why the lowering lives here and not in the printer
+//
+// `assert` has a lexer keyword, a parser production, an AST node and a
+// formatter case — but no prefix parselet in the general expression grammar and
+// no elaborator case.  Since EvaluateNamedTestBodyExprs works by printing the
+// body back to AILANG source and re-running the general pipeline, an
+// `*ast.AssertStmt` that reaches the printer becomes `assert <cond>` in a
+// context that cannot parse it: PAR_NO_PREFIX_PARSE, 100% of the time (#590).
+//
+// Lowering it in the printer would not work either, because short-circuiting is
+// a property of the SEQUENCE, not of a single node: printing `assert c` as a
+// bare `c` in non-final position gets swallowed by the surrounding
+// `let _seq = ... in ...` and the test goes vacuously green.  So the lowering
+// belongs where the sequence is built — here.
+//
+// # The lowering
+//
+// A body's CHECKS, left to right, 1-based, are: every top-level
+// `*ast.AssertStmt`, plus the final expression (counted once if it is itself an
+// assert).  The body lowers to an int sentinel:
+//
+//	0     — every check passed
+//	k ≥ 1 — check k was the FIRST to evaluate false; later checks are NOT evaluated
+//
+// Concretely, `{ assert a; assert b }` becomes
+//
+//	if a then (if b then 0 else 2) else 1
+//
+// All sentinels are ≥ 0 deliberately, so the lowering never needs a unary-minus
+// literal in `else` position.  The caller (EvaluateNamedTestBodyExprs) decodes
+// the resulting *eval.IntValue back into the runner's bool pass/fail contract.
+//
+// # The legacy path is preserved exactly
+//
+// A body containing NO `*ast.AssertStmt` returns exactly what FoldBodyExprs
+// returns, plus a nil []CheckInfo.  Every named test that passes today is
+// necessarily assert-free (assert bodies are 100% broken), so no currently
+// passing test changes code path.
+//
+// Note that non-final NON-assert expressions keep their legacy `let _seq = ...`
+// treatment even on the sentinel path.  Making those short-circuit too would
+// turn a non-bool non-final expression into a type error in bodies that pass
+// today — a semantics change rather than a bug fix, and deliberately out of
+// scope here (tracked separately as #604).  Adding it later is a one-case
+// extension of the switch below.
+func FoldTestBody(exprs []ast.Expr) (ast.Expr, []CheckInfo) {
+	if len(exprs) == 0 {
+		return nil, nil
+	}
+	if !containsAssertStmt(exprs) {
+		return FoldBodyExprs(exprs), nil
+	}
+
+	n := len(exprs)
+
+	// Pass 1: number the checks left to right, so ordinals read in source order.
+	// ordinals[i] == 0 means "expression i is not a check".
+	ordinals := make([]int, n)
+	next := 1
+	for i, e := range exprs {
+		if isCheck(e, i == n-1) {
+			ordinals[i] = next
+			next++
+		}
+	}
+
+	checks := make([]CheckInfo, 0, next-1)
+	for i, e := range exprs {
+		if ordinals[i] == 0 {
+			continue
+		}
+		checks = append(checks, CheckInfo{
+			Ordinal: ordinals[i],
+			Source:  PrintAILANGSource(checkCondition(e)),
+			Pos:     e.Position(),
+		})
+	}
+
+	// Pass 2: build the short-circuiting chain right to left.
+	var result ast.Expr
+	if ordinals[n-1] != 0 {
+		// Final check: passing it means the whole body passed → sentinel 0.
+		result = &ast.If{
+			Condition: checkCondition(exprs[n-1]),
+			Then:      intLit(0, exprs[n-1].Position()),
+			Else:      intLit(ordinals[n-1], exprs[n-1].Position()),
+		}
+	} else {
+		// Degenerate final element (e.g. a trailing `let` with no body). Leave it
+		// exactly as the legacy fold would, so we do not invent a new failure mode.
+		result = exprs[n-1]
+	}
+
+	for i := n - 2; i >= 0; i-- {
+		switch e := exprs[i].(type) {
+		case *ast.AssertStmt:
+			// Short-circuit: if the condition holds, carry on with the rest of the
+			// body; otherwise stop here and report this check's ordinal.
+			result = &ast.If{
+				Condition: e.Condition,
+				Then:      result,
+				Else:      intLit(ordinals[i], e.Pos),
+				Pos:       e.Pos,
+			}
+		case *ast.Let:
+			result = &ast.Let{
+				Name:  e.Name,
+				Type:  e.Type,
+				Value: e.Value,
+				Body:  result,
+				Pos:   e.Pos,
+			}
+		case *ast.LetRec:
+			result = &ast.LetRec{
+				Name:  e.Name,
+				Type:  e.Type,
+				Value: e.Value,
+				Body:  result,
+				Pos:   e.Pos,
+			}
+		default:
+			// Unchanged legacy treatment — see the doc comment above.
+			result = &ast.Let{
+				Name:  "_seq",
+				Value: exprs[i],
+				Body:  result,
+				Pos:   exprs[i].Position(),
+			}
+		}
+	}
+
+	return result, checks
+}
+
+// containsAssertStmt reports whether any top-level body expression is an assert.
+//
+// A flat scan is exhaustive: the parser dispatches on ASSERT only at statement
+// start (parseStatement, internal/parser/parser_test_decl.go), so `assert`
+// cannot appear nested inside another expression — `test "x" { let y = assert
+// true; y }` is a parse error.
+func containsAssertStmt(exprs []ast.Expr) bool {
+	for _, e := range exprs {
+		if _, ok := e.(*ast.AssertStmt); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// isCheck reports whether a body expression contributes a check. Every assert is
+// a check; so is the final expression, unless it is a binding form (a trailing
+// `let` is a degenerate body that has no value to check).
+func isCheck(e ast.Expr, isFinal bool) bool {
+	if _, ok := e.(*ast.AssertStmt); ok {
+		return true
+	}
+	if !isFinal {
+		return false
+	}
+	switch e.(type) {
+	case *ast.Let, *ast.LetRec:
+		return false
+	default:
+		return true
+	}
+}
+
+// checkCondition returns the bool-valued expression a check tests: an assert's
+// condition, or the expression itself for a trailing bare expression.
+func checkCondition(e ast.Expr) ast.Expr {
+	if a, ok := e.(*ast.AssertStmt); ok {
+		return a.Condition
+	}
+	return e
+}
+
+// intLit builds an int literal sentinel. ast.Literal's IntLit value must be an
+// int64 — a plain int panics downstream.
+func intLit(v int, pos ast.Pos) ast.Expr {
+	return &ast.Literal{Kind: ast.IntLit, Value: int64(v), Pos: pos}
+}

--- a/internal/testing/testdata/assert/assert_free_control.ail
+++ b/internal/testing/testdata/assert/assert_free_control.ail
@@ -1,0 +1,10 @@
+module assert_free_control
+
+-- Control: no assert anywhere, so this body must take the byte-identical
+-- legacy bool path and keep passing.
+
+export pure func add_one(x: int) -> int { x + 1 }
+
+test "assert-free control" {
+  add_one(1) == 2
+}

--- a/internal/testing/testdata/assert/assert_let_assert.ail
+++ b/internal/testing/testdata/assert/assert_let_assert.ail
@@ -1,0 +1,11 @@
+module assert_let_assert
+
+-- assert / let / assert: bindings must stay in scope across the chain.
+
+export pure func add_one(x: int) -> int { x + 1 }
+
+test "assert, let, assert" {
+  assert add_one(1) == 2;
+  let x = add_one(3);
+  assert x == 4
+}

--- a/internal/testing/testdata/assert/first_fails_short_circuit.ail
+++ b/internal/testing/testdata/assert/first_fails_short_circuit.ail
@@ -1,0 +1,12 @@
+module first_fails_short_circuit
+
+-- #590 anti-vacuous-green guard: a NON-FINAL false assert must fail the test.
+-- Under the legacy fold every non-final expression was bound to a dead `_seq`
+-- and discarded, so this body would have reported a vacuous pass.
+
+export pure func add_one(x: int) -> int { x + 1 }
+
+test "first assert fails, second would pass" {
+  assert add_one(1) == 99;
+  assert add_one(1) == 2
+}

--- a/internal/testing/testdata/assert/let_then_assert.ail
+++ b/internal/testing/testdata/assert/let_then_assert.ail
@@ -1,0 +1,10 @@
+module let_then_assert
+
+-- A `let` binding threaded around the sentinel chain.
+
+export pure func add_one(x: int) -> int { x + 1 }
+
+test "let then assert" {
+  let x = add_one(1);
+  assert x == 2
+}

--- a/internal/testing/testdata/assert/second_fails.ail
+++ b/internal/testing/testdata/assert/second_fails.ail
@@ -1,0 +1,11 @@
+module second_fails
+
+-- #590 / short-circuit: the FIRST assert holds, the SECOND does not.
+-- The reported ordinal must be 2.
+
+export pure func add_one(x: int) -> int { x + 1 }
+
+test "second assert fails" {
+  assert add_one(1) == 2;
+  assert add_one(3) == 99
+}

--- a/internal/testing/testdata/assert/single_fail.ail
+++ b/internal/testing/testdata/assert/single_fail.ail
@@ -1,0 +1,10 @@
+module single_fail
+
+-- #590: a named test body whose only check is a FAILING assert.
+-- Must fail as an assertion failure, not as a parse error.
+
+export pure func add_one(x: int) -> int { x + 1 }
+
+test "single failing assert" {
+  assert add_one(1) == 99
+}

--- a/internal/testing/testdata/assert/single_pass.ail
+++ b/internal/testing/testdata/assert/single_pass.ail
@@ -1,0 +1,10 @@
+module single_pass
+
+-- #590: a named test body whose only check is a passing assert.
+-- Before the assert lowering this failed with PAR_NO_PREFIX_PARSE.
+
+export pure func add_one(x: int) -> int { x + 1 }
+
+test "single passing assert" {
+  assert add_one(1) == 2
+}


### PR DESCRIPTION
## What

`test "name" { assert <cond> }` named test blocks failed **100% of the time** with `PAR_NO_PREFIX_PARSE`. `assert` is a reserved keyword with a lexer token, a parser production, an AST node and a formatter case — but no prefix parselet in the general expression grammar, and it was parseable in exactly one construct, which was broken. So the keyword had **no working call site anywhere in the language**.

`EvaluateNamedTestBodyExprs` folds a test body, prints it back to AILANG source with `PrintAILANGSource`, writes a temp module and re-runs the *general* pipeline. The printer emitted `assert <cond>` verbatim, which that pipeline cannot parse.

Fixes #590.

## Approach — the lowering lives in the fold, not the printer

The reporter proposed three shapes. Options (a) and (b) both need elaborator support for `ast.AssertStmt` that does not exist (`internal/elaborate` has **zero** handling; `expressions.go` ends in `normalization not implemented for %T`), so registering the parselet would just move the failure one stage later. (b) is additionally a language change and would need a Conflict Surface and quorum.

Option (c) — lower `AssertStmt` when printing — is the only single-package fix, but doing it *in the printer* is wrong: the printer sees one node and cannot see sequencing. Since non-final expressions in a test body are discarded (#604), printing `assert c` as bare `c` would make `{ assert false; assert true }` **pass**.

Short-circuiting is a property of the sequence, so it belongs in the fold. `FoldTestBody` emits a non-negative integer sentinel chain — `0` = every check passed, `k` = check `k` was the first to fail — decoded back to the runner's pass/fail contract in Go. Assert-free bodies keep the **byte-identical** legacy path.

## Behaviour

| body | before | after |
|---|---|---|
| `{ assert add_one(1) == 2 }` | rc=1 `PAR_NO_PREFIX_PARSE` | rc=0, `1 passed` |
| `{ assert add_one(1) == 99 }` | rc=1 `PAR_NO_PREFIX_PARSE` | rc=1 ``assertion 1 failed: `assert (add_one(1) == 99)` (at b.ail:6:3)`` |
| `{ assert false; assert true }` | rc=1 `PAR_NO_PREFIX_PARSE` | rc=1, names check **1** (short-circuits) |
| `{ add_one(1) == 2 }` (assert-free) | rc=0 | rc=0, unchanged legacy path |

## Verification

- **Controller re-ran every gate** outside the executor's environment: `go test ./internal/testing/...`, `./internal/parser/... ./internal/format/... ./internal/ast/...`, `./cmd/ailang/...`, `go vet`, `go build ./internal/... ./cmd/ailang`, `make check-file-sizes`, `make check-boundaries` — all rc=0; `gofmt -l` 0 files.
- **Not gated, and deliberately so**: `go build ./...` is rc=1 *at base* (`cmd/wasm`, `gen/main` have no native `main`) and `go test ./...` is rc=1 at base on `internal/smt TestSolve_HardTimeout_FakeSolverIgnoringT` under load (#602). Both were baselined on the pristine tree before the sprint, so neither is scored against it.
- **Mutation-tested.** The evaluator ran 7 independent mutations, all killed. The controller ran an 8th it had not: replacing the short-circuit `Else` with a fall-through re-arms #604 inside the assert path — **5 tests** went red, including the dedicated short-circuit test, and the file reverted sha256-byte-identical.
- **Each commit is green at its own boundary** (`go test ./internal/testing/` run at every one), so the history bisects.

## Evaluator

sonnet, **PASS 88/100 round 1, zero blocking** (generator≠judge: the executor ran on a different model). Its one substantive non-blocking finding was **acted on, not filed** — a severity label is an opinion, not a measurement. A trailing bare expression in an assert-bearing body is a check but is not an `assert`, and the failure message quoted it back as `` `assert (add_one(3) == 99)` `` — source appearing nowhere in the user's file, the same defect class as #539. `CheckInfo` now records `IsAssert`; the existing test asserted the failure *count* but never the *text*, which is why it shipped, and it now asserts both directions.

## Scope

Fixing #604 in general — non-final expressions discarded in **non**-assert bodies — is an explicit **non-goal**, verified unchanged by this PR. It alters the type obligation on currently-passing tests and needs its own pass.

`examples/experimental/{web_api,concurrent_pipeline}.ail` use the broken form but are deliberately left alone: both fail `ailang check` today for unrelated unimplemented features, their README already says the examples do not work, and `verify-examples` runs `ailang run`, never `ailang test` — so a gated example could not have guarded this bug anyway. The only viable instrument is the Go test added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
