### PR TITLE
fix(smt): retry the hard-timeout scenario when the fake solver loses its startup race (#602)

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -64,6 +64,13 @@
   is reported as ``check N failed`` rather than being quoted back as an `assert` the user
   never wrote. Bodies containing no `assert` keep the previous code path unchanged.
 
+- **`internal/smt` hard-timeout tests no longer red on a lost startup race (#602).** The fake
+  solver has ~3s to record its child PID before the process group is killed; measured over 500
+  trials, 1 spawn in 300 exceeds that under full-suite load, and when it does the pidfile can
+  never appear. A trial that never recorded a child PID now counts as inconclusive and the
+  scenario is retried (bounded, 3 attempts, loud failure on exhaustion) instead of failing. A
+  genuine process-group-kill regression still reds on every attempt.
+
 ### Added
 
 - **Embeddable serve-api surface complete — #498 Lane B M3 (final milestone).** The public

--- a/internal/smt/solver_timeout_test.go
+++ b/internal/smt/solver_timeout_test.go
@@ -16,50 +16,71 @@ import (
 
 const fakeSolverSleep = 30 * time.Second
 
+// maxRaceAttempts bounds how many times a hard-timeout test re-runs its scenario
+// when the fake solver loses its startup race. Measured at ~0.3% per spawn under
+// full-suite load (ailang#602), so three attempts leave a ~3e-8 residue.
+const maxRaceAttempts = 3
+
 func TestSolve_HardTimeout_FakeSolverIgnoringT(t *testing.T) {
-	fake, childPIDFile := writeSleepingFakeSolver(t)
+	for attempt := 1; attempt <= maxRaceAttempts; attempt++ {
+		fake, childPIDFile := writeSleepingFakeSolver(t)
 
-	start := time.Now()
-	result, err := Solve("(check-sat)\n", SolverConfig{
-		Z3Path:  fake,
-		Timeout: time.Second,
-	})
-	elapsed := time.Since(start)
+		start := time.Now()
+		result, err := Solve("(check-sat)\n", SolverConfig{
+			Z3Path:  fake,
+			Timeout: time.Second,
+		})
+		elapsed := time.Since(start)
 
-	if err != nil {
-		t.Fatalf("Solve returned an error: %v", err)
-	}
-	if elapsed >= 10*time.Second {
-		t.Errorf("Solve took %v, want less than 10s", elapsed)
-	}
-	if result.Status != StatusUnknown {
-		t.Errorf("status = %v, want %v (output: %q)", result.Status, StatusUnknown, result.RawOutput)
-	}
-	if result.Error != "solver timeout" {
-		t.Errorf("error = %q, want %q", result.Error, "solver timeout")
-	}
+		if err != nil {
+			t.Fatalf("Solve returned an error: %v", err)
+		}
+		if elapsed >= 10*time.Second {
+			t.Errorf("Solve took %v, want less than 10s", elapsed)
+		}
+		if result.Status != StatusUnknown {
+			t.Errorf("status = %v, want %v (output: %q)", result.Status, StatusUnknown, result.RawOutput)
+		}
+		if result.Error != "solver timeout" {
+			t.Errorf("error = %q, want %q", result.Error, "solver timeout")
+		}
 
-	childPID := readChildPID(t, childPIDFile)
-	assertProcessGoneWithin(t, childPID, 2*time.Second)
+		childPID, ok := readChildPIDIfPresent(t, childPIDFile)
+		if !ok {
+			t.Logf("attempt %d/%d inconclusive: fake solver killed before recording its child PID (ailang#602)", attempt, maxRaceAttempts)
+			continue
+		}
+		assertProcessGoneWithin(t, childPID, 2*time.Second)
+		return
+	}
+	t.Fatalf("all %d attempts lost the fake-solver startup race; child PID never recorded (ailang#602)", maxRaceAttempts)
 }
 
 func TestZ3Version_HardTimeout(t *testing.T) {
-	fake, childPIDFile := writeSleepingFakeSolver(t)
-	t.Setenv("AILANG_Z3_PATH", fake)
+	for attempt := 1; attempt <= maxRaceAttempts; attempt++ {
+		fake, childPIDFile := writeSleepingFakeSolver(t)
+		t.Setenv("AILANG_Z3_PATH", fake)
 
-	start := time.Now()
-	version := Z3Version()
-	elapsed := time.Since(start)
+		start := time.Now()
+		version := Z3Version()
+		elapsed := time.Since(start)
 
-	if elapsed >= 8*time.Second {
-		t.Errorf("Z3Version took %v, want less than 8s", elapsed)
+		if elapsed >= 8*time.Second {
+			t.Errorf("Z3Version took %v, want less than 8s", elapsed)
+		}
+		if version != "" {
+			t.Errorf("Z3Version = %q, want empty string", version)
+		}
+
+		childPID, ok := readChildPIDIfPresent(t, childPIDFile)
+		if !ok {
+			t.Logf("attempt %d/%d inconclusive: fake solver killed before recording its child PID (ailang#602)", attempt, maxRaceAttempts)
+			continue
+		}
+		assertProcessGoneWithin(t, childPID, 2*time.Second)
+		return
 	}
-	if version != "" {
-		t.Errorf("Z3Version = %q, want empty string", version)
-	}
-
-	childPID := readChildPID(t, childPIDFile)
-	assertProcessGoneWithin(t, childPID, 2*time.Second)
+	t.Fatalf("all %d attempts lost the fake-solver startup race; child PID never recorded (ailang#602)", maxRaceAttempts)
 }
 
 func writeSleepingFakeSolver(t *testing.T) (string, string) {
@@ -79,18 +100,29 @@ sleep %d
 	return scriptPath, childPIDFile
 }
 
-func readChildPID(t *testing.T, path string) int {
+// readChildPIDIfPresent reports the fake solver's recorded child PID. ok is false
+// when the pidfile is absent or empty, which means the fake solver was killed
+// before it could record its child — an inconclusive trial, not a failure
+// (ailang#602). A malformed pidfile is a real defect and fails loudly.
+func readChildPIDIfPresent(t *testing.T, path string) (int, bool) {
 	t.Helper()
 
 	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, false
+	}
 	if err != nil {
 		t.Fatalf("read child pid: %v", err)
 	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	text := strings.TrimSpace(string(data))
+	if text == "" {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(text)
 	if err != nil {
 		t.Fatalf("parse child pid %q: %v", data, err)
 	}
-	return pid
+	return pid, true
 }
 
 func assertProcessGoneWithin(t *testing.T, pid int, timeout time.Duration) {

--- a/internal/smt/solver_timeout_test.go
+++ b/internal/smt/solver_timeout_test.go
@@ -17,8 +17,19 @@ import (
 const fakeSolverSleep = 30 * time.Second
 
 // maxRaceAttempts bounds how many times a hard-timeout test re-runs its scenario
-// when the fake solver loses its startup race. Measured at ~0.3% per spawn under
-// full-suite load (ailang#602), so three attempts leave a ~3e-8 residue.
+// when the fake solver loses its startup race (ailang#602).
+//
+// The two tests do not share a budget, and the measurement below is the smaller
+// one. TestSolve_HardTimeout gets max(Timeout, effectiveTimeout)+solverKillGrace
+// = 3s; TestZ3Version_HardTimeout gets versionProbeTimeout = 5s outright, since
+// solverKillGrace is only its WaitDelay and not part of its context deadline.
+//
+// Time from spawn to the child pidfile appearing, measured over 500 trials:
+// idle 200/200 at mean 209ms / max 232ms; under a full `go test -count=1 ./...`
+// load, 1 trial in 300 exceeded 3s (at 3.435s) and 0 exceeded 5s. So ~0.3% per
+// spawn against the 3s budget — strictly less against 5s — and three attempts
+// leave a ~3e-8 residue. Retrying is safe because a genuine process-group-kill
+// regression fails assertProcessGoneWithin on every attempt instead.
 const maxRaceAttempts = 3
 
 func TestSolve_HardTimeout_FakeSolverIgnoringT(t *testing.T) {


### PR DESCRIPTION
Closes #602.

## The measurement, not the inference

`#602` reports `TestSolve_HardTimeout_FakeSolverIgnoringT` intermittently redding `go test ./...`. Reproduction was attempted first-party at `e70fb7484` **before** any fix, and **neither full-suite arm reproduced it** — so this is confirmed by measuring the variable directly, not by re-running until it broke.

**The issue's stated cause was off by 3×**: the fake solver is not killed by "the 1s solver timeout". `solver.go:158` computes `hardTimeout = max(config.Timeout, effectiveTimeout) + solverKillGrace` = **3s** (corroborated, not just read: the isolated arm takes 3.274s).

A probe replicating the spawn exactly (same script, same `Setpgid`, fresh TempDir + freshly-written script per trial), measuring time from spawn to `child.pid` appearing:

| Condition | n | mean | max | over 3s budget |
|---|---|---|---|---|
| Idle | 200 | 209ms | 232ms | **0** |
| During `go test -count=1 ./...` (load 13.6) | 150 | 424ms | **3.435s** | **1** |
| During `go test -count=1 ./...` (load 24.4) | 150 | 219ms | 268ms | **0** |

**1 spawn in 300 under load exceeds the budget** (~0.3%; the package spawns twice, so ~0.7% per suite run). That is why CI stays green, why it survived the CI-flake sprint, and why a couple of local runs cannot refute it. Note the over-budget trial happened at load **13.6**, not the higher **24.4** — a tail effect (first exec of a freshly written script), not a smooth function of load.

## Why the issue's suggested fix does not work

Polling for the pidfile cannot help: when the race is lost, the shell was killed **before** `echo $! > file` ever ran, so the file will never appear. Such a trial proves nothing about process-group kill.

## The fix

A trial that never recorded a child PID is **inconclusive**, so the scenario is retried — bounded at 3 attempts, loud `Fatalf` on exhaustion. At p≈0.003 that leaves a ~3e-8 residue.

## Mutation-proven by the controller (both reverted byte-identical, sha256-verified)

| Mutation | Expected | Observed |
|---|---|---|
| `syscall.Kill(pid)` instead of `-pid` — breaks process-group kill | reds on every attempt | **rc=1**, `child process 49684 still exists after 2s` |
| fake solver always misses the budget | loud exhaustion, not a silent pass | **rc=1**, 3 inconclusive logs + `all 3 attempts lost…` |

The first is the one that matters: the retry **cannot mask a real regression**.

## Gates (controller-run, outside any sandbox)

`gofmt -l` clean · `go vet` rc=0 · `go build ./internal/...` rc=0 · `go test -count=1 ./internal/smt/` rc=0 · `go test -count=5 -run HardTimeout` rc=0 (40s) · `make check-changelog` / `check-file-sizes` / `check-boundaries` / `fmt-check` / `vet` all rc=0 (gate list **derived from ci.yml**, not recalled).

⚠ **GitHub Actions is under a declared major outage** (incident 15:22Z, unresolved), so remote CI may not be obtainable — this PR is not to be treated as landed until an observed green.

Executor: pi + DeepSeek V4 Flash 0731 ($0.0063).

🤖 Generated with [Claude Code](https://claude.com/claude-code)