### PR TITLE
feat(testing): #517 Lane B1 M2 — the splicer refuses instead of inventing a unit value

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -45,6 +45,33 @@
   local daemon never served `/github/webhook` at all — it is registered only under
   `COORDINATOR_MODE=cloud`, verified by a live `404` on `:8765`.
 
+### Fixed
+
+- **A contract property test could pass on a value the harness had silently
+  invented.** When the generator produced a value kind the splicer had no arm
+  for, `valueToLiteral` quietly substituted `()` and the property was then
+  checked against that fabricated unit — so the run reported a pass for an input
+  it never actually tested. The splicer now **refuses**, returning an error, and
+  all three property paths (`ensures`, `requires`, `forall`) turn a refusal into
+  a `StatusFail` naming the offending Go type. Deliberately **never a skip**: a
+  skip would put the vacuous hole straight back. This is Lane B1 milestone M2 of
+  [#517](https://github.com/sunholo-data/ailang/issues/517), and it is the second
+  half of the mandated ordering — the splice arms from M1 had to exist first,
+  or every unit-typed value would have started failing.
+
+  Making the refusal *observable* needed a small production change, which is
+  worth naming because it is the point rather than a side effect: the four
+  call-site branches were unreachable from any test, since every generator
+  reachable today yields a kind M1 already splices — and they stay unreachable
+  after the rest of Lane B1, so they would have been permanently defensive code
+  nothing protects. `Runner` therefore gains an injectable generator seam, and
+  each branch now has a test that reds when the branch is neutered. One of the
+  five does not: the shrink path's guard is shadowed by the adjacent
+  `EvaluateExpression` error branch, so it is **declared redundant in the code**
+  with the measurement, and the implicit contract it rests on — that evaluating a
+  nil expression errors rather than panics — is pinned by its own test, which
+  reds if that ever changes.
+
 ### Added
 
 - Contract property tests can now splice **unit, record, tuple and constructor**

--- a/design_docs/planned/v0_31_0/m-property-generator-coverage-lane-b1-sprint-plan.md
+++ b/design_docs/planned/v0_31_0/m-property-generator-coverage-lane-b1-sprint-plan.md
@@ -468,11 +468,16 @@ must remain byte-identical).
 > ### ✅ M2 LANDED — completion record (V1 mission iteration 169, 2026-08-10)
 >
 > Executor `pi:openrouter/deepseek/deepseek-v4-flash-0731`, 51 turns, `metered=$0.086`. Delivered on
-> `sprint/iter169-b1-m2`: `value_splice.go` 92→109, `runner.go` 710→754 (800 gate still green),
+> `sprint/iter169-b1-m2`: `value_splice.go` 92→109, `runner.go` 710→**766** (800 gate still green),
 > `contract_domain.go` 194→203, `value_splice_test.go` 213→234, NEW `value_splice_refusal_test.go`
 > and `value_splice_roundtrip_test.go`. The seam landed as an unexported `Runner.genForType` field
 > bound in `NewRunnerWithConfig`, reached through a `genForTypeSeam` accessor that falls back to
-> `createGeneratorForType` for any `Runner` built another way.
+> `createGeneratorForType` for any `Runner` built another way — **that fallback is speculative, not
+> observed-necessary**: the evaluator measured exactly one `&Runner{` literal in the repo (the one
+> inside `NewRunnerWithConfig` itself, which doubled as its grep's known-positive control),
+> panic-mutated the fallback branch, and got a green package plus a clean corpus sweep. It is
+> defensive code for a construction path that does not exist today, and is recorded as such rather
+> than described as load-bearing.
 >
 > **Mutation drill, controller-run, every mutant asserted LANDED (sha256) and BUILDS (`go build`
 > rc=0) before its result was read, and every one restored byte-identical from a `cp` backup.** Each
@@ -500,8 +505,29 @@ must remain byte-identical).
 > mutating `EvaluateExpression` to `panic` on nil BUILDS rc=0 and reds it. If it ever fires, N-5
 > stops being decorative and its neutering mutation starts killing.
 >
+> **EVALUATOR (sonnet) PASS 96/100, zero blocking — and it sharpened the table above.** It attacked
+> all five named claims by running mutations rather than reading code, and both attempted
+> refutations (N-5's redundancy, the new pin's non-vacuity) failed to refute and instead reproduced
+> the controller's measurements independently. Its three non-blocking findings were each reproduced
+> first-party before being acted on, and two of them corrected this record:
+>
+> 1. **`runner.go` is 766, not 754** — corrected above. The figure had been transcribed from the
+>    executor's report rather than measured; the two adjacent counts the evaluator did *not* flag
+>    (109, 203) re-measure correct, so the instrument was sound and this was a single transcription
+>    slip. Rule 3b(v): a value you transcribed is not a measurement.
+> 2. **N-4 is closer to N-5 than "KILLED, sole killer" implies, and deserves the same disclosure.**
+>    Reproduced: with N-4 neutered the property's `Status` is *still* `StatusFail`, because the
+>    adjacent `EvaluateExpression` branch below sets it too. The observable that actually moves is
+>    `.Error`'s **text** — measured `"test 0: evaluation failed: PAR_NO_PREFIX_PARSE at
+>    _test.ail:1:1…"` where the test demands `"no literal splice"`. So the test genuinely reds and is
+>    not vacuous (error text is inside AC B1-3's stated observable), but what the N-4 guard buys is
+>    **diagnostic quality, not the verdict**: without it a splice refusal on the forall path still
+>    fails, just with a parser error naming the wrong cause. Stated here rather than left to be
+>    rediscovered.
+> 3. `genForTypeSeam`'s fallback is dead today — folded into the paragraph above.
+>
 > **AC status**: B1-1 ✅ (M1), **B1-2 ✅ — the debt iteration 168 named as owed is paid here**,
-> B1-3 ✅ with the N-5 caveat above stated in full.
+> B1-3 ✅ with the N-4 and N-5 caveats above stated in full.
 
 ---
 

--- a/design_docs/planned/v0_31_0/m-property-generator-coverage-lane-b1-sprint-plan.md
+++ b/design_docs/planned/v0_31_0/m-property-generator-coverage-lane-b1-sprint-plan.md
@@ -465,6 +465,44 @@ must remain byte-identical).
 >
 > Re-estimate M2: **90 impl / 160 test LOC · 0.35 d** (was 60/130 · 0.25 d).
 
+> ### ✅ M2 LANDED — completion record (V1 mission iteration 169, 2026-08-10)
+>
+> Executor `pi:openrouter/deepseek/deepseek-v4-flash-0731`, 51 turns, `metered=$0.086`. Delivered on
+> `sprint/iter169-b1-m2`: `value_splice.go` 92→109, `runner.go` 710→754 (800 gate still green),
+> `contract_domain.go` 194→203, `value_splice_test.go` 213→234, NEW `value_splice_refusal_test.go`
+> and `value_splice_roundtrip_test.go`. The seam landed as an unexported `Runner.genForType` field
+> bound in `NewRunnerWithConfig`, reached through a `genForTypeSeam` accessor that falls back to
+> `createGeneratorForType` for any `Runner` built another way.
+>
+> **Mutation drill, controller-run, every mutant asserted LANDED (sha256) and BUILDS (`go build`
+> rc=0) before its result was read, and every one restored byte-identical from a `cp` backup.** Each
+> killer was scoped with `-run`, and each was paired with the inverse arm (`-skip` the killer → rest
+> of the package rc=0) so it is the sole killer rather than a bystander.
+>
+> | # | Mutation | Killer | Verdict | Inverse arm |
+> |---|---|---|---|---|
+> | N-1 | `default:` arm neutered to `if false && true`, falls back to a unit literal | `TestRefusal_N1_DirectCall` | **KILLED** | also reds N-2/N-3/N-4 — broader protection, recorded rather than treated as a defect |
+> | N-2 | ensures `if false && err != nil` | `TestRefusal_N2_Ensures` | **KILLED** (panics in `astExprToCore(nil)`, the plan's predicted path — not "fixed") | sole killer |
+> | N-3 | requires `if false && err != nil` | `TestRefusal_N3_Requires` | **KILLED** | sole killer |
+> | N-4 | forall/`bindPropertyValues` `if false && err != nil` | `TestRefusal_N4_Forall` | **KILLED** | sole killer |
+> | N-5 | shrink `if false && err != nil { continue }` | `TestRefusal_N5_Shrink` | **SURVIVED** — see below | — |
+> | B1-2 | `RecordValue` arm emits `ast.Tuple` (plan §4's named mutation for this AC) | `TestB12_RoundTrip` | **KILLED** (`got (1, true), want {x: 1, y: true}` — reads the *evaluated value*, one step past the AST, exactly as the AC row promises) | also reds other arms |
+>
+> **N-5 is DECLARED REDUNDANT rather than quietly shipped** (rule 3j: an unreachable branch is
+> acceptable *when declared in the code and in the AC*; an undeclared one is a guard nobody is
+> protecting). The executor self-reported this before the controller measured it, and its stated
+> reason was checked rather than adopted (rule 3h): on a splice refusal `bindPropertyValues` returns
+> `(nil, err)`, and `EvaluateExpression` builds its program by string-formatting the AST, so a nil
+> expression yields unparseable source and **errors** — the adjacent pre-existing branch then
+> `continue`s for the same effect. The guard is kept, because depending on that is an implicit
+> contract, and the contract is now pinned: `TestShrinkNilExprContract` asserts
+> `EvaluateExpression(nil)` returns an error and does not panic. That pin is itself non-vacuous —
+> mutating `EvaluateExpression` to `panic` on nil BUILDS rc=0 and reds it. If it ever fires, N-5
+> stops being decorative and its neutering mutation starts killing.
+>
+> **AC status**: B1-1 ✅ (M1), **B1-2 ✅ — the debt iteration 168 named as owed is paid here**,
+> B1-3 ✅ with the N-5 caveat above stated in full.
+
 ---
 
 ### M3 — Structural derivation: records (named + anonymous + nested), tuples, unit, aliases

--- a/internal/testing/contract_domain.go
+++ b/internal/testing/contract_domain.go
@@ -71,7 +71,7 @@ func (r *Runner) runEnsuresProperty(propCase PropertyCase) PropertyResult {
 	params := propCase.Function.Params
 	generators := make([]Generator, len(params))
 	for i, p := range params {
-		gen, _ := r.createGeneratorForType(p.Type)
+		gen, _ := r.genForTypeSeam(p.Type)
 		if gen == nil {
 			result.Status = StatusSkip
 			result.SkipKind = SkipKindNoGenerator
@@ -96,9 +96,18 @@ func (r *Runner) runEnsuresProperty(propCase PropertyCase) PropertyResult {
 		for i, gen := range generators {
 			v := gen.Generate(rng)
 			generatedValues[i] = v
+			lit, err := r.valueToLiteral(v)
+			if err != nil {
+				// Loud failure, never a skip: a skip here would re-open the
+				// vacuous hole this milestone exists to close.
+				result.Status = StatusFail
+				result.Error = fmt.Sprintf("test %d: %v", result.GeneratedInputs-1, err)
+				result.Duration = time.Since(start)
+				return result
+			}
 			ensuresParams[i] = EnsuresParam{
 				Name:  params[i].Name,
-				Value: astExprToCore(r.valueToLiteral(v)),
+				Value: astExprToCore(lit),
 			}
 		}
 

--- a/internal/testing/runner.go
+++ b/internal/testing/runner.go
@@ -18,6 +18,13 @@ type Runner struct {
 	executor       *Executor
 	config         TestConfig
 	moduleIdentity string
+
+	// genForType is an injectable generator seam. It exists so tests can
+	// substitute a generator that produces a value kind valueToLiteral
+	// refuses, making the refusal branches at the three call sites observable
+	// (rule 3j: a guard is not a gate until something reds when you remove it).
+	// Defaults to createGeneratorForType and is bound in NewRunnerWithConfig.
+	genForType func(ast.Type) (Generator, Shrinker)
 }
 
 // NewRunner creates a new test runner using the default derived-seed policy.
@@ -44,12 +51,17 @@ func NewRunner(modulePath string) *Runner {
 // pre-resolved module identity. It never fails: callers resolve the identity via
 // ResolveModuleIdentity before calling.
 func NewRunnerWithConfig(modulePath string, cfg TestConfig, moduleIdentity string) *Runner {
-	return &Runner{
+	r := &Runner{
 		modulePath:     modulePath,
 		executor:       NewExecutor(modulePath),
 		config:         cfg,
 		moduleIdentity: moduleIdentity,
 	}
+	// Bind the generator seam to the built-in derivation after the Runner value
+	// exists, so the method value binds to the right receiver. Tests may
+	// override r.genForType afterwards to inject a refusal-producing generator.
+	r.genForType = r.createGeneratorForType
+	return r
 }
 
 // propertySeed derives the deterministic seed for a single property from the
@@ -278,7 +290,7 @@ func (r *Runner) runProperty(propCase PropertyCase) PropertyResult {
 	shrinkers := make([]Shrinker, len(propCase.Property.Binders))
 
 	for i, binder := range propCase.Property.Binders {
-		gen, shrink := r.createGeneratorForType(binder.Type)
+		gen, shrink := r.genForTypeSeam(binder.Type)
 		if gen == nil {
 			result.Status = StatusSkip
 			result.SkipKind = SkipKindNoGenerator
@@ -312,7 +324,14 @@ func (r *Runner) runProperty(propCase PropertyCase) PropertyResult {
 		}
 
 		// Bind generated values to property expression
-		boundExpr := r.bindPropertyValues(propCase.Property, generatedValues)
+		boundExpr, err := r.bindPropertyValues(propCase.Property, generatedValues)
+		if err != nil {
+			result.Status = StatusFail
+			result.Error = fmt.Sprintf("test %d: %v", testNum, err)
+			result.TestsRun = testNum + 1
+			result.Duration = time.Since(start)
+			return result
+		}
 
 		// Evaluate the property expression (should return bool)
 		resultValue, err := r.executor.EvaluateExpression(boundExpr)
@@ -412,7 +431,7 @@ func (r *Runner) runRequiresProperty(propCase PropertyCase) PropertyResult {
 	params := propCase.Function.Params
 	generators := make([]Generator, len(params))
 	for i, p := range params {
-		gen, _ := r.createGeneratorForType(p.Type)
+		gen, _ := r.genForTypeSeam(p.Type)
 		if gen == nil {
 			result.Status = StatusSkip
 			result.SkipKind = SkipKindNoGenerator
@@ -433,9 +452,17 @@ func (r *Runner) runRequiresProperty(propCase PropertyCase) PropertyResult {
 		for i, gen := range generators {
 			v := gen.Generate(rng)
 			generatedValues[i] = v
+			lit, err := r.valueToLiteral(v)
+			if err != nil {
+				result.Status = StatusFail
+				result.Error = fmt.Sprintf("test %d: %v", testNum, err)
+				result.TestsRun = testNum + 1
+				result.Duration = time.Since(start)
+				return result
+			}
 			harnessParams[i] = EnsuresParam{
 				Name:  params[i].Name,
-				Value: astExprToCore(r.valueToLiteral(v)),
+				Value: astExprToCore(lit),
 			}
 		}
 
@@ -592,6 +619,17 @@ func RunTestsFromFile(filePath string, ast *ast.File) (*SuiteResult, error) {
 	return RunTestsFromFileWithConfig(filePath, ast, cfg)
 }
 
+// genForTypeSeam returns the generator and shrinker for typ, routing through the
+// injectable genForType field so tests can substitute a generator that yields a
+// value kind valueToLiteral refuses. It falls back to the built-in
+// createGeneratorForType for any Runner not constructed via NewRunnerWithConfig.
+func (r *Runner) genForTypeSeam(typ ast.Type) (Generator, Shrinker) {
+	if r.genForType != nil {
+		return r.genForType(typ)
+	}
+	return r.createGeneratorForType(typ)
+}
+
 // createGeneratorForType creates a generator and shrinker for the given type.
 func (r *Runner) createGeneratorForType(typ ast.Type) (Generator, Shrinker) {
 	// Check for simple types
@@ -640,7 +678,7 @@ func (r *Runner) createGeneratorForType(typ ast.Type) (Generator, Shrinker) {
 // For: forall(x: int, y: int) => x + y == y + x
 // With values: [5, 10]
 // Returns: let x = 5 in let y = 10 in (x + y == y + x)
-func (r *Runner) bindPropertyValues(property *ast.Property, values []eval.Value) ast.Expr {
+func (r *Runner) bindPropertyValues(property *ast.Property, values []eval.Value) (ast.Expr, error) {
 	expr := property.Expr
 
 	// Bind in reverse order (innermost first)
@@ -648,8 +686,11 @@ func (r *Runner) bindPropertyValues(property *ast.Property, values []eval.Value)
 		binder := property.Binders[i]
 		value := values[i]
 
-		// Convert eval.Value to ast.Expr (literal)
-		valueLit := r.valueToLiteral(value)
+		// Convert eval.Value to ast.Expr (literal); refuse unspliceable values.
+		valueLit, err := r.valueToLiteral(value)
+		if err != nil {
+			return nil, err
+		}
 
 		// Wrap in let binding
 		expr = &ast.Let{
@@ -660,7 +701,7 @@ func (r *Runner) bindPropertyValues(property *ast.Property, values []eval.Value)
 		}
 	}
 
-	return expr
+	return expr, nil
 }
 
 // shrinkCounterexample finds the minimal counterexample using shrinking.
@@ -683,7 +724,22 @@ func (r *Runner) shrinkCounterexample(property *ast.Property, failingValues []ev
 			testValues[i] = shrunk
 
 			// Test if property still fails with shrunk value
-			boundExpr := r.bindPropertyValues(property, testValues)
+			boundExpr, err := r.bindPropertyValues(property, testValues)
+			if err != nil {
+				// Skip unusable shrink candidate (best-effort, must not panic).
+				//
+				// DECLARED REDUNDANT (measured, iteration 169): neutering this
+				// branch to `if false && err != nil` leaves the whole package
+				// green. On a splice refusal bindPropertyValues returns
+				// (nil, err), and EvaluateExpression string-formats the AST, so
+				// a nil expr yields unparseable source and errors — the
+				// adjacent branch below then continues for the same effect.
+				// The branch is kept because relying on that is an implicit
+				// contract; TestShrinkNilExprContract pins it, so if
+				// EvaluateExpression ever panics on nil instead of erroring,
+				// that test reds and this guard becomes load-bearing.
+				continue
+			}
 			result, err := r.executor.EvaluateExpression(boundExpr)
 			if err != nil {
 				continue // Skip if evaluation fails

--- a/internal/testing/value_splice.go
+++ b/internal/testing/value_splice.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/sunholo-data/ailang/internal/ast"
@@ -8,40 +9,49 @@ import (
 )
 
 // valueToLiteral converts an eval.Value to an ast.Expr expression.
-func (r *Runner) valueToLiteral(value eval.Value) ast.Expr {
+//
+// It returns (expr, nil) on success. It refuses — with a non-nil error — any
+// value kind it has no splice arm for (the default arm), so callers can turn a
+// refusal into a loud property failure rather than fabricating a unit literal
+// (see m-property-generator-coverage-lane-b1-sprint-plan.md §M2).
+func (r *Runner) valueToLiteral(value eval.Value) (ast.Expr, error) {
 	switch v := value.(type) {
 	case *eval.IntValue:
 		return &ast.Literal{
 			Kind:  ast.IntLit,
 			Value: v.Value,
-		}
+		}, nil
 	case *eval.FloatValue:
 		return &ast.Literal{
 			Kind:  ast.FloatLit,
 			Value: v.Value,
-		}
+		}, nil
 	case *eval.BoolValue:
 		return &ast.Literal{
 			Kind:  ast.BoolLit,
 			Value: v.Value,
-		}
+		}, nil
 	case *eval.StringValue:
 		return &ast.Literal{
 			Kind:  ast.StringLit,
 			Value: v.Value,
-		}
+		}, nil
 	case *eval.ListValue:
 		// Convert list elements
 		elements := make([]ast.Expr, len(v.Elements))
 		for i, elem := range v.Elements {
-			elements[i] = r.valueToLiteral(elem)
+			lit, err := r.valueToLiteral(elem)
+			if err != nil {
+				return nil, err
+			}
+			elements[i] = lit
 		}
-		return &ast.List{Elements: elements}
+		return &ast.List{Elements: elements}, nil
 	case *eval.UnitValue:
 		return &ast.Literal{
 			Kind:  ast.UnitLit,
 			Value: struct{}{},
-		}
+		}, nil
 	case *eval.RecordValue:
 		// Iterate field names in sorted order so the produced AST is
 		// deterministic (RecordValue.Fields is a Go map and ranging over it
@@ -53,40 +63,47 @@ func (r *Runner) valueToLiteral(value eval.Value) ast.Expr {
 		sort.Strings(names)
 		fields := make([]*ast.Field, 0, len(names))
 		for _, name := range names {
+			lit, err := r.valueToLiteral(v.Fields[name])
+			if err != nil {
+				return nil, err
+			}
 			fields = append(fields, &ast.Field{
 				Name:  name,
-				Value: r.valueToLiteral(v.Fields[name]),
+				Value: lit,
 			})
 		}
-		return &ast.Record{Fields: fields}
+		return &ast.Record{Fields: fields}, nil
 	case *eval.TupleValue:
 		elements := make([]ast.Expr, len(v.Elements))
 		for i, elem := range v.Elements {
-			elements[i] = r.valueToLiteral(elem)
+			lit, err := r.valueToLiteral(elem)
+			if err != nil {
+				return nil, err
+			}
+			elements[i] = lit
 		}
-		return &ast.Tuple{Elements: elements}
+		return &ast.Tuple{Elements: elements}, nil
 	case *eval.TaggedValue:
 		// Arity-split: injectADTConstructors binds nullary constructors to a
 		// *eval.TaggedValue rather than a closure, so emitting a FuncCall over
 		// a nullary constructor would die at runtime with
 		// "cannot apply non-function value: *eval.TaggedValue".
 		if len(v.Fields) == 0 {
-			return &ast.Identifier{Name: v.CtorName}
+			return &ast.Identifier{Name: v.CtorName}, nil
 		}
 		args := make([]ast.Expr, len(v.Fields))
 		for i, field := range v.Fields {
-			args[i] = r.valueToLiteral(field)
+			lit, err := r.valueToLiteral(field)
+			if err != nil {
+				return nil, err
+			}
+			args[i] = lit
 		}
 		return &ast.FuncCall{
 			Func: &ast.Identifier{Name: v.CtorName},
 			Args: args,
-		}
+		}, nil
 	default:
-		// TODO(M2): this silent default becomes a loud error in M2 (see
-		// m-property-generator-coverage-lane-b1-sprint-plan.md §M2)
-		return &ast.Literal{
-			Kind:  ast.UnitLit,
-			Value: struct{}{},
-		}
+		return nil, fmt.Errorf("no literal splice for generated value of type %T (%s)", value, value.Type())
 	}
 }

--- a/internal/testing/value_splice_refusal_test.go
+++ b/internal/testing/value_splice_refusal_test.go
@@ -1,0 +1,203 @@
+package testing
+
+import (
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/ast"
+	"github.com/sunholo-data/ailang/internal/eval"
+	"github.com/sunholo-data/ailang/internal/lexer"
+	"github.com/sunholo-data/ailang/internal/parser"
+)
+
+// unspliceableFuncValue returns a value kind valueToLiteral has no splice arm
+// for (a *eval.FunctionValue), so the default refusal branch fires.
+func unspliceableFuncValue() eval.Value {
+	return &eval.FunctionValue{}
+}
+
+// funcValueGenerator is a test generator that always yields an unspliceable
+// FunctionValue, driving the refusal branches at all three production call
+// sites via the genForType seam.
+type funcValueGenerator struct{}
+
+func (g *funcValueGenerator) Generate(rng *rand.Rand) eval.Value { return unspliceableFuncValue() }
+
+// funcValueShrinker yields an unspliceable FunctionValue as its single shrink
+// candidate, exercising the shrink path's refusal branch (best-effort continue).
+type funcValueShrinker struct{}
+
+func (s *funcValueShrinker) Shrink(val eval.Value) []eval.Value {
+	return []eval.Value{unspliceableFuncValue()}
+}
+
+// refusalRunnerFromSource parses src into a Runner with the genForType seam set
+// to gen, plus the collected TestSuite, so each property path reaches the
+// refusal branch with an injected refusal-producing generator.
+func refusalRunnerFromSource(t *testing.T, src string, gen func(ast.Type) (Generator, Shrinker)) (*Runner, *TestSuite) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "refusal.ail")
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	l := lexer.New(src, path)
+	p := parser.New(l)
+	file := p.ParseFile()
+	if errs := p.Errors(); len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	suite := NewCollector(path).Collect(file)
+	runner := NewRunner(path)
+	runner.executor.SetSourceFile(file)
+	runner.genForType = gen
+	return runner, suite
+}
+
+// TestRefusal_N1_DirectCall pumps an unspliceable value straight into
+// valueToLiteral and asserts a non-nil error that names the Go type. This is
+// the default refusal arm itself; it needs no seam.
+func TestRefusal_N1_DirectCall(t *testing.T) {
+	r := newSpliceRunner()
+	_, err := r.valueToLiteral(unspliceableFuncValue())
+	if err == nil {
+		t.Fatal("expected non-nil error for unspliceable value, got nil")
+	}
+	if !strings.Contains(err.Error(), "no literal splice") {
+		t.Errorf("error = %q, want it to contain \"no literal splice\"", err.Error())
+	}
+	if !strings.Contains(err.Error(), "*eval.FunctionValue") {
+		t.Errorf("error = %q, want it to name the Go type *eval.FunctionValue", err.Error())
+	}
+}
+
+// TestRefusal_N2_Ensures drives the ensures path with an injected generator
+// that yields an unspliceable value and asserts the splice refusal surfaces as
+// StatusFail (never StatusSkip — a skip would re-open the vacuous hole).
+func TestRefusal_N2_Ensures(t *testing.T) {
+	src := `module refusal_ensures
+export pure func f(x: int) -> int
+  ensures { result == x }
+{ x }
+export func main() -> int ! {} { 0 }
+`
+	runner, suite := refusalRunnerFromSource(t, src, func(typ ast.Type) (Generator, Shrinker) {
+		return &funcValueGenerator{}, NewNoOpShrinker()
+	})
+	result := runner.RunSuite(suite)
+	if len(result.Properties) == 0 {
+		t.Fatalf("expected at least one property result, got 0")
+	}
+	pr := result.Properties[0]
+	if pr.Status != StatusFail {
+		t.Fatalf("ensures refusal: expected StatusFail, got %v (error: %s)", pr.Status, pr.Error)
+	}
+	if !strings.Contains(pr.Error, "no literal splice") {
+		t.Errorf("ensures refusal error = %q, want it to contain \"no literal splice\"", pr.Error)
+	}
+}
+
+// TestRefusal_N3_Requires drives the requires path with an injected generator
+// that yields an unspliceable value and asserts StatusFail.
+func TestRefusal_N3_Requires(t *testing.T) {
+	src := `module refusal_requires
+export pure func f(x: int) -> int
+  requires { x == x }
+{ x }
+export func main() -> int ! {} { 0 }
+`
+	runner, suite := refusalRunnerFromSource(t, src, func(typ ast.Type) (Generator, Shrinker) {
+		return &funcValueGenerator{}, NewNoOpShrinker()
+	})
+	result := runner.RunSuite(suite)
+	if len(result.Properties) == 0 {
+		t.Fatalf("expected at least one property result, got 0")
+	}
+	pr := result.Properties[0]
+	if pr.Status != StatusFail {
+		t.Fatalf("requires refusal: expected StatusFail, got %v (error: %s)", pr.Status, pr.Error)
+	}
+	if !strings.Contains(pr.Error, "no literal splice") {
+		t.Errorf("requires refusal error = %q, want it to contain \"no literal splice\"", pr.Error)
+	}
+}
+
+// TestRefusal_N4_Forall drives the forall path (runProperty → bindPropertyValues)
+// with an injected generator that yields an unspliceable value and asserts
+// StatusFail. The refusal happens inside bindPropertyValues, before the legacy
+// EvaluateExpression path is touched.
+func TestRefusal_N4_Forall(t *testing.T) {
+	r := newSpliceRunner()
+	r.genForType = func(typ ast.Type) (Generator, Shrinker) {
+		return &funcValueGenerator{}, NewNoOpShrinker()
+	}
+	prop := &ast.Property{
+		Name: "forallRefusal",
+		Kind: ast.PropertyKind, // any non-ensures/requires kind dispatches to the forall path
+		Binders: []*ast.Binder{
+			{Name: "x", Type: &ast.SimpleType{Name: "int"}},
+		},
+		Expr: &ast.Literal{Kind: ast.BoolLit, Value: true},
+	}
+	pc := PropertyCase{Name: "forallRefusal", Property: prop}
+	result := r.runProperty(pc)
+	if result.Status != StatusFail {
+		t.Fatalf("forall refusal: expected StatusFail, got %v (error: %s)", result.Status, result.Error)
+	}
+	if !strings.Contains(result.Error, "no literal splice") {
+		t.Errorf("forall refusal error = %q, want it to contain \"no literal splice\"", result.Error)
+	}
+}
+
+// TestRefusal_N5_Shrink drives shrinkCounterexample directly with a shrinker
+// that yields an unspliceable candidate. The splice refusal must be skipped
+// (best-effort continue): the function returns a minimal slice and does not
+// panic, and it must not change the reported verdict.
+func TestRefusal_N5_Shrink(t *testing.T) {
+	r := newSpliceRunner()
+	prop := &ast.Property{
+		Name:    "shrinkRefusal",
+		Kind:    ast.PropertyKind,
+		Binders: []*ast.Binder{{Name: "x", Type: &ast.SimpleType{Name: "int"}}},
+		Expr:    &ast.Literal{Kind: ast.BoolLit, Value: true},
+	}
+	failing := []eval.Value{&eval.IntValue{Value: 42}}
+	// funcValueShrinker yields an unspliceable FunctionValue, so bindPropertyValues
+	// refuses it; shrinkCounterexample must continue and keep the original value.
+	minimal := r.shrinkCounterexample(prop, failing, []Shrinker{&funcValueShrinker{}})
+	if len(minimal) != 1 {
+		t.Fatalf("expected minimal slice of length 1, got %d", len(minimal))
+	}
+	if iv, ok := minimal[0].(*eval.IntValue); !ok || iv.Value != 42 {
+		t.Errorf("expected minimal value to be the original int 42, got %T %v", minimal[0], minimal[0])
+	}
+}
+
+// TestShrinkNilExprContract pins the implicit contract that makes the N-5 guard
+// in shrinkCounterexample redundant rather than load-bearing.
+//
+// Measured at iteration 169: neutering that guard to `if false && err != nil`
+// leaves the entire internal/testing package green, because a splice refusal
+// makes bindPropertyValues return (nil, err) and EvaluateExpression then errors
+// on the nil expression — the adjacent error branch continues for the same
+// effect. That redundancy is only true while EvaluateExpression ERRORS on nil
+// instead of panicking, which is an accident of its string-formatting
+// implementation, not a stated contract. This test states it. If it ever reds,
+// the N-5 guard has become the thing standing between a shrink attempt and a
+// panic, and its neutering mutation will start killing.
+func TestShrinkNilExprContract(t *testing.T) {
+	r := newSpliceRunner()
+	defer func() {
+		if p := recover(); p != nil {
+			t.Fatalf("EvaluateExpression(nil) panicked (%v); the N-5 guard in "+
+				"shrinkCounterexample is now load-bearing — re-run its neutering "+
+				"mutation and update the DECLARED REDUNDANT note in runner.go", p)
+		}
+	}()
+	if _, err := r.executor.EvaluateExpression(nil); err == nil {
+		t.Fatal("EvaluateExpression(nil) returned a nil error; the N-5 guard's " +
+			"redundancy rests on this erroring — see runner.go's DECLARED REDUNDANT note")
+	}
+}

--- a/internal/testing/value_splice_roundtrip_test.go
+++ b/internal/testing/value_splice_roundtrip_test.go
@@ -1,0 +1,100 @@
+package testing
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/eval"
+	"github.com/sunholo-data/ailang/internal/lexer"
+	"github.com/sunholo-data/ailang/internal/parser"
+)
+
+// newRoundTripEvaluator parses an ADT-bearing source so the tagged round-trip
+// values can resolve their constructors in the evaluator env (injectADTConstructors).
+func newRoundTripEvaluator(t *testing.T) (*eval.CoreEvaluator, *Runner) {
+	t.Helper()
+	const src = `module roundtrip
+type Season = SPRING | SUMMER
+type Block = Para(string) | Container({ blocks: list[string] })
+export func main() -> int ! {} { 0 }
+`
+	path := filepath.Join(t.TempDir(), "roundtrip.ail")
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	l := lexer.New(src, path)
+	p := parser.New(l)
+	file := p.ParseFile()
+	if errs := p.Errors(); len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	runner := NewRunner(path)
+	runner.executor.SetSourceFile(file)
+	evaluator := eval.NewCoreEvaluator()
+	runner.executor.injectADTConstructors(evaluator)
+	return evaluator, runner
+}
+
+// assertRoundTrip splices v to an AST, converts to Core, evaluates it, and
+// asserts the resulting eval.Value is structurally equal to v.
+func assertRoundTrip(t *testing.T, r *Runner, evaluator *eval.CoreEvaluator, v eval.Value) {
+	t.Helper()
+	lit, err := r.valueToLiteral(v)
+	if err != nil {
+		t.Fatalf("valueToLiteral(%T): %v", v, err)
+	}
+	result, err := evaluator.Eval(astExprToCore(lit))
+	if err != nil {
+		t.Fatalf("evaluate spliced %T: %v", v, err)
+	}
+	if !equalValues(result, v) {
+		t.Fatalf("round-trip mismatch: got %v, want %v", result, v)
+	}
+}
+
+// TestB12_RoundTrip (acceptance criterion B1-2): for each of the five splice
+// shapes, astExprToCore(valueToLiteral(v)) evaluated through the evaluator is
+// structurally equal to v. The tagged cases resolve their constructors via
+// injectADTConstructors. This reads one full step past the AST, so an AST that
+// is well-formed but semantically wrong still reds.
+func TestB12_RoundTrip(t *testing.T) {
+	evaluator, r := newRoundTripEvaluator(t)
+
+	// 1. unit
+	assertRoundTrip(t, r, evaluator, &eval.UnitValue{})
+
+	// 2. record (sorted fields survive the map round-trip)
+	assertRoundTrip(t, r, evaluator, &eval.RecordValue{
+		Fields: map[string]eval.Value{
+			"x": &eval.IntValue{Value: 1},
+			"y": &eval.BoolValue{Value: true},
+		},
+	})
+
+	// 3. tuple
+	assertRoundTrip(t, r, evaluator, &eval.TupleValue{
+		Elements: []eval.Value{
+			&eval.StringValue{Value: "hi"},
+			&eval.IntValue{Value: 7},
+		},
+	})
+
+	// 4. nullary tagged → bare identifier
+	assertRoundTrip(t, r, evaluator, &eval.TaggedValue{
+		ModulePath: "test",
+		TypeName:   "Season",
+		CtorName:   "SPRING",
+		Fields:     []eval.Value{},
+	})
+
+	// 5. n-ary tagged → constructor closure re-applied
+	assertRoundTrip(t, r, evaluator, &eval.TaggedValue{
+		ModulePath: "test",
+		TypeName:   "Block",
+		CtorName:   "Para",
+		Fields: []eval.Value{
+			&eval.StringValue{Value: "hello"},
+		},
+	})
+}

--- a/internal/testing/value_splice_test.go
+++ b/internal/testing/value_splice_test.go
@@ -17,7 +17,10 @@ func newSpliceRunner() *Runner {
 // literal.
 func TestValueToLiteral_UnitValue(t *testing.T) {
 	r := newSpliceRunner()
-	expr := r.valueToLiteral(&eval.UnitValue{})
+	expr, err := r.valueToLiteral(&eval.UnitValue{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	lit, ok := expr.(*ast.Literal)
 	if !ok {
@@ -32,12 +35,15 @@ func TestValueToLiteral_UnitValue(t *testing.T) {
 // ast.Record with a field per entry and sorted field order.
 func TestValueToLiteral_RecordValue(t *testing.T) {
 	r := newSpliceRunner()
-	expr := r.valueToLiteral(&eval.RecordValue{
+	expr, err := r.valueToLiteral(&eval.RecordValue{
 		Fields: map[string]eval.Value{
 			"x": &eval.IntValue{Value: 1},
 			"y": &eval.IntValue{Value: 2},
 		},
 	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	rec, ok := expr.(*ast.Record)
 	if !ok {
@@ -55,12 +61,15 @@ func TestValueToLiteral_RecordValue(t *testing.T) {
 // ast.Tuple keeping element order.
 func TestValueToLiteral_TupleValue(t *testing.T) {
 	r := newSpliceRunner()
-	expr := r.valueToLiteral(&eval.TupleValue{
+	expr, err := r.valueToLiteral(&eval.TupleValue{
 		Elements: []eval.Value{
 			&eval.IntValue{Value: 7},
 			&eval.BoolValue{Value: true},
 		},
 	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	tup, ok := expr.(*ast.Tuple)
 	if !ok {
@@ -80,12 +89,15 @@ func TestValueToLiteral_TupleValue(t *testing.T) {
 // would die at runtime with "cannot apply non-function value").
 func TestValueToLiteral_TaggedValue_Nullary(t *testing.T) {
 	r := newSpliceRunner()
-	expr := r.valueToLiteral(&eval.TaggedValue{
+	expr, err := r.valueToLiteral(&eval.TaggedValue{
 		ModulePath: "test",
 		TypeName:   "Season",
 		CtorName:   "SPRING",
 		Fields:     []eval.Value{},
 	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	ident, ok := expr.(*ast.Identifier)
 	if !ok {
@@ -100,7 +112,7 @@ func TestValueToLiteral_TaggedValue_Nullary(t *testing.T) {
 // splices to an *ast.FuncCall over the constructor identifier.
 func TestValueToLiteral_TaggedValue_Nary(t *testing.T) {
 	r := newSpliceRunner()
-	expr := r.valueToLiteral(&eval.TaggedValue{
+	expr, err := r.valueToLiteral(&eval.TaggedValue{
 		ModulePath: "test",
 		TypeName:   "Block",
 		CtorName:   "Para",
@@ -109,6 +121,9 @@ func TestValueToLiteral_TaggedValue_Nary(t *testing.T) {
 			&eval.IntValue{Value: 3},
 		},
 	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	call, ok := expr.(*ast.FuncCall)
 	if !ok {
@@ -140,7 +155,7 @@ func TestValueToLiteral_TaggedValue_Nary(t *testing.T) {
 // valueToLiteral: a record containing a tuple containing a list.
 func TestValueToLiteral_Nested(t *testing.T) {
 	r := newSpliceRunner()
-	expr := r.valueToLiteral(&eval.RecordValue{
+	expr, err := r.valueToLiteral(&eval.RecordValue{
 		Fields: map[string]eval.Value{
 			"outer": &eval.TupleValue{
 				Elements: []eval.Value{
@@ -154,6 +169,9 @@ func TestValueToLiteral_Nested(t *testing.T) {
 			},
 		},
 	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	rec, ok := expr.(*ast.Record)
 	if !ok {
@@ -196,7 +214,10 @@ func TestValueToLiteral_RecordFieldOrderSorted(t *testing.T) {
 		for _, n := range names {
 			fields[n] = &eval.IntValue{Value: 1}
 		}
-		expr := r.valueToLiteral(&eval.RecordValue{Fields: fields})
+		expr, err := r.valueToLiteral(&eval.RecordValue{Fields: fields})
+		if err != nil {
+			t.Fatalf("iteration %d: unexpected error: %v", i, err)
+		}
 		rec, ok := expr.(*ast.Record)
 		if !ok {
 			t.Fatalf("expected *ast.Record, got %T", expr)


### PR DESCRIPTION
Lane B1 milestone **M2** of #517 (V1 mission iteration 169). M1 landed in #637.

## What was wrong

A contract property test could **pass on a value the harness had fabricated**. When a generator produced a value kind `valueToLiteral` had no arm for, it silently substituted `()`, and the property was then checked against that unit — so the run reported a pass for an input it never actually tested.

## What changed

`valueToLiteral` returns `(ast.Expr, error)` and its default arm refuses. All three property paths — `ensures`, `requires`, `forall` — turn a refusal into `StatusFail` naming the offending Go type. **Never a skip**: a skip would put the vacuous hole straight back.

Making the refusal *observable* needed a small production change, which is the point rather than a side effect: the four call-site branches were unreachable from any test, because every generator reachable today yields a kind M1 already splices — and they stay unreachable after the rest of Lane B1. They would have shipped as permanently defensive code nothing protects. `Runner` therefore gains an unexported `genForType` seam, reached through `genForTypeSeam` so any `Runner` not built via `NewRunnerWithConfig` still falls back to the real derivation.

## Mutation drill (controller-run, not banked from the executor's report)

Every mutant asserted **LANDED** (sha256) and **BUILDS** (`go build` rc=0) before its result was read; each killer scoped with `-run`; each paired with the **inverse arm** (`-skip` the killer → rest of the package rc=0) so it is the sole killer rather than a bystander; each restored byte-identical from a `cp` backup.

| # | Mutation | Killer | Verdict |
|---|---|---|---|
| N-1 | default arm neutered | `TestRefusal_N1_DirectCall` | **KILLED** (also reds N-2..N-4) |
| N-2 | ensures `if false && err != nil` | `TestRefusal_N2_Ensures` | **KILLED**, sole killer |
| N-3 | requires `if false && err != nil` | `TestRefusal_N3_Requires` | **KILLED**, sole killer |
| N-4 | forall `if false && err != nil` | `TestRefusal_N4_Forall` | **KILLED**, sole killer |
| N-5 | shrink `continue` neutered | `TestRefusal_N5_Shrink` | **SURVIVED** — declared, below |
| B1-2 | `RecordValue` arm emits `ast.Tuple` | `TestB12_RoundTrip` | **KILLED** — `got (1, true), want {x: 1, y: true}` |

## N-5 is declared redundant, not quietly shipped

The executor **self-reported** this before the controller measured it, and its stated reason was checked rather than adopted: on a refusal `bindPropertyValues` returns `(nil, err)`, and `EvaluateExpression` builds its program by string-formatting the AST, so a nil expression yields unparseable source and **errors** — the adjacent pre-existing branch then `continue`s for the same effect.

The guard stays, because depending on that is an implicit contract, and the contract is now pinned by `TestShrinkNilExprContract`. **That pin is itself non-vacuous**: mutating `EvaluateExpression` to `panic` on nil builds clean (rc=0) and reds it. If it ever fires, N-5 stops being decorative and its neutering mutation starts killing.

## Also

Pays **B1-2**, the round-trip acceptance criterion iteration 168 named as owed: all five shapes are evaluated through the evaluator and compared as *values*, one step past the AST.

Gates green locally: `go build ./internal/... ./cmd/ailang/...`, `go vet`, `go test ./internal/testing/... -count=1`, `make check-file-sizes check-boundaries check-changelog check-skills fmt-check vet check-golden-drift test-coverage-gate`, `gofmt -l` clean. All were rc=0 on the pristine tree first (rule 3e), so a red is ours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)