### PR TITLE
feat(testing): #517 Lane B1 M3 — derive generators for records, tuples, unit, aliases

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -95,6 +95,32 @@
 
 ### Added
 
+- **Property tests now derive generators for records, tuples, unit and type
+  aliases** — Lane B1 milestone M3 of
+  [#517](https://github.com/sunholo-data/ailang/issues/517). A contract property
+  over an anonymous record (`{x: int, y: int}`), a nested record, a tuple, a
+  same-file named record type, or any `type X = ...` alias now runs its 100
+  cases instead of reporting a vacuous `no generator` skip. Derivation lives in
+  the new `internal/testing/derive.go` behind the existing seam, so all three
+  property paths (`forall`, `requires`, `ensures`) pick it up with no call-site
+  edits; every descent is bounded by a depth budget, and anything underivable —
+  an ADT (M4), an imported type, a too-deep nesting — still refuses honestly
+  (`nil` generator, loud skip), never substitutes a fabricated value. Fixes
+  measured on the contracts corpus: `record_pattern_verify` and
+  `nested_record_verify` go 5 vacuous → 0 and rc 1 → 0; only record/tuple/unit
+  rows move, ADT files are untouched.
+
+  Two defects fixed alongside, both found by measurement rather than review:
+  `RecordGenerator.Generate` **ranged a Go map while drawing from the RNG**, so
+  a fixed seed did not reproduce a counterexample (field order is now sorted
+  once at construction — the F-3 determinism fix, pinned by a 200-draw
+  byte-identity test that reds on the map-range revert); and the preserved list
+  arms derived their element with a **fresh root depth budget**, so a record
+  type recursive through a list (`type Tree = { val: int, kids: [Tree] }`) —
+  reachable for the first time now that named types derive — overflowed the
+  stack at derivation time (elements now derive within the descended budget,
+  pinned by a regression test that crashed pre-fix).
+
 - Contract property tests can now splice **unit, record, tuple and constructor**
   values into the generated program, not just scalars and lists
   (`internal/testing/value_splice.go`). This is Lane B1 milestone M1 of

--- a/cmd/ailang/test_json_output_test.go
+++ b/cmd/ailang/test_json_output_test.go
@@ -13,9 +13,12 @@ const jsonOutputTestSource = `module json_output_test
 test "passes" { true }
 `
 
+// The vacuous vehicle must be a type the runner cannot derive a generator
+// for. Records became derivable at Lane B1 M3 (#517), so the vehicle is an
+// ADT — underivable until M4, which will need to swap it again (F-M3-2).
 const mixedVacuousTestSource = `module mixed_vacuous_test
 
-export type Point = { x: int, y: int }
+export type Point = P | Q
 
 export func anchor(x: int) -> int ! {}
 ensures { result == x }
@@ -24,9 +27,9 @@ ensures { result == x }
 }
 
 export func shiftX(p: Point, dx: int) -> int ! {}
-ensures { result == p.x + dx }
+ensures { result == dx }
 {
-  p.x + dx
+  dx
 }
 
 export func headOr(xs: list[int], d: int) -> int ! {}

--- a/internal/testing/derive.go
+++ b/internal/testing/derive.go
@@ -1,0 +1,210 @@
+package testing
+
+import (
+	"github.com/sunholo-data/ailang/internal/ast"
+	"github.com/sunholo-data/ailang/internal/eval"
+)
+
+// maxDeriveDepth is the default recursion depth budget for structural type
+// derivation. The design doc recommends a default of 3 (see
+// m-property-generator-coverage.md, "Recursion bound"). M3 threads the budget
+// through record/tuple/named-type descent so mutually-referential types cannot
+// recurse unboundedly; M4 adds the ADT-aware behaviour at the bound.
+const maxDeriveDepth = 3
+
+// deriveCtx carries the generation budget through structural type derivation.
+//
+// depth is decremented on every derivation step, bounding recursion through
+// mutually-referential types (record → list → named type → record ...). At the
+// bound the derivation fails (nil, nil) — an honest vacuous skip, never a
+// fabricated generator.
+//
+// sizeBudget bounds collection lengths inside a derivation. M3 carries it for
+// M4's derivation-internal list cap (F-4); top-level list[<scalar>] keeps
+// today's 0..MaxSize so Lane A's measured behaviour is unchanged.
+type deriveCtx struct {
+	depth      int
+	sizeBudget int
+}
+
+// newDeriveCtx returns the root derivation context: the max derivation depth
+// and the default generation size budget.
+func newDeriveCtx() deriveCtx {
+	config := DefaultConfig()
+	return deriveCtx{depth: maxDeriveDepth, sizeBudget: config.MaxSize}
+}
+
+// descend returns the context for one derivation step deeper, decrementing the
+// depth budget.
+func (c deriveCtx) descend() deriveCtx {
+	c.depth--
+	return c
+}
+
+// exhausted reports whether the depth budget is spent; callers must then stop
+// deriving and return nil, nil.
+func (c deriveCtx) exhausted() bool {
+	return c.depth <= 0
+}
+
+// createGeneratorForType creates a generator and shrinker for the given type.
+//
+// It is the derivation entry point wired to all three generator call sites —
+// runProperty (forall) and runRequiresProperty in runner.go, runEnsuresProperty
+// in contract_domain.go — through the genForTypeSeam, so no further wiring is
+// needed when new arms are added (M3 wires records/tuples/unit/aliases; M4 adds
+// ADTs and user-type TypeApp substitution).
+//
+// It is a thin wrapper over deriveType with a fresh root context, so every
+// recursive descent is budgeted.
+func (r *Runner) createGeneratorForType(typ ast.Type) (Generator, Shrinker) {
+	return r.deriveType(typ, newDeriveCtx())
+}
+
+// deriveType derives a generator and shrinker for typ within ctx.
+//
+// M3 arms: scalars, unit (), anonymous/nested record types, tuple types, and
+// same-file named type declarations (records and aliases). AlgebraicType (ADTs)
+// and TypeApp over user types are intentionally M4 and fall through to
+// nil, nil until then.
+func (r *Runner) deriveType(typ ast.Type, ctx deriveCtx) (Generator, Shrinker) {
+	if ctx.exhausted() {
+		return nil, nil
+	}
+
+	// Check for simple types
+	if simpleType, ok := typ.(*ast.SimpleType); ok {
+		switch simpleType.Name {
+		case "int":
+			config := DefaultConfig()
+			return NewIntGenerator(config.MinInt, config.MaxInt), NewIntShrinker()
+		case "float":
+			config := DefaultConfig()
+			return NewFloatGenerator(config.MinFloat, config.MaxFloat), NewFloatShrinker()
+		case "bool":
+			return NewBoolGenerator(), NewNoOpShrinker()
+		case "string":
+			config := DefaultConfig()
+			return NewStringGenerator(0, config.MaxSize, ""), NewStringShrinker()
+		case "()":
+			// Unit: zero-arg functions parse to a `_ : ()` parameter
+			// (parser_func.go S-CALL0 convention), and `()` in parameter
+			// position parses to SimpleType{Name:"()"} (§1.5).
+			return NewConstantGenerator(&eval.UnitValue{}), NewNoOpShrinker()
+		}
+		// Named type: same-file TypeDecl lookup. Imported types (no decl, or no
+		// sourceFile) stay honest vacuous skips — Lane A already makes them loud.
+		return r.deriveNamedType(simpleType.Name, ctx)
+	}
+
+	// Anonymous record types, including nested ones
+	// ({ name: string, pos: { x: int, y: int } }).
+	if recordType, ok := typ.(*ast.RecordType); ok {
+		return r.deriveRecordType(recordType, ctx)
+	}
+
+	// Tuple types: (int, string).
+	if tupleType, ok := typ.(*ast.TupleType); ok {
+		elemGens := make([]Generator, 0, len(tupleType.Elements))
+		for _, elem := range tupleType.Elements {
+			elemGen, _ := r.deriveType(elem, ctx.descend())
+			if elemGen == nil {
+				// No silent substitution (CLAUDE.md §2): an underivable element
+				// makes the whole tuple underivable.
+				return nil, nil
+			}
+			elemGens = append(elemGens, elemGen)
+		}
+		return NewTupleGenerator(elemGens), NewNoOpShrinker()
+	}
+
+	// The parser represents both [a] and list[a] as TypeApp.
+	// Element derivation must stay inside this derivation's depth budget
+	// (deriveType, not createGeneratorForType): a fresh root context here lets
+	// a record-type cycle routed through a list reset the budget every pass
+	// and overflow the stack — reachable since M3 made named types derivable.
+	if app, ok := typ.(*ast.TypeApp); ok && app.Constructor == "list" && len(app.Args) == 1 {
+		elemGen, elemShrink := r.deriveType(app.Args[0], ctx.descend())
+		if elemGen == nil {
+			return nil, nil
+		}
+		config := DefaultConfig()
+		return NewListGenerator(elemGen, 0, config.MaxSize), NewListShrinker(elemShrink)
+	}
+
+	// Check for list types [a]
+	if listType, ok := typ.(*ast.ListType); ok {
+		// Create generator for element type (same budget rule as the TypeApp arm).
+		elemGen, elemShrink := r.deriveType(listType.Element, ctx.descend())
+		if elemGen == nil {
+			return nil, nil
+		}
+		config := DefaultConfig()
+		return NewListGenerator(elemGen, 0, config.MaxSize), NewListShrinker(elemShrink)
+	}
+
+	// Unsupported type
+	return nil, nil
+}
+
+// deriveRecordType derives a record generator over per-field derived
+// generators. Any underivable field makes the whole record underivable
+// (nil, nil) — no silent substitution (CLAUDE.md §2).
+func (r *Runner) deriveRecordType(recordType *ast.RecordType, ctx deriveCtx) (Generator, Shrinker) {
+	if ctx.exhausted() {
+		return nil, nil
+	}
+	fieldGens := make(map[string]Generator, len(recordType.Fields))
+	for _, field := range recordType.Fields {
+		fieldGen, _ := r.deriveType(field.Type, ctx.descend())
+		if fieldGen == nil {
+			return nil, nil
+		}
+		fieldGens[field.Name] = fieldGen
+	}
+	return NewRecordGenerator(fieldGens), NewNoOpShrinker()
+}
+
+// deriveNamedType resolves a same-file named type (a SimpleType whose name is
+// not a scalar, e.g. `Point` in `p: Point`) to its TypeDecl and derives from
+// the declaration's definition. A nil executor sourceFile, an unresolvable
+// name, or a definition kind M3 does not derive (AlgebraicType, ...) all
+// return nil, nil — imported types stay honest vacuous skips (loud per Lane A).
+func (r *Runner) deriveNamedType(name string, ctx deriveCtx) (Generator, Shrinker) {
+	if ctx.exhausted() {
+		return nil, nil
+	}
+	if r.executor == nil || r.executor.sourceFile == nil {
+		return nil, nil
+	}
+	for _, node := range r.executor.sourceFile.Decls {
+		decl, ok := node.(*ast.TypeDecl)
+		if !ok || decl.Name != name {
+			continue
+		}
+		return r.deriveTypeDef(decl, ctx)
+	}
+	return nil, nil
+}
+
+// deriveTypeDef derives a generator from a TypeDecl's Definition.
+//
+// M3 handles RecordType definitions and TypeAlias targets — every
+// `type X = ...` alias (record, tuple, list, scalar) recurses on .Target (§1.5:
+// the design doc omits TypeAlias entirely, but without it every alias-typed
+// parameter stays vacuous). AlgebraicType (ADTs) is M4 and stays nil.
+func (r *Runner) deriveTypeDef(decl *ast.TypeDecl, ctx deriveCtx) (Generator, Shrinker) {
+	if ctx.exhausted() {
+		return nil, nil
+	}
+	switch def := decl.Definition.(type) {
+	case *ast.RecordType:
+		return r.deriveRecordType(def, ctx)
+	case *ast.TypeAlias:
+		// Recurse on the alias target.
+		return r.deriveType(def.Target, ctx.descend())
+	default:
+		// AlgebraicType and anything else: M4.
+		return nil, nil
+	}
+}

--- a/internal/testing/derive_cycle_test.go
+++ b/internal/testing/derive_cycle_test.go
@@ -1,0 +1,29 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/ast"
+)
+
+// TestDerive_ListMediatedRecursiveRecordBounded pins the depth budget across
+// the list arms. A record type that references itself through a list
+// (`type Tree = { val: int, kids: [Tree] }`) is only reachable since M3 made
+// named types derivable; if the list arms derive their element with a fresh
+// root context instead of the descended one, every pass through the cycle
+// resets the budget and derivation overflows the stack (measured: goroutine
+// stack exhaustion at iteration-170 review). At the bound the derivation must
+// refuse — an honest vacuous skip, never a crash.
+func TestDerive_ListMediatedRecursiveRecordBounded(t *testing.T) {
+	src := `module derive_cycle
+
+export type Tree = { val: int, kids: [Tree] }
+
+export func main() -> int ! {} { 0 }
+`
+	r := deriveRunnerFromSource(t, src)
+	gen, shrink := r.createGeneratorForType(&ast.SimpleType{Name: "Tree"})
+	if gen != nil || shrink != nil {
+		t.Fatalf("expected nil, nil for list-mediated recursive record, got generator=%T shrinker=%T", gen, shrink)
+	}
+}

--- a/internal/testing/derive_test.go
+++ b/internal/testing/derive_test.go
@@ -1,0 +1,351 @@
+package testing
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/ast"
+	"github.com/sunholo-data/ailang/internal/eval"
+	"github.com/sunholo-data/ailang/internal/lexer"
+	"github.com/sunholo-data/ailang/internal/parser"
+)
+
+// deriveRunnerFromSource parses src into a Runner whose executor holds the
+// source file, so same-file named-type derivation can resolve TypeDecls. The
+// genForType seam stays bound to the built-in createGeneratorForType.
+func deriveRunnerFromSource(t *testing.T, src string) *Runner {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "derive.ail")
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	l := lexer.New(src, path)
+	p := parser.New(l)
+	file := p.ParseFile()
+	if errs := p.Errors(); len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	runner := NewRunner(path)
+	runner.executor.SetSourceFile(file)
+	return runner
+}
+
+// deriveOnce derives typ via the production seam and draws a single value from
+// a seeded RNG, returning the derived generator and the value.
+func deriveOnce(t *testing.T, r *Runner, typ ast.Type) (Generator, eval.Value) {
+	t.Helper()
+	gen, shrink := r.genForTypeSeam(typ)
+	if gen == nil {
+		t.Fatalf("expected generator for %v, got nil", typ)
+	}
+	if shrink == nil {
+		t.Fatalf("expected shrinker for %v, got nil", typ)
+	}
+	rng := newRNG(42)
+	return gen, gen.Generate(rng)
+}
+
+// TestDerive_UnitParamM3KillsOnMissingArm derives `()` — the explicit unit arm
+// added in M3. Without it, `()` in parameter position stays a vacuous skip.
+func TestDerive_UnitParam(t *testing.T) {
+	r := NewRunner("test.ail")
+	gen, shrink := r.createGeneratorForType(&ast.SimpleType{Name: "()"})
+	if gen == nil {
+		t.Fatal("expected generator for (), got nil")
+	}
+	if shrink == nil {
+		t.Fatal("expected shrinker for (), got nil")
+	}
+	rng := newRNG(42)
+	val := gen.Generate(rng)
+	if _, ok := val.(*eval.UnitValue); !ok {
+		t.Fatalf("expected UnitValue, got %T", val)
+	}
+}
+
+// TestDerive_AnonymousRecord derives an anonymous record type — the single most
+// common vacuous shape in the corpus (§1.4: {x:int,y:int} everywhere).
+func TestDerive_AnonymousRecord(t *testing.T) {
+	r := NewRunner("test.ail")
+	_, val := deriveOnce(t, r, &ast.RecordType{
+		Fields: []*ast.RecordField{
+			{Name: "x", Type: &ast.SimpleType{Name: "int"}},
+			{Name: "y", Type: &ast.SimpleType{Name: "int"}},
+		},
+	})
+	rec, ok := val.(*eval.RecordValue)
+	if !ok {
+		t.Fatalf("expected RecordValue, got %T", val)
+	}
+	if len(rec.Fields) != 2 {
+		t.Fatalf("expected 2 fields, got %d", len(rec.Fields))
+	}
+	for _, name := range []string{"x", "y"} {
+		if _, ok := rec.Fields[name].(*eval.IntValue); !ok {
+			t.Errorf("field %q: expected IntValue, got %T", name, rec.Fields[name])
+		}
+	}
+}
+
+// TestDerive_NestedAnonymousRecord derives a nested anonymous record — the
+// B1-8 shape ({ name: string, pos: { x: int, y: int } }).
+func TestDerive_NestedAnonymousRecord(t *testing.T) {
+	r := NewRunner("test.ail")
+	_, val := deriveOnce(t, r, &ast.RecordType{
+		Fields: []*ast.RecordField{
+			{Name: "name", Type: &ast.SimpleType{Name: "string"}},
+			{
+				Name: "pos",
+				Type: &ast.RecordType{
+					Fields: []*ast.RecordField{
+						{Name: "x", Type: &ast.SimpleType{Name: "int"}},
+						{Name: "y", Type: &ast.SimpleType{Name: "int"}},
+					},
+				},
+			},
+		},
+	})
+	rec, ok := val.(*eval.RecordValue)
+	if !ok {
+		t.Fatalf("expected RecordValue, got %T", val)
+	}
+	if _, ok := rec.Fields["name"].(*eval.StringValue); !ok {
+		t.Errorf("name: expected StringValue, got %T", rec.Fields["name"])
+	}
+	pos, ok := rec.Fields["pos"].(*eval.RecordValue)
+	if !ok {
+		t.Fatalf("pos: expected nested RecordValue, got %T", rec.Fields["pos"])
+	}
+	if len(pos.Fields) != 2 {
+		t.Fatalf("pos: expected 2 fields, got %d", len(pos.Fields))
+	}
+	for _, name := range []string{"x", "y"} {
+		if _, ok := pos.Fields[name].(*eval.IntValue); !ok {
+			t.Errorf("pos.%q: expected IntValue, got %T", name, pos.Fields[name])
+		}
+	}
+}
+
+// TestDerive_Tuple derives a tuple type (int, string).
+func TestDerive_Tuple(t *testing.T) {
+	r := NewRunner("test.ail")
+	_, val := deriveOnce(t, r, &ast.TupleType{
+		Elements: []ast.Type{
+			&ast.SimpleType{Name: "int"},
+			&ast.SimpleType{Name: "string"},
+		},
+	})
+	tup, ok := val.(*eval.TupleValue)
+	if !ok {
+		t.Fatalf("expected TupleValue, got %T", val)
+	}
+	if len(tup.Elements) != 2 {
+		t.Fatalf("expected 2 elements, got %d", len(tup.Elements))
+	}
+	if _, ok := tup.Elements[0].(*eval.IntValue); !ok {
+		t.Errorf("element 0: expected IntValue, got %T", tup.Elements[0])
+	}
+	if _, ok := tup.Elements[1].(*eval.StringValue); !ok {
+		t.Errorf("element 1: expected StringValue, got %T", tup.Elements[1])
+	}
+}
+
+// TestDerive_NamedRecordFromSourceFile derives a same-file named record type
+// (`type Point = { x: int, y: int }`) via the TypeDecl lookup.
+func TestDerive_NamedRecordFromSourceFile(t *testing.T) {
+	src := `module derive_named
+
+export type Point = { x: int, y: int }
+
+export func main() -> int ! {} { 0 }
+`
+	r := deriveRunnerFromSource(t, src)
+	_, val := deriveOnce(t, r, &ast.SimpleType{Name: "Point"})
+	rec, ok := val.(*eval.RecordValue)
+	if !ok {
+		t.Fatalf("expected RecordValue, got %T", val)
+	}
+	if len(rec.Fields) != 2 {
+		t.Fatalf("expected 2 fields, got %d", len(rec.Fields))
+	}
+}
+
+// TestDerive_NamedTypeMissing_SourceNil pins B1-10's honest-skip half: a named
+// type with no source file on the executor stays a vacuous skip (nil, nil) —
+// it must never fall back to a fabricated unit generator.
+func TestDerive_NamedTypeMissing_SourceNil(t *testing.T) {
+	r := NewRunner("test.ail") // executor.sourceFile is nil here
+	gen, shrink := r.createGeneratorForType(&ast.SimpleType{Name: "Cell"})
+	if gen != nil || shrink != nil {
+		t.Fatalf("expected nil, nil for unresolvable named type, got generator=%T shrinker=%T", gen, shrink)
+	}
+}
+
+// TestDerive_NamedTypeMissing_NoDecl pins the same honest-skip behaviour when a
+// source file exists but contains no matching TypeDecl (imported types).
+func TestDerive_NamedTypeMissing_NoDecl(t *testing.T) {
+	src := `module derive_missing
+
+export func main() -> int ! {} { 0 }
+`
+	r := deriveRunnerFromSource(t, src)
+	gen, shrink := r.createGeneratorForType(&ast.SimpleType{Name: "Cell"})
+	if gen != nil || shrink != nil {
+		t.Fatalf("expected nil, nil for undeclared named type, got generator=%T shrinker=%T", gen, shrink)
+	}
+}
+
+// TestDerive_TypeAliasToTuple covers §1.5's TypeAlias omission: `type Pair =
+// (int, int)` parses to TypeAlias{Target: TupleType} and must recurse on the
+// target, or every alias-typed parameter stays vacuous.
+func TestDerive_TypeAliasToTuple(t *testing.T) {
+	src := `module derive_alias_tuple
+
+export type Pair = (int, int)
+
+export func main() -> int ! {} { 0 }
+`
+	r := deriveRunnerFromSource(t, src)
+	_, val := deriveOnce(t, r, &ast.SimpleType{Name: "Pair"})
+	tup, ok := val.(*eval.TupleValue)
+	if !ok {
+		t.Fatalf("expected TupleValue via alias target, got %T", val)
+	}
+	if len(tup.Elements) != 2 {
+		t.Fatalf("expected 2 elements, got %d", len(tup.Elements))
+	}
+}
+
+// TestDerive_TypeAliasToScalar covers `type UserId = int` (TypeAlias over a
+// scalar) — without the alias arm, UserId-typed parameters stay vacuous.
+func TestDerive_TypeAliasToScalar(t *testing.T) {
+	src := `module derive_alias_scalar
+
+export type UserId = int
+
+export func main() -> int ! {} { 0 }
+`
+	r := deriveRunnerFromSource(t, src)
+	_, val := deriveOnce(t, r, &ast.SimpleType{Name: "UserId"})
+	if _, ok := val.(*eval.IntValue); !ok {
+		t.Fatalf("expected IntValue via alias target, got %T", val)
+	}
+}
+
+// TestDerive_TypeAliasToList covers `type Names = [string]` (TypeAlias over a
+// list TypeApp) — the alias arm recurses into the preserved Lane A list arm.
+func TestDerive_TypeAliasToList(t *testing.T) {
+	src := `module derive_alias_list
+
+export type Names = [string]
+
+export func main() -> int ! {} { 0 }
+`
+	r := deriveRunnerFromSource(t, src)
+	_, val := deriveOnce(t, r, &ast.SimpleType{Name: "Names"})
+	if _, ok := val.(*eval.ListValue); !ok {
+		t.Fatalf("expected ListValue via alias target, got %T", val)
+	}
+}
+
+// TestDerive_UnderivableFieldKillsWholeRecord pins the nil-on-any-underivable-
+// field rule: an ADT field (M4 territory) makes the entire record underivable
+// rather than silently substituting the other fields.
+func TestDerive_UnderivableFieldKillsWholeRecord(t *testing.T) {
+	src := `module derive_underv
+
+export type Shade = Light | Dark(level: int)
+
+export type Rec = { ok: int, shade: Shade }
+
+export func main() -> int ! {} { 0 }
+`
+	r := deriveRunnerFromSource(t, src)
+	gen, shrink := r.createGeneratorForType(&ast.SimpleType{Name: "Rec"})
+	if gen != nil || shrink != nil {
+		t.Fatalf("expected nil, nil for record with underivable ADT field, got generator=%T shrinker=%T", gen, shrink)
+	}
+}
+
+// TestDerive_ADTIsM4 pins that AlgebraicType definitions do NOT derive in M3 —
+// they stay honest vacuous skips until M4's arm lands.
+func TestDerive_ADTIsM4(t *testing.T) {
+	src := `module derive_adt_m4
+
+export type Shade = Light | Dark(level: int)
+
+export func main() -> int ! {} { 0 }
+`
+	r := deriveRunnerFromSource(t, src)
+	gen, shrink := r.createGeneratorForType(&ast.SimpleType{Name: "Shade"})
+	if gen != nil || shrink != nil {
+		t.Fatalf("expected nil, nil for ADT at M3, got generator=%T shrinker=%T", gen, shrink)
+	}
+}
+
+// TestDerive_ListArmPreserved pins that the Lane A list arm is untouched:
+// list[int] still derives, list[Shade] (ADT element, M4) still fails.
+func TestDerive_ListArmPreserved(t *testing.T) {
+	src := `module derive_list
+
+export type Shade = Light | Dark(level: int)
+
+export func main() -> int ! {} { 0 }
+`
+	r := deriveRunnerFromSource(t, src)
+	gen, _ := r.createGeneratorForType(&ast.TypeApp{
+		Constructor: "list",
+		Args:        []ast.Type{&ast.SimpleType{Name: "int"}},
+	})
+	if gen == nil {
+		t.Fatal("expected list[int] to keep deriving (Lane A arm preserved)")
+	}
+	gen, _ = r.createGeneratorForType(&ast.TypeApp{
+		Constructor: "list",
+		Args:        []ast.Type{&ast.SimpleType{Name: "Shade"}},
+	})
+	if gen != nil {
+		t.Fatal("expected list[Shade] to stay underivable at M3 (ADT element)")
+	}
+}
+
+// TestDerive_RecursiveNamedRecordBounded pins the depth budget: a
+// self-referential named record cannot recurse forever at M3 — it degrades to
+// an honest nil, nil rather than a stack overflow.
+func TestDerive_RecursiveNamedRecordBounded(t *testing.T) {
+	src := `module derive_rec
+
+export type L = { val: int, next: L }
+
+export func main() -> int ! {} { 0 }
+`
+	r := deriveRunnerFromSource(t, src)
+	gen, shrink := r.createGeneratorForType(&ast.SimpleType{Name: "L"})
+	if gen != nil || shrink != nil {
+		t.Fatalf("expected nil, nil for unbounded recursive record at depth budget, got generator=%T shrinker=%T", gen, shrink)
+	}
+}
+
+// TestDerive_UnderivableElemKillsWholeTuple pins the tuple arm's refusal
+// branch: an underivable element (an ADT, which is M4) makes the whole tuple
+// underivable — nil, nil, never a partially-derived tuple. Added at
+// iteration-170 review: neutering this branch (`if false && elemGen == nil`)
+// left the entire package green, so nothing else protects it.
+func TestDerive_UnderivableElemKillsWholeTuple(t *testing.T) {
+	src := `module derive_tuple_refuse
+
+export type Color = Red | Green
+
+export func main() -> int ! {} { 0 }
+`
+	r := deriveRunnerFromSource(t, src)
+	typ := &ast.TupleType{Elements: []ast.Type{
+		&ast.SimpleType{Name: "int"},
+		&ast.SimpleType{Name: "Color"},
+	}}
+	gen, shrink := r.createGeneratorForType(typ)
+	if gen != nil || shrink != nil {
+		t.Fatalf("expected nil, nil for tuple with underivable element, got generator=%T shrinker=%T", gen, shrink)
+	}
+}

--- a/internal/testing/generator_advanced.go
+++ b/internal/testing/generator_advanced.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"math/rand"
+	"sort"
 
 	"github.com/sunholo-data/ailang/internal/eval"
 )
@@ -191,21 +192,33 @@ func (g *ADTGenerator) Generate(rng *rand.Rand) eval.Value {
 // RecordGenerator generates record values (field: value maps).
 type RecordGenerator struct {
 	fieldGens map[string]Generator
+	// fieldOrder holds the field names in sorted order, fixed once at
+	// construction. Generate iterates this slice so the per-field RNG draw
+	// order is deterministic across runs — ranging the Go map directly would
+	// randomise the draw order per Generate call and break seeded replayability
+	// (F-3 in m-property-generator-coverage-lane-b1-sprint-plan.md).
+	fieldOrder []string
 }
 
 // NewRecordGenerator creates a generator for record values.
 func NewRecordGenerator(fieldGens map[string]Generator) *RecordGenerator {
+	fieldOrder := make([]string, 0, len(fieldGens))
+	for name := range fieldGens {
+		fieldOrder = append(fieldOrder, name)
+	}
+	sort.Strings(fieldOrder)
 	return &RecordGenerator{
-		fieldGens: fieldGens,
+		fieldGens:  fieldGens,
+		fieldOrder: fieldOrder,
 	}
 }
 
 // Generate produces a record value.
 func (g *RecordGenerator) Generate(rng *rand.Rand) eval.Value {
-	fields := make(map[string]eval.Value)
+	fields := make(map[string]eval.Value, len(g.fieldOrder))
 
-	for fieldName, fieldGen := range g.fieldGens {
-		fields[fieldName] = fieldGen.Generate(rng)
+	for _, fieldName := range g.fieldOrder {
+		fields[fieldName] = g.fieldGens[fieldName].Generate(rng)
 	}
 
 	return &eval.RecordValue{Fields: fields}

--- a/internal/testing/generator_determinism_test.go
+++ b/internal/testing/generator_determinism_test.go
@@ -1,0 +1,90 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/ast"
+	"github.com/sunholo-data/ailang/internal/eval"
+)
+
+// TestDerivedRecordGenerator_DeterministicDraws is acceptance B1-4: the
+// derived generator for {x:int, y:int, s:string}, drawing once from a fresh
+// newRNG(42), 200 times, yields 200 byte-identical RecordValues.
+//
+// The write the assertion reads is the field→value assignment in the produced
+// RecordValue — exactly what changes when the per-field RNG draw order varies.
+// RecordGenerator used to range over the fieldGens Go map (random order per
+// range statement), so the order of RNG draws varied run-to-run and a fixed
+// seed no longer reproduced a fixed record (F-3). The fix sorts the field
+// names once in NewRecordGenerator and always draws in that order.
+//
+// Canonical serialisation: RecordValue.String() sorts field keys before
+// emitting, so two values whose field→value assignments are identical produce
+// identical bytes regardless of map storage order; two values whose *draw
+// order* differed (and therefore assigned different values to fields) differ.
+func TestDerivedRecordGenerator_DeterministicDraws(t *testing.T) {
+	// Build through the production derivation path, exactly as the contract
+	// harnesses do at the three generator call sites.
+	r := NewRunner("test.ail")
+	gen, shrink := r.createGeneratorForType(&ast.RecordType{
+		Fields: []*ast.RecordField{
+			{Name: "x", Type: &ast.SimpleType{Name: "int"}},
+			{Name: "y", Type: &ast.SimpleType{Name: "int"}},
+			{Name: "s", Type: &ast.SimpleType{Name: "string"}},
+		},
+	})
+	if gen == nil {
+		t.Fatal("expected derived generator for {x:int, y:int, s:string}")
+	}
+	if shrink == nil {
+		t.Fatal("expected derived shrinker for {x:int, y:int, s:string}")
+	}
+
+	const draws = 200
+	first := ""
+	for i := 0; i < draws; i++ {
+		rng := newRNG(42)
+		val := gen.Generate(rng)
+		rec, ok := val.(*eval.RecordValue)
+		if !ok {
+			t.Fatalf("draw %d: expected RecordValue, got %T", i, val)
+		}
+		if len(rec.Fields) != 3 {
+			t.Fatalf("draw %d: expected 3 fields, got %d", i, len(rec.Fields))
+		}
+		s := rec.String()
+		if i == 0 {
+			first = s
+			continue
+		}
+		if s != first {
+			t.Fatalf("draw %d diverged from draw 0: got %s want %s", i, s, first)
+		}
+	}
+}
+
+// TestRecordGenerator_DeterministicAcrossInstances is the companion check on
+// the plain combinator: two NewRecordGenerator instances over the same field
+// map draw the same field→value assignment from the same seed. This is the
+// direct unit target of the F-3 fix (the derived path above already routes
+// through NewRecordGenerator, but a regression here must be attributable to
+// the combinator, not the derivation).
+func TestRecordGenerator_DeterministicAcrossInstances(t *testing.T) {
+	fieldGens := map[string]Generator{
+		"x": NewIntGenerator(-10, 10),
+		"y": NewIntGenerator(-10, 10),
+		"s": NewStringGenerator(0, 5, ""),
+	}
+	genA := NewRecordGenerator(fieldGens)
+	genB := NewRecordGenerator(fieldGens)
+
+	rngA := newRNG(7)
+	rngB := newRNG(7)
+	for i := 0; i < 50; i++ {
+		a := genA.Generate(rngA)
+		b := genB.Generate(rngB)
+		if a.String() != b.String() {
+			t.Fatalf("stream draw %d diverged between instances:\nA=%s\nB=%s", i, a.String(), b.String())
+		}
+	}
+}

--- a/internal/testing/runner.go
+++ b/internal/testing/runner.go
@@ -630,50 +630,6 @@ func (r *Runner) genForTypeSeam(typ ast.Type) (Generator, Shrinker) {
 	return r.createGeneratorForType(typ)
 }
 
-// createGeneratorForType creates a generator and shrinker for the given type.
-func (r *Runner) createGeneratorForType(typ ast.Type) (Generator, Shrinker) {
-	// Check for simple types
-	if simpleType, ok := typ.(*ast.SimpleType); ok {
-		switch simpleType.Name {
-		case "int":
-			config := DefaultConfig()
-			return NewIntGenerator(config.MinInt, config.MaxInt), NewIntShrinker()
-		case "float":
-			config := DefaultConfig()
-			return NewFloatGenerator(config.MinFloat, config.MaxFloat), NewFloatShrinker()
-		case "bool":
-			return NewBoolGenerator(), NewNoOpShrinker()
-		case "string":
-			config := DefaultConfig()
-			return NewStringGenerator(0, config.MaxSize, ""), NewStringShrinker()
-		}
-	}
-
-	// The parser represents both [a] and list[a] as TypeApp.
-	if app, ok := typ.(*ast.TypeApp); ok && app.Constructor == "list" && len(app.Args) == 1 {
-		elemGen, elemShrink := r.createGeneratorForType(app.Args[0])
-		if elemGen == nil {
-			return nil, nil
-		}
-		config := DefaultConfig()
-		return NewListGenerator(elemGen, 0, config.MaxSize), NewListShrinker(elemShrink)
-	}
-
-	// Check for list types [a]
-	if listType, ok := typ.(*ast.ListType); ok {
-		// Create generator for element type
-		elemGen, elemShrink := r.createGeneratorForType(listType.Element)
-		if elemGen == nil {
-			return nil, nil
-		}
-		config := DefaultConfig()
-		return NewListGenerator(elemGen, 0, config.MaxSize), NewListShrinker(elemShrink)
-	}
-
-	// Unsupported type
-	return nil, nil
-}
-
 // bindPropertyValues binds generated values to forall parameters in a property expression.
 // For: forall(x: int, y: int) => x + y == y + x
 // With values: [5, 10]

--- a/internal/testing/runner_seed_test.go
+++ b/internal/testing/runner_seed_test.go
@@ -217,7 +217,7 @@ func TestRunner_MasterSeedChangesEveryStream(t *testing.T) {
 func TestRunProperty_SeedSetEvenOnSkip(t *testing.T) {
 	src := `module skip_seed
 
-type Tree = { }
+type Tree = TreeNode | TreeLeaf
 
 export pure func walk(t: Tree) -> int
   ensures { result >= 0 }

--- a/internal/testing/runner_skip_kind_test.go
+++ b/internal/testing/runner_skip_kind_test.go
@@ -63,13 +63,13 @@ func TestRunProperty_SkipTaxonomyIsTotal(t *testing.T) {
 func TestRunContractProperties_SkipKinds(t *testing.T) {
 	src := `module skip_kinds
 
-type Point = { x: int }
+type Point = P | Q
 
 export pure func unsupported(p: Point) -> int
-  requires { p.x > 0 }
+  requires { true }
   ensures { result > 0 }
 {
-  p.x
+  1
 }
 
 export pure func outOfContract(x: int) -> int


### PR DESCRIPTION
Lane B1 milestone M3 of #517, executed by the V1 mission loop (iteration 170).

**What**: structural generator derivation behind the existing `genForTypeSeam` — anonymous + nested records, tuples, unit `()`, same-file named record TypeDecls, TypeAlias targets. Depth-budgeted descent; ADTs and TypeApp-over-user-types stay honest `nil` until M4. `createGeneratorForType` moves out of `runner.go` (766 → 722 lines) into the new `derive.go`.

**Two defects fixed alongside**:
- F-3: `RecordGenerator.Generate` ranged a Go map while drawing from the RNG — a fixed seed did not reproduce counterexamples. Field order now sorted once at construction; pinned by a 200-draw byte-identity test.
- Controller find at review: the preserved list arms derived elements with a fresh root budget, so `type Tree = { val: int, kids: [Tree] }` (newly reachable) **overflowed the stack**. Elements now derive within the descended budget; regression test crashed pre-fix.

**Verification**: full mutation drill (B1-4/5/8/10/11 all killed by their named rows, each mutant sha256-LANDED + BUILDS-asserted, inverse arms checked); the tuple refusal branch survived neutering and is now pinned. `make test` rc 0, `make lint` rc 0, `verify-examples` rc 0, corpus sweep: only record/tuple/unit rows move. Evaluator (sonnet, independent): **95/100 PASS, zero blocking**.

Executor: `pi:openrouter/deepseek/deepseek-v4-flash-0731` (67 turns, $0.16 metered). Sprint plan: `design_docs/planned/v0_31_0/m-property-generator-coverage-lane-b1-sprint-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)