### PR TITLE
feat(testing): M2B — deterministic property seeds, wall clock deleted (#535)

### DIFF
--- a/design_docs/planned/v0_31_0/m-property-seed-determinism-sprint-plan.md
+++ b/design_docs/planned/v0_31_0/m-property-seed-determinism-sprint-plan.md
@@ -1075,18 +1075,46 @@ test "$a" != "$c"
 
 #### AC-SEED-SWEEP-M2 — every RNG path went through the derivation (§5.1's failure shape)
 
+**REPAIRED at iteration 162 — (b) and (c) as originally written are unrunnable, and (d) is
+vacuous for the defect it names. Both repairs are measured, not reasoned; see the two notes below.**
+
 ```bash
+PROD=($(ls internal/testing/*.go | grep -v '_test\.go$'))                  # production files only
 grep -rn 'time\.Now()\.UnixNano' internal/testing/ ; test $? -ne 0        # (a)
-test "$(grep -rnE 'newRNG\(' internal/testing/*.go | grep -vc 'func newRNG')" -eq 3   # (b)
-grep -rnE 'newRNG\(' internal/testing/*.go | grep -v 'func newRNG' \
-  | grep -c 'propertySeed' | grep -qx 3                                    # (c)
+test "$(grep -nE 'newRNG\(' "${PROD[@]}" | grep -vc 'func newRNG')" -eq 3  # (b)
+test "$(grep -nE 'newRNG\(' "${PROD[@]}" | grep -v 'func newRNG' \
+  | grep -c 'propertySeed')" -eq 3                                         # (c)
 go test ./internal/testing -run 'TestRunner_AllThreePropertyPathsUseDerivedSeed' -count=1  # (d)
+go test ./internal/testing -run 'TestRunner_DerivedSeedDrivesSampleStreams' -count=1       # (e)
 ```
 
 **Baseline**: (a) fails (the sentinel is at `runner.go:667`); (b) **passes at baseline** (there are
 already exactly 3 sites) — it is a *count guard* against a fourth appearing, not evidence; (c) fails
-(zero sites mention `propertySeed`); (d) fails (test does not exist). (c) and (d) are the
-discriminating arms, and (d) is the one that catches `contract_domain.go:89` specifically.
+(zero sites mention `propertySeed`); (d) and (e) fail (tests do not exist). (c) and (e) are the
+discriminating arms, and **(e)** — not (d) — is the one that catches `contract_domain.go:89`.
+
+**Repair 1 — the scope was wrong, and the executor caught it (self-reported deviation, adjudicated
+by measurement).** The original arms glob `internal/testing/*.go`, which includes `_test.go`. S10's
+own spec (§5.6) requires it to call `newRNG(0)`/`newRNG(1)` directly, so the moment S10 exists the
+`-eq 3` guard reads **6**; with S11b's doc comment quoting the call form it reads **8**, and (c)
+reads **4**. Measured at iteration 162: as-written (b)=8 / (c)=4 → both FAIL on a correct tree;
+production-scoped (b)=3 / (c)=3 → both PASS. The guard is about *production* call sites, so the
+glob, not the count, was the defect.
+
+**Repair 2 — (d) does not kill the mutation it is documented to kill.** S11 observes
+`PropertyResult.Seed`, which each path stamps into its result initializer **independently of what it
+hands to `newRNG`**. Measured at iteration 162 with the mutant landed and building
+(`go build ./internal/testing` rc=0): replacing `newRNG(r.propertySeed(...))` with a constant at
+`contract_domain.go:89` leaves **the entire seed suite green**. §5.6's S11 row therefore pins the
+stamp, not the stream, and the milestone's whole point — the sweep — was unguarded. S11b
+(`TestRunner_DerivedSeedDrivesSampleStreams`) closes it by observing facts downstream of the
+generator: the ensures path's accept/discard counts under M1's domain filter, and the requires
+path's counterexample text. Both are exact and reproducible (fixed seeds ⇒ fixed samples), and both
+mutants now red. **Residual, recorded rather than papered over**: the *forall* site
+(`runner.go:293`) has no stream observable in this package — every forall property in a unit-test
+fixture fails on its first generated input with `evaluation failed: empty program`, a pre-existing
+harness limitation unrelated to this milestone — so a constant-seed mutant there still survives.
+That site is pinned by arm (c) plus the seed stamp only. M3 owes it a CLI-level e2e arm.
 
 #### AC-SCOPE-M2 — no scope creep
 

--- a/internal/testing/contract_domain.go
+++ b/internal/testing/contract_domain.go
@@ -26,6 +26,7 @@ func (r *Runner) runEnsuresProperty(propCase PropertyCase) PropertyResult {
 		Name:     propCase.Name,
 		Location: propCase.Location.String(),
 		TestsRun: 0,
+		Seed:     r.propertySeed(propCase.Name),
 	}
 
 	if propCase.Function == nil {
@@ -85,8 +86,7 @@ func (r *Runner) runEnsuresProperty(propCase PropertyCase) PropertyResult {
 		requiredAccepted = 100
 		maxAttempts      = 1000
 	)
-	config := DefaultConfig()
-	rng := newRNG(config.Seed)
+	rng := newRNG(r.propertySeed(propCase.Name))
 	requires := r.findAllLoweredContractPredicates(propCase, core.RequiresKind)
 
 	for result.TestsRun < requiredAccepted && result.GeneratedInputs < maxAttempts {

--- a/internal/testing/result.go
+++ b/internal/testing/result.go
@@ -41,19 +41,23 @@ type PropertyResult struct {
 	Error           string        // Error message (if failed)
 	Location        string        // Source location
 	SkipKind        string        // Machine-readable reason when StatusSkip
+	Seed            int64         // Derived seed used for this property's RNG stream
 }
 
 // SuiteResult aggregates results from all tests in a test suite.
 type SuiteResult struct {
-	ModulePath    string           // Module path
-	Tests         []TestResult     // All test results
-	Properties    []PropertyResult // All property results
-	TotalTests    int              // Total number of tests
-	PassedTests   int              // Number of passing tests
-	FailedTests   int              // Number of failing tests
-	SkippedTests  int              // Number of skipped tests
-	VacuousSkips  int              // Skipped properties that executed no meaningful cases
-	TotalDuration time.Duration    // Total execution time
+	ModulePath     string           // Module path
+	Tests          []TestResult     // All test results
+	Properties     []PropertyResult // All property results
+	TotalTests     int              // Total number of tests
+	PassedTests    int              // Number of passing tests
+	FailedTests    int              // Number of failing tests
+	SkippedTests   int              // Number of skipped tests
+	VacuousSkips   int              // Skipped properties that executed no meaningful cases
+	TotalDuration  time.Duration    // Total execution time
+	SeedMode       SeedMode         // Derived or master seed policy
+	MasterSeed     int64            // Master seed (0 in derived mode)
+	SeedDerivation string           // Seed derivation contract tag
 }
 
 // NewSuiteResult creates a new empty suite result.
@@ -84,6 +88,14 @@ func (sr *SuiteResult) AddTestResult(result TestResult) {
 	case StatusSkip:
 		sr.SkippedTests++
 	}
+}
+
+// SetSeedMetadata copies the seed-relevant fields of cfg onto the suite result.
+// Both CLI aggregates call this; it is the single mutator so they cannot drift.
+func (sr *SuiteResult) SetSeedMetadata(cfg TestConfig) {
+	sr.SeedMode = cfg.SeedMode
+	sr.MasterSeed = cfg.MasterSeed
+	sr.SeedDerivation = SeedDerivationV1
 }
 
 // AddPropertyResult adds a property result and updates counters.

--- a/internal/testing/runner.go
+++ b/internal/testing/runner.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"fmt"
 	"math/rand"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -13,16 +14,47 @@ import (
 
 // Runner executes tests and properties.
 type Runner struct {
-	modulePath string
-	executor   *Executor
+	modulePath     string
+	executor       *Executor
+	config         TestConfig
+	moduleIdentity string
 }
 
-// NewRunner creates a new test runner.
+// NewRunner creates a new test runner using the default derived-seed policy.
+//
+// It is a convenience wrapper over NewRunnerWithConfig: the workspace root is
+// inferred from the module file's own directory (SeedModeDerived, master 0) and
+// the module identity is left unresolved. CLI code must not use this — it should
+// use RunTestsFromFileWithConfig so the module identity is resolved properly.
 func NewRunner(modulePath string) *Runner {
-	return &Runner{
-		modulePath: modulePath,
-		executor:   NewExecutor(modulePath),
+	abs, err := filepath.Abs(modulePath)
+	if err != nil {
+		abs = modulePath
 	}
+	cfg := TestConfig{
+		WorkspaceRoot: filepath.Dir(abs),
+		SeedMode:      SeedModeDerived,
+		MasterSeed:    0,
+	}
+	return NewRunnerWithConfig(modulePath, cfg, "")
+}
+
+// NewRunnerWithConfig creates a test runner with an explicit seed config and a
+// pre-resolved module identity. It never fails: callers resolve the identity via
+// ResolveModuleIdentity before calling.
+func NewRunnerWithConfig(modulePath string, cfg TestConfig, moduleIdentity string) *Runner {
+	return &Runner{
+		modulePath:     modulePath,
+		executor:       NewExecutor(modulePath),
+		config:         cfg,
+		moduleIdentity: moduleIdentity,
+	}
+}
+
+// propertySeed derives the deterministic seed for a single property from the
+// runner's master seed, module identity, and the property name.
+func (r *Runner) propertySeed(name string) int64 {
+	return DeriveSeedV1(r.config.MasterSeed, r.moduleIdentity, name)
 }
 
 // RunSuite executes all tests in a test suite and returns aggregated results.
@@ -234,6 +266,7 @@ func (r *Runner) runProperty(propCase PropertyCase) PropertyResult {
 		Name:     propCase.Name,
 		Location: propCase.Location.String(),
 		TestsRun: 0,
+		Seed:     r.propertySeed(propCase.Name),
 	}
 
 	// Number of test cases to generate per property
@@ -257,8 +290,7 @@ func (r *Runner) runProperty(propCase PropertyCase) PropertyResult {
 	}
 
 	// Run property tests
-	config := DefaultConfig()
-	rng := newRNG(config.Seed)
+	rng := newRNG(r.propertySeed(propCase.Name))
 
 	for testNum := 0; testNum < numTests; testNum++ {
 		result.GeneratedInputs = testNum + 1
@@ -330,6 +362,7 @@ func (r *Runner) runRequiresProperty(propCase PropertyCase) PropertyResult {
 		Name:     propCase.Name,
 		Location: propCase.Location.String(),
 		TestsRun: 0,
+		Seed:     r.propertySeed(propCase.Name),
 	}
 
 	if propCase.Function == nil {
@@ -380,8 +413,7 @@ func (r *Runner) runRequiresProperty(propCase PropertyCase) PropertyResult {
 	}
 
 	const numTests = 100
-	config := DefaultConfig()
-	rng := newRNG(config.Seed)
+	rng := newRNG(r.propertySeed(propCase.Name))
 
 	for testNum := 0; testNum < numTests; testNum++ {
 		result.GeneratedInputs = testNum + 1
@@ -497,19 +529,54 @@ func formatEnsuresInputs(params []*ast.Param, values []eval.Value) string {
 	return strings.Join(parts, ", ")
 }
 
-// RunTestsFromFile is a convenience function that parses, collects, and runs tests from a file.
-func RunTestsFromFile(filePath string, ast *ast.File) (*SuiteResult, error) {
+// RunTestsFromFileWithConfig parses, collects, and runs tests from a file with an
+// explicit seed config. It validates the config, resolves the module identity
+// (module-bearing files are path-independent; module-less files are made
+// workspace-relative), and stamps the seed metadata onto the result.
+func RunTestsFromFileWithConfig(filePath string, file *ast.File, cfg TestConfig) (*SuiteResult, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Resolve the stable module identity before the Runner exists (D4: one
+	// consumption point for WorkspaceRoot).
+	declared := ""
+	if file.Module != nil {
+		declared = file.Module.Path
+	}
+	identity, err := ResolveModuleIdentity(cfg.WorkspaceRoot, filePath, declared)
+	if err != nil {
+		return nil, err
+	}
+
 	// Collect tests from AST
 	collector := NewCollector(filePath)
-	suite := collector.Collect(ast)
+	suite := collector.Collect(file)
 
 	// Run tests
-	runner := NewRunner(filePath)
+	runner := NewRunnerWithConfig(filePath, cfg, identity)
 	// Provide source file context to executor
-	runner.executor.SetSourceFile(ast)
+	runner.executor.SetSourceFile(file)
 	result := runner.RunSuite(suite)
+	result.SetSeedMetadata(cfg)
 
 	return result, nil
+}
+
+// RunTestsFromFile is a convenience function that parses, collects, and runs
+// tests from a file with the default derived-seed policy (workspace root is the
+// module file's own directory). It is a wrapper over RunTestsFromFileWithConfig.
+func RunTestsFromFile(filePath string, ast *ast.File) (*SuiteResult, error) {
+	abs, err := filepath.Abs(filePath)
+	if err != nil {
+		abs = filePath
+	}
+	cfg := TestConfig{
+		WorkspaceRoot: filepath.Dir(abs),
+		SeedMode:      SeedModeDerived,
+		MasterSeed:    0,
+	}
+	return RunTestsFromFileWithConfig(filePath, ast, cfg)
 }
 
 // createGeneratorForType creates a generator and shrinker for the given type.
@@ -661,10 +728,9 @@ func (r *Runner) shrinkCounterexample(property *ast.Property, failingValues []ev
 	return minimal
 }
 
-// newRNG creates a random number generator.
+// newRNG creates a random number generator from a fixed seed. The seed is always
+// used verbatim — there is deliberately no wall-clock fallback, so property
+// streams are deterministic and replayable.
 func newRNG(seed int64) *rand.Rand {
-	if seed == 0 {
-		seed = time.Now().UnixNano()
-	}
 	return rand.New(rand.NewSource(seed))
 }

--- a/internal/testing/runner_seed_test.go
+++ b/internal/testing/runner_seed_test.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -119,6 +120,82 @@ func TestRunner_AllThreePropertyPathsUseDerivedSeed(t *testing.T) {
 	}
 }
 
+// streamObservables reduces a suite result to the per-property facts that are a
+// function of the RNG *stream* rather than of the seed field: how many inputs
+// were generated and discarded, and the counterexample text. PropertyResult.Seed
+// is deliberately excluded — it is stamped in each path's initializer and is
+// therefore identical whether or not the stream actually consumed it.
+func streamObservables(t *testing.T, result *SuiteResult) map[string]string {
+	t.Helper()
+	obs := make(map[string]string, len(result.Properties))
+	for _, p := range result.Properties {
+		obs[p.Name] = fmt.Sprintf("status=%s testsRun=%d generated=%d discarded=%d err=%s",
+			p.Status, p.TestsRun, p.GeneratedInputs, p.DiscardedInputs, p.Error)
+	}
+	return obs
+}
+
+// S11b — TestRunner_DerivedSeedDrivesSampleStreams is the arm S11 cannot be.
+//
+// S11 observes PropertyResult.Seed, which each path stamps into its result
+// initializer *independently of what it hands to newRNG*. So S11 stays green
+// under the exact defect it is documented to kill: replacing
+// `newRNG(r.propertySeed(...))` with `newRNG(<constant>)` at contract_domain.go's
+// ensures site leaves every seed field untouched. Verified by mutation at
+// mission iteration 162 — the mutant built and the whole seed suite passed.
+//
+// This test instead observes facts downstream of the generator stream:
+//   - the ensures path's accept/discard counts under M1's domain filter, and
+//   - the requires path's counterexample text,
+//
+// each of which changes if and only if that site's RNG actually consumed the
+// derived seed. Both are exact and reproducible, not statistical: the seeds are
+// fixed constants, so the sampled values are fixed too.
+//
+// The forall site (runner.go's runProperty) has no stream observable in this
+// package today — every forall property in a unit-test fixture fails on its
+// first generated input with "evaluation failed: empty program", a pre-existing
+// harness limitation unrelated to this milestone. That site is pinned by the
+// seed stamp plus AC-SEED-SWEEP-M2 arm (c), and is called out here so a future
+// reader does not mistake its absence for coverage.
+func TestRunner_DerivedSeedDrivesSampleStreams(t *testing.T) {
+	const (
+		requiresProp = "g_property_1" // the requires path (runner.go)
+		ensuresProp  = "g_property_2" // the ensures path (contract_domain.go)
+	)
+
+	master0a := streamObservables(t, runSeedFixture(t, testConfig(t.TempDir(), 0)))
+	master0b := streamObservables(t, runSeedFixture(t, testConfig(t.TempDir(), 0)))
+	master42 := streamObservables(t, runSeedFixture(t, testConfig(t.TempDir(), 42)))
+
+	// Non-vacuity: an empty or renamed property set must fail loudly rather than
+	// leave every assertion below with nothing to compare.
+	for _, name := range []string{requiresProp, ensuresProp} {
+		if _, ok := master0a[name]; !ok {
+			t.Fatalf("instrument failure: fixture produced no property %q (have %v)", name, master0a)
+		}
+	}
+
+	// Determinism: the same master must reproduce the stream exactly, from a
+	// different workspace root, in a different temp directory.
+	for name, want := range master0a {
+		if got := master0b[name]; got != want {
+			t.Fatalf("property %q is not reproducible at the same master:\n  run A: %s\n  run B: %s", name, want, got)
+		}
+	}
+
+	// Sensitivity, per site. Each of these fails if that site's newRNG stops
+	// consuming the derived seed.
+	if master42[ensuresProp] == master0a[ensuresProp] {
+		t.Fatalf("ensures path (contract_domain.go) ignored the master seed: master 0 and 42 both gave %s",
+			master0a[ensuresProp])
+	}
+	if master42[requiresProp] == master0a[requiresProp] {
+		t.Fatalf("requires path (runner.go) ignored the master seed: master 0 and 42 both gave %s",
+			master0a[requiresProp])
+	}
+}
+
 // S12 — TestRunner_MasterSeedChangesEveryStream kills a hard-coded or ignored
 // master: at master 0 vs 42 all three seed values must differ.
 func TestRunner_MasterSeedChangesEveryStream(t *testing.T) {
@@ -169,6 +246,13 @@ export func main() -> int ! {} { 0 }
 	result, err := RunTestsFromFileWithConfig(tmpFile, file, cfg)
 	if err != nil {
 		t.Fatalf("RunTestsFromFileWithConfig: %v", err)
+	}
+
+	// Non-vacuity: with no property results the loop below asserts nothing and
+	// this test passes for the wrong reason. Verified non-vacuous at iteration
+	// 162 by adding this guard and observing the test still pass.
+	if len(result.Properties) == 0 {
+		t.Fatal("instrument failure: fixture produced zero property results")
 	}
 
 	for _, prop := range result.Properties {

--- a/internal/testing/runner_seed_test.go
+++ b/internal/testing/runner_seed_test.go
@@ -1,0 +1,204 @@
+package testing
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/lexer"
+	"github.com/sunholo-data/ailang/internal/parser"
+)
+
+// seedFixtureSource is a single contract-bearing module with all three property
+// classes: a forall, a requires, and an ensures. It is module-bearing so its
+// identity is the declared module path and is independent of temp locations.
+const seedFixtureSource = `module seed_fixture
+
+export pure func g(x: int) -> int
+  requires { x > 0 }
+  ensures { result == x }
+{
+  x
+}
+
+property "commutative" {
+  forall(x: int) => x + 0 == x
+}
+
+export func main() -> int ! {} { 0 }
+`
+
+// runSeedFixture writes the fixture source to a temp file and runs it through
+// RunTestsFromFileWithConfig with the given config, returning the suite result.
+func runSeedFixture(t *testing.T, cfg TestConfig) *SuiteResult {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "seed_fixture.ail")
+	if err := os.WriteFile(tmpFile, []byte(seedFixtureSource), 0644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	l := lexer.New(seedFixtureSource, tmpFile)
+	p := parser.New(l)
+	file := p.ParseFile()
+	if errs := p.Errors(); len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+
+	result, err := RunTestsFromFileWithConfig(tmpFile, file, cfg)
+	if err != nil {
+		t.Fatalf("RunTestsFromFileWithConfig: %v", err)
+	}
+	return result
+}
+
+// seedFixtureSeeds returns the seeds for the three property paths of
+// seedFixtureSource, keyed by status class (requires/ensures forall comes first).
+func seedFixtureSeeds(t *testing.T, result *SuiteResult) []int64 {
+	t.Helper()
+	var seeds []int64
+	for _, p := range result.Properties {
+		if p.Seed == 0 {
+			t.Fatalf("property %q had zero seed", p.Name)
+		}
+		seeds = append(seeds, p.Seed)
+	}
+	return seeds
+}
+
+func testConfig(root string, master int64) TestConfig {
+	return TestConfig{
+		WorkspaceRoot: root,
+		SeedMode:      SeedModeDerived,
+		MasterSeed:    master,
+	}
+}
+
+// S10 — TestNewRNG_HasNoWallClockBranch kills leaving the `seed == 0` sentinel
+// in place. With a wall clock, two newRNG(0) calls would almost surely differ.
+func TestNewRNG_HasNoWallClockBranch(t *testing.T) {
+	a := newRNG(0).Int63()
+	b := newRNG(0).Int63()
+	if a != b {
+		t.Fatalf("zero-seed generation is nondeterministic: first Int63() %d vs %d (wall clock still present)", a, b)
+	}
+	// Sanity: the seed actually matters.
+	c := newRNG(1).Int63()
+	if c == a {
+		t.Fatalf("seed 1 produced the same first Int63() as seed 0: %d", c)
+	}
+}
+
+// S11 — TestRunner_AllThreePropertyPathsUseDerivedSeed kills guarding two sites
+// and missing contract_domain.go's ensures path. Run twice through
+// RunTestsFromFileWithConfig; every property seed is non-zero, the three differ
+// from each other, and both runs agree field-for-field.
+func TestRunner_AllThreePropertyPathsUseDerivedSeed(t *testing.T) {
+	cfg := testConfig(t.TempDir(), 0)
+
+	first := runSeedFixture(t, cfg)
+	second := runSeedFixture(t, cfg)
+
+	firstSeeds := seedFixtureSeeds(t, first)
+	if len(firstSeeds) != 3 {
+		t.Fatalf("expected 3 property results, got %d", len(firstSeeds))
+	}
+
+	// The three property streams must differ from one another.
+	if firstSeeds[0] == firstSeeds[1] || firstSeeds[0] == firstSeeds[2] || firstSeeds[1] == firstSeeds[2] {
+		t.Fatalf("all three derived seeds should differ, got %v", firstSeeds)
+	}
+
+	// Both runs must agree seed-for-seed.
+	secondSeeds := seedFixtureSeeds(t, second)
+	for i := range firstSeeds {
+		if firstSeeds[i] != secondSeeds[i] {
+			t.Fatalf("run %d: seed %d != %d across runs (not deterministic)", i, firstSeeds[i], secondSeeds[i])
+		}
+	}
+}
+
+// S12 — TestRunner_MasterSeedChangesEveryStream kills a hard-coded or ignored
+// master: at master 0 vs 42 all three seed values must differ.
+func TestRunner_MasterSeedChangesEveryStream(t *testing.T) {
+	base := testConfig(t.TempDir(), 0)
+	altered := testConfig(t.TempDir(), 42)
+
+	baseSeeds := seedFixtureSeeds(t, runSeedFixture(t, base))
+	alteredSeeds := seedFixtureSeeds(t, runSeedFixture(t, altered))
+
+	for i := 0; i < 3; i++ {
+		if baseSeeds[i] == alteredSeeds[i] {
+			t.Fatalf("property %d: master 0 and master 42 produced the same seed %d (master ignored)", i, baseSeeds[i])
+		}
+	}
+}
+
+// S13 — TestRunProperty_SeedSetEvenOnSkip kills setting the seed after an early
+// return: a no_generator property must still carry a non-zero Seed.
+func TestRunProperty_SeedSetEvenOnSkip(t *testing.T) {
+	src := `module skip_seed
+
+type Tree = { }
+
+export pure func walk(t: Tree) -> int
+  ensures { result >= 0 }
+{
+  0
+}
+
+export func main() -> int ! {} { 0 }
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "skip_seed.ail")
+	if err := os.WriteFile(tmpFile, []byte(src), 0644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	l := lexer.New(src, tmpFile)
+	p := parser.New(l)
+	file := p.ParseFile()
+	if errs := p.Errors(); len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	cfg := TestConfig{
+		WorkspaceRoot: tmpDir,
+		SeedMode:      SeedModeDerived,
+		MasterSeed:    0,
+	}
+	result, err := RunTestsFromFileWithConfig(tmpFile, file, cfg)
+	if err != nil {
+		t.Fatalf("RunTestsFromFileWithConfig: %v", err)
+	}
+
+	for _, prop := range result.Properties {
+		if prop.Status != StatusSkip {
+			t.Fatalf("expected a skip, got %s (%s)", prop.Status, prop.Error)
+		}
+		if prop.Seed == 0 {
+			t.Fatalf("property %q skipped but had zero seed (seed set too late)", prop.Name)
+		}
+	}
+}
+
+// S14 — TestSuiteResult_SetSeedMetadata kills a partial copy: all three fields
+// must be copied from a TestConfig.
+func TestSuiteResult_SetSeedMetadata(t *testing.T) {
+	cfg := TestConfig{
+		WorkspaceRoot: "/work",
+		SeedMode:      SeedModeMaster,
+		MasterSeed:    -987654321,
+	}
+	sr := NewSuiteResult("some/module")
+	sr.SetSeedMetadata(cfg)
+
+	if sr.SeedMode != SeedModeMaster {
+		t.Fatalf("SeedMode = %q, want %q", sr.SeedMode, SeedModeMaster)
+	}
+	if sr.MasterSeed != -987654321 {
+		t.Fatalf("MasterSeed = %d, want -987654321", sr.MasterSeed)
+	}
+	if sr.SeedDerivation != SeedDerivationV1 {
+		t.Fatalf("SeedDerivation = %q, want %q", sr.SeedDerivation, SeedDerivationV1)
+	}
+}


### PR DESCRIPTION
Milestone **M2B** of `m-property-seed-determinism` (sprint plan §5.4). M2A landed on `dev` at `7be6a2b8a`/`ac306084b`.

## What changed

Property sampling was seeded from `time.Now().UnixNano()` whenever `DefaultConfig().Seed` was 0 — which it always is. This threads a `TestConfig` through the `Runner` and derives a per-property seed via the frozen `DeriveSeedV1`, then deletes the wall-clock branch outright.

All **three** RNG call sites swept, including `contract_domain.go:89` (ensures) which the design doc's Conflict Surface omits — §5.1 names "guard the helper, miss a call site" as this repo's recurring failure shape, so the sweep is grep-checkable via AC-SEED-SWEEP-M2.

## Evidence — end-to-end, with a negative control

`examples/runnable/contracts/list_recursive_verify.ail`, `--format json`, `duration` stripped, 5 runs each:

| binary | distinct output hashes |
|---|---|
| pre-M2B (`dev` HEAD, wall clock) | **5 of 5** |
| this branch (derived seed) | **1 of 5** |

Same shape on `quantifier_verify.ail` (3/3 → 1/3). The control binary was rebuilt from the main checkout after a first attempt accidentally built it from inside the worktree — a contaminated control that read as "both arms identical".

## Mutation drill

Each mutant asserted **LANDED** and **BUILDS** (`go build ./internal/testing` rc=0) before its result was believed; source restored byte-identical after each.

| mutant | outcome |
|---|---|
| ensures site → constant seed | **RED** (S11b) |
| requires site → constant seed | **RED** (S11b) |
| `newRNG` wall clock restored | **RED** (S10) |
| forall site → constant seed | **GREEN** — recorded, not papered over |

The second commit exists because the *first* two mutants **survived** as delivered: S11 observes `PropertyResult.Seed`, which is stamped in each path's initializer independently of what reaches `newRNG`. S11b observes the generator stream instead (ensures accept/discard counts, requires counterexample text). The forall residual is a pre-existing harness limitation (`evaluation failed: empty program` on the first generated input in any unit-test fixture) and is called out in the code and the plan; M3 owes it a CLI-level arm.

## Gates (all run by the controller outside the executor)

`make test` rc=0 (13,266 PASS, 0 FAIL) · `make verify-examples` rc=0 · `fmt-check` · `vet` · `GOOS=windows vet` · `check-file-sizes` · `check-boundaries` · `check-changelog` · `check-golden-drift` — all rc=0. `go build ./...` fails only on `cmd/wasm`/`gen/main`, **identically on pristine `dev`** (baselined, not introduced here).

AC-SCOPE-M2 stop conditions all empty: no diff under `internal/{parser,types,elaborate,eval,core,pipeline,link,effects}`, none under `cmd/`, none to `executor.go`/`harness.go`/`source_strip.go`; M1's frozen 100/1000 bounds intact.

## Not in this milestone

No CLI flags, no seed reporting — that is M2C. `Fixes #535` goes on the final commit of the series per §5.9, so this PR only `Refs` it.

Executor: `pi:openrouter/deepseek/deepseek-v4-flash-0731`. Mission iteration 162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)