### PR TITLE
feat(testing): #517 Lane B1 M1 — splice unit/record/tuple/constructor values (plan + M1)

### DIFF
--- a/.ailang/state/sprints/sprint_M-PROPERTY-GENERATOR-LANE-B1.json
+++ b/.ailang/state/sprints/sprint_M-PROPERTY-GENERATOR-LANE-B1.json
@@ -1,0 +1,289 @@
+{
+  "sprint_id": "M-PROPERTY-GENERATOR-LANE-B1",
+  "status": "planned",
+  "created": "2026-08-10T00:00:00Z",
+  "design_doc": "design_docs/planned/v0_31_0/m-property-generator-coverage.md",
+  "sprint_plan": "design_docs/planned/v0_31_0/m-property-generator-coverage-lane-b1-sprint-plan.md",
+  "github_issues": [
+    517
+  ],
+  "risk_level": "medium-high",
+  "metadata": {
+    "planner-model": "claude-opus-5",
+    "mission_iteration": 168,
+    "scope": "Lane B1 ONLY of m-property-generator-coverage. IN: structural generator derivation from same-file surface-AST TypeDecls for records (named + anonymous + nested), ADTs, tuples, unit (), and *ast.TypeAlias targets; the valueToLiteral value-splice arms (UnitValue/RecordValue/TupleValue/TaggedValue) followed by the loud-error default; a recursion depth budget (default 3) and a size budget; deterministic record-field ordering. OUT: Lane A (LANDED at a81d66983, PR #536 - do NOT redo the list arm, skip taxonomy, Success(), reporter, or JSON preamble); Lane B2 entirely (gen<TypeName> escape hatch, alias-first hint text / B-9, refined types) - DEFERRED by the 2026-07-29 quorum on reviewer gpt5-6-sol's own proposal, BLOCKED ON a deterministic evaluator fuel budget; imported / cross-module named types (stay honest vacuous skips); cross-constructor ADT shrinking.",
+    "estimated_effort": "2.25 days (doc says ~1.5-2d; the doc predates Lane A and omits the RecordGenerator determinism fix, the size budget, and the measured 87-property triage load)",
+    "base_commit": "22ba8626d8265f86cb2b9fdaa6b4ff0ae0facb19",
+    "base_note": "Branch dev. All measurements taken FIRST-PARTY in the MAIN CHECKOUT at this commit with `go build -o /tmp/ailang_planner168 ./cmd/ailang` (binary self-reports Commit: 22ba862). No repo file was modified during planning; no scratch-patch probe was applied to internal/testing.",
+    "premises_verified_live": true,
+    "verification_date": "2026-08-10",
+    "read_only_main_checkout": true,
+    "executor_cannot_run_git": "The executor cannot run git AT ALL. The controller reconstructs each commit from a per-milestone .snap/M<k>/ snapshot. Every milestone's `files` field lists the exact NEW/MOD set to snapshot. Report any touched file not on its milestone's list - an unlisted file is a planning defect, not a silent extra.",
+    "mandatory_ordering": "M1 (valueToLiteral gains UnitValue/RecordValue/TupleValue/TaggedValue arms, default STILL silent) MUST land before M2 (default becomes a loud error). Reversing this fails the harness for every unit-typed generated value - the exact defect gemini-3-1-pro caught in quorum round 2. M1 is behaviour-inert at the CLI (no generator yet produces these value kinds), which is what makes a bisect landing on M1 exonerating.",
+    "three_generator_call_sites": "REFUTES the controller brief's two-site claim. createGeneratorForType has THREE callers across TWO files: internal/testing/runner.go:281 (runProperty / forall binders), internal/testing/runner.go:415 (runRequiresProperty), and internal/testing/contract_domain.go:74 (runEnsuresProperty). runEnsuresProperty was moved out of runner.go into contract_domain.go (194 lines) after the design doc was written, and the doc's Lane B 'Files to Modify' list omits contract_domain.go entirely. Every ensures-derived property in the corpus flows through it. Mitigation: M3 routes all three through a single deriveType entry point so contract_domain.go needs no edit for derivation (it is still edited in M2 for the valueToLiteral error thread).",
+    "three_splice_call_sites": "valueToLiteral has THREE external call sites across TWO files - contract_domain.go:101 (ensures), runner.go:438 (requires), runner.go:652 (bindPropertyValues, also reached from shrinkCounterexample:725) - plus an internal recursion at runner.go:693. Changing the signature to (ast.Expr, error) also changes bindPropertyValues' signature and therefore its callers runProperty:315 and shrinkCounterexample:725. This is not a one-file edit.",
+    "file_size_gate": "internal/testing/runner.go = 749 lines; make check-file-sizes fails >800 (make/code-health.mk:122). Only 51 lines of headroom, and B1 adds far more. The plan therefore MOVES valueToLiteral out of runner.go into a new internal/testing/value_splice.go (M1, ~-38 lines) and createGeneratorForType into a new internal/testing/derive.go (M3, ~-42 lines), landing runner.go near 669. These moves are deliberate size-gate relief, not drive-by refactoring. make check-file-sizes is a gate on EVERY milestone.",
+    "bounded_wait_recipe": "CRITICAL, REFUTES the Lane A plan's guidance. `perl -e 'alarm N; exec @ARGV'` DOES NOT BOUND A GO BINARY: the Go runtime classifies SIGALRM as notify-only and, with no os/signal listener, ignores it. Measured with a positive control: a 20s Go binary under `alarm 3` ran the full 20s and exited 0; /bin/sleep 20 under the same wrapper died at 3s with rc 142. `timeout` and `gtimeout` are NOT on PATH on this rig. Use background-and-kill instead: `\"$@\" & pid=$!; ( sleep LIM; kill -9 $pid 2>/dev/null ) & w=$!; wait $pid; rc=$?; kill $w 2>/dev/null; exit $rc` - verified to bound a Go binary (rc 137) and to leave a fast one alone (rc 0).",
+    "pristine_baselines": "MEASURED at 22ba8626d, all first-party. GREEN and usable as gates: `go test ./internal/testing/... -count=1` rc 0 (ok, 1.347s); `go vet ./internal/testing/...` rc 0; `make check-file-sizes` rc 0; `make lint` rc 0 (BUT it prints `1 issues: * unused: 1` and still exits 0 - gate on the EXIT CODE, never on that line's absence); `go build ./internal/... ./cmd/ailang/...` rc 0; `make verify-examples` rc 0 (186 modules checked, 0 drift, 1 missing-on-disk). ALREADY RED - NOT A GATE: `go build ./...` rc 1 (cmd/wasm and gen/main declare no native main). UNINFORMATIVE UNDER SANDBOX (never pass/fail): `go test ./cmd/ailang/...` and `make test`, which bind loopback sockets in six cmd/ailang test files.",
+    "flags_before_path": "MANDATORY. `ailang test f.ail --format json` silently ignores --format (Go flag stops at the first non-flag arg; #534, out of scope). Every command in the plan is flags-first. A flags-last acceptance check tests nothing.",
+    "corpus_measurement": "FULL 33-file sweep of examples/runnable/contracts at 22ba8626d, 32 measured + per_function_depth_verify UNMEASURED (exceeds a 60s bound, rc 137). Total 111 vacuous skips. B1 fixes 87; 24 remain BY DESIGN: Cell x3 and list[Tree] x1 (imported from cross_module_types_lib), Mail x9 (imported from inbox_v2_lib), string<email> x11 (refined type, B2). This SUPERSEDES V34, which was an explicit lower bound (~17 of 33 files under a 2-minute cap) and which missed scoring.ail (6 vacuous: SkillLevel, Tenure, Performance, Department) and showcase.ail (9 vacuous: {subtotal,tax,discount}, Priority) entirely.",
+    "must_stay_green_files": "FALSE-RED GUARDS - these five are rc 0 today and MUST stay rc 0 with vacuous_skips == 0: cross_module_functions, cross_module_functions_lib, hof_verify, temperature, unencodable_callee_skip. Their skips are out_of_contract, deliberately forgiven.",
+    "triage_expectation": "87 never-executed properties across 15 files start running. Failures are the feature working, NOT regressions - but every newly-failing property must be classified inside this sprint as (a) deliberate (record_verify.ail:59 brokenDistance; the file header at :8 says 'Expect: 4 verified, 1 violation'), (b) a genuine latent bug in the EXAMPLE's contract (fix the example, name the line), or (c) a B1 defect (fix B1, re-run that milestone's gate). Zero unclassified.",
+    "two_out_of_contract_texts": "The ensures path (contract_domain.go:144) and the requires path (runner.go:465) emit DIFFERENT out_of_contract texts: 'unverified: requires filter accepted N of M generated inputs; need 100 (K discarded)' vs 'requires not satisfied by random input (consider tighter generators): ...'. Never assert a single out_of_contract substring across both paths.",
+    "no_examples_dir_trap": "Adding examples/runnable/contracts/shapes_verify.ail REQUIRES a matching examples/manifest.json entry (path/status/tags/description) or scripts/validate_manifest.go --ci reds make verify-examples, AND the file must `ailang run` successfully - every manifest'd contracts example has an `export func main() -> int ! {}`. Unlike Lane A (which correctly skipped its example because Lane A added zero syntax), B1's user-visible payoff IS 'these shapes now get tested', so the example is kept."
+  },
+  "velocity": {
+    "target_loc_per_day": 649,
+    "estimated_total_loc": 1460,
+    "estimated_days": 2.25,
+    "loc_note": "1460 = 590 impl + 870 test. Deliberately test-heavy: the impl is derivation plumbing over an already-existing combinator layer, and the value is in the mutation-backed acceptance suite (16 criteria, 5 refusal-branch neutering mutations). The 2.25d budget is gated by M6's measured triage of 87 newly-executing properties across 15 files (Lane A's 16 properties cost it 0.4d) plus two defects the design doc does not contain: the RecordGenerator map-iteration nondeterminism (+0.15d) and the missing size budget (+0.2d)."
+  },
+  "features": [
+    {
+      "id": "M1_SPLICE_ARMS_DEFAULT_STILL_SILENT",
+      "description": "FIRST HALF OF THE MANDATED ORDERING. Move valueToLiteral (runner.go:666-703) verbatim into a NEW internal/testing/value_splice.go, keeping the (r *Runner) receiver - this buys ~38 lines of headroom in runner.go (749 -> ~711) before anything is added. Then add four arms BEFORE the default: *eval.UnitValue -> ast.Literal{Kind: ast.UnitLit, Value: struct{}{}}; *eval.RecordValue -> *ast.Record with fields emitted in SORTED field-name order (RecordValue.Fields is a map, so unsorted emission would produce a nondeterministic AST); *eval.TupleValue -> *ast.Tuple; *eval.TaggedValue -> ARITY-SPLIT: len(Fields)==0 yields a bare *ast.Identifier{Name: CtorName}, otherwise *ast.FuncCall{Func: Identifier(CtorName), Args: ...}. The arity split is load-bearing, not cosmetic: injectADTConstructors (executor_helpers.go:483-489) binds NULLARY constructors to a *eval.TaggedValue rather than a closure, so emitting FuncCall for a nullary constructor produces core.App over a non-function and dies with 'cannot apply non-function value: *eval.TaggedValue' (eval_operations.go:245). The default arm stays SILENT in this milestone (add a TODO(M2) comment naming this plan). M1 is behaviour-inert at the CLI because no generator yet produces these value kinds.",
+      "estimated_loc": 230,
+      "dependencies": [],
+      "acceptance_criteria": [
+        "B1-1: valueToLiteral returns *ast.Record for RecordValue, *ast.Tuple for TupleValue, ast.Literal{UnitLit} for UnitValue, *ast.Identifier for a NULLARY TaggedValue, and *ast.FuncCall for an n-ary TaggedValue. BASELINE at 22ba8626d: all five currently fall through to the default and return ast.Literal{UnitLit} (read at runner.go:696-701); no corpus path reaches them. Red-turning mutation: delete any one arm - that value falls to the default and the node-type assertion fails.",
+        "B1-2 (ROUND-TRIP, the downstream observable): for each of the five shapes, astExprToCore(valueToLiteral(v)) evaluated through an eval.CoreEvaluator (with injectADTConstructors applied for the ADT case) is STRUCTURALLY EQUAL to v. The assertion reads the EVALUATED eval.Value, one full step past the AST, so an AST that is well-formed but semantically wrong still reds. Red-turning mutation: emit ast.Tuple for RecordValue - it compiles and produces a valid AST, but the round-tripped value differs.",
+        "INERTNESS PROOF: re-run the 32-file bounded corpus sweep and diff success / passed / failed / skipped / vacuous_skips against the plan's section 1.4 table - must be BYTE-IDENTICAL. Use the background-and-kill bounded-wait recipe; perl alarm does NOT bound a Go binary.",
+        "go test ./internal/testing/... -count=1 rc 0 (base rc 0); go vet ./internal/testing/... rc 0; make check-file-sizes rc 0; make lint rc 0 (gate on exit code only - it prints '1 issues: * unused: 1' at base and still exits 0); go build ./internal/... ./cmd/ailang/... rc 0 (do NOT use go build ./... - it is rc 1 on the pristine tree).",
+        "Report go test ./cmd/ailang/... as UNINFORMATIVE UNDER SANDBOX. Snapshot exactly: NEW internal/testing/value_splice.go, MOD internal/testing/runner.go, NEW internal/testing/value_splice_test.go."
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": null
+    },
+    {
+      "id": "M2_SPLICE_LOUD_DEFAULT_REFUSAL",
+      "description": "SECOND HALF OF THE MANDATED ORDERING - must not land before M1. valueToLiteral's signature becomes (ast.Expr, error) and its default arm returns nil plus fmt.Errorf(\"no literal splice for generated value of type %T (%s)\", value, value.Type()). Thread the error through all FOUR call sites: contract_domain.go:101 (ensures) -> Status: StatusFail with the message, NEVER StatusSkip (a skip here would re-open the vacuous-pass hole this doc exists to close); runner.go:438 (requires) -> same; bindPropertyValues (runner.go:643) gains (ast.Expr, error) and runProperty:315 -> StatusFail; shrinkCounterexample:725 treats a splice error as an unusable shrink candidate and `continue`s, exactly as the existing EvaluateExpression error branch already does (best-effort by design - it must not panic and must not change the reported verdict). The internal list-element recursion at runner.go:693 propagates.",
+      "estimated_loc": 190,
+      "dependencies": [
+        "M1_SPLICE_ARMS_DEFAULT_STILL_SILENT"
+      ],
+      "acceptance_criteria": [
+        "B1-3: an unknown eval.Value (e.g. &eval.FuncValue{}) makes valueToLiteral return a NON-NIL error, and each of the three property paths turns it into Status == StatusFail carrying that message - never StatusSkip. BASELINE at 22ba8626d: the default silently splices (), so a property can PASS on a fabricated unit value.",
+        "REFUSAL BRANCH N-1 (default arm refuses): neutering mutation `default: if false && true { return nil, fmt.Errorf(...) }; return &ast.Literal{Kind: ast.UnitLit}, nil`. The unit test asserting a non-nil error for an unknown eval.Value must go RED. Apply, observe red, revert, and record the observation in the milestone report.",
+        "REFUSAL BRANCH N-2 (ensures site converts error to StatusFail): neutering mutation `if false && err != nil { ...fail... }` at contract_domain.go. The ensures-path test asserting StatusFail + message must go RED. NOTE: with the mutant, astExprToCore(nil) panics - a panic is a red Go test, which is the correct outcome. Do NOT 'fix' that panic.",
+        "REFUSAL BRANCH N-3 (requires site converts error to StatusFail): neutering mutation `if false && err != nil { ... }` at runner.go:438. The requires-path test asserting StatusFail must go RED.",
+        "REFUSAL BRANCH N-4 (forall / bindPropertyValues site converts error to StatusFail): neutering mutation `if false && err != nil { ... }` at runner.go:315. The forall-path unit test asserting StatusFail must go RED.",
+        "REFUSAL BRANCH N-5 (shrink site skips an unusable candidate instead of crashing): neutering mutation `if false && err != nil { continue }`. The shrink test with one unspliceable candidate must still return a minimal value and must not panic; with the mutant it panics.",
+        "All FIVE neutering mutations applied, observed red, and reverted - one line per branch in the milestone report. A guard is not a gate until something reds when you remove it.",
+        "INERTNESS at the corpus level: no generator yet produces the new value kinds, so the 32-file sweep must STILL be byte-identical to section 1.4.",
+        "go test ./internal/testing/... -count=1 rc 0; go vet rc 0; make check-file-sizes rc 0; make lint rc 0; go build ./internal/... ./cmd/ailang/... rc 0. Snapshot exactly: MOD internal/testing/value_splice.go, MOD internal/testing/runner.go, MOD internal/testing/contract_domain.go, MOD internal/testing/value_splice_test.go, NEW internal/testing/value_splice_refusal_test.go."
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": null
+    },
+    {
+      "id": "M3_DERIVE_RECORDS_TUPLES_UNIT_ALIASES",
+      "description": "Create NEW internal/testing/derive.go and MOVE createGeneratorForType (runner.go:596-637) into it verbatim (another ~42 lines out of runner.go, landing it near 669), then extend. Introduce a deriveCtx carrying depth and sizeBudget; createGeneratorForType becomes a thin wrapper over deriveType(typ, newDeriveCtx()) so all THREE call sites (runner.go:281, runner.go:415, contract_domain.go:74) are wired by construction with no edit to contract_domain.go. New arms: *ast.SimpleType{Name:\"()\"} -> NewConstantGenerator(&eval.UnitValue{}) + NewNoOpShrinker (unit parses to SimpleType{\"()\"}, NOT an empty tuple - parser_type.go:96, parser_func.go:72); *ast.RecordType (anonymous, including nested) -> NewRecordGenerator over per-field derived generators, returning nil if ANY field is underivable (no silent substitution, CLAUDE.md principle 2); *ast.TupleType -> NewTupleGenerator; a non-scalar *ast.SimpleType{Name: X} -> look up *ast.TypeDecl{Name: X} in r.executor.sourceFile.Decls and derive a *ast.RecordType Definition, returning nil,nil when sourceFile is nil or no decl matches (imported types stay honest vacuous skips); *ast.TypeAlias -> RECURSE ON .Target. PRESERVE the existing list TypeApp arm and the ListType arm untouched - the doc's SCOPE UPDATE block is explicit that B1 adds beside them, never replaces them. ADTs and TypeApp-over-user-types are M4. ALSO in this milestone: the F-3 determinism fix - NewRecordGenerator sorts and stores its field names once and Generate iterates the sorted slice (signature unchanged, zero call-site churn).",
+      "estimated_loc": 400,
+      "dependencies": [
+        "M2_SPLICE_LOUD_DEFAULT_REFUSAL"
+      ],
+      "acceptance_criteria": [
+        "B1-4 (DETERMINISM, F-3): constructing the derived generator for {x:int, y:int, s:string} and drawing once from a FRESH newRNG(42), 200 times, yields 200 byte-identical RecordValues. BASELINE: REFUTED at base - RecordGenerator.Generate (generator_advanced.go:203-212) ranges a map[string]Generator and calls Generate(rng) inside the loop; Go randomises map iteration order per range statement (measured: 3 distinct orders in a 6-run probe over a 4-key map), so the RNG DRAW ORDER varies run to run and a fixed seed no longer reproduces a fixed record. This contradicts the doc's own axiom table (A1: Determinism, score 0) and defeats the propertySeed/SetSeedMetadata replayability machinery. Observable: the field->value ASSIGNMENT in the produced RecordValue, which is exactly what changes when draw order changes. Red-turning mutation: revert to `for k, g := range g.fieldGens`.",
+        "B1-5: anonymous record parameter {x: int, y: int} runs 100 cases. examples/runnable/contracts/record_pattern_verify.ail goes 5 vacuous -> 0 vacuous and rc 1 -> 0. BASELINE measured: success=false, 0 passed / 0 failed / 5 skipped, vacuous_skips=5, all 'no generator for parameter p: { x: int, y: int }'. Observable: CLI JSON vacuous_skips plus per-property tests_run. Red-turning mutation: restrict derivation to named TypeDecls only (drop the direct *ast.RecordType arm).",
+        "B1-8: NESTED anonymous records derive. examples/runnable/contracts/nested_record_verify.ail ({ name: string, pos: { x: int, y: int } }) goes 5 vacuous -> 0 and rc 1 -> 0. BASELINE measured: success=false, 0/0/5, vacuous_skips=5. Red-turning mutation: make the record arm derive only scalar fields (return nil for a *ast.RecordType field).",
+        "B1-10 (imported types stay honest): examples/runnable/contracts/cross_module_types.ail keeps Cell x3 and list[Tree] x1 as no_generator vacuous skips (rc stays 1) while its () parameter starts running - vacuous_skips goes 5 -> 4. BASELINE measured: success=false, 2/0/6, vacuous_skips=5, comprising Cell x3, list[Tree] x1, () x1; Cell and Tree verified IMPORTED at cross_module_types.ail:18. Red-turning mutation: make an unresolvable named type fall back to a unit-constant generator.",
+        "B1-11 (NO FALSE REDS): cross_module_functions, cross_module_functions_lib, hof_verify, temperature, unencodable_callee_skip all still exit rc 0 with vacuous_skips == 0. BASELINE: all five measured rc 0 at 22ba8626d. Red-turning mutation: make the record arm return a generator for ANY type, so out_of_contract files acquire vacuous labels.",
+        "*ast.TypeAlias arm exists and is unit-tested for a scalar target, a list target and a tuple target (type UserId = int / type Names = [string] / type Pair = (int, string) all parse to TypeAlias per parser_type_decl.go:98-118,179-186). The design doc omits TypeAlias entirely. There is NO corpus occurrence, so this is a UNIT-LEVEL criterion only - do not claim a corpus observable for it.",
+        "go test ./internal/testing/... -count=1 rc 0; go vet rc 0; make check-file-sizes rc 0 (runner.go must be well under 800 after the move); make lint rc 0; go build ./internal/... ./cmd/ailang/... rc 0.",
+        "Snapshot exactly: NEW internal/testing/derive.go, MOD internal/testing/runner.go, MOD internal/testing/generator_advanced.go, NEW internal/testing/derive_test.go, NEW internal/testing/generator_determinism_test.go, and MOD internal/testing/generator_advanced_test.go ONLY IF an existing assertion depended on map order - if so, report it explicitly (pre-authorised exception to the no-test-edits rule)."
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": null
+    },
+    {
+      "id": "M4_DERIVE_ADTS_DEPTH_AND_SIZE_BUDGET",
+      "description": "In derive.go: *ast.AlgebraicType -> NewOneOfGenerator over one NewADTGenerator(ctor.Name, fieldGens, true) per constructor; a constructor with any underivable field makes the WHOLE type underivable (nil, nil) - do not silently drop constructors, that biases the distribution invisibly. DEPTH BUDGET default 3, decremented on EVERY derivation step (not only ADT arms) so mutual recursion through record->list->ADT->record is bounded; at the bound restrict ADT choice to non-recursive constructors (per-constructor recursiveness computed once per decl, memoised); if none exist return nil,nil for an honest vacuous skip. SIZE BUDGET (F-4): inside a derivation (depth < max), cap generated list length by remaining depth instead of 0..MaxSize; top-level list[<scalar>] keeps today's 0..MaxSize so Lane A's measured behaviour is unchanged. *ast.TypeApp over a USER type with args -> substitute args into the decl's TypeParams before deriving, bounded by depth, keeping the list arm first. Also parameterise ADTGenerator with the real module path and type name in generator_advanced.go - COSMETIC/DIAGNOSTIC ONLY, see the adt_typename_refutation note.",
+      "estimated_loc": 340,
+      "dependencies": [
+        "M3_DERIVE_RECORDS_TUPLES_UNIT_ALIASES"
+      ],
+      "acceptance_criteria": [
+        "B1-6 (ADT CONSTRUCTOR COVERAGE - replaces the doc's B-3, whose mutation kills nothing): across one property run over a same-file ADT with >=2 constructors (park.ail's Season, 6 vacuous today), EVERY constructor is observed at least once in the generated stream. BASELINE measured: park.ail success=false, 1/0/7, vacuous_skips=6, 'no generator for parameter season: Season' x6. Observable: the multiset of CtorNames actually applied in the harness, downstream of the OneOf sum. Red-turning mutation: replace NewOneOfGenerator(ctors...) with the first constructor only.",
+        "B1-7 (NULLARY-vs-N-ARY SPLICE): a property over an ADT with BOTH a nullary and an n-ary constructor (Shade = Light | Dark(level: int)) runs 100 cases with no evaluation error. Observable: the EVALUATOR's verdict - a nullary emitted as FuncCall dies with 'cannot apply non-function value: *eval.TaggedValue' (eval_operations.go:245), because injectADTConstructors binds nullary constructors to a TaggedValue rather than a closure. Red-turning mutation: make the TaggedValue arm always emit ast.FuncCall regardless of arity.",
+        "B1-9 (SIZE BOUND, F-4): for the in-repo mutually-recursive Doc (record_adt_cycle_verify.ail:7-8 - `type Block = Para(string) | Container({ blocks: list[Block], kind: string })` and `type Doc = { title: string, blocks: list[Block] }`), EVERY one of 200 derived draws has total node count <= a stated constant N, AND the file completes inside a 60s bounded wait. BASELINE measured: success=false, 0/0/1, vacuous_skips=1, 'no generator for parameter d: Doc'; DefaultConfig().MaxSize == 100 read at generator.go:30. At depth 3 with uncapped lists one Doc draw is ~2500 nodes, x100 cases. Observable: the SIZE of the generated value - deterministic, so the gate cannot flake on wall clock. Red-turning mutation: remove the depth-scaled list cap (restore 0..MaxSize inside derivation).",
+        "B1-12 (DEPTH EXHAUSTION IS AN HONEST SKIP, not a hang or a fabrication): a same-file ADT with NO non-recursive constructor (`type Endless = Wrap(Endless)`, unit-level fixture) derives to nil,nil so the property reports skip_kind == \"no_generator\". Observable: PropertyResult.SkipKind written at contract_domain.go:77. Red-turning mutation: at the depth bound, return the first constructor anyway - the derivation then recurses past the bound and the test times out or stack-overflows.",
+        "B1-13 (LANE A BEHAVIOUR PRESERVED): hof_verify (2 pass x100), list_verify (5 pass + 1 deliberate fail), and invoice's 2 list[int] properties all keep their exact tests_run counts. BASELINE measured in the plan's section 1.4. Red-turning mutation: apply the depth-scaled size cap to top-level list[<scalar>] too - list lengths shrink and Lane A's measured counts drift.",
+        "ADT-heavy corpus files move as predicted: access_control 4 vacuous -> 0 (rc 1->0), cross_function 5 -> 0 (rc 1->0), finance 4 -> 0 (rc 1 kept, 1 real fail), insurance 6 -> 0 (rc 1->0), park 6 -> 0 (rc 1->0), scoring 6 -> 0 (rc 1->0), showcase 9 -> 0 (rc 1 kept, 1 real fail), invoice 13 -> 0 (rc 1 kept, 1 real fail).",
+        "ADTGenerator module/type parameterisation is asserted at UNIT LEVEL ONLY and explicitly NOT claimed as an end-to-end fix. See metadata.adt_typename_refutation: nothing downstream reads TaggedValue.TypeName or .ModulePath on this path, and the splice discards the generated TaggedValue entirely.",
+        "go test ./internal/testing/... -count=1 rc 0; go vet rc 0; make check-file-sizes rc 0; make lint rc 0; go build ./internal/... ./cmd/ailang/... rc 0. Snapshot exactly: MOD internal/testing/derive.go, MOD internal/testing/generator_advanced.go, MOD internal/testing/derive_test.go, NEW internal/testing/derive_adt_test.go."
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": null
+    },
+    {
+      "id": "M5_DERIVED_SHRINKERS_DROPPABLE",
+      "description": "DROPPABLE MILESTONE - unit-observable only. Add RecordShrinker (per-field, composing the existing field shrinkers) and TupleShrinker (per-element) to internal/testing/shrink.go and return them from the M3/M4 derivation arms; ADTs reuse the existing NewADTShrinker. RATIONALE FOR THE DROPPABLE FLAG (F-5): createGeneratorForType returns (Generator, Shrinker) but BOTH contract paths discard the shrinker - contract_domain.go:74 and runner.go:415 are both `gen, _ := ...`. The only consumer is shrinkCounterexample, reached only from runProperty (the forall path), which is broken upstream ('empty program', #624 / doc V10 and V36) and cannot produce a counterexample at all. So a derived shrinker cannot be observed through `ailang test` by any means. If the sprint is behind at the end of M4, DROP this milestone and file it as a follow-up - nothing downstream depends on it.",
+      "estimated_loc": 200,
+      "dependencies": [
+        "M4_DERIVE_ADTS_DEPTH_AND_SIZE_BUDGET"
+      ],
+      "acceptance_criteria": [
+        "B1-14: RecordShrinker and TupleShrinker produce field-wise / element-wise simplifications and never return the input unchanged. BASELINE: no such shrinkers exist - `grep 'func New.*Shrinker' internal/testing/shrink.go` returns Int, Float, String, List, ADT, NoOp only. Observable: the returned []eval.Value. Red-turning mutation: delete the per-field loop, yielding an empty shrink set.",
+        "NO criterion in this milestone may claim improved counterexample quality, shrink quality, or any CLI-visible effect. State plainly in the milestone report that these shrinkers are unreachable from `ailang test` today and why (F-5).",
+        "go test ./internal/testing/... -count=1 rc 0; go vet rc 0; make check-file-sizes rc 0; make lint rc 0.",
+        "If DROPPED: say so explicitly, leave shrink.go untouched, and record the follow-up. Do not partially land it. Snapshot exactly (if landed): MOD internal/testing/shrink.go, MOD internal/testing/derive.go, NEW internal/testing/shrink_derived_test.go."
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": null
+    },
+    {
+      "id": "M6_CORPUS_TRIAGE_EXAMPLE_AND_CLOSEOUT",
+      "description": "TRIAGE-DOMINATED (0.5 of its 0.55d). Re-sweep all 33 examples/runnable/contracts files with the background-and-kill bounded-wait recipe and produce the after-table against the plan's section 1.4. Classify EVERY newly-failing property. Add NEW examples/runnable/contracts/shapes_verify.ail (the doc's shapes.ail: record + ADT + tuple + scalar ensures) PLUS an `export func main() -> int ! {}`, and a matching examples/manifest.json entry. Update changelogs/v0.18-current.md [Unreleased] and mark B1 landed in the design doc, recording refutations F-1 through F-7. File follow-ups without implementing them. SIZING NOTE: estimated_loc 100 counts code/fixture lines only (40 impl + 60 test), consistent with the other milestones; the ~120 lines of CHANGELOG + design-doc prose are excluded so the milestone sum matches velocity.estimated_total_loc.",
+      "estimated_loc": 100,
+      "dependencies": [
+        "M5_DERIVED_SHRINKERS_DROPPABLE"
+      ],
+      "acceptance_criteria": [
+        "B1-16 (ZERO UNCLASSIFIED): every newly-failing property in the after-sweep is classified as (a) DELIBERATE - the example is documented as broken, e.g. record_verify.ail:59 brokenDistance with the file header at :8 stating 'Expect: 4 verified, 1 violation'; record and leave failing; (b) GENUINE LATENT BUG in the example's contract - fix the EXAMPLE, not the runner, and name the line; or (c) a B1 DEFECT - fix B1 and re-run the affected milestone's gate. BASELINE: 111 vacuous skips today, 87 of which start running.",
+        "B1-15: make verify-examples rc 0 with shapes_verify.ail in the manifest. BASELINE measured rc 0 at 22ba8626d ('186 modules checked, 0 drift, 1 missing-on-disk'; 'all examples pass and manifest is in sync') - an already-green gate, so a red here is a real defect, not pre-existing noise. Red-turning mutation: omit the manifest entry - scripts/validate_manifest.go --ci reds.",
+        "shapes_verify.ail has an `export func main() -> int ! {}` (every manifest'd contracts example does; make verify-examples runs `ailang run`, not `ailang test`) and its manifest entry carries path / status:\"working\" / tags / description.",
+        "CHANGELOG entry in changelogs/v0.18-current.md [Unreleased]: record / ADT / tuple / unit parameters now get derived generators; 87 previously-never-executed contract properties across 15 in-repo examples now run; the files that flip rc 1 -> 0 are named; the 24 skips that REMAIN (Cell x3 + list[Tree] x1 + Mail x9 imported, string<email> x11 refined) are named as B2 scope, not omissions.",
+        "The design doc is updated to mark B1 landed AND to record: F-1 (its success metric is WRONG - B1 fixes ZERO properties in inbox_injection_v2.ail and inbox_v2_app.ail, so the headline 'the prompt-injection safety demos have never executed' claim is not addressed by B1); F-2 (ADTGenerator TypeName parameterisation is cosmetic, and B-3's mutation kills nothing); F-3 (RecordGenerator nondeterminism, which contradicts the doc's own A1 score); F-4 (depth alone does not bound generation cost); F-5 (derived shrinkers are unreachable); F-7 (the Lane B file list must include contract_domain.go).",
+        "Follow-ups FILED, NOT implemented: derived shrinkers if M5 was dropped; TypeAlias-shaped named aliases have no corpus coverage; imported-type resolution via the typechecker env is the fix for the 13 remaining imported-type skips; refined-type generation stays with B2 behind the evaluator fuel budget.",
+        "make verify-examples rc 0; go test ./internal/testing/... -count=1 rc 0; go vet rc 0; make check-file-sizes rc 0; make lint rc 0; go build ./internal/... ./cmd/ailang/... rc 0.",
+        "Snapshot exactly: NEW examples/runnable/contracts/shapes_verify.ail, MOD examples/manifest.json, MOD changelogs/v0.18-current.md, MOD design_docs/planned/v0_31_0/m-property-generator-coverage.md, plus EACH examples/runnable/contracts/*.ail fixed under classification (b) - list every one."
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": null
+    }
+  ],
+  "discrepancies_found": [
+    {
+      "id": "F-1",
+      "severity": "high",
+      "doc_claim": "Design doc Success metrics: 'After Lane B1, the five silent-shape example files above run their skipped properties (or fail honestly).' Problem Statement: 'The first two are the prompt-injection safety demos - their safety properties have never executed.'",
+      "finding": "REFUTED. B1 fixes ZERO properties in either injection demo. inbox_injection_v2.ail's 10 vacuous skips are ALL `no generator for parameter rawEmail/rawBody: string<email>` - a REFINED type, explicitly out of B1 scope and parked with B2. inbox_v2_app.ail's are `Mail` x9 plus one string<email>; Mail is declared in inbox_v2_lib.ail and IMPORTED at inbox_v2_app.ail:24, so the same-file derivation bound leaves it vacuous. Verified: `grep -E '^(export )?type Mail' inbox_v2_app.ail` returns nothing.",
+      "action": "No acceptance criterion may expect those two files to change; section 1.4 pins them as UNCHANGED. The mission-visible claim that B1 makes the injection demos honest is false - the honest claim is that Lane A already made them LOUD (they exit 1 today) and B2 makes them RUN. Correct the design doc at M6 and flag it for the release note."
+    },
+    {
+      "id": "F-2",
+      "severity": "high",
+      "doc_claim": "Lane B1 bullet: 'Prerequisite fix: ADTGenerator.Generate hardcodes ModulePath: \"test\", TypeName: \"ADT\" (generator_advanced.go:171-176) - parameterize with the real module path + type name or generated TaggedValues won't match/typecheck in the harness.' Acceptance B-3's red-turning mutation is 'Restore hardcoded ModulePath/TypeName in ADTGenerator.Generate'.",
+      "finding": "REFUTED ON BOTH LEGS, and B-3's mutation kills nothing. (1) NOTHING MATCHES ON TypeName/ModulePath: matchPattern's *core.ConstructorPattern arm (internal/eval/eval_patterns.go:178-194) compares ONLY tagged.CtorName != p.Name and arity; taggedValuesEqual (:410) compares only CtorName + fields; isTag (:749) - the one function that does compare TypeName - has ZERO non-test callers (only adt_runtime_test.go:140); TaggedValue.String() (value.go:362) prints CtorName(fields...) and never the type name, so it is not observable in counterexample text either. (2) THE SPLICE THROWS THE GENERATED TaggedValue AWAY: valueToLiteral(TaggedValue) becomes ast.FuncCall(Identifier(ctor), fields) -> core.App{Func: core.Var{ctor}} -> the harness env's ConstructorClosure.Apply (eval_operations.go:241, value.go:395) REBUILDS a fresh TaggedValue using the TypeName injected by injectADTConstructors (executor_helpers.go:461-501), which is the correct one. (3) There is no typechecking on this path at all: evaluateEnsuresHarnessCore (executor.go:144-167) builds a core.Program and calls EvalCoreProgram directly.",
+      "action": "B-3 is REPLACED by two criteria with real downstream writes: B1-6 (every ADT constructor observed at least once across a run - downstream of the OneOf sum; mutation = collapse to the first constructor) and B1-7 (nullary-vs-n-ary splice - downstream of the arity split; mutation = always emit FuncCall, which dies with 'cannot apply non-function value: *eval.TaggedValue'). ADTGenerator parameterisation is retained as a COSMETIC/DIAGNOSTIC change with a unit-level criterion only, demoted from 'prerequisite'."
+    },
+    {
+      "id": "F-3",
+      "severity": "high",
+      "doc_claim": "Axiom Compliance table: 'A1: Determinism | 0 | Derived generators use the existing seeded RNG (newRNG(config.Seed)); no new nondeterminism.'",
+      "finding": "REFUTED - wiring RecordGenerator as-is introduces run-to-run nondeterminism. RecordGenerator.Generate (generator_advanced.go:203-212) iterates `for fieldName, fieldGen := range g.fieldGens` over a map[string]Generator and calls fieldGen.Generate(rng) INSIDE the loop. Go randomises map iteration order per range statement - measured this sprint with a 6-run probe over a 4-key map: 3 distinct orders observed. So the ORDER OF RNG DRAWS varies run to run and a fixed seed no longer reproduces a fixed record. This defeats the propertySeed / SetSeedMetadata / result.SetSeedMetadata replayability machinery: a reported counterexample would not reproduce from its reported seed. The doc scores A1 at 0 on the assumption that reusing the seeded RNG is sufficient; it is not, because the CONSUMPTION ORDER is unspecified.",
+      "action": "MANDATORY fix in M3: NewRecordGenerator sorts and stores its field names once; Generate iterates the sorted slice. Signature unchanged, so zero call-site churn. Acceptance B1-4 asserts 200 byte-identical draws from a fresh newRNG(42) - non-flaky, since under map-range the probability of 200 identical multi-field draws is effectively zero. The same sorted-order discipline applies to valueToLiteral's RecordValue arm in M1 (RecordValue.Fields is also a map). Correct the doc's A1 justification at M6."
+    },
+    {
+      "id": "F-4",
+      "severity": "high",
+      "doc_claim": "Lane B1 'Recursion bound: depth budget (default 3) threaded through derivation' - the ONLY bound the doc specifies for structural generation.",
+      "finding": "INSUFFICIENT - this is the same critique the quorum levelled at B2, applied to B1's own generation, and the doc does not address it. DefaultConfig().MaxSize == 100 (generator.go:30) and the list arm generates lengths 0..MaxSize. The in-repo fixture record_adt_cycle_verify.ail is MUTUALLY RECURSIVE through a record, an ADT and a list: `export type Block = Para(string) | Container({ blocks: list[Block], kind: string })` and `export type Doc = { title: string, blocks: list[Block] }`. At depth 3 with uncapped list lengths, one Doc draw carries ~50 Blocks each containing ~50 more - roughly 2500 nodes with strings up to 100 chars - times 100 cases. Depth bounds recursion; it does not bound total work.",
+      "action": "MANDATORY in M4: thread a SIZE budget alongside the depth budget - cap derivation-internal list length by remaining depth, while top-level list[<scalar>] keeps 0..MaxSize so Lane A's measured behaviour on hof_verify / list_verify / invoice is unchanged (pinned by B1-13). Acceptance B1-9 asserts a DETERMINISTIC size bound on the generated values (not a wall-clock time, so the gate cannot flake), with the 60s bounded completion of record_adt_cycle_verify.ail as a secondary smoke."
+    },
+    {
+      "id": "F-5",
+      "severity": "medium",
+      "doc_claim": "Lane B1 'Shrinking: minimal honest scope - per-element TupleShrinker and per-field RecordShrinker ... Shrinking behaviour for derived generators was NOT investigated beyond code reading - treat quality of shrunk counterexamples as unvalidated until B1's tests exist.'",
+      "finding": "UNDERSTATED - they are not merely unvalidated, they are UNREACHABLE. createGeneratorForType returns (Generator, Shrinker), but BOTH contract paths discard the shrinker: contract_domain.go:74 and runner.go:415 are both `gen, _ := r.createGeneratorForType(...)`. The only consumer is shrinkCounterexample, reached only from runProperty (the forall path), which is broken upstream ('empty program', #624 / doc V10 and V36) and cannot produce a counterexample at all. So no derived shrinker can be observed through `ailang test` by any means, at any level above a unit test.",
+      "action": "M5 is scoped as UNIT-OBSERVABLE ONLY and flagged DROPPABLE - cut it if the sprint is behind after M4 and file a follow-up. No acceptance criterion in this sprint may claim improved counterexample quality."
+    },
+    {
+      "id": "F-6",
+      "severity": "medium",
+      "doc_claim": "Lane A sprint plan section 0.8 / R-9: 'Use a bounded wait when sweeping (gtimeout/perl alarm - note plain timeout is NOT on PATH on this rig).'",
+      "finding": "REFUTED, with a positive control, and it bit this planner. `perl -e 'alarm 3; exec @ARGV'` against a 20s Go binary ran the FULL 20 SECONDS and exited 0 - not bounded. The same wrapper against /bin/sleep 20 died at 3s with rc 142. The Go runtime classifies SIGALRM as notify-only and, with no os/signal listener, ignores it. gtimeout is not installed either. The planner's first corpus sweep hung on per_function_depth_verify.ail because of this and had to be killed.",
+      "action": "Use background-and-kill instead: `\"$@\" & pid=$!; ( sleep LIM; kill -9 $pid 2>/dev/null ) & w=$!; wait $pid; rc=$?; kill $w 2>/dev/null; exit $rc`. Verified to bound a Go binary at the limit (rc 137) and to leave a fast one alone (rc 0). This matters beyond this sprint: an unbounded wait wedges the whole mission loop."
+    },
+    {
+      "id": "F-7",
+      "severity": "medium",
+      "doc_claim": "Design doc 'Files to Modify/Create (Lane B, B1 only)': internal/testing/derive.go (new), internal/testing/runner.go (+40/-10), internal/testing/generator_advanced.go, internal/testing/shrink.go, internal/testing/derive_test.go, examples/. Controller brief: 'Callers: :281 (forall binder path) and :415 (contract-derived property path).'",
+      "finding": "BOTH INCOMPLETE. runEnsuresProperty was moved out of runner.go into internal/testing/contract_domain.go (194 lines) after the doc was written. There are THREE createGeneratorForType call sites across TWO files - runner.go:281 (forall), runner.go:415 (requires) and contract_domain.go:74 (ENSURES, the site every contract-derived property in the corpus actually flows through) - and THREE valueToLiteral call sites across the same two files (contract_domain.go:101, runner.go:438, runner.go:652) plus an internal recursion at runner.go:693. Changing valueToLiteral's signature also changes bindPropertyValues' signature and therefore runProperty:315 and shrinkCounterexample:725. Separately, the two out_of_contract skip texts now DIFFER by path: contract_domain.go:144 emits 'unverified: requires filter accepted N of M generated inputs; need 100 (K discarded)' while runner.go:465 emits 'requires not satisfied by random input (consider tighter generators): ...'.",
+      "action": "contract_domain.go is added to the file set (M2). M3 routes all three generator call sites through a single deriveType entry point so derivation needs no contract_domain.go edit. No test may assert a single out_of_contract substring across both paths. Correct the doc's Lane B file list at M6."
+    },
+    {
+      "id": "F-8",
+      "severity": "medium",
+      "doc_claim": "Verification Log V34, flagged by the controller as a LOWER BOUND: 'B1's remaining scope, re-measured. Shapes still emitting no generator for parameter ... at HEAD' - measured over ~17 of 33 files under a 2-minute cap.",
+      "finding": "CONFIRMED as a lower bound, and the full sweep found TWO WHOLE FILES V34 never reached. scoring.ail: 6 vacuous skips over SkillLevel x3, Tenure, Performance, Department - four ADT names V34 does not list. showcase.ail: 9 vacuous skips over `{ subtotal: int, tax: int, discount: int }` x5 and Priority x4. Neither file appears in V34 or in the doc's blast-radius paragraph. Full sweep at 22ba8626d: 32 of 33 files measured (per_function_depth_verify exceeds a 60s bound, reported UNMEASURED, never pass/fail); 111 total vacuous skips; B1 fixes 87; 24 remain by design.",
+      "action": "The plan's section 1.4 table is the complete measurement and supersedes V34 as the sprint's scope of record. Do not quote V34."
+    },
+    {
+      "id": "F-9",
+      "severity": "medium",
+      "doc_claim": "Lane B1 derivation rules list TypeDecl{Definition: *ast.RecordType}, anonymous *ast.RecordType, TypeDecl{Definition: *ast.AlgebraicType}, *ast.TupleType, unit (), and *ast.TypeApp over a user type.",
+      "finding": "INCOMPLETE - *ast.TypeAlias is missing entirely. parser_type_decl.go:79-198 shows that `type Pair = (int, string)` parses to TypeAlias{Target:*ast.TupleType} (:112-118), `type Names = [string]` to TypeAlias{Target:*ast.TypeApp{\"list\"}} (:98-104), and `type UserId = int` to TypeAlias{Target:*ast.SimpleType} (:179-186). Only `type X = { ... }` yields a bare *ast.RecordType and only pipe-separated forms yield *ast.AlgebraicType. Without a TypeAlias arm, every scalar/list/tuple named alias stays vacuous. Separately, the unit type parses to *ast.SimpleType{Name:\"()\"} (parser_type.go:96, parser_func.go:72), NOT an empty tuple - the derivation arm belongs in the SimpleType switch.",
+      "action": "M3 adds a one-line *ast.TypeAlias arm recursing on .Target, and puts unit in the SimpleType switch. There is NO corpus occurrence of an alias-shaped named type used as a parameter (verified by grep over all 33 contract examples), so its acceptance is UNIT-LEVEL ONLY - do not claim a corpus observable for it."
+    },
+    {
+      "id": "F-10",
+      "severity": "low",
+      "doc_claim": "Controller brief: 'go build ./... fails rc=1 on untouched dev (cmd/wasm, gen/main have no native main) - do not write it as a gate.'",
+      "finding": "CONFIRMED first-party (rc 1, exactly those two packages) and RESOLVED: `go build ./internal/... ./cmd/ailang/...` is rc 0 at base and is the correct substitute. Also confirmed: `make lint` prints `1 issues: * unused: 1` at base and STILL EXITS 0 - a plan that gated on the absence of that line would have written an already-red gate of a different kind.",
+      "action": "Section 1.7 records every gate with its measured baseline. Gate on exit codes only, and use the scoped go build."
+    }
+  ],
+  "risks": [
+    {
+      "id": "RISK-1",
+      "risk": "87 never-executed properties across 15 files start running; some fail on real latent bugs in the examples.",
+      "impact": "sprint time (0.5d budgeted in M6)",
+      "mitigation": "M6 requires every newly-failing property to be classified (a) deliberate / (b) example bug fixed / (c) B1 defect fixed - zero unclassified. record_verify.ail's brokenDistance (:59) is documented as deliberate at :8 ('Expect: 4 verified, 1 violation'). Failures are the feature working; do not treat them as regressions or 'fix' them by weakening the runner."
+    },
+    {
+      "id": "RISK-2",
+      "risk": "Derivation returns a generator for a shape it should not, converting a deliberate out_of_contract skip into a vacuous label and flipping a green file red.",
+      "impact": "high if missed (false red)",
+      "mitigation": "B1-11 pins the five must-stay-rc-0 files (cross_module_functions, cross_module_functions_lib, hof_verify, temperature, unencodable_callee_skip) at CLI level in M3 and again in the M4 and M6 sweeps. Derivation returns nil,nil for any underivable component - no silent substitution (CLAUDE.md principle 2)."
+    },
+    {
+      "id": "RISK-3",
+      "risk": "F-3: wiring RecordGenerator as-is ships an axiom-A1 determinism violation - a reported counterexample would not reproduce from its reported seed.",
+      "impact": "high (silent correctness/replayability defect)",
+      "mitigation": "Mandatory sorted-field-order fix in M3, plus B1-4's 200-identical-draws assertion, plus the same sorted discipline in M1's RecordValue splice arm. Measured evidence: 3 distinct map orders in a 6-run probe."
+    },
+    {
+      "id": "RISK-4",
+      "risk": "F-4: depth-3 derivation over the in-repo mutually-recursive Doc/Block types blows up to ~2500-node values x100 cases with MaxSize 100.",
+      "impact": "high (sprint stalls on a pathologically slow gate, or the harness effectively hangs)",
+      "mitigation": "Mandatory size budget in M4 with B1-9's DETERMINISTIC size assertion (not wall clock, so it cannot flake) plus a 60s bounded-wait smoke on record_adt_cycle_verify.ail. B1-13 pins that the cap does NOT apply to top-level list[<scalar>], preserving Lane A behaviour."
+    },
+    {
+      "id": "RISK-5",
+      "risk": "The M1-before-M2 ordering is violated (loud default lands before the arms), failing the harness for every unit-typed generated value.",
+      "impact": "high (the exact defect gemini-3-1-pro caught in quorum round 2)",
+      "mitigation": "Enforced as separate milestones with M2 declaring M1 as a dependency, and M1 carrying its own unit-level round-trip tests (B1-2) so the arms are proven before the default is flipped. Both milestones additionally require corpus inertness proofs."
+    },
+    {
+      "id": "RISK-6",
+      "risk": "runner.go crosses the 800-line file-size gate (749 today, 51 headroom) while B1 adds hundreds of lines.",
+      "impact": "medium (gate red mid-sprint, forcing an unplanned refactor)",
+      "mitigation": "Pre-planned relief, not reactive: M1 moves valueToLiteral into value_splice.go (-38) and M3 moves createGeneratorForType into derive.go (-42), landing runner.go near 669. make check-file-sizes is a gate on EVERY milestone."
+    },
+    {
+      "id": "RISK-7",
+      "risk": "F-6: an unbounded corpus sweep hangs on per_function_depth_verify.ail (or another slow example) and wedges the loop.",
+      "impact": "high (loop-level, not just sprint-level)",
+      "mitigation": "The background-and-kill recipe in section 1.6, verified against a Go binary with a positive control. per_function_depth_verify.ail is reported UNMEASURED (exceeds bounded wait), never pass/fail, and must never block a milestone gate."
+    },
+    {
+      "id": "RISK-8",
+      "risk": "The executor writes acceptance commands flags-last, so they silently test nothing (#534).",
+      "impact": "high (false green on the sprint's own gates)",
+      "mitigation": "Every command in the plan is flags-first; stated as executor constraint 0.2. #534 is out of scope - do not fix it here."
+    }
+  ]
+}

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -6,6 +6,22 @@
 
 ### Added
 
+- Contract property tests can now splice **unit, record, tuple and constructor**
+  values into the generated program, not just scalars and lists
+  (`internal/testing/value_splice.go`). This is Lane B1 milestone M1 of
+  [#517](https://github.com/sunholo-data/ailang/issues/517) and is deliberately
+  **inert on its own** — no generator yet produces these shapes, so no test's
+  behaviour changes. It is the prerequisite half of a mandated ordering: the
+  splice arms must exist before the silent fallthrough (which today turns any
+  unrecognised value into `()`) can be converted into a loud error, because that
+  fallthrough is currently what makes unit values work. Two details are
+  load-bearing and each is pinned by a test that fails when it is removed: record
+  fields are emitted in **sorted** order (`RecordValue.Fields` is a Go map, so
+  ranging it directly would make a fixed seed stop reproducing a counterexample),
+  and a **nullary** constructor is emitted as a bare identifier rather than a
+  call — `injectADTConstructors` binds nullary constructors to a value, not a
+  closure, so a call would die with `cannot apply non-function value`.
+
 - `std/bytes.toInts(b: bytes) -> [int]` — every byte value as a list of ints, the
   exact inverse of `fromInts`. This is the missing half of
   `design_docs/implemented/v0_21_0/m-bytes-toints-byteAt.md`, which specified

--- a/design_docs/planned/v0_31_0/m-property-generator-coverage-lane-b1-sprint-plan.md
+++ b/design_docs/planned/v0_31_0/m-property-generator-coverage-lane-b1-sprint-plan.md
@@ -1,0 +1,690 @@
+# Sprint Plan — M-PROPERTY-GENERATOR-COVERAGE **Lane B1 only**
+
+**Design doc**: [m-property-generator-coverage.md](m-property-generator-coverage.md) (Lane B1 = the `B1. Structural derivation` block)
+**Sprint ID**: `M-PROPERTY-GENERATOR-LANE-B1`
+**Upstream filing**: sunholo-data/ailang#517
+**Predecessor**: Lane A **LANDED** (`a81d66983`, PR #536) — see [lane-a sprint plan](m-property-generator-coverage-lane-a-sprint-plan.md)
+**Base**: `22ba8626d` (branch `dev`)
+**Planner**: V1 mission iteration 168. Every fact in §1 and §2 was measured first-party in the **main checkout** at `22ba8626d` with `go build -o /tmp/ailang_planner168 ./cmd/ailang` (binary self-reports `Commit: 22ba862`).
+**Estimate**: **2.25 days** (doc says ~1.5–2 d; the doc's estimate predates Lane A and omits three real work items — see §7)
+**Risk**: medium-high (derivation touches a hot path; 87 never-executed properties start running; two genuine determinism/termination defects must be fixed *inside* this sprint)
+
+**Scope**: Lane B1 **only**.
+**B2 is OUT** — deferred by the 2026-07-29 quorum, blocked on a deterministic evaluator fuel budget, on the
+reviewer's own proposal. Do not implement `gen<TypeName>`, do not implement the alias-first hint text
+(B-9), do not touch refined types. **Lane A is done** — do not re-do the list arm, the skip taxonomy,
+`Success()`, the reporter, or the JSON preamble.
+
+---
+
+## 0. Executor operating constraints (read first)
+
+1. **You cannot run `git` at all.** The controller reconstructs each commit from your per-milestone
+   `.snap/M<k>/` snapshot. Every milestone below states its **exact file set** (NEW / MOD). Snapshot
+   exactly those files, and report any file you touched that is not on the list — an unlisted file is a
+   planning defect, not a silent extra.
+2. **Flags BEFORE the positional path, always.** `ailang test f.ail --format json` silently ignores
+   `--format` (root cause `cmd/ailang/main.go`'s `flag.Parse` stopping at the first non-flag arg; filed
+   as **#534**, out of scope). Every command in this plan is written flags-first. A flags-last
+   acceptance check tests nothing.
+3. **`perl -e 'alarm N; exec @ARGV'` DOES NOT BOUND A GO BINARY.** The Lane A plan's §0.8/R-9 recipe is
+   a silent no-op against `ailang`: the Go runtime classifies `SIGALRM` as notify-only, and with no
+   `os/signal` listener it is **ignored**. Measured this sprint with a positive control (§2, F-6). Use
+   the background-and-kill recipe in §1.6 instead. This matters: an unbounded sweep wedges the loop.
+4. **Sandbox-uninformative gates.** `go test ./internal/testing/... -count=1` binds no sockets —
+   **informative**, and it is your primary gate. `go test ./cmd/ailang/...` and `make test`
+   (= `go test ./...`) bind loopback sockets in six `cmd/ailang` test files and MUST be reported as
+   **`UNINFORMATIVE UNDER SANDBOX`**, never pass/fail. The controller re-runs them.
+5. **`go build ./...` IS RED ON THE PRISTINE TREE** (rc 1: `cmd/wasm` and `gen/main` declare no native
+   `main`). It is **not** a gate. Use `go build ./internal/... ./cmd/ailang/...` (measured rc **0** at
+   base) wherever you want a build gate.
+6. **`make lint` prints `1 issues: * unused: 1` and still exits 0** at base. Gate on the **exit code**,
+   never on the absence of that line.
+7. **File-size gate is live and binding.** `internal/testing/runner.go` is **749** lines against the
+   800-line limit at `make/code-health.mk:122` — **51 lines of headroom**. B1 adds far more than that.
+   The plan therefore *removes* two functions from `runner.go` into new files (M1, M3); this is
+   deliberate, not drive-by refactoring. `make check-file-sizes` is a gate on **every** milestone.
+8. **Do not modify existing test assertions.** As in Lane A, `git diff -U0 -- '*_test.go'` should show
+   **no removed lines** in pre-existing test files. Two exceptions are pre-authorised and named
+   explicitly in M3 (`generator_advanced_test.go`, only if the determinism fix changes an
+   order-dependent assertion) — if you use them, say so per milestone.
+9. **Adding a file under `examples/runnable/` requires a matching `examples/manifest.json` entry**
+   (`path` / `status` / `tags` / `description`), and the file must `ailang run` successfully — every
+   contracts example in the manifest has an `export func main() -> int`. See M6.
+10. **Never assert `stderr == ""`.** A legitimate `Warning: stdlib version mismatch: expected dev, found
+    v0.33.0 …` already goes to stderr on this rig (observed in the §1.4 sweep). Assert on stdout only.
+
+---
+
+## 1. Ground truth measured for this plan
+
+### 1.1 The generator surface at `22ba8626d`
+
+`createGeneratorForType` (`internal/testing/runner.go:596`) has **three** arms:
+
+| Arm | Line | Status |
+|---|---|---|
+| `*ast.SimpleType` ∈ {`int`,`float`,`bool`,`string`} | 598–612 | live |
+| `*ast.TypeApp{Constructor:"list", len(Args)==1}` | **615** | **live — shipped in Lane A (`a81d66983`)** |
+| `*ast.ListType` | 625 | dead from parsed programs; kept for Go-test constructions |
+| fallthrough `return nil, nil` | 636 | the vacuous-skip source |
+
+**`list[T]` is NOT B1 work.** It already ships and it recurses into `createGeneratorForType`, so
+`list[<anything B1 derives>]` falls out of B1 for free.
+
+### 1.2 There are **THREE** generator call sites, across **TWO** files
+
+The controller's brief names two (`runner.go:281`, `runner.go:415`). A third — **the most important
+one** — lives in a different file:
+
+| # | Call site | Path | Skip text on `nil` |
+|---|---|---|---|
+| 1 | `internal/testing/runner.go:281` | `runProperty` (forall binders) | `no generator for type %v` |
+| 2 | `internal/testing/runner.go:415` | `runRequiresProperty` | `no generator for parameter %s: %v` |
+| 3 | **`internal/testing/contract_domain.go:74`** | **`runEnsuresProperty`** | `no generator for parameter %s: %v` |
+
+`runEnsuresProperty` was moved out of `runner.go` into `contract_domain.go` (194 lines) at some point
+after the design doc was written. **The doc's "Files to Modify" list for Lane B does not mention
+`contract_domain.go` at all**, and every `ensures`-derived property in the corpus flows through it.
+Wiring only `runner.go` would leave the majority of the corpus unfixed.
+
+### 1.3 The value-splice surface — **THREE** `valueToLiteral` call sites, across **TWO** files
+
+| # | Call site | Consumer |
+|---|---|---|
+| 1 | `internal/testing/contract_domain.go:101` | `EnsuresParam.Value = astExprToCore(r.valueToLiteral(v))` |
+| 2 | `internal/testing/runner.go:438` | requires-path `EnsuresParam.Value` |
+| 3 | `internal/testing/runner.go:652` | `bindPropertyValues` (forall path; also reached from `shrinkCounterexample` at `:725`) |
+
+Plus one internal recursive call at `runner.go:693` (list elements).
+
+`valueToLiteral`'s default arm is at **`runner.go:696-701`** and silently returns
+`&ast.Literal{Kind: ast.UnitLit, Value: struct{}{}}`. Changing its signature to `(ast.Expr, error)`
+therefore ripples through **`bindPropertyValues`** (whose own signature must change) and its two callers
+`runProperty:315` and `shrinkCounterexample:725`. Budget for this; it is not a one-file edit.
+
+### 1.4 Full 33-file corpus sweep at `22ba8626d` (measured; supersedes V34)
+
+Command per file (bounded, §1.6): `ailang test --format json --no-color <file>`.
+**V34 was a lower bound and understated the corpus**: it never reached `scoring.ail` or `showcase.ail`,
+which together hold **15** vacuous skips and four type names V34 never lists (`SkillLevel`, `Tenure`,
+`Performance`, `Department`).
+
+`vac` = JSON `vacuous_skips`. `B1 fixes` = vacuous skips whose shape B1 derives **and** whose type is
+resolvable same-file.
+
+| File | succ | p/f/s | vac | Vacuous shapes | B1 fixes | After B1 |
+|---|---|---|---|---|---|---|
+| access_control | false | 0/0/4 | 4 | `Role` (ADT, same-file) ×4 | **4** | rc 1→**0** |
+| basic | false | 3/2/3 | 0 | — (3 × out_of_contract) | 0 | rc 1 (2 real fails) |
+| cross_function | false | 0/0/5 | 5 | `Region` ×4, `Priority` ×1 (ADT, same-file) | **5** | rc 1→**0** |
+| cross_module_functions | **true** | 3/0/2 | 0 | — (ooc) | 0 | rc 0 — **must stay 0** |
+| cross_module_functions_lib | **true** | 2/0/1 | 0 | — (ooc) | 0 | rc 0 — **must stay 0** |
+| cross_module_types | false | 2/0/6 | 5 | `Cell` ×3 **(IMPORTED)**, `list[Tree]` ×1 **(IMPORTED)**, `()` ×1 | **1** | rc 1 (4 vacuous remain) |
+| cross_module_types_lib | false | 0/0/0 | 0 | — (no tests) | 0 | rc 1 |
+| ensures_violation_demo | false | 1/1/0 | 0 | — | 0 | rc 1 |
+| finance | false | 0/1/5 | 4 | `TaxBracket` (ADT, same-file) ×4 | **4** | rc 1 (1 real fail) |
+| hof_verify | **true** | 2/0/0 | 0 | — | 0 | rc 0 — **must stay 0** |
+| inbox_injection | false | 3/1/6 | 0 | — (ooc) | 0 | rc 1 |
+| inbox_injection_v2 | false | 1/0/10 | 10 | `string<email>` **(REFINED — B2)** ×10 | **0** | rc 1 — **unchanged** |
+| inbox_v2_app | false | 1/0/10 | 10 | `Mail` **(IMPORTED)** ×9, `string<email>` ×1 | **0** | rc 1 — **unchanged** |
+| inbox_v2_lib | false | 0/0/0 | 0 | — (no tests) | 0 | rc 1 |
+| insurance | false | 0/0/6 | 6 | `AgeBand` ×4, `RiskTier`, `Coverage` (ADT, same-file) | **6** | rc 1→**0** |
+| invoice | false | 4/1/16 | 13 | `CustomerTier` ×5, `TaxRegion` ×3 (ADT), `{subtotal,tax,discount}` ×5 | **13** | rc 1 (1 real fail) |
+| list_recursive_verify | false | 0/0/6 | 0 | — (ooc; see Lane A H1) | 0 | rc 1 |
+| list_verify | false | 5/1/1 | 0 | — (ooc) | 0 | rc 1 (1 deliberate fail) |
+| nested_record_verify | false | 0/0/5 | 5 | `{ name: string, pos: { x: int, y: int } }` **(NESTED anon)** ×5 | **5** | rc 1→**0** |
+| park | false | 1/0/7 | 6 | `Season` (ADT, same-file) ×6 | **6** | rc 1→**0** |
+| per_function_depth_verify | **UNMEASURED** | — | — | exceeds a 60 s bound (rc 137) | ? | report UNMEASURED |
+| quantifier_verify | false | 2/1/4 | 0 | — (4 × ooc) | 0 | rc 1 |
+| record_adt_cycle_verify | false | 0/0/1 | 1 | `Doc` (named record, same-file, **MUTUALLY RECURSIVE**) | **1** | rc 1→**0** or honest fail |
+| record_adt_sort_verify | false | 0/0/1 | 1 | `Proposal` (named record, same-file, recursive-ish) | **1** | rc 1→**0** or honest fail |
+| record_discovery_verify | false | 2/0/8 | 6 | `{x:int,y:int}` ×4, `{a:int,b:int}` ×2 | **6** | rc 1 (2 ooc remain) |
+| record_pattern_verify | false | 0/0/5 | 5 | `{x:int,y:int}` ×5 | **5** | rc 1→**0** |
+| record_verify | false | 0/0/15 | 15 | `{x:int,y:int}` ×15 | **15** | **expect ≥1 GENUINE FAIL** (`brokenDistance`, `:59`) |
+| recursive_verify | false | 0/0/9 | 0 | — (ooc) | 0 | rc 1 |
+| scoring | false | 0/0/6 | 6 | `SkillLevel` ×3, `Tenure`, `Performance`, `Department` (ADT, same-file) | **6** | rc 1→**0** |
+| showcase | false | 5/1/9 | 9 | `{subtotal,tax,discount}` ×5, `Priority` (ADT) ×4 | **9** | rc 1 (1 real fail) |
+| string_verify | false | 4/1/0 | 0 | — | 0 | rc 1 |
+| temperature | **true** | 2/0/2 | 0 | — (ooc) | 0 | rc 0 — **must stay 0** |
+| unencodable_callee_skip | **true** | 1/0/1 | 0 | — (ooc) | 0 | rc 0 — **must stay 0** |
+
+**Totals**: **111** vacuous skips across 32 measured files. **B1 fixes 87. 24 remain and stay honest
+vacuous skips**: `Cell` ×3 + `list[Tree]` ×1 (imported), `Mail` ×9 (imported), `string<email>` ×11
+(refined). Those 24 are B2/out-of-scope by design.
+
+**Files that MUST keep rc 0** (false-red guards): `cross_module_functions`,
+`cross_module_functions_lib`, `hof_verify`, `temperature`, `unencodable_callee_skip`.
+
+### 1.5 Type-declaration shapes B1 must resolve (parser-verified)
+
+Measured against `internal/parser/parser_type_decl.go:79-198`:
+
+| Surface syntax | `TypeDecl.Definition` | Doc covers it? |
+|---|---|---|
+| `type Doc = { title: string, blocks: list[Block] }` | `*ast.RecordType` | yes |
+| `type Season = SPRING \| SUMMER` | `*ast.AlgebraicType` | yes |
+| `type Block = Para(string) \| Container({...})` | `*ast.AlgebraicType` (positional `ConstructorField`, `Name == ""`) | yes |
+| `type Pair = (int, string)` | **`*ast.TypeAlias{Target:*ast.TupleType}`** | **NO — doc omits `TypeAlias` entirely** |
+| `type Names = [string]` | **`*ast.TypeAlias{Target:*ast.TypeApp{"list"}}`** | **NO** |
+| `type UserId = int` | **`*ast.TypeAlias{Target:*ast.SimpleType}`** | **NO** |
+| parameter `()` | `*ast.SimpleType{Name:"()"}` (`parser_type.go:96`, `parser_func.go:72`) | doc says "unit"; **the concrete node is `SimpleType`, not an empty tuple** |
+| parameter `{x: int, y: int}` | `*ast.RecordType` (also implements `ast.Type`) | yes |
+| parameter `string<email>` | `*ast.LabelledType` | out of scope (B2) |
+
+**`*ast.TypeAlias` is a required derivation arm the design doc never lists.** It is one line
+(recurse on `.Target`) but without it every `type UserId = int` parameter stays vacuous. There is **no
+corpus occurrence**, so its acceptance is unit-level only — say so, do not claim a corpus observable.
+
+### 1.6 Bounded-wait recipe that actually works
+
+```bash
+# /tmp/bwait.sh <seconds> <cmd...>
+lim=$1; shift
+"$@" & pid=$!
+( sleep "$lim"; kill -9 "$pid" 2>/dev/null ) & w=$!
+wait "$pid"; rc=$?
+kill "$w" 2>/dev/null; wait "$w" 2>/dev/null
+exit $rc
+```
+Verified this sprint: bounds a Go binary at the limit (rc 137) and does **not** kill a fast one (rc 0).
+`timeout` and `gtimeout` are **not on PATH** on this rig.
+
+### 1.7 Measured pristine-tree baselines for every gate used below
+
+| Gate | Baseline at `22ba8626d` | Usable as a gate? |
+|---|---|---|
+| `go test ./internal/testing/... -count=1` | **rc 0** (`ok … 1.347s`) | **yes — primary** |
+| `go vet ./internal/testing/...` | **rc 0**, no output | yes |
+| `make check-file-sizes` | **rc 0** (`✓ All files within 800 line limit`) | yes |
+| `make lint` | **rc 0** — but prints `1 issues: * unused: 1` | yes, **on exit code only** |
+| `go build ./internal/... ./cmd/ailang/...` | **rc 0** | yes |
+| `go build ./...` | **rc 1** — `cmd/wasm`, `gen/main` have no native `main` | **NO — already red** |
+| `go test ./cmd/ailang/...`, `make test` | socket-binding | **NO — `UNINFORMATIVE UNDER SANDBOX`** |
+| `make verify-examples` | **rc 0** (`186 modules checked, 0 drift, 1 missing-on-disk`; `✅ all examples pass and manifest is in sync`). It invokes `ailang run`, never `ailang test` | yes, but only meaningful in M6 |
+| `ailang test --format json --no-color <corpus file>` | per-file rc/counters in §1.4 | yes, per-file |
+
+---
+
+## 2. Refutations and new findings (read before executing)
+
+### F-1 — REFUTES the doc's Success metric: **B1 does not fix the prompt-injection safety demos**
+
+The doc's headline motivation is that `inbox_injection_v2.ail` and `inbox_v2_app.ail` — "the
+prompt-injection safety demos — their safety properties have never executed" — and its success metric
+says "after Lane B1, the five silent-shape example files above run their skipped properties".
+
+**Measured: B1 fixes ZERO properties in either file.**
+`inbox_injection_v2`'s 10 vacuous skips are all `string<email>` — a **refined type**, explicitly out of
+scope for B1 and parked with B2. `inbox_v2_app`'s are `Mail` ×9 — declared in
+`inbox_v2_lib.ail` and **imported** (`inbox_v2_app.ail:24`), so the same-file derivation bound leaves
+it vacuous — plus one `string<email>`. Verified with `grep -E '^(export )?type Mail' inbox_v2_app.ail`
+→ no match, and `grep '^import' inbox_v2_app.ail` → the lib import.
+
+**Action**: do not write an acceptance criterion that expects those two files to change. §1.4 pins them
+as *unchanged*. The mission-visible claim that B1 makes the injection demos honest is **false**; the
+honest claim is that Lane A already made them *loud* (they exit 1 today) and B2 makes them *run*.
+
+### F-2 — REFUTES B-3 and the "prerequisite fix" for `ADTGenerator`
+
+The doc calls parameterising `ADTGenerator.Generate`'s hardcoded `ModulePath:"test", TypeName:"ADT"` a
+**prerequisite**, "or generated `TaggedValue`s won't match/typecheck in the harness", and makes
+restoring the hardcode B-3's red-turning mutation. Both legs are refuted:
+
+1. **Nothing matches on `TypeName`/`ModulePath`.** `matchPattern`'s `*core.ConstructorPattern` arm
+   (`internal/eval/eval_patterns.go:178-194`) compares **only** `tagged.CtorName != p.Name` and arity.
+   `taggedValuesEqual` (`:410`) compares only `CtorName` + fields. `isTag` — the one function that does
+   compare `TypeName` (`:749`) — has **zero non-test callers** (only `adt_runtime_test.go:140`).
+   `TaggedValue.String()` (`value.go:362`) prints `CtorName(fields…)` and never the type name, so it is
+   not observable in counterexample text either.
+2. **The splice throws the generated `TaggedValue` away.** `valueToLiteral(TaggedValue)` becomes
+   `ast.FuncCall(Identifier(ctor), fields)` → `core.App{Func: core.Var{ctor}}` → the harness env's
+   `ConstructorClosure.Apply` (`eval_operations.go:241`, `value.go:395`) **rebuilds** a fresh
+   `TaggedValue` using the `TypeName` injected by `injectADTConstructors`
+   (`executor_helpers.go:461-501`) — which is the *correct* one. The generator's own tag fields never
+   reach the evaluator.
+3. **There is no typechecking on this path.** `evaluateEnsuresHarnessCore` (`executor.go:144-167`)
+   builds a `core.Program` and calls `EvalCoreProgram` directly. Nothing typechecks the spliced value.
+
+**So B-3's stated mutation kills nothing** — it is an observable *adjacent* to the mechanism. Replaced
+in §4 by **B1-6** (constructor coverage, downstream of the `OneOf` sum) and **B1-7** (nullary-vs-n-ary
+splice, downstream of the arity split), both of which have real downstream writes. Parameterising
+`ADTGenerator` is retained as a **cosmetic/diagnostic** change in M4 with an honest *unit-level*
+criterion, not as a prerequisite.
+
+### F-3 — NEW, load-bearing: `RecordGenerator` is **NONDETERMINISTIC**; wiring it as-is breaks axiom A1
+
+`RecordGenerator.Generate` (`generator_advanced.go:203-212`) iterates `map[string]Generator` with
+`for fieldName, fieldGen := range g.fieldGens` and calls `fieldGen.Generate(rng)` inside the loop.
+**Go randomises map iteration order per range statement** — measured this sprint with a 6-run probe
+over a 4-key map: 3 distinct orders observed. So the *order of RNG draws* varies run to run, and a
+fixed seed no longer reproduces a fixed record.
+
+This directly contradicts the doc's own axiom table ("A1: Determinism | 0 | Derived generators use the
+existing seeded RNG; no new nondeterminism") and defeats the whole `propertySeed` / `SetSeedMetadata`
+replayability machinery — a counterexample would not reproduce from its reported seed.
+
+**Action (M3, mandatory)**: give `RecordGenerator` a deterministic field order (sort the keys once in
+`NewRecordGenerator`, iterate the sorted slice in `Generate`). Constructor signature unchanged, so no
+call-site churn. Acceptance **B1-4** in §4.
+
+### F-4 — NEW, load-bearing: a depth budget alone does **not** bound generation cost
+
+`DefaultConfig().MaxSize == 100` (`generator.go:30`) and the list arm generates lengths `0..MaxSize`.
+The in-repo fixture `record_adt_cycle_verify.ail` is **mutually recursive through a record, an ADT and
+a list**:
+
+```
+export type Block = Para(string) | Container({ blocks: list[Block], kind: string })
+export type Doc   = { title: string, blocks: list[Block] }
+```
+
+At depth 3 with uncapped list lengths, one `Doc` draw has ~50 `Block`s, each `Container` ~50 more →
+~2,500 nodes with strings up to 100 chars, **×100 cases**. This is the *same* critique the quorum
+levelled at B2 (depth bounds recursion, not total work), applied to B1's own structural generation —
+and the doc does not address it.
+
+**Action (M4, mandatory)**: thread a **size budget** alongside the depth budget — cap list/collection
+length as a function of remaining depth (e.g. `maxLen = min(MaxSize, remainingDepth)` for
+derivation-internal lists; top-level `list[scalar]` keeps today's `0..MaxSize` so Lane A behaviour is
+unchanged). Acceptance **B1-9** in §4 asserts a *deterministic size bound on the generated values*, not
+a wall-clock time, so the gate cannot flake.
+
+### F-5 — REFUTES the doc's shrinking bullet: derived shrinkers have **no downstream observable**
+
+`createGeneratorForType` returns `(Generator, Shrinker)`, but **both** contract paths discard the
+shrinker: `contract_domain.go:74` and `runner.go:415` are both `gen, _ := …`. The only consumer is
+`shrinkCounterexample`, reached only from `runProperty` (the **forall** path), which is broken upstream
+(`empty program`, #624 / doc V10, V36) and cannot produce a counterexample at all.
+
+So a `RecordShrinker`/`TupleShrinker` cannot be observed through `ailang test` by any means. The doc's
+own note ("treat quality of shrunk counterexamples as unvalidated") understates it: they are not merely
+unvalidated, they are **unreachable**.
+
+**Action**: M5 is scoped as **unit-observable only** and marked **DROPPABLE** (see §6). No acceptance
+criterion in this sprint may claim a counterexample-quality improvement.
+
+### F-6 — REFUTES the Lane A plan's bounded-wait guidance (and it bit this sprint)
+
+Lane A §0.8 / R-9 tells the executor to bound sweeps with "`gtimeout`/`perl alarm`". Measured with a
+positive control:
+
+| Command | Elapsed | rc |
+|---|---|---|
+| `perl -e 'alarm 3; exec @ARGV' <20s Go binary>` | **20 s** | 0 — **not bounded** |
+| `perl -e 'alarm 3; exec @ARGV' /bin/sleep 20` (control) | 3 s | 142 — bounded |
+
+The Go runtime treats `SIGALRM` as notify-only; with no listener it is ignored. `gtimeout` is not
+installed. This planner's first sweep attempt hung on `per_function_depth_verify.ail` because of it.
+**Use §1.6's recipe.**
+
+### F-7 — `runEnsuresProperty` moved files; the doc's Lane B file list is wrong
+
+See §1.2. `internal/testing/contract_domain.go` is not in the doc's "Files to Modify (Lane B)" list and
+must be. Also: the out-of-contract skip text on the ensures path is now
+`unverified: requires filter accepted N of M generated inputs; need 100 (K discarded)` — a *different*
+string from the requires path's `requires not satisfied by random input …`. Do not assert a single
+out-of-contract substring across both paths.
+
+### F-8 — V34 is confirmed a lower bound; two whole files were missing
+
+`scoring.ail` (6 vacuous: `SkillLevel`, `Tenure`, `Performance`, `Department`) and `showcase.ail`
+(9 vacuous: `{subtotal,tax,discount}`, `Priority`) appear in neither V34 nor the doc's blast-radius
+paragraph. §1.4 is the complete 32-of-33 measurement (`per_function_depth_verify` exceeds a 60 s bound
+and is reported UNMEASURED, not pass/fail).
+
+---
+
+## 3. Milestones
+
+Each milestone is **independently committable and bisectable**, has its **own runnable test package
+boundary**, and states its exact file set. **Every** milestone additionally requires
+`make check-file-sizes` rc 0, `go vet ./internal/testing/...` rc 0, `make lint` rc 0, `gofmt` clean on
+touched files, and `go test ./internal/testing/... -count=1` rc 0.
+
+**Ordering is non-negotiable across M1 → M2**: `valueToLiteral` gains its arms **before** the default
+becomes a loud error. Reversing it fails the harness for every unit-typed generated value (quorum
+round 2, `gemini-3-1-pro`).
+
+---
+
+### M1 — Splice arms (`UnitValue` / `RecordValue` / `TupleValue` / `TaggedValue`), default still silent
+
+**This is the first half of the mandated ordering.** No behaviour change is observable at the CLI: no
+generator yet produces these value kinds, so the arms are exercised only by unit tests. That is the
+point — M1 is provably inert, so a bisect that lands here is exonerated.
+
+**Change**
+1. **Move** `valueToLiteral` (currently `runner.go:666-703`) into a new file
+   `internal/testing/value_splice.go`, unchanged. This buys ~38 lines of headroom in `runner.go`
+   (749 → ~711) before M2/M3 add anything. Keep the receiver `(r *Runner)`.
+2. Add four arms, **in this order before the default**:
+   - `*eval.UnitValue` → `&ast.Literal{Kind: ast.UnitLit, Value: struct{}{}}`
+   - `*eval.RecordValue` → `&ast.Record{Fields: []*ast.Field{...}}` — **iterate field names in sorted
+     order** so the produced AST is deterministic (`RecordValue.Fields` is a map).
+   - `*eval.TupleValue` → `&ast.Tuple{Elements: [...]}`
+   - `*eval.TaggedValue` → **arity-split**: `len(Fields) == 0` ⇒ bare
+     `&ast.Identifier{Name: v.CtorName}`; otherwise
+     `&ast.FuncCall{Func: &ast.Identifier{Name: v.CtorName}, Args: [...]}`.
+     The split is load-bearing: `injectADTConstructors` binds nullary constructors to a
+     **`*eval.TaggedValue`**, not a closure (`executor_helpers.go:483-489`), so emitting `FuncCall` for
+     a nullary constructor produces `core.App` over a non-function and dies with
+     `cannot apply non-function value: *eval.TaggedValue` (`eval_operations.go:245`).
+3. Default arm **unchanged** (still silently returns unit). Add a `TODO(M2)` comment naming this plan.
+
+**Files**
+- NEW `internal/testing/value_splice.go`
+- MOD `internal/testing/runner.go` (remove `valueToLiteral`; no other change)
+- NEW `internal/testing/value_splice_test.go`
+
+**Gate M1**
+```bash
+go test ./internal/testing/... -count=1     # base rc 0 → must stay rc 0
+go vet ./internal/testing/... && make check-file-sizes && make lint
+go build ./internal/... ./cmd/ailang/...    # base rc 0
+# INERTNESS PROOF (behaviour must be byte-identical to base):
+#   re-run the §1.4 sweep over the 32 measurable files and diff succ/p/f/s/vac against §1.4
+```
+
+**Est.**: 90 impl / 140 test LOC · 0.25 d
+
+---
+
+### M2 — Loud default (the refusal), signature `(ast.Expr, error)`, error → property **Fail**
+
+**This is the second half of the mandated ordering — it may not land before M1.**
+
+**Change**
+1. `valueToLiteral` returns `(ast.Expr, error)`. Default arm returns
+   `nil, fmt.Errorf("no literal splice for generated value of type %T (%s)", value, value.Type())`.
+2. Thread the error through **all four** internal/external call sites named in §1.3:
+   - `contract_domain.go:101` (ensures) → on error set `Status: StatusFail`, `Error:` the message,
+     `Duration`, and return. **Never `StatusSkip`** — a skip here would re-open the vacuous hole.
+   - `runner.go:438` (requires) → same.
+   - `bindPropertyValues` (`runner.go:643`) gains `(ast.Expr, error)`; `runProperty:315` → `StatusFail`.
+   - `shrinkCounterexample:725` → a splice error means "this shrink candidate is unusable"; `continue`,
+     exactly as the existing `EvaluateExpression` error branch already does. Best-effort by design;
+     it must **not** panic and must **not** change the reported verdict.
+   - internal recursion `runner.go:693` (list elements) propagates.
+
+**Refusal branches and their required neutering mutations** (a guard is not a gate until something reds
+when you remove it — write each as `if false && <cond>` so the mutant still compiles):
+
+| # | Refusal branch | Neutering mutation | What must red |
+|---|---|---|---|
+| N-1 | `valueToLiteral` default returns an error | `default: if false && true { return nil, fmt.Errorf(...) }; return &ast.Literal{Kind: ast.UnitLit}, nil` | unit test asserting an unknown `eval.Value` (e.g. `&eval.FuncValue{}`) yields a non-nil error |
+| N-2 | ensures site converts the error to `StatusFail` | `if false && err != nil { …fail… }` at `contract_domain.go` | ensures-path test asserting `Status == StatusFail` + message; with the mutant, `astExprToCore(nil)` panics ⇒ still red (do **not** "fix" that panic) |
+| N-3 | requires site converts the error to `StatusFail` | `if false && err != nil { … }` at `runner.go:438` | requires-path test asserting `StatusFail` |
+| N-4 | forall/`bindPropertyValues` site converts the error to `StatusFail` | `if false && err != nil { … }` at `runner.go:315` | forall-path unit test asserting `StatusFail` |
+| N-5 | shrink site skips an unusable candidate instead of crashing | `if false && err != nil { continue }` | shrink test with one unspliceable candidate: must still return a minimal value, not panic |
+
+Each neutering mutation must be **applied, observed red, and reverted** by the executor, and the
+observation recorded in the milestone report (one line per branch). Five branches, five mutations.
+
+**Files**
+- MOD `internal/testing/value_splice.go`
+- MOD `internal/testing/runner.go`
+- MOD `internal/testing/contract_domain.go`
+- MOD `internal/testing/value_splice_test.go`
+- NEW `internal/testing/value_splice_refusal_test.go`
+
+**Gate M2**: all §3 common gates, plus B1-1, B1-2, B1-3 (§4), plus the five recorded neutering
+observations, plus the §1.4 inertness re-sweep (still no generator produces these shapes, so the corpus
+must remain byte-identical).
+
+**Est.**: 60 impl / 130 test LOC · 0.25 d
+
+> ### ⚠ CONTROLLER CORRECTION — M2 AS WRITTEN IS NOT EXECUTABLE (V1 mission iteration 168, 2026-08-10)
+>
+> **N-2 … N-5 cannot be observed red, because at M2 the branches they pin are unreachable from any
+> production path.** The four call-site branches only fire when `valueToLiteral` refuses a value, and
+> refusal requires a generated value of a kind M1 did not give an arm to. Measured at `973803c65`:
+> the only generators *reachable* at M2 are the five `createGeneratorForType` returns — `Int`, `Float`,
+> `Bool`, `String`, `List` — all of which yield kinds `valueToLiteral` already splices. (The
+> `generator_advanced.go` combinators are richer, but M2 has no path to them: they are unwired until
+> M3/M4, which is the whole premise of Lane B.) And `Runner` (`runner.go:16`) has **four unexported
+> fields and no seam**: `createGeneratorForType` is a plain method, so a test cannot inject a generator
+> that yields an unspliceable value. The first executor run spent its entire slot deliberating about
+> exactly this and wrote no code; the finding is what the slot bought, and it is a real one.
+>
+> Note this is **not** a "wait until M3" problem. M3/M4 derive generators for records, tuples, unit and
+> ADTs — which are precisely the kinds M1 adds arms for — so the default arm stays unreachable *after*
+> the whole of B1. It is a permanently defensive branch, which by this mission's own standard (rule 3j:
+> a guard is not a gate until something reds when you remove it) is the kind most likely to rot.
+>
+> **Decision: add the seam.** M2 gains an unexported function field on `Runner`, defaulting to
+> `(*Runner).createGeneratorForType`, that the three generator call sites route through
+> (`contract_domain.go:74`, `runner.go:281`, `runner.go:415`). A test then injects a generator returning
+> an unspliceable value (e.g. `&eval.FuncValue{}`) and each of N-2…N-5 becomes observable. This is a
+> small, documented production change whose entire purpose is to make five guards real rather than
+> decorative — the alternative, declaring them unreachable per rule 3j, would ship four error paths
+> nothing protects.
+>
+> **N-1 is unaffected** — the default arm itself is reachable by unit-calling `valueToLiteral` directly,
+> so it needs no seam.
+>
+> Re-estimate M2: **90 impl / 160 test LOC · 0.35 d** (was 60/130 · 0.25 d).
+
+---
+
+### M3 — Structural derivation: records (named + anonymous + nested), tuples, unit, aliases
+
+**Change**
+1. NEW `internal/testing/derive.go`. **Move** `createGeneratorForType` (`runner.go:596-637`) into it
+   verbatim (another ~42 lines out of `runner.go`, → ~669), then extend it:
+   - a `deriveCtx` carrying `depth int` and `sizeBudget int`; `createGeneratorForType(typ)` becomes a
+     thin wrapper calling `deriveType(typ, newDeriveCtx())` so all three call sites in §1.2 are wired
+     by construction, with **no edit** to `contract_domain.go`.
+   - `*ast.SimpleType{Name:"()"}` → `NewConstantGenerator(&eval.UnitValue{})`, `NewNoOpShrinker()`.
+   - `*ast.RecordType` (anonymous, incl. nested) → `NewRecordGenerator` over per-field derived
+     generators; **nil if any field is underivable** (no silent substitution — CLAUDE.md §2).
+   - `*ast.TupleType` → `NewTupleGenerator`.
+   - `*ast.SimpleType{Name: X}` not in the scalar set → look up `*ast.TypeDecl{Name: X}` in
+     `r.executor.sourceFile.Decls`; if found and `Definition` is `*ast.RecordType`, derive it.
+     **If `sourceFile` is nil or no decl matches, return `nil, nil`** — imported types stay honest
+     vacuous skips (Lane A already makes them loud).
+   - **`*ast.TypeAlias` → recurse on `.Target`** (§1.5; the doc omits this).
+   - `*ast.AlgebraicType` and `*ast.TypeApp` over a user type are **M4**.
+   - **Preserve the existing `list` `TypeApp` arm and the `ListType` arm untouched** — the SCOPE UPDATE
+     block in the doc is explicit that B1 must add beside them, never replace them.
+2. MOD `internal/testing/generator_advanced.go` — **F-3 determinism fix**: `NewRecordGenerator` sorts
+   and stores the field names once; `Generate` iterates the sorted slice. Signature unchanged.
+
+**Files**
+- NEW `internal/testing/derive.go`
+- MOD `internal/testing/runner.go` (remove `createGeneratorForType`)
+- MOD `internal/testing/generator_advanced.go` (determinism fix only)
+- NEW `internal/testing/derive_test.go`
+- NEW `internal/testing/generator_determinism_test.go`
+- MOD `internal/testing/generator_advanced_test.go` — **only if** an existing assertion depends on map
+  order; report explicitly if used (pre-authorised exception to §0.8)
+
+**Gate M3**: common gates, plus B1-4, B1-5, B1-8, B1-10, B1-11 (§4), plus the §1.4 corpus sweep showing
+**exactly** the record/tuple/unit rows moving and every `must stay rc 0` file still rc 0.
+
+**Est.**: 170 impl / 230 test LOC · 0.5 d
+
+---
+
+### M4 — ADTs, recursion depth budget, size budget, `TypeApp` substitution
+
+**Change** (all in `derive.go` unless noted)
+1. `*ast.AlgebraicType` → `NewOneOfGenerator` of one `NewADTGenerator(ctor.Name, fieldGens, true)` per
+   constructor. A constructor whose any field is underivable makes the **whole type** underivable
+   (`nil, nil`) — do not silently drop constructors, that would bias the distribution invisibly.
+2. **Depth budget, default 3**, decremented on **every** derivation step (not only ADT arms), so
+   mutual recursion through record→list→ADT→record is bounded. At the bound, restrict ADT choice to
+   **non-recursive constructors** (compute per-constructor recursiveness once per decl, memoised). If
+   no non-recursive constructor exists → `nil, nil` ⇒ honest vacuous skip.
+3. **Size budget (F-4)**: inside a derivation (depth < max), cap generated list length by remaining
+   depth instead of `0..MaxSize`. Top-level `list[<scalar>]` keeps today's `0..MaxSize` so Lane A's
+   measured behaviour on `hof_verify` / `list_verify` / `invoice` is unchanged.
+4. `*ast.TypeApp` over a **user** type with args → substitute args into the decl's `TypeParams` before
+   deriving, bounded by depth. Keep the `list` arm first.
+5. MOD `generator_advanced.go`: parameterise `ADTGenerator` with the real module path + type name
+   (**cosmetic / diagnostic only — F-2**; unit-level criterion, no end-to-end claim).
+
+**Files**
+- MOD `internal/testing/derive.go`
+- MOD `internal/testing/generator_advanced.go`
+- MOD `internal/testing/derive_test.go`
+- NEW `internal/testing/derive_adt_test.go`
+
+**Gate M4**: common gates, plus B1-6, B1-7, B1-9, B1-12, B1-13 (§4), plus the §1.4 sweep showing the
+ADT rows moving and `record_adt_cycle_verify.ail` completing **inside a 60 s bounded wait**.
+
+**Est.**: 140 impl / 200 test LOC · 0.5 d
+
+---
+
+### M5 — Derived shrinkers (**DROPPABLE — unit-observable only**)
+
+Per **F-5** there is no path from a derived shrinker to any `ailang test` output. Implement, unit-test,
+and say so plainly. **If the sprint is behind at the end of M4, drop this milestone** and file it as a
+follow-up; nothing downstream depends on it.
+
+**Change**: `RecordShrinker` (per-field, composing existing field shrinkers) and `TupleShrinker`
+(per-element) in `shrink.go`; return them from the M3/M4 derivation arms; ADTs reuse the existing
+`NewADTShrinker`.
+
+**Files**
+- MOD `internal/testing/shrink.go`
+- MOD `internal/testing/derive.go`
+- NEW `internal/testing/shrink_derived_test.go`
+
+**Gate M5**: common gates + B1-14 (§4). **No criterion may claim improved counterexample quality.**
+
+**Est.**: 90 impl / 110 test LOC · 0.2 d
+
+---
+
+### M6 — Corpus triage, feature example, closeout
+
+**This milestone is triage-dominated: 87 never-executed properties across 15 files start running.**
+Per the doc's Conflict Surface, failures here are the feature working — but they must be triaged
+**inside** this sprint, not left red.
+
+**Change**
+1. **Re-sweep all 33 files** with §1.6's bounded recipe and produce the after-table against §1.4.
+   For **every** newly-`fail` property, classify as one of:
+   - **(a) deliberate** — the example is documented as broken (`record_verify.ail:59 brokenDistance`,
+     header at `:8` says "Expect: 4 verified, 1 violation"). Record and leave failing.
+   - **(b) genuine latent bug in the example's contract** — fix the *example*, not the runner, and say
+     which line.
+   - **(c) a B1 defect** — fix B1 and re-run the affected milestone's gate.
+   No newly-failing property may be left unclassified.
+2. NEW `examples/runnable/contracts/shapes_verify.ail` — the doc's `shapes.ail` (record + ADT + tuple +
+   scalar `ensures`) **plus an `export func main() -> int ! {}`** (every manifest'd contracts example
+   has one; `ailang run` is what `make verify-examples` executes). MOD `examples/manifest.json` with a
+   matching entry (`path`, `status: "working"`, `tags`, `description`). Then `make verify-examples`.
+3. MOD `changelogs/v0.18-current.md` `[Unreleased]`: record/ADT/tuple/unit parameters now get derived
+   generators; **87 previously-never-executed contract properties across 15 in-repo examples now run**;
+   name the files that flip rc 1 → 0; note the 24 skips that remain (imported + refined) and that they
+   are B2.
+4. MOD `design_docs/planned/v0_31_0/m-property-generator-coverage.md`: mark B1 landed; record F-1
+   (the injection demos are **not** fixed by B1 — the doc's success metric is wrong), F-2, F-3, F-4,
+   F-5, F-7; correct the Lane B file list to include `contract_domain.go`.
+5. File follow-ups (**do not implement**): derived shrinkers if M5 dropped; `TypeAlias`-shaped named
+   aliases lack corpus coverage; imported-type resolution (typechecker env) is the fix for the
+   remaining 13 imported-type skips.
+
+**Files**
+- NEW `examples/runnable/contracts/shapes_verify.ail`
+- MOD `examples/manifest.json`
+- MOD `changelogs/v0.18-current.md`
+- MOD `design_docs/planned/v0_31_0/m-property-generator-coverage.md`
+- MOD any `examples/runnable/contracts/*.ail` fixed under classification (b) — **list each one**
+
+**Gate M6**: common gates + `make verify-examples` rc 0 + the complete after-sweep table with every
+newly-failing property classified (a)/(b)/(c).
+
+**Est.**: 40 impl / 60 test LOC (+ ~120 doc lines) · 0.55 d, of which **0.5 d is triage**
+
+---
+
+## 4. Acceptance criteria — each with its measured pristine-tree baseline and a downstream mutation
+
+**Rule applied to every row (controller requirement 4)**: the "observable" column names the *write* the
+assertion reads, and that write is **downstream** of the mechanism, not adjacent to it.
+
+| # | M | Criterion | Baseline at `22ba8626d` | Observable (which write the assertion reads) | Red-turning mutation |
+|---|---|---|---|---|---|
+| **B1-1** | M1 | `valueToLiteral(&eval.RecordValue{...})` → `*ast.Record`; `TupleValue` → `*ast.Tuple`; `UnitValue` → `ast.Literal{UnitLit}`; nullary `TaggedValue` → `*ast.Identifier`; n-ary → `*ast.FuncCall` | today all five return `ast.Literal{UnitLit}` (`runner.go:696-701`) — **measured by reading the default arm**; the sweep shows no corpus path reaches them | the returned AST node type | delete any one arm ⇒ that value falls to the default and the type assertion fails |
+| **B1-2** | M1 | **Round-trip**: for each of the five shapes, `astExprToCore(valueToLiteral(v))` evaluated through a `eval.CoreEvaluator` (with `injectADTConstructors` for the ADT case) is structurally equal to `v` | not reachable today | the **evaluated `eval.Value`** — one full step past the AST, so an AST that is well-formed but semantically wrong still reds | emit `ast.Tuple` for `RecordValue` (compiles, round-trip value differs) |
+| **B1-3** | M2 | Unknown `eval.Value` ⇒ `valueToLiteral` returns a **non-nil error**, and each of the three property paths turns it into `Status == StatusFail` with that message — **never `StatusSkip`** | today: silent `()` splice, property can *pass* on a fabricated unit | `PropertyResult.Status` + `.Error` at each of the three sites | N-1…N-5 (§3 M2), each applied and observed |
+| **B1-4** | M3 | **Determinism**: constructing the derived generator for `{x:int, y:int, s:string}` and drawing once from a fresh `newRNG(42)`, **200 times**, yields 200 byte-identical `RecordValue`s | **REFUTED at base**: map-range order randomised — measured 3 distinct orders in a 6-run probe (§F-3) | the **field→value assignment** in the produced `RecordValue`, which is what changes when draw order changes | revert `NewRecordGenerator` to `for k, g := range g.fieldGens` ⇒ the 200 draws diverge |
+| **B1-5** | M3 | Anonymous record param `{x: int, y: int}` runs **100 cases**: `examples/runnable/contracts/record_pattern_verify.ail` goes 5 vacuous → 0 vacuous, rc 1 → **0** | measured: `succ=false p/f/s = 0/0/5, vac=5`, all `no generator for parameter p: { x: int, y: int }` | the CLI JSON `vacuous_skips` + per-property `tests_run` | restrict derivation to named `TypeDecl`s only (drop the direct `*ast.RecordType` arm) |
+| **B1-6** | M4 | **ADT constructor coverage**: across one property run over a same-file ADT with ≥2 constructors (`park.ail` `Season`, 6 vacuous today), **every** constructor is observed at least once in the generated stream | measured: `park.ail succ=false p/f/s=1/0/7, vac=6`, `no generator for parameter season: Season` ×6 | the multiset of `CtorName`s **actually applied by `ConstructorClosure`/env lookup in the harness**, collected from the derived generator's stream | replace `NewOneOfGenerator(ctors…)` with the first constructor only ⇒ coverage assertion reds. *(This replaces the doc's B-3, whose mutation kills nothing — F-2.)* |
+| **B1-7** | M4 | **Nullary-vs-n-ary splice**: a property over an ADT with **both** a nullary and an n-ary constructor (e.g. `Shade = Light \| Dark(level:int)`) runs 100 cases with no evaluation error | not reachable today | the harness's evaluated result — a nullary `FuncCall` dies with `cannot apply non-function value: *eval.TaggedValue` (`eval_operations.go:245`), so the assertion reads the **evaluator's** verdict | make the `TaggedValue` arm always emit `ast.FuncCall` regardless of arity |
+| **B1-8** | M3 | **Nested** anonymous records derive: `nested_record_verify.ail` (`{ name: string, pos: { x: int, y: int } }`) 5 vacuous → 0, rc 1 → **0** | measured: `succ=false 0/0/5, vac=5` | CLI `vacuous_skips` + `tests_run` | make the record arm derive only scalar fields (return nil for a `*ast.RecordType` field) |
+| **B1-9** | M4 | **Size bound**: for the in-repo mutually-recursive `Doc` (`record_adt_cycle_verify.ail:7-8`), **every** one of 200 derived draws has total node count ≤ a stated constant N, and the file completes under a 60 s bounded wait | measured: `succ=false 0/0/1, vac=1`, `no generator for parameter d: Doc`. `DefaultConfig().MaxSize == 100` measured at `generator.go:30` | the **size of the generated value**, deterministic — not wall clock, so it cannot flake | remove the depth-scaled list cap (restore `0..MaxSize` inside derivation) ⇒ sizes blow past N |
+| **B1-10** | M3 | **Imported types stay honest**: `cross_module_types.ail`'s `Cell` ×3 and `list[Tree]` ×1 remain `no_generator` vacuous skips (rc stays 1), while its `()` param starts running | measured: `succ=false 2/0/6, vac=5` — `Cell`×3, `list[Tree]`×1, `()`×1; `Cell`/`Tree` verified **imported** (`cross_module_types.ail:18`) | CLI `vacuous_skips == 4` (was 5) + the surviving skip texts | make an unresolvable named type fall back to a unit-constant generator |
+| **B1-11** | M3 | **No false reds**: `cross_module_functions`, `cross_module_functions_lib`, `hof_verify`, `temperature`, `unencodable_callee_skip` all still rc **0** with `vacuous_skips == 0` | measured rc 0 for all five (§1.4) | CLI exit code + `vacuous_skips` | make the record arm return a generator for *any* type (so out-of-contract files acquire vacuous labels) |
+| **B1-12** | M4 | **Depth exhaustion is an honest skip, not a hang or a fabrication**: a same-file ADT with **no** non-recursive constructor (`type Endless = Wrap(Endless)`, unit-level fixture) derives to `nil, nil` ⇒ `skip_kind == "no_generator"` | not reachable today | `PropertyResult.SkipKind` written at `contract_domain.go:77` | at the depth bound, return the first constructor anyway ⇒ the derivation recurses past the bound and the test times out / stack-overflows |
+| **B1-13** | M4 | **Lane A behaviour preserved**: `hof_verify` (2 pass ×100), `list_verify` (5 pass + 1 deliberate fail), `invoice`'s 2 `list[int]` properties all keep their exact `tests_run` counts | measured §1.4 | per-property `tests_run` in the CLI JSON | apply the depth-scaled size cap to top-level `list[scalar]` too ⇒ list lengths shrink and counts/behaviour drift |
+| **B1-14** | M5 | `RecordShrinker`/`TupleShrinker` produce field-/element-wise simplifications and never return the input unchanged | no such shrinkers exist (`grep 'func New.*Shrinker' shrink.go` → Int/Float/String/List/ADT/NoOp only) | the returned `[]eval.Value` | delete the per-field loop ⇒ empty shrink set. **Unit-observable only — F-5** |
+| **B1-15** | M6 | `make verify-examples` rc 0 with the new `shapes_verify.ail` in the manifest | **measured rc 0** at base (`186 modules checked, 0 drift`) — an already-green gate, so a red here is a real defect | gate exit code | omit the manifest entry ⇒ `validate_manifest.go --ci` reds |
+| **B1-16** | M6 | Every newly-failing property in the after-sweep is classified (a) deliberate / (b) example bug fixed / (c) B1 defect fixed — **zero unclassified** | 111 vacuous today; 87 start running | the after-sweep table vs §1.4 | leave any newly-failing property unexplained |
+
+---
+
+## 5. Regression fixtures
+
+| # | Fixture | Assertion |
+|---|---|---|
+| 1 | `cross_module_functions_lib.ail` | rc **0**, `vacuous_skips == 0`, its skip stays `out_of_contract` (Lane A's key false-red guard) |
+| 2 | `temperature.ail`, `unencodable_callee_skip.ail`, `cross_module_functions.ail` | rc **0** preserved, `vacuous_skips == 0` |
+| 3 | `hof_verify.ail` | rc **0**, both `list[int]` properties still `tests_run == 100` (Lane A's A-3, unchanged) |
+| 4 | `list_verify.ail` | rc 1 preserved with its **one deliberate** failure; do not "fix" it |
+| 5 | `record_verify.ail` | after B1: 15 properties run; `brokenDistance` (`:59`) **fails honestly** — the file header (`:8`) says "Expect: 4 verified, 1 violation" |
+| 6 | `inbox_injection_v2.ail`, `inbox_v2_app.ail` | **unchanged** — 10 vacuous each. F-1: B1 does not touch refined or imported types |
+| 7 | `per_function_depth_verify.ail` | report **UNMEASURED (exceeds bounded wait)**; never pass/fail. Do not let it block a gate |
+
+---
+
+## 6. Recommended descopes
+
+| Item | Recommendation | Reason |
+|---|---|---|
+| **M5 derived shrinkers** | **Droppable** — cut if behind after M4 | **F-5**: both contract paths discard the shrinker (`gen, _ :=`); the only consumer is the broken forall path (#624). No downstream observable exists at any level above a unit test |
+| **`ADTGenerator` module/type parameterisation** | Keep, but **demote from "prerequisite" to cosmetic** | **F-2**: `TypeName`/`ModulePath` are read by nothing on this path — not `matchPattern`, not `taggedValuesEqual`, not `TaggedValue.String()`, and the splice discards the value entirely |
+| **`shapes_verify.ail` example** | **Keep** (unlike Lane A, which skipped its example) | B1's user-visible payoff *is* "these shapes now get tested"; the doc pre-wrote the module. Cost is one manifest entry + an `export func main` |
+| **Refined types, imported types, `gen<TypeName>`, hint-text branching (B-9)** | **OUT — already deferred with B2** | Quorum 2026-07-29, blocked on the evaluator fuel budget. 24 of the corpus's 111 vacuous skips stay vacuous by design |
+
+---
+
+## 7. Velocity & sizing
+
+| Milestone | impl LOC | test LOC | est. |
+|---|---|---|---|
+| M1 splice arms (default still silent) | 90 | 140 | 0.25 d |
+| M2 loud default + 5 refusal mutations | 60 | 130 | 0.25 d |
+| M3 records / tuples / unit / aliases + determinism fix | 170 | 230 | 0.5 d |
+| M4 ADTs + depth budget + size budget + `TypeApp` | 140 | 200 | 0.5 d |
+| M5 derived shrinkers (**droppable**) | 90 | 110 | 0.2 d |
+| M6 corpus triage + example + closeout | 40 | 60 (+120 docs) | 0.55 d |
+| **Total** | **590** | **870** | **2.25 d** |
+
+**Why 2.25 d and not the doc's 1.5–2 d.** The doc's estimate predates Lane A and omits three items this
+plan measured into existence:
+
+1. **+0.15 d** — the `RecordGenerator` determinism fix (**F-3**) and its non-flaky 200-draw test. Not in
+   the doc; without it the sprint would ship an axiom-A1 violation.
+2. **+0.2 d** — the size budget (**F-4**) and its deterministic size assertion. The doc bounds depth
+   only, and `MaxSize == 100` over a mutually-recursive in-repo type is a real blow-up.
+3. **+0.4 d** — triage. The doc budgeted triage for "the five silent files"; the measured number is
+   **87 newly-executing properties across 15 files**, ~5× Lane A's 16 (which cost Lane A 0.4 d).
+
+Offsetting: `list[T]` is already done (Lane A), and the combinator layer already exists — which is why
+the total is 2.25 d and not 3.
+
+---
+
+## 8. Open questions for the controller
+
+1. **Depth default 3** is the doc's recommendation and this plan adopts it. If `record_adt_cycle_verify`
+   turns out to need depth 4+ to produce interesting `Container` values, the executor should report the
+   trade-off rather than silently raising it.
+2. **F-1 is a mission-visible correction**: the "prompt-injection safety demos have never executed"
+   framing survives into PROGRAM.md-level reporting. B1 does **not** fix them. Whoever writes the
+   release note should say so.

--- a/internal/testing/runner.go
+++ b/internal/testing/runner.go
@@ -663,45 +663,6 @@ func (r *Runner) bindPropertyValues(property *ast.Property, values []eval.Value)
 	return expr
 }
 
-// valueToLiteral converts an eval.Value to an ast.Literal expression.
-func (r *Runner) valueToLiteral(value eval.Value) ast.Expr {
-	switch v := value.(type) {
-	case *eval.IntValue:
-		return &ast.Literal{
-			Kind:  ast.IntLit,
-			Value: v.Value,
-		}
-	case *eval.FloatValue:
-		return &ast.Literal{
-			Kind:  ast.FloatLit,
-			Value: v.Value,
-		}
-	case *eval.BoolValue:
-		return &ast.Literal{
-			Kind:  ast.BoolLit,
-			Value: v.Value,
-		}
-	case *eval.StringValue:
-		return &ast.Literal{
-			Kind:  ast.StringLit,
-			Value: v.Value,
-		}
-	case *eval.ListValue:
-		// Convert list elements
-		elements := make([]ast.Expr, len(v.Elements))
-		for i, elem := range v.Elements {
-			elements[i] = r.valueToLiteral(elem)
-		}
-		return &ast.List{Elements: elements}
-	default:
-		// For unsupported types, return a unit literal
-		return &ast.Literal{
-			Kind:  ast.UnitLit,
-			Value: struct{}{},
-		}
-	}
-}
-
 // shrinkCounterexample finds the minimal counterexample using shrinking.
 func (r *Runner) shrinkCounterexample(property *ast.Property, failingValues []eval.Value, shrinkers []Shrinker) []eval.Value {
 	// Try shrinking each parameter independently

--- a/internal/testing/value_splice.go
+++ b/internal/testing/value_splice.go
@@ -1,0 +1,92 @@
+package testing
+
+import (
+	"sort"
+
+	"github.com/sunholo-data/ailang/internal/ast"
+	"github.com/sunholo-data/ailang/internal/eval"
+)
+
+// valueToLiteral converts an eval.Value to an ast.Expr expression.
+func (r *Runner) valueToLiteral(value eval.Value) ast.Expr {
+	switch v := value.(type) {
+	case *eval.IntValue:
+		return &ast.Literal{
+			Kind:  ast.IntLit,
+			Value: v.Value,
+		}
+	case *eval.FloatValue:
+		return &ast.Literal{
+			Kind:  ast.FloatLit,
+			Value: v.Value,
+		}
+	case *eval.BoolValue:
+		return &ast.Literal{
+			Kind:  ast.BoolLit,
+			Value: v.Value,
+		}
+	case *eval.StringValue:
+		return &ast.Literal{
+			Kind:  ast.StringLit,
+			Value: v.Value,
+		}
+	case *eval.ListValue:
+		// Convert list elements
+		elements := make([]ast.Expr, len(v.Elements))
+		for i, elem := range v.Elements {
+			elements[i] = r.valueToLiteral(elem)
+		}
+		return &ast.List{Elements: elements}
+	case *eval.UnitValue:
+		return &ast.Literal{
+			Kind:  ast.UnitLit,
+			Value: struct{}{},
+		}
+	case *eval.RecordValue:
+		// Iterate field names in sorted order so the produced AST is
+		// deterministic (RecordValue.Fields is a Go map and ranging over it
+		// directly would produce a nondeterministic field order).
+		names := make([]string, 0, len(v.Fields))
+		for name := range v.Fields {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		fields := make([]*ast.Field, 0, len(names))
+		for _, name := range names {
+			fields = append(fields, &ast.Field{
+				Name:  name,
+				Value: r.valueToLiteral(v.Fields[name]),
+			})
+		}
+		return &ast.Record{Fields: fields}
+	case *eval.TupleValue:
+		elements := make([]ast.Expr, len(v.Elements))
+		for i, elem := range v.Elements {
+			elements[i] = r.valueToLiteral(elem)
+		}
+		return &ast.Tuple{Elements: elements}
+	case *eval.TaggedValue:
+		// Arity-split: injectADTConstructors binds nullary constructors to a
+		// *eval.TaggedValue rather than a closure, so emitting a FuncCall over
+		// a nullary constructor would die at runtime with
+		// "cannot apply non-function value: *eval.TaggedValue".
+		if len(v.Fields) == 0 {
+			return &ast.Identifier{Name: v.CtorName}
+		}
+		args := make([]ast.Expr, len(v.Fields))
+		for i, field := range v.Fields {
+			args[i] = r.valueToLiteral(field)
+		}
+		return &ast.FuncCall{
+			Func: &ast.Identifier{Name: v.CtorName},
+			Args: args,
+		}
+	default:
+		// TODO(M2): this silent default becomes a loud error in M2 (see
+		// m-property-generator-coverage-lane-b1-sprint-plan.md §M2)
+		return &ast.Literal{
+			Kind:  ast.UnitLit,
+			Value: struct{}{},
+		}
+	}
+}

--- a/internal/testing/value_splice_test.go
+++ b/internal/testing/value_splice_test.go
@@ -119,7 +119,20 @@ func TestValueToLiteral_TaggedValue_Nary(t *testing.T) {
 		t.Errorf("expected Func to be identifier Para, got %T %v", call.Func, call.Func)
 	}
 	if len(call.Args) != 2 {
-		t.Errorf("expected 2 args, got %d", len(call.Args))
+		t.Fatalf("expected 2 args, got %d", len(call.Args))
+	}
+
+	// Assert the argument VALUES, not just the count. Checking name+arity only
+	// would pass identically if the arm spliced constants instead of recursing
+	// through valueToLiteral — measured: replacing both args with a literal 999
+	// leaves the whole internal/testing suite rc=0 without these two blocks.
+	arg0, ok := call.Args[0].(*ast.Literal)
+	if !ok || arg0.Kind != ast.StringLit || arg0.Value != "hello" {
+		t.Errorf("arg 0: expected string literal %q, got %T %+v", "hello", call.Args[0], call.Args[0])
+	}
+	arg1, ok := call.Args[1].(*ast.Literal)
+	if !ok || arg1.Kind != ast.IntLit || arg1.Value != 3 {
+		t.Errorf("arg 1: expected int literal 3, got %T %+v", call.Args[1], call.Args[1])
 	}
 }
 

--- a/internal/testing/value_splice_test.go
+++ b/internal/testing/value_splice_test.go
@@ -1,0 +1,200 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/ast"
+	"github.com/sunholo-data/ailang/internal/eval"
+)
+
+// newSpliceRunner returns a bare Runner whose valueToLiteral method can be
+// exercised directly.
+func newSpliceRunner() *Runner {
+	return NewRunner("value_splice_test.ail")
+}
+
+// TestValueToLiteral_UnitValue verifies that a UnitValue splices to a UnitLit
+// literal.
+func TestValueToLiteral_UnitValue(t *testing.T) {
+	r := newSpliceRunner()
+	expr := r.valueToLiteral(&eval.UnitValue{})
+
+	lit, ok := expr.(*ast.Literal)
+	if !ok {
+		t.Fatalf("expected *ast.Literal, got %T", expr)
+	}
+	if lit.Kind != ast.UnitLit {
+		t.Errorf("expected UnitLit, got %v", lit.Kind)
+	}
+}
+
+// TestValueToLiteral_RecordValue verifies that a RecordValue splices to an
+// ast.Record with a field per entry and sorted field order.
+func TestValueToLiteral_RecordValue(t *testing.T) {
+	r := newSpliceRunner()
+	expr := r.valueToLiteral(&eval.RecordValue{
+		Fields: map[string]eval.Value{
+			"x": &eval.IntValue{Value: 1},
+			"y": &eval.IntValue{Value: 2},
+		},
+	})
+
+	rec, ok := expr.(*ast.Record)
+	if !ok {
+		t.Fatalf("expected *ast.Record, got %T", expr)
+	}
+	if len(rec.Fields) != 2 {
+		t.Fatalf("expected 2 fields, got %d", len(rec.Fields))
+	}
+	if rec.Fields[0].Name != "x" || rec.Fields[1].Name != "y" {
+		t.Errorf("expected sorted order [x y], got [%s %s]", rec.Fields[0].Name, rec.Fields[1].Name)
+	}
+}
+
+// TestValueToLiteral_TupleValue verifies that a TupleValue splices to an
+// ast.Tuple keeping element order.
+func TestValueToLiteral_TupleValue(t *testing.T) {
+	r := newSpliceRunner()
+	expr := r.valueToLiteral(&eval.TupleValue{
+		Elements: []eval.Value{
+			&eval.IntValue{Value: 7},
+			&eval.BoolValue{Value: true},
+		},
+	})
+
+	tup, ok := expr.(*ast.Tuple)
+	if !ok {
+		t.Fatalf("expected *ast.Tuple, got %T", expr)
+	}
+	if len(tup.Elements) != 2 {
+		t.Fatalf("expected 2 elements, got %d", len(tup.Elements))
+	}
+	first, ok := tup.Elements[0].(*ast.Literal)
+	if !ok || first.Kind != ast.IntLit {
+		t.Errorf("expected first element to be IntLit, got %T", tup.Elements[0])
+	}
+}
+
+// TestValueToLiteral_TaggedValue_Nullary verifies that a nullary TaggedValue
+// splices to a bare *ast.Identifier (a FuncCall over a nullary constructor
+// would die at runtime with "cannot apply non-function value").
+func TestValueToLiteral_TaggedValue_Nullary(t *testing.T) {
+	r := newSpliceRunner()
+	expr := r.valueToLiteral(&eval.TaggedValue{
+		ModulePath: "test",
+		TypeName:   "Season",
+		CtorName:   "SPRING",
+		Fields:     []eval.Value{},
+	})
+
+	ident, ok := expr.(*ast.Identifier)
+	if !ok {
+		t.Fatalf("expected *ast.Identifier for nullary constructor, got %T", expr)
+	}
+	if ident.Name != "SPRING" {
+		t.Errorf("expected identifier name SPRING, got %s", ident.Name)
+	}
+}
+
+// TestValueToLiteral_TaggedValue_Nary verifies that an n-ary TaggedValue
+// splices to an *ast.FuncCall over the constructor identifier.
+func TestValueToLiteral_TaggedValue_Nary(t *testing.T) {
+	r := newSpliceRunner()
+	expr := r.valueToLiteral(&eval.TaggedValue{
+		ModulePath: "test",
+		TypeName:   "Block",
+		CtorName:   "Para",
+		Fields: []eval.Value{
+			&eval.StringValue{Value: "hello"},
+			&eval.IntValue{Value: 3},
+		},
+	})
+
+	call, ok := expr.(*ast.FuncCall)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCall for n-ary constructor, got %T", expr)
+	}
+	fn, ok := call.Func.(*ast.Identifier)
+	if !ok || fn.Name != "Para" {
+		t.Errorf("expected Func to be identifier Para, got %T %v", call.Func, call.Func)
+	}
+	if len(call.Args) != 2 {
+		t.Errorf("expected 2 args, got %d", len(call.Args))
+	}
+}
+
+// TestValueToLiteral_Nested verifies that composite values recurse through
+// valueToLiteral: a record containing a tuple containing a list.
+func TestValueToLiteral_Nested(t *testing.T) {
+	r := newSpliceRunner()
+	expr := r.valueToLiteral(&eval.RecordValue{
+		Fields: map[string]eval.Value{
+			"outer": &eval.TupleValue{
+				Elements: []eval.Value{
+					&eval.ListValue{
+						Elements: []eval.Value{
+							&eval.IntValue{Value: 1},
+							&eval.IntValue{Value: 2},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	rec, ok := expr.(*ast.Record)
+	if !ok {
+		t.Fatalf("expected *ast.Record, got %T", expr)
+	}
+	if len(rec.Fields) != 1 || rec.Fields[0].Name != "outer" {
+		t.Fatalf("unexpected record fields: %+v", rec.Fields)
+	}
+	tup, ok := rec.Fields[0].Value.(*ast.Tuple)
+	if !ok {
+		t.Fatalf("expected outer field value to be *ast.Tuple, got %T", rec.Fields[0].Value)
+	}
+	if len(tup.Elements) != 1 {
+		t.Fatalf("expected 1 tuple element, got %d", len(tup.Elements))
+	}
+	lst, ok := tup.Elements[0].(*ast.List)
+	if !ok {
+		t.Fatalf("expected tuple element to be *ast.List, got %T", tup.Elements[0])
+	}
+	if len(lst.Elements) != 2 {
+		t.Fatalf("expected 2 list elements, got %d", len(lst.Elements))
+	}
+	if lit, ok := lst.Elements[0].(*ast.Literal); !ok || lit.Value != 1 {
+		t.Errorf("expected first list element IntLit 1, got %T %v", lst.Elements[0], lst.Elements[0])
+	}
+}
+
+// TestValueToLiteral_RecordFieldOrderSorted verifies that RecordValue fields
+// are emitted in sorted order regardless of Go map iteration order. It runs
+// many iterations so that a broken unsorted implementation (ranging directly
+// over the map) cannot pass by a map-order fluke.
+func TestValueToLiteral_RecordFieldOrderSorted(t *testing.T) {
+	r := newSpliceRunner()
+	// Chosen so the sorted order differs from typical random map orders.
+	names := []string{"zebra", "apple", "mango", "banana"}
+	want := []string{"apple", "banana", "mango", "zebra"}
+
+	for i := 0; i < 1000; i++ {
+		fields := make(map[string]eval.Value, len(names))
+		for _, n := range names {
+			fields[n] = &eval.IntValue{Value: 1}
+		}
+		expr := r.valueToLiteral(&eval.RecordValue{Fields: fields})
+		rec, ok := expr.(*ast.Record)
+		if !ok {
+			t.Fatalf("expected *ast.Record, got %T", expr)
+		}
+		if len(rec.Fields) != len(want) {
+			t.Fatalf("iteration %d: expected %d fields, got %d", i, len(want), len(rec.Fields))
+		}
+		for j, f := range rec.Fields {
+			if f.Name != want[j] {
+				t.Fatalf("iteration %d: field %d = %q, want %q (order not sorted)", i, j, f.Name, want[j])
+			}
+		}
+	}
+}


### PR DESCRIPTION
V1 mission iteration 168. Milestone **M1** of Lane B1 (`#517`), plus the sprint plan that scopes the rest of the lane.

## What lands

- **`internal/testing/value_splice.go`** (new): `valueToLiteral` moves out of `runner.go` and gains arms for `UnitValue`, `RecordValue`, `TupleValue` and `TaggedValue`. The silent default that turns any unrecognised value into `()` is **deliberately left alone** — it is currently what makes unit values work, so flipping it before the arms exist would fail the harness for every unit-typed generated value. M2 converts it, and only after this lands.
- **M1 is inert by construction**: no generator yet produces these shapes, so no CLI behaviour changes and the new arms are exercised only by unit tests. A bisect landing here is exonerated.
- `runner.go` **749 → 710** lines — also headroom against the 800-line gate that M2/M3 would otherwise have breached.

## Two details that are load-bearing, each pinned by a mutation

| Mutant | Builds | Killed by |
|---|---|---|
| record fields sorted in **reverse** | rc=0 | `TestValueToLiteral_RecordValue` ("expected sorted order [x y], got [y x]"), `..._RecordFieldOrderSorted` |
| `if false && len(v.Fields) == 0` (drop the nullary arity split) | rc=0 | `TestValueToLiteral_TaggedValue_Nullary` |
| tagged n-ary args → constant `999` | rc=0 | `TestValueToLiteral_TaggedValue_Nary` (added in `161c8f511`) |

Inverse arm run for each: with the killer `-skip`ped, the rest of the suite is rc=0 **with the defect present** — so these are the sole killers, not bystanders. Deleting the sort instead of reversing it leaves `sort` unused and the mutant fails to *compile*, a red that proves nothing; every mutant above was re-checked to build rc=0 first.

Sorting matters because `RecordValue.Fields` is a Go map — ranging it directly makes a fixed seed stop reproducing a counterexample. The nullary split matters because `injectADTConstructors` binds nullary constructors to a `*eval.TaggedValue` rather than a closure, so a `FuncCall` over one dies with `cannot apply non-function value`.

## Evaluator

sonnet, **82/100 PASS**, one blocking-caliber finding — **reproduced first-party, and the reproduction narrowed it**. Scoped with `-run`, three arms looked vacuous on value content; at suite level only **one** genuinely was (tagged n-ary args), because `TestValueToLiteral_Nested` already covers record and tuple values. A decorative *row* is not an unprotected *file*. Fixed in `161c8f511`.

Acceptance criterion **B1-2** (round-trip the spliced AST back through the evaluator) is M1-scoped in the plan and remains **unmet** — recorded as owed rather than quietly dropped.

## Plan correction included

The plan commit carries a controller correction: M2's `N-2…N-5` mutations cannot be observed red as written, because those call-site refusal branches are unreachable at M2 and `Runner` has no seam to inject an unspliceable value — and it is not a "wait for M3" problem, since M3/M4 derive exactly the kinds M1 gives arms to. M2 therefore gains a test seam. The evaluator attacked this claim and found it **overstated for one of the four**: `N-5` (`shrinkCounterexample`) takes its values as plain parameters and *is* reachable today with no production change. Recorded; the deferral still stands for the other three.

## Gates (all controller-run, outside the executor)

`go build ./internal/... ./cmd/ailang/...` · `go vet` · `go test ./internal/testing/...` · `check-file-sizes` · `check-boundaries` · `check-changelog` · `check-skills` · `fmt-check` · `test-coverage-gate` · `check-golden-drift` · `test-lowering` · `test-regression-guards` · `verify-no-shim` — all rc=0, list **derived from `ci.yml`** rather than recalled. `go build ./...` is rc=1 on untouched `dev` (`cmd/wasm`, `gen/main`) — pre-existing, not a gate.

Executor `pi:deepseek-v4-flash-0731` (26 turns, $0.021) · evaluator sonnet · controller opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)