### PR TITLE
feat(testing): M2C — --seed/--random-seed + both test.go aggregates (#535)

### DIFF
--- a/cmd/ailang/main.go
+++ b/cmd/ailang/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sunholo-data/ailang/internal/observatory"
 	"github.com/sunholo-data/ailang/internal/prompt"
 	"github.com/sunholo-data/ailang/internal/schema"
+	ailangTesting "github.com/sunholo-data/ailang/internal/testing"
 	"github.com/sunholo-data/ailang/internal/version"
 )
 
@@ -115,6 +116,8 @@ func main() {
 		noColorFlag := testFlags.Bool("no-color", false, "Disable colored output")
 		packageFlag := testFlags.Bool("package", false, "Run tests in package mode (discovers *_test.ail via ailang.toml)")
 		allowSkipsFlag := testFlags.Bool("allow-skips", false, "Exit 0 even when all tests are skipped (default: skipped-only suites exit 1)")
+		seedFlag := testFlags.Int64("seed", 0, "Master seed for property generation (signed int64)")
+		randomSeedFlag := testFlags.Bool("random-seed", false, "Read one master seed from crypto/rand and report it")
 		helpTestFlag := testFlags.Bool("help", false, "Show help for test command")
 
 		_ = testFlags.Parse(flag.Args()[1:]) // Parse errors handled by flags package
@@ -124,15 +127,56 @@ func main() {
 			return
 		}
 
+		// Both flags are registered above so the CLI accepts them. D1 mandates
+		// detecting PRESENCE via Visit — presence, not value — so the returned
+		// randomSeedFlag value is intentionally unused (--seed 0 must not be
+		// confused with unset); blank it rather than dereference it.
+		_ = randomSeedFlag
+
+		// Detect flag PRESENCE via Visit (D1) — presence, not value, because
+		// --seed 0 is a legitimate explicit master seed and must not be confused
+		// with "unset". Visit iterates only flags that were set on the command line.
+		seedSet, randomSet := false, false
+		testFlags.Visit(func(f *flag.Flag) {
+			switch f.Name {
+			case "seed":
+				seedSet = true
+			case "random-seed":
+				randomSet = true
+			}
+		})
+		if seedSet && randomSet { // D2 — mutual exclusion on stderr, exit 2
+			fmt.Fprintln(os.Stderr, "Error: --seed and --random-seed cannot be used together")
+			os.Exit(2)
+		}
+		// Capture os.Getwd() ONCE, before any path walking.
+		cwd, err := os.Getwd()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: cannot determine working directory: %v\n", err)
+			os.Exit(1)
+		}
+		cfg := ailangTesting.TestConfig{WorkspaceRoot: cwd, SeedMode: ailangTesting.SeedModeDerived, MasterSeed: 0}
+		switch {
+		case seedSet:
+			cfg.SeedMode, cfg.MasterSeed = ailangTesting.SeedModeMaster, *seedFlag
+		case randomSet:
+			m, err := ailangTesting.NewRandomMasterSeed()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1) // BEFORE any property runs
+			}
+			cfg.SeedMode, cfg.MasterSeed = ailangTesting.SeedModeMaster, m
+		}
+
 		path := "."
 		if testFlags.NArg() >= 1 {
 			path = testFlags.Arg(0)
 		}
 
 		if *packageFlag {
-			runPackageTests(path, *formatFlag, !*noColorFlag, *allowSkipsFlag)
+			runPackageTests(path, *formatFlag, !*noColorFlag, *allowSkipsFlag, cfg)
 		} else {
-			runTestsV2(path, *formatFlag, !*noColorFlag, *allowSkipsFlag)
+			runTestsV2(path, *formatFlag, !*noColorFlag, *allowSkipsFlag, cfg)
 		}
 
 	case "watch":

--- a/cmd/ailang/test.go
+++ b/cmd/ailang/test.go
@@ -14,7 +14,7 @@ import (
 
 // runTestsV2 executes all tests in the given path.
 // Replaces the stub implementation in main.go.
-func runTestsV2(path string, formatStr string, colorEnabled bool, allowSkips bool) {
+func runTestsV2(path string, formatStr string, colorEnabled bool, allowSkips bool, cfg ailangTesting.TestConfig) {
 	preambleWriter := os.Stdout
 	if formatStr == "json" {
 		preambleWriter = os.Stderr
@@ -47,10 +47,11 @@ func runTestsV2(path string, formatStr string, colorEnabled bool, allowSkips boo
 
 	// Aggregate results across all files
 	aggregateResults := ailangTesting.NewSuiteResult("All Tests")
+	aggregateResults.SetSeedMetadata(cfg)
 
 	// Run tests for each file
 	for _, file := range testFiles {
-		fileResult := runTestFile(file)
+		fileResult := runTestFile(file, cfg)
 		if fileResult != nil {
 			// Merge results into aggregate
 			aggregateResults.Tests = append(aggregateResults.Tests, fileResult.Tests...)
@@ -90,7 +91,7 @@ func runTestsV2(path string, formatStr string, colorEnabled bool, allowSkips boo
 
 // runTestFile runs all tests in a single file.
 // Returns nil if the file has no tests.
-func runTestFile(filename string) *ailangTesting.SuiteResult {
+func runTestFile(filename string, cfg ailangTesting.TestConfig) *ailangTesting.SuiteResult {
 	// Read source
 	source, err := os.ReadFile(filename)
 	if err != nil {
@@ -116,7 +117,7 @@ func runTestFile(filename string) *ailangTesting.SuiteResult {
 	}
 
 	// Use the built-in test runner
-	result, err := ailangTesting.RunTestsFromFile(filename, file)
+	result, err := ailangTesting.RunTestsFromFileWithConfig(filename, file, cfg)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s: Failed to run tests in %s: %v\n", yellow("⚠"), filename, err)
 		return nil
@@ -133,7 +134,7 @@ func runTestFile(filename string) *ailangTesting.SuiteResult {
 // runPackageTests discovers and runs *_test.ail files in a package directory.
 // It reads ailang.toml for package metadata, finds test files by convention,
 // and runs them using the existing test framework.
-func runPackageTests(dir string, formatStr string, colorEnabled bool, allowSkips bool) {
+func runPackageTests(dir string, formatStr string, colorEnabled bool, allowSkips bool, cfg ailangTesting.TestConfig) {
 	// Load package manifest
 	manifest, err := pkg.LoadManifest(dir)
 	if err != nil {
@@ -183,9 +184,10 @@ func runPackageTests(dir string, formatStr string, colorEnabled bool, allowSkips
 
 	// Aggregate results across all test files
 	aggregateResults := ailangTesting.NewSuiteResult(manifest.Package.Name)
+	aggregateResults.SetSeedMetadata(cfg)
 
 	for _, file := range testFiles {
-		fileResult := runTestFile(file)
+		fileResult := runTestFile(file, cfg)
 		if fileResult != nil {
 			aggregateResults.Tests = append(aggregateResults.Tests, fileResult.Tests...)
 			aggregateResults.Properties = append(aggregateResults.Properties, fileResult.Properties...)
@@ -232,6 +234,8 @@ func printTestHelp() {
 	fmt.Println("  --no-color         Disable colored output")
 	fmt.Println("  --package          Package mode: discover *_test.ail files via ailang.toml")
 	fmt.Println("  --allow-skips      Exit 0 even if all tests were skipped (default: exit 1)")
+	fmt.Println("  --seed N           Master seed for property generation (signed int64; replayable)")
+	fmt.Println("  --random-seed      Read one master seed from crypto/rand and report it for replay")
 	fmt.Println()
 	fmt.Println("Examples:")
 	fmt.Println("  ailang test                    # Run all tests in current directory")

--- a/cmd/ailang/test_seed_test.go
+++ b/cmd/ailang/test_seed_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// seedAggFixtureSource is a passing module-bearing fixture. In FILE mode
+// runTestsV2 is the aggregate; in PACKAGE mode runPackageTests is the aggregate.
+// The declared module is the stable identity on both paths, so the fixture
+// needs no module-path match (the package loader relaxes MOD010 for the
+// on-disk mismatch in the package arm, and the file arm never runs `check`).
+const seedAggFixtureSource = `module seedtest/pkg/prop_test
+
+export func ok(x: int) -> bool ! {}
+ensures { result == true } { true }
+`
+
+const seedAggManifest = `[package]
+name = "seedtest/pkg"
+version = "0.1.0"
+edition = "1"
+
+[exports]
+modules = ["seedtest/pkg/prop"]
+
+[stability]
+level = "experimental"
+`
+
+// S17 — the AGGREGATE that the command path actually built must carry the seed
+// metadata in BOTH modes. runTestsV2 and runPackageTests both os.Exit, so they
+// cannot be called directly from a unit test; this test drives the built
+// binary and asserts on the JSON the command path emitted, exactly as
+// AC-SEED-AGG-M2C does. This is deliberately NOT a SetSeedMetadata-unit test
+// (that is S14, which passes with both call sites deleted): deleting the
+// SetSeedMetadata call in runPackageTests must make the package arm here fail.
+func TestPackageAndFileAggregatesBothCarrySeedMetadata(t *testing.T) {
+	bin := buildAilang(t)
+
+	// FILE mode drives runTestsV2.
+	file := filepath.Join(t.TempDir(), "prop_test.ail")
+	if err := os.WriteFile(file, []byte(seedAggFixtureSource), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stdout, stderr, exit := runAilangBin(t, bin, "test", "--format", "json", "--no-color", file)
+	if exit != 0 {
+		t.Fatalf("file mode exit = %d, want 0\nstderr:\n%s", exit, stderr)
+	}
+	assertSeedMetadataJSON(t, stdout, "file-mode aggregate (runTestsV2)")
+
+	// PACKAGE mode drives runPackageTests.
+	pkgDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(pkgDir, "ailang.toml"), []byte(seedAggManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "prop_test.ail"), []byte(seedAggFixtureSource), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pkgOut, pkgErr, pkgExit := runAilangBin(t, bin, "test", "--package", "--format", "json", "--no-color", pkgDir)
+	if pkgExit != 0 {
+		t.Fatalf("package mode exit = %d, want 0\nstderr:\n%s", pkgExit, pkgErr)
+	}
+	assertSeedMetadataJSON(t, pkgOut, "package-mode aggregate (runPackageTests)")
+}
+
+// assertSeedMetadataJSON verifies the three top-level seed fields that the
+// aggregate must stamp via SetSeedMetadata. An empty seed_mode / seed_derivation
+// here is exactly the silent green-passing defect §5.5(b) and S17 guard against.
+func assertSeedMetadataJSON(t *testing.T, raw, label string) {
+	t.Helper()
+	var output struct {
+		SeedMode       string            `json:"seed_mode"`
+		Seed           string            `json:"seed"`
+		SeedDerivation string            `json:"seed_derivation"`
+		Properties     []json.RawMessage `json:"properties"`
+	}
+	if err := json.Unmarshal([]byte(raw), &output); err != nil {
+		t.Fatalf("%s: invalid JSON from aggregate: %v\n%s", label, err, raw)
+	}
+	if output.SeedMode != "derived" {
+		t.Errorf("%s: seed_mode = %q, want %q", label, output.SeedMode, "derived")
+	}
+	if output.Seed != "0" {
+		t.Errorf("%s: seed = %q, want %q", label, output.Seed, "0")
+	}
+	if output.SeedDerivation != "ailang-property-seed-v1" {
+		t.Errorf("%s: seed_derivation = %q, want %q", label, output.SeedDerivation, "ailang-property-seed-v1")
+	}
+	if len(output.Properties) == 0 {
+		t.Errorf("%s: aggregate emitted no properties", label)
+	}
+	var anySeed bool
+	for _, p := range output.Properties {
+		var prop struct {
+			Seed *string `json:"seed"`
+		}
+		if err := json.Unmarshal(p, &prop); err != nil {
+			t.Fatalf("%s: invalid property object: %v", label, err)
+		}
+		if prop.Seed != nil {
+			anySeed = true
+		}
+	}
+	if !anySeed {
+		t.Errorf("%s: no property carried a per-property seed", label)
+	}
+}

--- a/design_docs/planned/v0_31_0/m-property-seed-determinism-sprint-plan.md
+++ b/design_docs/planned/v0_31_0/m-property-seed-determinism-sprint-plan.md
@@ -813,7 +813,11 @@ case randomSet:
 switches from `RunTestsFromFile(filename, file)` to `RunTestsFromFileWithConfig(filename, file, cfg)`.
 **In BOTH aggregation blocks**, immediately after `NewSuiteResult(...)` (line 48 and line 185), call
 `aggregateResults.SetSeedMetadata(cfg)`. Missing either one silently emits an empty `seed_mode` for
-that mode — this is the §5.1 fourth call-site class.
+that mode — this is the §5.1 fourth call-site class. **`runTestsV2` (line 17) is FILE mode;
+`runPackageTests` (line 136) is `--package` mode, and every other M2 acceptance arm runs file mode
+only** — so the second call site is guarded solely by **`AC-SEED-AGG-M2C` (§5.11) and row S17
+(§5.6)**, both added at iteration 163 for exactly this reason. Run them; do not treat the file-mode
+arms going green as evidence that this half landed.
 
 **(c) `printTestHelp` (`cmd/ailang/test.go:225-246`).** Add two Options lines. The literal strings
 `--seed N` and `--random-seed` **must appear verbatim** — AC6 greps for them with `grep -F`:
@@ -853,6 +857,50 @@ New file `internal/testing/config_test.go` (M2A), additions to
 | S14 | `TestSuiteResult_SetSeedMetadata` | copies all three fields from a `TestConfig` | a partial copy |
 | S15 | `TestReporter_JSONSeedFieldsAreDecimalStrings` | top-level `seed` and per-property `seed` decode as **strings** matching `^-?[0-9]+$`; `seed_derivation == "ailang-property-seed-v1"`; a negative master round-trips exactly | emitting a JSON number (float64 precision loss above 2^53) |
 | S16 | `TestReporter_ReplayOnlyOnFailure` | `replay` present on a `fail` property, **absent** on pass/skip, and equal to `ailang test --seed <master> <module_path>` | emitting `replay` unconditionally (would break AC6 byte-identity only if it varied — assert the text) |
+
+**ADDED at iteration 163, BEFORE routing M2C — §5.5(b)'s named risk is not gated in the milestone
+that creates it.** §5.5(b) instructs the executor to call `SetSeedMetadata(cfg)` in **both**
+aggregation blocks and states the consequence of missing one: "silently emits an empty `seed_mode`
+for that mode — this is the §5.1 fourth call-site class."
+
+**Being precise about what was and was not already there**, because the honest version of this
+finding is narrower than the first draft of it: §5.10 *does* carry a row —
+"package-mode propagation test | M3 | temp `ailang.toml` package, asserts top-level seed fields" —
+so the sprint was not blind to package mode. But that row (a) is scheduled for **M3, one milestone
+after the call sites are written**, (b) has **no S-ID and no entry in the §5.6 test table**, (c) has
+**no acceptance criterion**, and (d) specifies a **temp** `ailang.toml`, which is the same
+environment-dependent shape AC6(a) already had to repair with `--relax-modules`. So M2C would land,
+pass every gate it owns, and the defect would be undetectable until a later milestone's untracked
+row happened to catch it. Moving the guard into the milestone that creates the risk is the repair;
+S17 gives it an ID and `AC-SEED-AGG-M2C` gives it a runnable, baselined arm off `$TMPDIR`.
+
+Measured at `bb7a8a8a9` before any code was written:
+
+- Every arm of `AC-SEED-SWEEP-M2` — the AC whose title is "every RNG path went through the
+  derivation (§5.1's failure shape)" — scopes to `internal/testing/` production files or
+  `go test ./internal/testing`. **None of them reads `cmd/ailang/test.go`**, which is where both
+  aggregation call sites live.
+- `--package` appears in this plan exactly **twice** (lines 120 and 608), both as prose describing
+  the *current* flag set, and **zero** times in an AC command; it appears **zero** times in the
+  design doc. Control: `--seed` appears **26** times in this plan, so the instrument sees positives.
+- S14/S15/S16 are `internal/testing` unit tests and never execute `cmd/ailang/test.go`.
+- `runPackageTests` genuinely emits properties: `cmd/ailang/test.go:56` appends
+  `fileResult.Properties` into the package aggregate, verified live below.
+
+So M2C as specified would ship **two call sites with one guarded**, and every gate in the sprint
+would stay green — the exact shape iteration 162 found in S11, caught here before routing rather
+than after. Row S17 and `AC-SEED-AGG-M2C` (§5.11) close it.
+
+| ID | Test | Asserts | Kills which mutation |
+|---|---|---|---|
+| S17 | `TestPackageAndFileAggregatesBothCarrySeedMetadata` (`cmd/ailang/test_seed_test.go`, new) | drives **both** `runTestsV2` and `runPackageTests` over the same fixture and asserts each aggregate's `SeedMode`/`MasterSeed`/`SeedDerivation` are populated — **not** that `SetSeedMetadata` works | §5.5(b): adding `SetSeedMetadata` to only ONE of the two aggregation blocks |
+
+> **Read S17 against rule 3i before implementing it.** The observable must be the *aggregate that
+> the command path actually built*, reached through `runTestsV2` / `runPackageTests`. A test that
+> constructs a `SuiteResult` by hand and calls `SetSeedMetadata` on it is S14 again and kills
+> nothing here — S14 already passes with both call sites deleted. If the two functions cannot be
+> called directly (they `os.Exit`), assert through the CLI instead, exactly as `AC-SEED-AGG-M2C`
+> does, and say so rather than weakening the observable.
 
 ### 5.7 M3 — integration, CLI end-to-end, and repository gates
 
@@ -916,9 +964,10 @@ appear with any closing keyword.
 | `cmd/ailang/test.go` | M2C | config threading through 3 funcs, `SetSeedMetadata` at **both** aggregates, configured entry point, help text | +55 |
 | `internal/testing/reporter.go` | M2C | 3 top-level keys, per-property `seed`, conditional `replay`, human seed/replay block | +45 |
 | `internal/testing/reporter_test.go` | M2C | S15–S16 | +55 |
+| `cmd/ailang/test_seed_test.go` (NEW) | **M2C** | **S17** — both aggregates carry seed metadata (**MOVED FROM M3 at iteration 163**; see the note under §5.6's S17 row) | +40 |
 | `cmd/ailang/test_seed_e2e_test.go` (NEW) | M3 | AC5/AC6 end-to-end + help literals | +150 |
 | `cmd/ailang/test_contract_domain_test.go` (NEW, descopable) | M3 | M1's deferred AC1/AC2/AC3 CLI e2e | +110 |
-| package-mode propagation test | M3 | temp `ailang.toml` package, asserts top-level seed fields | +40 |
+| ~~package-mode propagation test~~ | ~~M3~~ | **MOVED TO M2C as S17 + `AC-SEED-AGG-M2C`** — it guards a call site M2C writes, so deferring it left that site unguarded for a whole milestone; also re-specified OFF `$TMPDIR` (the AC6(a) class) | — |
 | `changelogs/v0.18-current.md` | M3 | Unreleased → Fixed | +15 |
 
 **Net ≈ +850 (must-ship ≈ +700).** File-size headroom after M2+M3 (cap 800, Q5/Q6):
@@ -1130,6 +1179,72 @@ mutants now red. **Residual, recorded rather than papered over**: the *forall* s
 fixture fails on its first generated input with `evaluation failed: empty program`, a pre-existing
 harness limitation unrelated to this milestone — so a constant-seed mutant there still survives.
 That site is pinned by arm (c) plus the seed stamp only. M3 owes it a CLI-level e2e arm.
+
+#### AC-SEED-AGG-M2C — BOTH aggregation blocks carry the seed metadata (§5.5(b)'s fourth call site)
+
+**ADDED at iteration 163, before routing.** Every other M2 arm runs `ailang test` in **file** mode,
+so all of them pass with `SetSeedMetadata` wired into `runTestsV2` alone. This arm is the only one
+that reaches `runPackageTests`.
+
+```bash
+set -u
+fix=$(cd "$(dirname "$0")" && pwd)/.ac-seed-agg-fixture   # any NON-temp dir; see the note below
+rm -rf "$fix"; mkdir -p "$fix"
+cat >"$fix/ailang.toml" <<'EOF'
+[package]
+name = "seedtest/pkg"
+version = "0.1.0"
+edition = "1"
+
+[exports]
+modules = ["seedtest/pkg/prop"]
+
+[stability]
+level = "experimental"
+EOF
+cat >"$fix/prop_test.ail" <<'EOF'
+module seedtest/pkg/prop_test
+
+export func ok(x: int) -> bool ! {}
+ensures { result == true } { true }
+EOF
+
+# (a) PACKAGE mode — the discriminating arm, and the one no other AC covers
+./bin/ailang test --package --format json --no-color "$fix" >"$fix/pkg.json" 2>"$fix/pkg.err"
+jq -e '.seed_mode == "derived" and .seed == "0"
+       and .seed_derivation == "ailang-property-seed-v1"
+       and ([.properties[] | select(.seed != null)] | length > 0)' "$fix/pkg.json"
+
+# (b) FILE mode over the SAME fixture — proves (a)'s failure is mode-specific, not fixture-specific
+./bin/ailang test --format json --no-color "$fix/prop_test.ail" >"$fix/file.json" 2>"$fix/file.err"
+jq -e '.seed_mode == "derived" and .seed_derivation == "ailang-property-seed-v1"' "$fix/file.json"
+
+# (c) KNOWN-POSITIVE CONTROL — must pass at baseline AND after; if this fails the fixture is broken,
+#     not the feature, and (a)'s red means nothing (rule 3a).
+jq -e '.module_path == "seedtest/pkg" and (.properties | length) == 1' "$fix/pkg.json"
+
+# (d) --package + --seed replays too (the master-mode half of the same call site)
+./bin/ailang test --package --seed=42 --format json --no-color "$fix" >"$fix/pkg42.json" 2>/dev/null
+jq -e '.seed_mode == "master" and .seed == "42"' "$fix/pkg42.json"
+```
+
+**Baseline on pristine `dev` (`bb7a8a8a9`), measured 2026-08-07 — every value below is from a
+command run, not reasoned:**
+- (a) **DISCRIMINATES** — `rc=1`; the three keys are absent from the package-mode JSON entirely.
+- (b) **DISCRIMINATES** — `rc=1`, same reason.
+- (c) **PASSES at baseline (`rc=0`)** — this is the control, and it is what makes (a)'s red a
+  measurement rather than a broken fixture. Package mode really does run the property:
+  `properties[0]` is `ok_property_1`, `status pass`, `tests_run 100`, `generated_inputs 100`.
+- (d) **DISCRIMINATES** — `rc=2` at baseline (`flag provided but not defined: -seed`).
+
+**Fixture-location note (the AC6(a) class, and it bites here too).** Put the fixture in a
+**non-temp** directory. Under `$TMPDIR` the loader's `IsTempPath` auto-relaxes MOD010 to a warning,
+so a module-path mismatch that would fail elsewhere passes silently — the arm would then be
+measuring `$TMPDIR`, not the code. As written above the module path never matches the on-disk path,
+so MOD010 is relaxed *by the package loader* in both locations; the arm does not depend on it
+either way, but keep the fixture off `/tmp` so the failure mode stays legible. Verified live at
+baseline: package mode emitted `WARNING MOD010 (relaxed)` on stderr and still ran the property to
+`tests_run 100`, so the warning is not a blocker for this arm.
 
 #### AC-SCOPE-M2 — no scope creep
 

--- a/internal/testing/reporter.go
+++ b/internal/testing/reporter.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 )
 
@@ -47,16 +48,19 @@ func (r *Reporter) Report(result *SuiteResult) error {
 func (r *Reporter) reportJSON(result *SuiteResult) error {
 	// Create a JSON-friendly structure
 	output := map[string]interface{}{
-		"module_path":    result.ModulePath,
-		"total_tests":    result.TotalTests,
-		"passed_tests":   result.PassedTests,
-		"failed_tests":   result.FailedTests,
-		"skipped_tests":  result.SkippedTests,
-		"vacuous_skips":  result.VacuousSkips,
-		"total_duration": result.TotalDuration.String(),
-		"success":        result.Success(),
-		"tests":          r.formatTestsJSON(result.Tests),
-		"properties":     r.formatPropertiesJSON(result.Properties),
+		"module_path":     result.ModulePath,
+		"total_tests":     result.TotalTests,
+		"passed_tests":    result.PassedTests,
+		"failed_tests":    result.FailedTests,
+		"skipped_tests":   result.SkippedTests,
+		"vacuous_skips":   result.VacuousSkips,
+		"total_duration":  result.TotalDuration.String(),
+		"success":         result.Success(),
+		"tests":           r.formatTestsJSON(result.Tests),
+		"properties":      r.formatPropertiesJSON(result),
+		"seed_mode":       string(result.SeedMode),
+		"seed":            strconv.FormatInt(result.MasterSeed, 10),
+		"seed_derivation": result.SeedDerivation,
 	}
 
 	encoder := json.NewEncoder(r.writer)
@@ -81,8 +85,11 @@ func (r *Reporter) formatTestsJSON(tests []TestResult) []map[string]interface{} 
 	return output
 }
 
-// formatPropertiesJSON converts property results to JSON-friendly format.
-func (r *Reporter) formatPropertiesJSON(properties []PropertyResult) []map[string]interface{} {
+// formatPropertiesJSON converts property results to JSON-friendly format. It
+// takes the whole SuiteResult because the replay command (D9) and per-property
+// seed are derived from the master seed and module path carried by the suite.
+func (r *Reporter) formatPropertiesJSON(result *SuiteResult) []map[string]interface{} {
+	properties := result.Properties
 	output := make([]map[string]interface{}, len(properties))
 	for i, prop := range properties {
 		output[i] = map[string]interface{}{
@@ -94,12 +101,16 @@ func (r *Reporter) formatPropertiesJSON(properties []PropertyResult) []map[strin
 			"discarded_inputs": prop.DiscardedInputs,
 			"location":         prop.Location,
 			"skip_kind":        prop.SkipKind,
+			"seed":             strconv.FormatInt(prop.Seed, 10),
 		}
 		if prop.Error != "" {
 			output[i]["error"] = prop.Error
 		}
 		if prop.FailingInput != "" {
 			output[i]["failing_input"] = prop.FailingInput
+		}
+		if prop.Status == StatusFail {
+			output[i]["replay"] = fmt.Sprintf("ailang test --seed %d %s", result.MasterSeed, result.ModulePath)
 		}
 	}
 	return output
@@ -244,6 +255,15 @@ func (r *Reporter) reportSummaryHuman(result *SuiteResult) {
 	if result.SkippedTests > 0 {
 		fmt.Fprintf(r.writer, "  %s %d\n", r.color(colorYellow, "⊘ Skipped:"), result.SkippedTests)
 	}
+
+	// Seed / replay block (D10). Mode, master seed, derivation version and the
+	// copy/paste replay command are mandatory content.
+	fmt.Fprintf(r.writer, "\n%s\n", r.color(colorBold, "Seed:"))
+	fmt.Fprintf(r.writer, "  mode: %s\n", string(result.SeedMode))
+	fmt.Fprintf(r.writer, "  master seed: %d\n", result.MasterSeed)
+	fmt.Fprintf(r.writer, "  derivation: %s\n", result.SeedDerivation)
+	fmt.Fprintf(r.writer, "  replay: ailang test --seed %d %s\n", result.MasterSeed, result.ModulePath)
+
 	fmt.Fprintln(r.writer)
 }
 

--- a/internal/testing/reporter_test.go
+++ b/internal/testing/reporter_test.go
@@ -3,6 +3,8 @@ package testing
 import (
 	"bytes"
 	"encoding/json"
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -532,5 +534,108 @@ func TestReporter_UnknownFormat(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "unknown output format") {
 		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+// S15 — the top-level and per-property seed fields must decode as decimal
+// STRINGS, never JSON numbers. A JSON number is float64 on decode and silently
+// loses precision above 2^53; both cases here exercise values beyond that bound
+// (positive and negative) so a JSON-number mutant genuinely discriminates.
+func TestReporter_JSONSeedFieldsAreDecimalStrings(t *testing.T) {
+	seedRe := regexp.MustCompile(`^-?[0-9]+$`)
+	cases := []struct {
+		master   int64
+		propSeed int64
+	}{
+		{master: 9007199254740993, propSeed: 9007199254740999},   // 2^53+1 / 2^53+7
+		{master: -9007199254740993, propSeed: -9007199254747319}, // negative round-trip
+	}
+	for _, c := range cases {
+		result := NewSuiteResult("case/stable.ail")
+		result.SetSeedMetadata(TestConfig{WorkspaceRoot: "/work", SeedMode: SeedModeMaster, MasterSeed: c.master})
+		result.AddPropertyResult(PropertyResult{Name: "p", Status: StatusPass, Seed: c.propSeed})
+
+		var buf bytes.Buffer
+		if err := NewReporter(FormatJSON, &buf, false).Report(result); err != nil {
+			t.Fatalf("Report() error: %v", err)
+		}
+		var output map[string]interface{}
+		if err := json.Unmarshal(buf.Bytes(), &output); err != nil {
+			t.Fatalf("Invalid JSON output: %v", err)
+		}
+
+		// Top-level seed: a decimal string matching the master exactly.
+		topSeed, ok := output["seed"].(string)
+		if !ok {
+			t.Fatalf("master %d: top-level seed is %T (%v), want string", c.master, output["seed"], output["seed"])
+		}
+		if !seedRe.MatchString(topSeed) {
+			t.Errorf("master %d: top-level seed %q does not match decimal regex", c.master, topSeed)
+		}
+		if topSeed != strconv.FormatInt(c.master, 10) {
+			t.Errorf("master %d: round-trip got %q, want %q", c.master, topSeed, strconv.FormatInt(c.master, 10))
+		}
+
+		// Derivation tag.
+		if output["seed_derivation"] != SeedDerivationV1 {
+			t.Errorf("master %d: seed_derivation = %v, want %q", c.master, output["seed_derivation"], SeedDerivationV1)
+		}
+
+		// Per-property seed: also a decimal string.
+		prop := output["properties"].([]interface{})[0].(map[string]interface{})
+		propSeed, ok := prop["seed"].(string)
+		if !ok {
+			t.Fatalf("master %d: property seed is %T (%v), want string", c.master, prop["seed"], prop["seed"])
+		}
+		if !seedRe.MatchString(propSeed) {
+			t.Errorf("master %d: property seed %q does not match decimal regex", c.master, propSeed)
+		}
+		if propSeed != strconv.FormatInt(c.propSeed, 10) {
+			t.Errorf("master %d: property seed round-trip got %q, want %q", c.master, propSeed, strconv.FormatInt(c.propSeed, 10))
+		}
+	}
+}
+
+// S16 — replay appears on a FAIL property and is absent on pass and skip, and
+// equals the exact copy/paste command text (D9).
+func TestReporter_ReplayOnlyOnFailure(t *testing.T) {
+	result := NewSuiteResult("mods/example.ail")
+	result.SetSeedMetadata(TestConfig{SeedMode: SeedModeMaster, MasterSeed: 42})
+	result.AddPropertyResult(PropertyResult{Name: "fail_prop", Status: StatusFail})
+	result.AddPropertyResult(PropertyResult{Name: "pass_prop", Status: StatusPass})
+	result.AddPropertyResult(PropertyResult{Name: "skip_prop", Status: StatusSkip, SkipKind: SkipKindNoGenerator})
+
+	var buf bytes.Buffer
+	if err := NewReporter(FormatJSON, &buf, false).Report(result); err != nil {
+		t.Fatalf("Report() error: %v", err)
+	}
+	var output struct {
+		Properties []map[string]interface{} `json:"properties"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &output); err != nil {
+		t.Fatalf("Invalid JSON output: %v", err)
+	}
+	props := map[string]map[string]interface{}{}
+	for _, p := range output.Properties {
+		props[p["name"].(string)] = p
+	}
+
+	wantReplay := "ailang test --seed 42 mods/example.ail"
+	for name, p := range props {
+		got, present := p["replay"]
+		if name == "fail_prop" {
+			if !present {
+				t.Errorf("fail property missing replay key")
+			} else if got != wantReplay {
+				t.Errorf("fail replay = %v, want %q", got, wantReplay)
+			}
+		} else if present {
+			t.Errorf("%s property should NOT have replay, got %v", name, got)
+		}
+	}
+	for _, name := range []string{"fail_prop", "pass_prop", "skip_prop"} {
+		if _, ok := props[name]; !ok {
+			t.Errorf("missing property %q in output", name)
+		}
 	}
 }

--- a/internal/testing/runner.go
+++ b/internal/testing/runner.go
@@ -27,14 +27,15 @@ type Runner struct {
 // the module identity is left unresolved. CLI code must not use this — it should
 // use RunTestsFromFileWithConfig so the module identity is resolved properly.
 func NewRunner(modulePath string) *Runner {
-	abs, err := filepath.Abs(modulePath)
-	if err != nil {
-		abs = modulePath
-	}
+	// WorkspaceRoot is deliberately left empty and the original filepath.Abs is
+	// gone: this convenience wrapper does not resolve the module identity
+	// (moduleIdentity is empty), and WorkspaceRoot is read only by Validate and
+	// ResolveModuleIdentity — neither of which this path ever invokes. Computing
+	// it here would be dead state with a silent-fallback shape (CLAUDE.md §2);
+	// the CLI must use RunTestsFromFileWithConfig so the identity is resolved.
 	cfg := TestConfig{
-		WorkspaceRoot: filepath.Dir(abs),
-		SeedMode:      SeedModeDerived,
-		MasterSeed:    0,
+		SeedMode:   SeedModeDerived,
+		MasterSeed: 0,
 	}
 	return NewRunnerWithConfig(modulePath, cfg, "")
 }
@@ -569,7 +570,9 @@ func RunTestsFromFileWithConfig(filePath string, file *ast.File, cfg TestConfig)
 func RunTestsFromFile(filePath string, ast *ast.File) (*SuiteResult, error) {
 	abs, err := filepath.Abs(filePath)
 	if err != nil {
-		abs = filePath
+		// No silent fallback to a non-absolute root: this value feeds the module
+		// identity, which feeds the seed (CLAUDE.md §2). Surface the error.
+		return nil, err
 	}
 	cfg := TestConfig{
 		WorkspaceRoot: filepath.Dir(abs),


### PR DESCRIPTION
Milestone **M2C** of sprint `M-PROPERTY-TEST-TRUST` (#535), plan §5.5.

M2B made property seeds derived; M2C exposes them at the CLI and makes a failing run replayable.

## What landed
- `--seed N` / `--random-seed`, presence-detected via `Visit` so `--seed 0` is explicit, not "unset"; mutual exclusion exits 2 on stderr.
- `TestConfig` threaded through `runTestsV2` / `runPackageTests` / `runTestFile`; `SetSeedMetadata` at **both** aggregates.
- `seed_mode` / `seed` / `seed_derivation` top-level, per-property `seed`, `replay` only on failure; human seed block. Seeds are **decimal strings** — a random master is a full int64 and would lose precision as a JSON number (measured: `-3301048329090153793`, replayed byte-identically).
- The two swallowed `filepath.Abs` errors are gone (CLAUDE.md §2).

## The Gate-2 finding this PR also fixes
Plan §5.5(b) warned that missing either `SetSeedMetadata` call site "silently emits an empty `seed_mode` for that mode" — and nothing in M2C checked it. Every arm of `AC-SEED-SWEEP-M2` scopes to `internal/testing/`; no AC ran `--package`; S14/S15/S16 never execute `cmd/ailang/test.go`. §5.10 had a package-mode row, but scheduled for **M3**, with no ID, no AC, and a temp `ailang.toml`.

Commit 1 moves that guard into the milestone that creates the risk (row **S17** + **AC-SEED-AGG-M2C**, baselined off `$TMPDIR`).

## Why S17 is not decorative
Mutation drill, controller-run, mutant asserted **LANDED** (sha256) and **BUILDS** (`go build` rc=0) before its result was believed:

| arm | result |
|---|---|
| delete package-mode `SetSeedMetadata` → S17 | **FAIL** — `seed_mode = "", want "derived"` |
| same mutant → `go test ./cmd/ailang` minus S17 | rc=0 |
| same mutant → `go test ./internal/testing` | rc=0 |
| same mutant → `AC-SEED-SWEEP-M2` (b)/(c) | 3/3 pass |
| same mutant → file-mode `AC5(iv)` | pass |

Every other gate in the sprint stays green with the defect present. Source restored byte-identical after each mutant.

## Gates
`make test` rc=0, **13,269 PASS / 0 FAIL** (13,266 + S15/S16/S17) · `fmt-check`, `vet`, `GOOS=windows vet`, `check-boundaries`, `check-changelog`, `check-file-sizes`, `check-golden-drift` all rc=0 · `go build ./...` fails only on `cmd/wasm`, identically on a pristine worktree at `bb7a8a8a9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)