### PR TITLE
feat(testing): M3 — the emitted replay command was never runnable (#535)

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -96,6 +96,32 @@
 
 ### Fixed
 
+- **Property-test seeds are now deterministic and replayable ([#535](https://github.com/sunholo-data/ailang/issues/535))** — the hidden
+  wall-clock seeding is gone. `ailang test` used to seed every property RNG from
+  `time.Now().UnixNano()`, so unchanged contracts generated different samples on
+  every run (and could flip verdicts run-to-run). Property seeds are now derived
+  deterministically from a master seed via a stable v1 derivation
+  (`ailang-property-seed-v1`). Two flags control the master seed:
+  `--seed N` (any signed int64, including `0`) and `--random-seed` (reads one
+  master from `crypto/rand` and reports it for replay). They are mutually
+  exclusive — passing both exits 2 with an error on stderr. The default (no
+  flag) is derived mode: a fixed, reproducible sample stream per property.
+- **Additive JSON seed/replay fields.** The JSON report now carries top-level
+  `seed_mode`, `seed`, and `seed_derivation`, plus a per-property `seed` and (on
+  failures) a copy/paste **runnable** `replay` command that reproduces the exact
+  invocation — the runnable form the old emitted command never was (it printed
+  the aggregate display label `All Tests` instead of the actual target).
+- **Three intentional incompatibilities** (design doc
+  `m-property-seed-determinism.md`): (1) out-of-contract `ensures` failures are
+  now discarded attempts rather than violations, so affected contracts may pass
+  or skip; (2) default samples change **once** and then stabilise; (3)
+  `GenConfig.Seed == 0` now means exactly zero rather than "seed from the
+  clock".
+- **Known limitation:** `forall`-style properties still fail on their first
+  generated input (`evaluation failed: empty program`) on the legacy
+  source-synthesis path, so their seed is derived and reported but no sample
+  stream is produced. Pre-existing and tracked separately from #535.
+
 - Agent-mode `cost_usd` now bills the model that actually ran. Executors that
   compute cost from token counts were using their own hardcoded table — the
   codex executor billed **every** model it ran at gpt-5-codex's `$1.25/$10` per

--- a/cmd/ailang/main.go
+++ b/cmd/ailang/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/sunholo-data/ailang/internal/agentprompt"
@@ -171,6 +172,15 @@ func main() {
 		path := "."
 		if testFlags.NArg() >= 1 {
 			path = testFlags.Arg(0)
+		}
+
+		// Record the CLI argument tail that reproduces this run, shell-safe, so
+		// the emitted replay command is runnable (defect §3(A)); see
+		// replayTargetArg for the quoting rules.
+		if *packageFlag {
+			cfg.ReplayTarget = "--package " + replayTargetArg(path)
+		} else {
+			cfg.ReplayTarget = replayTargetArg(path)
 		}
 
 		if *packageFlag {
@@ -567,4 +577,16 @@ func main() {
 		printHelp()
 		os.Exit(1)
 	}
+}
+
+// replayTargetArg renders a CLI argument tail that reproduces a test run,
+// shell-safe. A space, single quote, or double quote triggers single-quote
+// wrapping with embedded single quotes escaped as '\”; otherwise the argument
+// is emitted bare. It lives in ONE helper (used only by the test subcommand)
+// so the package mode and ordinary mode targets cannot diverge.
+func replayTargetArg(path string) string {
+	if strings.ContainsAny(path, " '\"") {
+		return "'" + strings.ReplaceAll(path, "'", "'\\''") + "'"
+	}
+	return path
 }

--- a/cmd/ailang/test_contract_domain_test.go
+++ b/cmd/ailang/test_contract_domain_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// This file is the M3 CLI-level e2e for the design doc's AC1/AC2/AC3 contract
+// soundness criteria (deferred from M1 by plan §3.4). It drives the built
+// binary over the four checked-in fixtures in internal/testing/testdata/contracts/
+// and asserts on the JSON verdict fields the design doc pins: status,
+// generated_inputs, discarded_inputs, and the `unverified:` skip text — NOT
+// wall time. Every run uses an explicit --seed 42 so the assertions are
+// reproducible. runAilangBin runs with cwd = repo root, and each fixture
+// declares its own module, so the relative paths here are stable.
+
+// runContractFixture runs one checked-in fixture with --seed 42 and parses its
+// JSON output. It returns the raw doc and the parsed property list.
+func runContractFixture(t *testing.T, bin, relPath string, wantExit int) []map[string]interface{} {
+	t.Helper()
+	stdout, stderr, exit := runAilangBin(t, bin, "test", "--seed", "42", "--format", "json", "--no-color", relPath)
+	if exit != wantExit {
+		t.Fatalf("%s: exit = %d, want %d\nstderr:\n%s", relPath, exit, wantExit, stderr)
+	}
+	var doc struct {
+		Properties []json.RawMessage `json:"properties"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &doc); err != nil {
+		t.Fatalf("%s: output is not JSON: %v\n%s", relPath, err, stdout)
+	}
+	props := make([]map[string]interface{}, 0, len(doc.Properties))
+	for _, raw := range doc.Properties {
+		var m map[string]interface{}
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatalf("%s: bad property object: %v", relPath, err)
+		}
+		props = append(props, m)
+	}
+	return props
+}
+
+func propStatus(p map[string]interface{}) string { return p["status"].(string) }
+func propName(p map[string]interface{}) string   { return p["name"].(string) }
+func propErr(p map[string]interface{}) string {
+	if e, ok := p["error"].(string); ok {
+		return e
+	}
+	return ""
+}
+func propNum(p map[string]interface{}, key string) int {
+	f, _ := p[key].(float64)
+	return int(f)
+}
+
+func propByName(t *testing.T, props []map[string]interface{}, substr string) map[string]interface{} {
+	t.Helper()
+	for _, p := range props {
+		if strings.Contains(propName(p), substr) {
+			return p
+		}
+	}
+	t.Fatalf("no property whose name contains %q in %d properties", substr, len(props))
+	return nil
+}
+
+// propByNameStatus returns the FIRST property whose name contains substr AND
+// whose status equals want. Several contracts emit one requires property and
+// one ensures property for the same function (e.g. big_property_1 vs
+// big_property_2); the design-doc ACs pin the verdict on the ensures one, so
+// selecting by name alone is ambiguous and we disambiguate by status.
+func propByNameStatus(t *testing.T, props []map[string]interface{}, substr, want string) map[string]interface{} {
+	t.Helper()
+	for _, p := range props {
+		if strings.Contains(propName(p), substr) && propStatus(p) == want {
+			return p
+		}
+	}
+	t.Fatalf("no %s property whose name contains %q in %d properties", want, substr, len(props))
+	return nil
+}
+
+var counterexampleRe = regexp.MustCompile(`x=[1-9][0-9]{2,}`)
+
+// TestContractDomain_AC1_ExcludedInputsNoLongerFail — precond2.ail: the big()
+// ensures contract passes (100 in-contract inputs with discards); the requires
+// property is an honest out_of_contract skip, never a fail. Suite exits 0.
+func TestContractDomain_AC1_ExcludedInputsNoLongerFail(t *testing.T) {
+	bin := buildAilang(t)
+	props := runContractFixture(t, bin, "internal/testing/testdata/contracts/precond2.ail", 0)
+	big := propByNameStatus(t, props, "big", "pass")
+	if got := propStatus(big); got != "pass" {
+		t.Errorf("big contract status = %q, want pass", got)
+	}
+	if got := propNum(big, "tests_run"); got != 100 {
+		t.Errorf("big contract tests_run = %d, want 100", got)
+	}
+	if got := propNum(big, "discarded_inputs"); got <= 0 {
+		t.Errorf("big contract discarded_inputs = %d, want > 0 (requires filter active)", got)
+	}
+}
+
+// TestContractDomain_AC2_GenuineViolationStillFails — precond_negative.ail: an
+// in-domain violation is still a fail with an x > 100 counterexample (the
+// negative control that proves filtering did not create a vacuous pass).
+func TestContractDomain_AC2_GenuineViolationStillFails(t *testing.T) {
+	bin := buildAilang(t)
+	props := runContractFixture(t, bin, "internal/testing/testdata/contracts/precond_negative.ail", 1)
+	broken := propByNameStatus(t, props, "broken", "fail")
+	if got := propStatus(broken); got != "fail" {
+		t.Errorf("broken contract status = %q, want fail", got)
+	}
+	if errText := propErr(broken); !strings.Contains(errText, "ensures violated") {
+		t.Errorf("broken contract error missing %q: %q", "ensures violated", errText)
+	} else if !counterexampleRe.MatchString(errText) {
+		t.Errorf("broken contract error has no x>100 counterexample: %q", errText)
+	}
+}
+
+// TestContractDomain_AC3_UnreachableDomainIsUnverified — requires_unreachable.ail:
+// exhausting 1000 attempts before 100 acceptances is a bounded out_of_contract
+// skip carrying the `unverified:` text with exact counts — never pass or fail.
+func TestContractDomain_AC3_UnreachableDomainIsUnverified(t *testing.T) {
+	bin := buildAilang(t)
+	props := runContractFixture(t, bin, "internal/testing/testdata/contracts/requires_unreachable.ail", 0)
+	// Both impossible_property_{1,2} are out_of_contract skips; select the
+	// cap-exhausted ensures one (generated_inputs == 1000), not the requires
+	// one that exits after 1 generated input.
+	var impossible map[string]interface{}
+	for _, p := range props {
+		if strings.Contains(propName(p), "impossible") && propNum(p, "generated_inputs") == 1000 {
+			impossible = p
+		}
+	}
+	if impossible == nil {
+		t.Fatalf("no cap-exhausted impossible property (generated_inputs=1000) in %d properties", len(props))
+	}
+	if got := propStatus(impossible); got != "skip" {
+		t.Errorf("impossible contract status = %q, want skip", got)
+	}
+	if got := propNum(impossible, "tests_run"); got != 0 {
+		t.Errorf("impossible contract tests_run = %d, want 0", got)
+	}
+	if got := propNum(impossible, "generated_inputs"); got != 1000 {
+		t.Errorf("impossible contract generated_inputs = %d, want 1000", got)
+	}
+	if got := propNum(impossible, "discarded_inputs"); got != 1000 {
+		t.Errorf("impossible contract discarded_inputs = %d, want 1000", got)
+	}
+	if errText := propErr(impossible); !strings.HasPrefix(errText, "unverified:") {
+		t.Errorf("impossible contract error does not start with %q: %q", "unverified:", errText)
+	}
+}
+
+// TestContractDomain_OrderedRequiresBothInDomainPass — ordered.ail: the
+// comma-separated requires contract (g) accepts enough in-domain inputs to pass
+// 100 cases with discards, and the no-requires contract (h) passes with zero
+// discards. Guards source-order enumeration of the requires conjunction.
+func TestContractDomain_OrderedRequiresBothInDomainPass(t *testing.T) {
+	bin := buildAilang(t)
+	props := runContractFixture(t, bin, "internal/testing/testdata/contracts/ordered.ail", 0)
+	g := propByName(t, props, "g_property_3")
+	if got := propStatus(g); got != "pass" {
+		t.Errorf("g contract status = %q, want pass", got)
+	}
+	if got := propNum(g, "tests_run"); got != 100 {
+		t.Errorf("g contract tests_run = %d, want 100", got)
+	}
+	if got := propNum(g, "discarded_inputs"); got <= 0 {
+		t.Errorf("g contract discarded_inputs = %d, want > 0", got)
+	}
+	h := propByName(t, props, "h_property_1")
+	if got := propStatus(h); got != "pass" {
+		t.Errorf("h contract status = %q, want pass", got)
+	}
+	if got := propNum(h, "discarded_inputs"); got != 0 {
+		t.Errorf("h contract discarded_inputs = %d, want 0 (no requires)", got)
+	}
+}

--- a/cmd/ailang/test_seed_e2e_test.go
+++ b/cmd/ailang/test_seed_e2e_test.go
@@ -32,6 +32,28 @@ export func good(x: int) -> bool ! {}
 ensures { result == true } { x == x }
 `
 
+// seedE2EPkgManifest is the package manifest for the package-mode replay
+// fixture. Package mode is a SECOND ReplayTarget branch in cmd/ailang/main.go
+// (it prefixes "--package "), and every other test in this file drives file
+// mode only.
+const seedE2EPkgManifest = `[package]
+name = "seede2e/pkg"
+version = "0.1.0"
+edition = "1"
+
+[exports]
+modules = ["seede2e/pkg/fail"]
+
+[stability]
+level = "experimental"
+`
+
+const seedE2EPkgFailSource = `module seede2e/pkg/fail_test
+
+export func bad(x: int) -> bool ! {}
+ensures { result == true } { false }
+`
+
 // writeSeedE2EFixture writes src to a fresh t.TempDir file and returns it.
 func writeSeedE2EFixture(t *testing.T, name, src string) string {
 	t.Helper()
@@ -92,6 +114,7 @@ func TestReplayTargetArg(t *testing.T) {
 	}
 }
 
+// TestSeedE2E_DefaultRunIsDeterministic — AC5-M2: two default runs over the
 // same fixture produce byte-identical normalized JSON, and the default mode is
 // reported as derived with the v1 derivation tag.
 func TestSeedE2E_DefaultRunIsDeterministic(t *testing.T) {
@@ -279,5 +302,75 @@ func TestSeedE2E_EmittedReplayCommandActuallyReplays(t *testing.T) {
 	nReplay := normalizeRunJSON(t, []byte(replayOut))
 	if string(nFirst) != string(nReplay) {
 		t.Errorf("emitted replay command did NOT reproduce the run byte-identically:\n---first---\n%s\n---replay (%q)---\n%s", nFirst, replay, nReplay)
+	}
+}
+
+// TestSeedE2E_PackageModeEmittedReplayCarriesPackageFlag closes a gap the
+// iteration-166 evaluator found by mutation, and it is the same defect class as
+// the "All Tests" bug this milestone exists to fix — one branch of an emitted
+// artifact guarded, the sibling branch not.
+//
+// cmd/ailang/main.go builds ReplayTarget on TWO branches: package mode prefixes
+// "--package ", ordinary mode does not. Every other test here drives file mode,
+// and the pre-existing package-mode test
+// (TestPackageAndFileAggregatesBothCarrySeedMetadata) uses a PASSING fixture —
+// and `replay` is emitted only for FAILING properties. So the package branch had
+// no observer at all: dropping the `"--package " +` prefix left
+// `go test ./cmd/ailang/... ./internal/testing/...` fully rc=0 (reproduced
+// first-party before this test was written). This test uses a failing fixture so
+// the key is emitted, asserts the flag survives, and then RUNS the emitted text.
+func TestSeedE2E_PackageModeEmittedReplayCarriesPackageFlag(t *testing.T) {
+	bin := buildAilang(t)
+
+	pkgDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(pkgDir, "ailang.toml"), []byte(seedE2EPkgManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "fail_test.ail"), []byte(seedE2EPkgFailSource), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	firstOut, firstErr, firstExit := runAilangBin(t, bin,
+		"test", "--package", "--seed", "42", "--format", "json", "--no-color", pkgDir)
+	if firstExit != 1 {
+		t.Fatalf("expected failing package fixture to exit 1, got %d\nstdout:\n%s\nstderr:\n%s", firstExit, firstOut, firstErr)
+	}
+	var firstDoc struct {
+		Properties []struct {
+			Replay string `json:"replay"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal([]byte(firstOut), &firstDoc); err != nil {
+		t.Fatalf("package run output is not JSON: %v\n%s", err, firstOut)
+	}
+	if len(firstDoc.Properties) == 0 || firstDoc.Properties[0].Replay == "" {
+		t.Fatalf("package mode emitted no replay command for a failing property\n%s", firstOut)
+	}
+	replay := firstDoc.Properties[0].Replay
+
+	// The discriminating assertion: without the prefix the emitted command
+	// re-runs the directory in FILE mode, which is a different discovery path.
+	if !strings.Contains(replay, "--package") {
+		t.Fatalf("package-mode replay lost the --package flag: %q", replay)
+	}
+	if strings.Contains(replay, "All Tests") {
+		t.Fatalf("emitted replay contains the un-runnable %q label: %q", "All Tests", replay)
+	}
+
+	// Execute the emitted text verbatim (flags inserted after the subcommand —
+	// see the note in TestSeedE2E_EmittedReplayCommandActuallyReplays). The
+	// t.TempDir path has no spaces, so Fields-splitting is faithful here;
+	// replayTargetArg's quoting is covered directly by TestReplayTargetArg.
+	fields := strings.Fields(replay)
+	if len(fields) < 3 || fields[0] != "ailang" || fields[1] != "test" {
+		t.Fatalf("unexpected replay command shape: %q", replay)
+	}
+	replayArgs := append([]string{"test", "--format", "json", "--no-color"}, fields[2:]...)
+	replayOut, replayErr, replayExit := runAilangBin(t, bin, replayArgs...)
+	if replayExit != firstExit {
+		t.Errorf("replayed exit = %d, first exit = %d\nreplay stderr:\n%s", replayExit, firstExit, replayErr)
+	}
+	if got, want := string(normalizeRunJSON(t, []byte(replayOut))), string(normalizeRunJSON(t, []byte(firstOut))); got != want {
+		t.Errorf("package-mode replay %q did NOT reproduce the run byte-identically:\n---first---\n%s\n---replay---\n%s", replay, want, got)
 	}
 }

--- a/cmd/ailang/test_seed_e2e_test.go
+++ b/cmd/ailang/test_seed_e2e_test.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// seedE2EMixSource has one passing ensures property and one failing ensures
+// property. The declared module gives both a stable, path-independent identity
+// (ResolveModuleIdentity), so the derived seeds are stable across t.TempDir
+// locations — which is what makes two runs byte-comparable.
+const seedE2EMixSource = `module seed_e2e_mix
+
+export func good(x: int) -> bool ! {}
+ensures { result == true } { x == x }
+
+export func bad(x: int) -> bool ! {}
+ensures { result == true } { false }
+`
+
+// seedE2EFailFirstSource has the FAILING ensures property declared first, so
+// .properties[0] carries the replay key (source order is preserved).
+const seedE2EFailFirstSource = `module seed_e2e_fail_first
+
+export func bad(x: int) -> bool ! {}
+ensures { result == true } { false }
+
+export func good(x: int) -> bool ! {}
+ensures { result == true } { x == x }
+`
+
+// writeSeedE2EFixture writes src to a fresh t.TempDir file and returns it.
+func writeSeedE2EFixture(t *testing.T, name, src string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// normalizeRunJSON strips the two timing fields that legitimately vary between
+// identical runs (the suite total and every per-test / per-property duration)
+// and re-marshals deterministically. It is the same field-deletion set AC6-M2
+// uses, so byte-identity after normalization is a real determinism assertion
+// over every remaining field (seed, seed_derivation, per-property seed, verdicts).
+func normalizeRunJSON(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var doc map[string]interface{}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("run output is not JSON: %v\n%s", err, raw)
+	}
+	delete(doc, "total_duration")
+	for _, key := range []string{"tests", "properties"} {
+		list, _ := doc[key].([]interface{})
+		for _, item := range list {
+			if m, ok := item.(map[string]interface{}); ok {
+				delete(m, "duration")
+			}
+		}
+	}
+	out, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		t.Fatalf("re-marshal normalized JSON: %v", err)
+	}
+	return out
+}
+
+// TestReplayTargetArg pins the shell-quoting rules the CLI applies when
+// recording the replay target (T2 §3). A plain path is bare; any space, single
+// quote, or double quote forces single-quote wrapping with embedded single
+// quotes escaped as '\”. The emitted command must re-tokenize to the original
+// path in a shell, which is what makes the replay command runnable.
+func TestReplayTargetArg(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{in: "folder/a.ail", want: "folder/a.ail"},
+		{in: "path with space/a.ail", want: "'path with space/a.ail'"},
+		{in: "it's/a.ail", want: "'it'\\''s/a.ail'"},
+		{in: `quo"te/a.ail`, want: "'quo\"te/a.ail'"},
+		{in: "sp ace and 'quote/f.ail", want: "'sp ace and '\\''quote/f.ail'"},
+	}
+	for _, c := range cases {
+		if got := replayTargetArg(c.in); got != c.want {
+			t.Errorf("replayTargetArg(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// same fixture produce byte-identical normalized JSON, and the default mode is
+// reported as derived with the v1 derivation tag.
+func TestSeedE2E_DefaultRunIsDeterministic(t *testing.T) {
+	bin := buildAilang(t)
+	file := writeSeedE2EFixture(t, "mix.ail", seedE2EMixSource)
+
+	raw1, _, exit1 := runAilangBin(t, bin, "test", "--format", "json", "--no-color", file)
+	raw2, _, exit2 := runAilangBin(t, bin, "test", "--format", "json", "--no-color", file)
+	if exit1 != 1 || exit2 != 1 {
+		t.Fatalf("expected both runs to exit 1 (one failing property), got %d then %d", exit1, exit2)
+	}
+
+	a := normalizeRunJSON(t, []byte(raw1))
+	b := normalizeRunJSON(t, []byte(raw2))
+	if string(a) != string(b) {
+		t.Fatalf("default runs are NOT byte-identical after normalization:\n---run 1---\n%s\n---run 2---\n%s", a, b)
+	}
+
+	var doc struct {
+		SeedMode       string `json:"seed_mode"`
+		SeedDerivation string `json:"seed_derivation"`
+	}
+	if err := json.Unmarshal([]byte(raw1), &doc); err != nil {
+		t.Fatalf("parse run 1: %v", err)
+	}
+	if doc.SeedMode != "derived" {
+		t.Errorf("seed_mode = %q, want %q", doc.SeedMode, "derived")
+	}
+	if doc.SeedDerivation != "ailang-property-seed-v1" {
+		t.Errorf("seed_derivation = %q, want %q", doc.SeedDerivation, "ailang-property-seed-v1")
+	}
+}
+
+// TestSeedE2E_RandomThenExplicitReplaysByteIdentical — the AC6-M2 shape in Go:
+// a --random-seed run reports a master seed, and re-running with --seed=<that
+// value> reproduces the run byte-for-byte (exit codes included), with the
+// replay run reporting seed_mode master.
+func TestSeedE2E_RandomThenExplicitReplaysByteIdentical(t *testing.T) {
+	bin := buildAilang(t)
+	file := writeSeedE2EFixture(t, "mix.ail", seedE2EMixSource)
+
+	randomOut, _, randomExit := runAilangBin(t, bin, "test", "--random-seed", "--format", "json", "--no-color", file)
+	var randomDoc struct {
+		Seed     string `json:"seed"`
+		SeedMode string `json:"seed_mode"`
+	}
+	if err := json.Unmarshal([]byte(randomOut), &randomDoc); err != nil {
+		t.Fatalf("random run output is not JSON: %v\n%s", err, randomOut)
+	}
+	if randomDoc.Seed == "" {
+		t.Fatalf("--random-seed run reported no seed")
+	}
+	if randomDoc.SeedMode != "master" {
+		t.Errorf("random run seed_mode = %q, want %q", randomDoc.SeedMode, "master")
+	}
+
+	// Replay with the reported seed as --seed=<value>.
+	replayOut, _, replayExit := runAilangBin(t, bin, "test", "--seed="+randomDoc.Seed, "--format", "json", "--no-color", file)
+	if replayExit != randomExit {
+		t.Errorf("replay exit = %d, random exit = %d — exit codes differ", replayExit, randomExit)
+	}
+
+	a := normalizeRunJSON(t, []byte(randomOut))
+	b := normalizeRunJSON(t, []byte(replayOut))
+	if string(a) != string(b) {
+		t.Errorf("random run and --seed replay are NOT byte-identical after normalization:\n---random---\n%s\n---replay---\n%s\n", a, b)
+	}
+
+	var replayDoc struct {
+		SeedMode string `json:"seed_mode"`
+	}
+	if err := json.Unmarshal([]byte(replayOut), &replayDoc); err != nil {
+		t.Fatalf("parse replay output: %v", err)
+	}
+	if replayDoc.SeedMode != "master" {
+		t.Errorf("replay seed_mode = %q, want %q (explicit seed means master mode)", replayDoc.SeedMode, "master")
+	}
+
+	// The reported master must actually DRIVE the sample stream — the seed is
+	// derived, not a constant. Two distinct explicit masters must produce
+	// different SAMPLES. The reported per-property `seed` field is derived from
+	// the master independently of the RNG consumption, so it differs between
+	// masters even under a constant-seed mutant and cannot discriminate; the
+	// sample-driven fields (the failing input embedded in `error`) can. M-b of
+	// the M3 drill forces the ensures RNG to a constant, which collapses the
+	// sample output for two distinct masters to identical — caught here.
+	normalizeNoSeed := func(raw []byte) []byte {
+		var doc map[string]interface{}
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			t.Fatalf("run output is not JSON: %v", err)
+		}
+		delete(doc, "total_duration")
+		delete(doc, "seed")
+		if props, ok := doc["properties"].([]interface{}); ok {
+			for _, item := range props {
+				if m, ok := item.(map[string]interface{}); ok {
+					delete(m, "duration")
+					delete(m, "seed")
+					delete(m, "replay") // embeds the master seed; would mask a constant RNG
+				}
+			}
+		}
+		out, _ := json.MarshalIndent(doc, "", "  ")
+		return out
+	}
+	seedA, _, exitA := runAilangBin(t, bin, "test", "--seed=100", "--format", "json", "--no-color", file)
+	seedB, _, exitB := runAilangBin(t, bin, "test", "--seed=200", "--format", "json", "--no-color", file)
+	if exitA != exitB {
+		t.Errorf("distinct seeds exited differently (%d vs %d)", exitA, exitB)
+	}
+	nA := normalizeNoSeed([]byte(seedA))
+	nB := normalizeNoSeed([]byte(seedB))
+	if string(nA) == string(nB) {
+		t.Errorf("two distinct explicit seeds produced byte-identical SAMPLE output — the master seed does not drive the sample stream")
+	}
+}
+
+// TestSeedE2E_HelpNamesBothFlags — `test --help` advertises both new flags.
+// Help currently goes to stdout, but we check both streams so the assertion
+// survives a future move.
+func TestSeedE2E_HelpNamesBothFlags(t *testing.T) {
+	bin := buildAilang(t)
+	stdout, stderr, _ := runAilangBin(t, bin, "test", "--help")
+	blob := stdout + stderr
+	for _, literal := range []string{"--seed", "--random-seed"} {
+		if !strings.Contains(blob, literal) {
+			t.Errorf("test --help output missing %q\nstdout:\n%s\nstderr:\n%s", literal, stdout, stderr)
+		}
+	}
+}
+
+// TestSeedE2E_EmittedReplayCommandActuallyReplays — THE pin for the §3(A)
+// defect. AC6-M2 misses it because it builds --seed=${seed} "$tmp/multi.ail"
+// from its own inputs rather than executing the exact string the tool emitted.
+// Here we read .properties[0].replay straight out of the JSON and RUN THAT
+// TEXT back through the binary; a test that rebuilt the command from .seed
+// instead would not close the defect and is rejected on review.
+func TestSeedE2E_EmittedReplayCommandActuallyReplays(t *testing.T) {
+	bin := buildAilang(t)
+	file := writeSeedE2EFixture(t, "fail_first.ail", seedE2EFailFirstSource)
+
+	// Run with an explicit seed so the replay run is also master-mode (a
+	// derived initial run would emit "--seed 0" and differ only in seed_mode,
+	// which is outside the AC6-M2 duration-deletion normalisation set).
+	firstOut, firstErr, firstExit := runAilangBin(t, bin, "test", "--seed", "42", "--format", "json", "--no-color", file)
+	if firstExit != 1 {
+		t.Fatalf("expected failing fixture to exit 1, got %d\nstderr:\n%s", firstExit, firstErr)
+	}
+	var firstDoc struct {
+		Properties []struct {
+			Replay string `json:"replay"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal([]byte(firstOut), &firstDoc); err != nil {
+		t.Fatalf("first run output is not JSON: %v\n%s", err, firstOut)
+	}
+	if len(firstDoc.Properties) == 0 || firstDoc.Properties[0].Replay == "" {
+		t.Fatalf("properties[0] did not emit a replay command\n%s", firstOut)
+	}
+	replay := firstDoc.Properties[0].Replay
+	if strings.Contains(replay, "All Tests") {
+		t.Fatalf("emitted replay contains the un-runnable %q label: %q", "All Tests", replay)
+	}
+
+	// Execute the EMITTED command text: split it, drop the leading `ailang`
+	// token, and hand the remaining args back to the binary. The JSON/colour
+	// flags are INSERTED after the `test` subcommand (not appended after the
+	// positional path) because Go's flag parser stops at the first non-flag
+	// argument — a flag placed after the path is silently ignored and the run
+	// would fall back to human output. The emitted seed AND path tokens are
+	// passed through verbatim; only the two output-format flags are added.
+	fields := strings.Fields(replay)
+	if len(fields) < 3 || fields[0] != "ailang" || fields[1] != "test" {
+		t.Fatalf("unexpected replay command shape: %q", replay)
+	}
+	replayArgs := []string{"test", "--format", "json", "--no-color"}
+	replayArgs = append(replayArgs, fields[2:]...)
+	replayOut, replayErr, replayExit := runAilangBin(t, bin, replayArgs...)
+	if replayExit != firstExit {
+		t.Errorf("replayed exit = %d, first exit = %d\nreplay stderr:\n%s", replayExit, firstExit, replayErr)
+	}
+	_ = replayErr
+
+	nFirst := normalizeRunJSON(t, []byte(firstOut))
+	nReplay := normalizeRunJSON(t, []byte(replayOut))
+	if string(nFirst) != string(nReplay) {
+		t.Errorf("emitted replay command did NOT reproduce the run byte-identically:\n---first---\n%s\n---replay (%q)---\n%s", nFirst, replay, nReplay)
+	}
+}

--- a/design_docs/planned/v0_31_0/m-property-seed-determinism-sprint-plan.md
+++ b/design_docs/planned/v0_31_0/m-property-seed-determinism-sprint-plan.md
@@ -1351,6 +1351,26 @@ no shared config. The design doc's "partial rollback is unsafe" warning applies 
 combined state, and specifically to keeping M2 while dropping M1. Dropping M2 while keeping M1 is
 the safe direction and is exactly what tonight ships.
 
+### 5.14 M3 residuals — recorded, not papered over
+
+- **T5 — `make verify-examples` is not evidence that any contract property ran.**
+  `make verify-examples` invokes the **`run`** subcommand
+  (`scripts/verify_examples.go:104-115`), never `ailang test`, so a green
+  `verify-examples` is **not** evidence that any contract property executed. It
+  is a module/compile-linking gate only.
+- **T6 — the `forall` residual (measured, §3(C) of the M3 directive).**
+  `forall`-style properties still run on the broken `EvaluateExpression`
+  source-synthesis path and die on their FIRST generated input, so there is no
+  sample stream to observe at any level — CLI included. Measured on a fresh
+  `property "ints are self equal" { forall(x: int) => x == x }` fixture:
+  `generated_inputs: 1`, `error: "test 0: evaluation failed: empty program"`,
+  identical under `--seed 42`. The §5.11 note "M3 owes it a CLI-level e2e arm"
+  is **retracted as unachievable** — the site is pinned by the seed stamp and
+  by acceptance arm (c) only, until the legacy `EvaluateExpression` path is
+  replaced. This gap is declared in-code too: a comment immediately above the
+  `rng := newRNG(...)` line in `runner.go`'s forall path names the reason no
+  test observable exists downstream of it.
+
 ---
 
 ## 6. Executor operating notes

--- a/internal/testing/config.go
+++ b/internal/testing/config.go
@@ -30,6 +30,11 @@ type TestConfig struct {
 	WorkspaceRoot string // absolute; the CLI's initial os.Getwd()
 	SeedMode      SeedMode
 	MasterSeed    int64
+	// ReplayTarget is the CLI argument tail that reproduces this invocation,
+	// already shell-safe. Empty is legal and means "no replay target known"
+	// (library callers that build a SuiteResult directly rely on that to fall
+	// back to ModulePath).
+	ReplayTarget string
 }
 
 // Validate returns an error when the config is not usable for seed derivation.

--- a/internal/testing/reporter.go
+++ b/internal/testing/reporter.go
@@ -85,6 +85,20 @@ func (r *Reporter) formatTestsJSON(tests []TestResult) []map[string]interface{} 
 	return output
 }
 
+// replayCommand builds the copy/paste command that reproduces a suite run. It
+// prefers ReplayTarget — the shell-safe CLI argument tail recorded at
+// invocation time (see replayTargetArg in cmd/ailang) — and falls back to
+// ModulePath when ReplayTarget is empty, preserving today's behaviour for
+// library callers and tests that build a SuiteResult directly. Both the JSON
+// and human reporters go through this ONE helper so the two can never drift.
+func replayCommand(result *SuiteResult) string {
+	target := result.ReplayTarget
+	if target == "" {
+		target = result.ModulePath
+	}
+	return fmt.Sprintf("ailang test --seed %d %s", result.MasterSeed, target)
+}
+
 // formatPropertiesJSON converts property results to JSON-friendly format. It
 // takes the whole SuiteResult because the replay command (D9) and per-property
 // seed are derived from the master seed and module path carried by the suite.
@@ -110,7 +124,7 @@ func (r *Reporter) formatPropertiesJSON(result *SuiteResult) []map[string]interf
 			output[i]["failing_input"] = prop.FailingInput
 		}
 		if prop.Status == StatusFail {
-			output[i]["replay"] = fmt.Sprintf("ailang test --seed %d %s", result.MasterSeed, result.ModulePath)
+			output[i]["replay"] = replayCommand(result)
 		}
 	}
 	return output
@@ -262,7 +276,7 @@ func (r *Reporter) reportSummaryHuman(result *SuiteResult) {
 	fmt.Fprintf(r.writer, "  mode: %s\n", string(result.SeedMode))
 	fmt.Fprintf(r.writer, "  master seed: %d\n", result.MasterSeed)
 	fmt.Fprintf(r.writer, "  derivation: %s\n", result.SeedDerivation)
-	fmt.Fprintf(r.writer, "  replay: ailang test --seed %d %s\n", result.MasterSeed, result.ModulePath)
+	fmt.Fprintf(r.writer, "  replay: %s\n", replayCommand(result))
 
 	fmt.Fprintln(r.writer)
 }

--- a/internal/testing/reporter_test.go
+++ b/internal/testing/reporter_test.go
@@ -639,3 +639,70 @@ func TestReporter_ReplayOnlyOnFailure(t *testing.T) {
 		}
 	}
 }
+
+// T2 — the replay command prefers ReplayTarget (the shell-safe CLI argument
+// tail recorded at invocation time) and falls back to ModulePath when
+// ReplayTarget is empty, preserving the historical behaviour for library
+// callers and tests that build a SuiteResult directly. One arm carries a space
+// (and one an embedded single quote) to assert the shell quoting rules.
+func TestReplayCommand_FallsBackToModulePath(t *testing.T) {
+	// The three non-empty-target arms pass the target the way the CLI records it:
+	// ALREADY shell-safe (the quoting lives in replayTargetArg in cmd/ailang — the
+	// reporter must emit it verbatim and never fall back to ModulePath). The 'want'
+	// strings therefore carry the quotes as produced upstream.
+	cases := []struct {
+		name         string
+		replayTarget string
+		modulePath   string
+		want         string
+	}{
+		{
+			name:         "empty target falls back to module path",
+			replayTarget: "",
+			modulePath:   "mods/a.ail",
+			want:         "ailang test --seed 7 mods/a.ail",
+		},
+		{
+			name:         "explicit target is preferred over module path",
+			replayTarget: "path/to/f.ail",
+			modulePath:   "mods/a.ail (ignored)",
+			want:         "ailang test --seed 7 path/to/f.ail",
+		},
+		{
+			name:         "target with a space is single-quoted",
+			replayTarget: "'dir with space/ f.ail'",
+			modulePath:   "mods/a.ail",
+			want:         "ailang test --seed 7 'dir with space/ f.ail'",
+		},
+		{
+			name:         "target with an embedded single quote is escaped",
+			replayTarget: "'it'\\''s here/ f.ail'",
+			modulePath:   "mods/a.ail",
+			want:         "ailang test --seed 7 'it'\\''s here/ f.ail'",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := NewSuiteResult(c.modulePath)
+			result.SetSeedMetadata(TestConfig{SeedMode: SeedModeMaster, MasterSeed: 7, ReplayTarget: c.replayTarget})
+			result.AddPropertyResult(PropertyResult{Name: "fail_prop", Status: StatusFail})
+
+			var buf bytes.Buffer
+			if err := NewReporter(FormatJSON, &buf, false).Report(result); err != nil {
+				t.Fatalf("Report() error: %v", err)
+			}
+			var output struct {
+				Properties []map[string]interface{} `json:"properties"`
+			}
+			if err := json.Unmarshal(buf.Bytes(), &output); err != nil {
+				t.Fatalf("Invalid JSON output: %v", err)
+			}
+			if len(output.Properties) != 1 {
+				t.Fatalf("expected 1 property, got %d", len(output.Properties))
+			}
+			if got, ok := output.Properties[0]["replay"].(string); !ok || got != c.want {
+				t.Errorf("replay = %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/testing/result.go
+++ b/internal/testing/result.go
@@ -47,6 +47,7 @@ type PropertyResult struct {
 // SuiteResult aggregates results from all tests in a test suite.
 type SuiteResult struct {
 	ModulePath     string           // Module path
+	ReplayTarget   string           // Shell-safe CLI arg tail that reproduces this run (empty = unknown)
 	Tests          []TestResult     // All test results
 	Properties     []PropertyResult // All property results
 	TotalTests     int              // Total number of tests
@@ -96,6 +97,7 @@ func (sr *SuiteResult) SetSeedMetadata(cfg TestConfig) {
 	sr.SeedMode = cfg.SeedMode
 	sr.MasterSeed = cfg.MasterSeed
 	sr.SeedDerivation = SeedDerivationV1
+	sr.ReplayTarget = cfg.ReplayTarget
 }
 
 // AddPropertyResult adds a property result and updates counters.

--- a/internal/testing/runner.go
+++ b/internal/testing/runner.go
@@ -291,6 +291,13 @@ func (r *Runner) runProperty(propCase PropertyCase) PropertyResult {
 	}
 
 	// Run property tests
+	// M-M3-RESIDUAL (T6): this forall path has NO test observable downstream of
+	// it. It still runs on the broken EvaluateExpression source-synthesis path
+	// (see runProperty's dispatch comment above), so every generated input
+	// fails with "test 0: evaluation failed: empty program" on the FIRST
+	// sample — no sample stream exists to observe at any level. Its seed is
+	// derived and reported (so the seed machinery is covered) but the sample
+	// stream is not, until the legacy EvaluateExpression path is replaced.
 	rng := newRNG(r.propertySeed(propCase.Name))
 
 	for testNum := 0; testNum < numTests; testNum++ {


### PR DESCRIPTION
Closes the `m-property-seed-determinism` sprint (M1 ✅ M2A ✅ M2B ✅ M2C ✅ **M3**). **Fixes #535.**

## The defect M3 found in the milestone it was closing

`internal/testing/reporter.go` built the replay command from `SuiteResult.ModulePath`, which in the ordinary CLI path is the aggregate **display label** `"All Tests"` (`cmd/ailang/test.go:49`). Every failing property told the user to run:

```
ailang test --seed 0 All Tests
```

`All Tests` is not a path. The replay command is the entire user-facing payoff of #535, and it has been unrunnable since M2C landed. `AC6-M2` was green throughout because it **reconstructs** the command from `.seed` instead of **executing** the string the tool emits — the observable was never downstream of the mechanism.

**Fix**: one `replayCommand(result)` helper used by *both* reporters (JSON `:113`, human `:265`), fed by a new shell-safe `TestConfig.ReplayTarget` / `SuiteResult.ReplayTarget` recorded at invocation time. Empty falls back to `ModulePath`, preserving behaviour for library callers.

**Pin**: `TestSeedE2E_EmittedReplayCommandActuallyReplays` executes the emitted string verbatim.

## Also shipped

- `cmd/ailang/test_seed_e2e_test.go` — default determinism, random→explicit replay byte-identity, `--help` flag literals, emitted-replay execution.
- `cmd/ailang/test_contract_domain_test.go` — M1's deferred CLI-level AC1/AC2/AC3.
- `changelogs/v0.18-current.md` — #535, both flags, additive JSON fields, the three intentional incompatibilities, the `forall` limitation.
- Plan `§5.14` — two residuals recorded.

## The `forall` debt is retracted, not paid

Plan `§5.11` said *"M3 owes it a CLI-level e2e arm"*. Measured first-party: `forall` properties die on their **first** generated input (`generated_inputs: 1`, `evaluation failed: empty program`, identical under `--seed 42`) on the legacy `EvaluateExpression` path — no sample stream exists at CLI level either. Unachievable as specified; declared in-code above the `forall` `newRNG` site and in `§5.14`.

## Mutation drill (controller-run; both arms LANDED + BUILD)

| arm | mutant | target test | rest of `cmd/ailang` | restore |
|---|---|---|---|---|
| M-a | `reporter.go` ignores `ReplayTarget` | `EmittedReplayCommandActuallyReplays` **rc=1** — *un-runnable "All Tests" label* | rc=0 | byte-identical |
| M-b | `contract_domain.go:89` constant seed | `RandomThenExplicitReplaysByteIdentical` **rc=1** — *distinct explicit seeds produced byte-identical SAMPLE output* | rc=0 | byte-identical |

## Executor deviations — three self-reported, all adjudicated CORRECT by command

1. M-b's ensures RNG site is `contract_domain.go:89`, not `runner.go` (directive was wrong).
2. Go's `flag` stops parsing at the first positional, so appended flags are ignored — measured both arms.
3. **Load-bearing**: the directive's byte-identity assertion cannot kill M-b (a constant RNG is consumed identically by both arms), so the executor added a two-distinct-masters **sample** comparison. Under M-b that added assertion is the **only** one that fires.

## Gates (controller-run, and all rc=0 on the pristine base too)

`go test ./internal/testing/...` **0** · `go test ./cmd/ailang/...` **0** (10 new tests pass) · `make lint` **0** · `make verify-examples` **0** · `make check-changelog` **0** · `make check-file-sizes` **0** · `make check-boundaries` **0** · `go vet` **0** · `gofmt -l` empty · scope fences empty · M1's `100`/`1000` bounds intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)