### PR TITLE
feat(ollama): #618 M1 — idle/TTFT/hard-deadline stream reader, watchdog and RoundTripper

### DIFF
--- a/internal/ai/ollama/idlereader.go
+++ b/internal/ai/ollama/idlereader.go
@@ -1,0 +1,358 @@
+package ollama
+
+// idlereader.go — M1 of M-OLLAMA-V1-STREAMING-IDLE-TIMEOUT (ailang#618).
+//
+// A streaming /v1 response can stall in three distinct ways, and the three
+// need distinct diagnoses:
+//
+//	TTFT   — the model never emitted a first byte (cold load, GPU contention).
+//	IDLE   — bytes flowed, then stopped mid-stream (the S2 hang we actually see).
+//	HARD   — the stream is alive but has run past its total budget.
+//
+// A blocked Read cannot interrupt itself, so a watchdog goroutine samples the
+// last-activity timestamp and, on expiry, calls a supplied context.CancelFunc;
+// the transport then fails the pending Read. The watchdog records WHICH window
+// fired via an atomic CAS (first writer wins) so the error surfaced to the
+// caller is a typed sentinel, never a generic "context canceled".
+//
+// M1 adds no call sites — nothing in this file is wired into Step yet, so
+// runtime behaviour is unchanged by construction. M2 does the wiring.
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Typed sentinels. All four are distinguishable with errors.Is, which is what
+// lets the caller tell "model never started" from "model went quiet mid-stream"
+// from "we blew the total budget".
+var (
+	// ErrTTFTTimeout — no first byte arrived within the TTFT window.
+	ErrTTFTTimeout = errors.New("ollama stream: time-to-first-token timeout")
+	// ErrIdleTimeout — bytes flowed, then the stream went silent past the idle window.
+	ErrIdleTimeout = errors.New("ollama stream: idle timeout")
+	// ErrStreamDeadlineExceeded — the stream ran past its total hard deadline.
+	ErrStreamDeadlineExceeded = errors.New("ollama stream: hard deadline exceeded")
+	// ErrStreamDeadlineInvalid — the configured hard deadline is unusable.
+	ErrStreamDeadlineInvalid = errors.New("ollama stream: invalid hard deadline configuration")
+)
+
+// Window defaults, in seconds.
+const (
+	// defaultOllamaIdleTimeoutSec bounds silence *between* bytes. Short, because
+	// a healthy stream emits tokens continuously.
+	defaultOllamaIdleTimeoutSec = 120
+	// defaultOllamaTTFTTimeoutSec bounds silence *before* the first byte. Long,
+	// because a cold 35B load under GPU contention legitimately takes minutes.
+	defaultOllamaTTFTTimeoutSec = 600
+	// defaultOllamaStreamDeadlineSec bounds the whole stream.
+	defaultOllamaStreamDeadlineSec = 3600
+)
+
+// ollamaIdleTimeout resolves the inter-byte silence window.
+// Override with AILANG_OLLAMA_IDLE_TIMEOUT_SEC (a positive integer, seconds).
+func ollamaIdleTimeout() time.Duration {
+	return envSeconds("AILANG_OLLAMA_IDLE_TIMEOUT_SEC", defaultOllamaIdleTimeoutSec)
+}
+
+// ollamaTTFTTimeout resolves the pre-first-byte window.
+// Override with AILANG_OLLAMA_TTFT_TIMEOUT_SEC (a positive integer, seconds).
+func ollamaTTFTTimeout() time.Duration {
+	return envSeconds("AILANG_OLLAMA_TTFT_TIMEOUT_SEC", defaultOllamaTTFTTimeoutSec)
+}
+
+// envSeconds reads a positive-integer seconds value, falling back to def when
+// unset or unusable. Only used for the two *soft* windows, where a bad value
+// costs nothing but a wrong watchdog period.
+func envSeconds(key string, defSec int) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return time.Duration(n) * time.Second
+		}
+	}
+	return time.Duration(defSec) * time.Second
+}
+
+// ollamaStreamHardDeadline resolves the total-stream budget for the STREAMING
+// path from AILANG_OLLAMA_HTTP_TIMEOUT_SEC, defaulting to 3600s.
+//
+// Deliberately NOT ollamaV1Timeout(). That resolver maps "0" (and negatives) to
+// "no timeout at all" for the legacy buffered path, and TestOllamaV1Timeout pins
+// that behaviour. An unbounded *stream* is precisely the failure mode this work
+// exists to remove, so here <= 0 is rejected rather than silently honoured — no
+// silent fallback on a value that decides whether a rig job can hang forever.
+func ollamaStreamHardDeadline() (time.Duration, error) {
+	v := os.Getenv("AILANG_OLLAMA_HTTP_TIMEOUT_SEC")
+	if v == "" {
+		return defaultOllamaStreamDeadlineSec * time.Second, nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, fmt.Errorf("%w: AILANG_OLLAMA_HTTP_TIMEOUT_SEC=%q is not an integer", ErrStreamDeadlineInvalid, v)
+	}
+	if n <= 0 {
+		return 0, fmt.Errorf("%w: AILANG_OLLAMA_HTTP_TIMEOUT_SEC=%d must be > 0 in streaming mode "+
+			"(an unbounded stream is the hang this guard exists to prevent)", ErrStreamDeadlineInvalid, n)
+	}
+	return time.Duration(n) * time.Second, nil
+}
+
+// Which window fired. Stored in an atomic int32 so the watchdog and the reader
+// agree without a lock on the hot Read path.
+const (
+	firedNone int32 = iota
+	firedTTFT
+	firedIdle
+	firedDeadline
+)
+
+// idleReaderConfig carries the three windows. Tests construct this directly at
+// millisecond scale rather than going through the env resolvers.
+type idleReaderConfig struct {
+	// TTFT bounds the wait for the first byte. Zero disables the TTFT window.
+	TTFT time.Duration
+	// Idle bounds silence after at least one byte. Zero disables the idle window.
+	Idle time.Duration
+	// Hard bounds the whole stream. Zero disables the hard deadline.
+	Hard time.Duration
+	// Tick is the watchdog sampling period. Zero derives one from the windows.
+	Tick time.Duration
+}
+
+// idleReader wraps a streaming response body with TTFT/idle/hard watchdogs.
+//
+// It is an io.ReadCloser, not an io.Reader, on purpose: StreamStep does
+// `defer httpResp.Body.Close()` (internal/ai/openai/streamstep.go:100), and that
+// Close is what shuts the watchdog down. A bare Reader would lose the underlying
+// Close and leave the timer armed after the request finished.
+type idleReader struct {
+	body   io.ReadCloser
+	cancel func()
+	cfg    idleReaderConfig
+	hardAt time.Time
+
+	mu       sync.Mutex
+	last     time.Time
+	sawBytes bool
+
+	fired   atomic.Int32
+	stopped atomic.Bool
+	stop    chan struct{}
+	done    chan struct{}
+}
+
+var _ io.ReadCloser = (*idleReader)(nil)
+
+// newIdleReader wraps body and starts the watchdog. cancel is invoked once, from
+// the watchdog goroutine, when a window expires; in production it is the request
+// context's CancelFunc, which makes the transport fail the pending Read.
+func newIdleReader(body io.ReadCloser, cancel func(), cfg idleReaderConfig) *idleReader {
+	now := time.Now()
+	r := &idleReader{
+		body:   body,
+		cancel: cancel,
+		cfg:    cfg,
+		last:   now,
+		stop:   make(chan struct{}),
+		done:   make(chan struct{}),
+	}
+	if cfg.Hard > 0 {
+		r.hardAt = now.Add(cfg.Hard)
+	}
+	go r.watch(watchdogTick(cfg))
+	return r
+}
+
+// watchdogTick picks a sampling period roughly a tenth of the tightest window,
+// clamped so tests at millisecond scale stay responsive and production does not
+// spin.
+func watchdogTick(cfg idleReaderConfig) time.Duration {
+	if cfg.Tick > 0 {
+		return cfg.Tick
+	}
+	tightest := time.Duration(0)
+	for _, w := range []time.Duration{cfg.TTFT, cfg.Idle, cfg.Hard} {
+		if w > 0 && (tightest == 0 || w < tightest) {
+			tightest = w
+		}
+	}
+	if tightest == 0 {
+		return time.Second
+	}
+	tick := tightest / 10
+	if tick < time.Millisecond {
+		tick = time.Millisecond
+	}
+	if tick > 250*time.Millisecond {
+		tick = 250 * time.Millisecond
+	}
+	return tick
+}
+
+// watchdogDone is closed when the watchdog goroutine has exited. Tests assert
+// shutdown against it; nothing in production needs to wait on it.
+func (r *idleReader) watchdogDone() <-chan struct{} { return r.done }
+
+// watch samples last-activity until a window expires or Close stops it.
+func (r *idleReader) watch(tick time.Duration) {
+	defer close(r.done)
+
+	t := time.NewTicker(tick)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-r.stop:
+			return
+		case now := <-t.C:
+			r.mu.Lock()
+			firstRead := !r.sawBytes
+			last := r.last
+			r.mu.Unlock()
+
+			elapsed := now.Sub(last)
+
+			if !r.hardAt.IsZero() && now.After(r.hardAt) {
+				r.fire(firedDeadline)
+				return
+			}
+			if firstRead && r.cfg.TTFT > 0 && elapsed > r.cfg.TTFT {
+				r.fire(firedTTFT)
+				return
+			}
+			if !firstRead && r.cfg.Idle > 0 && elapsed > r.cfg.Idle {
+				r.fire(firedIdle)
+				return
+			}
+		}
+	}
+}
+
+// fire records which window expired (first writer wins) and unblocks the reader.
+func (r *idleReader) fire(code int32) {
+	r.fired.CompareAndSwap(firedNone, code)
+	if r.cancel != nil {
+		r.cancel()
+	}
+}
+
+// Read proxies the underlying body, refreshing the activity clock on every
+// non-empty read. Once a window has fired, the error is translated to the
+// matching typed sentinel so the caller never sees a bare "context canceled".
+func (r *idleReader) Read(p []byte) (int, error) {
+	if code := r.fired.Load(); code != firedNone {
+		return 0, r.sentinel(code, nil)
+	}
+
+	n, err := r.body.Read(p)
+	if n > 0 {
+		r.mu.Lock()
+		r.sawBytes = true
+		r.last = time.Now()
+		r.mu.Unlock()
+	}
+	if err != nil {
+		if code := r.fired.Load(); code != firedNone {
+			return n, r.sentinel(code, err)
+		}
+		return n, err
+	}
+	return n, nil
+}
+
+// sentinel maps a fired-window code to its typed error, keeping the transport's
+// own error as context.
+func (r *idleReader) sentinel(code int32, cause error) error {
+	var s error
+	switch code {
+	case firedTTFT:
+		s = ErrTTFTTimeout
+	case firedIdle:
+		s = ErrIdleTimeout
+	case firedDeadline:
+		s = ErrStreamDeadlineExceeded
+	default:
+		return cause
+	}
+	if cause == nil {
+		return s
+	}
+	// %v, not %w, for the cause: the sentinel must be the only thing errors.Is
+	// matches, so a caller asking "was this idle?" cannot get a yes from TTFT.
+	return fmt.Errorf("%w (transport: %v)", s, cause)
+}
+
+// Close stops the watchdog first, then closes the underlying body. It is
+// idempotent: a second Close does not close the body again.
+func (r *idleReader) Close() error {
+	if r.stopped.CompareAndSwap(false, true) {
+		close(r.stop)
+		return r.body.Close()
+	}
+	return nil
+}
+
+// --- RoundTripper -----------------------------------------------------------
+
+// The base transport is built ONCE, cloned from http.DefaultTransport.
+//
+// Two things it must not do: mutate http.DefaultTransport (process-global), or
+// build a fresh &http.Transport{} per call. The /v1 client is constructed per
+// request (step.go:293), and a bare http.Transport has IdleConnTimeout: 0 —
+// unlimited — so a per-call transport would accumulate idle connections forever
+// across thousands of rig requests. Cloning inherits IdleConnTimeout: 90s and
+// the proxy configuration; only ResponseHeaderTimeout is set on the clone.
+var (
+	streamTransportOnce sync.Once
+	streamTransportBase *http.Transport
+)
+
+func streamBaseTransport() *http.Transport {
+	streamTransportOnce.Do(func() {
+		if base, ok := http.DefaultTransport.(*http.Transport); ok {
+			streamTransportBase = base.Clone()
+		} else {
+			streamTransportBase = &http.Transport{IdleConnTimeout: 90 * time.Second}
+		}
+		streamTransportBase.ResponseHeaderTimeout = ollamaTTFTTimeout()
+	})
+	return streamTransportBase
+}
+
+// idleTimeoutTransport is the cheap per-request wrapper: it holds this request's
+// cancel func and windows, and delegates the actual round trip to the shared
+// base transport.
+type idleTimeoutTransport struct {
+	// base is the delegate; nil means the shared package-level base transport.
+	base   http.RoundTripper
+	cancel func()
+	cfg    idleReaderConfig
+}
+
+var _ http.RoundTripper = (*idleTimeoutTransport)(nil)
+
+// newIdleTimeoutTransport builds the per-request wrapper over the shared base.
+func newIdleTimeoutTransport(cancel func(), cfg idleReaderConfig) *idleTimeoutTransport {
+	return &idleTimeoutTransport{cancel: cancel, cfg: cfg}
+}
+
+// RoundTrip performs the request and wraps the response body in the watchdog.
+func (t *idleTimeoutTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = streamBaseTransport()
+	}
+	resp, err := base.RoundTrip(req)
+	if err != nil || resp == nil || resp.Body == nil {
+		return resp, err
+	}
+	resp.Body = newIdleReader(resp.Body, t.cancel, t.cfg)
+	return resp, nil
+}

--- a/internal/ai/ollama/idlereader_test.go
+++ b/internal/ai/ollama/idlereader_test.go
@@ -1,0 +1,514 @@
+package ollama
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// errWatchdogCanceled stands in for what the real transport does when the
+// request context is cancelled: it fails the pending Read with *some* error.
+// The point of the reader is that this generic error never reaches the caller.
+var errWatchdogCanceled = errors.New("test transport: canceled by watchdog")
+
+// newPipeIdleReader drives an idleReader from an io.Pipe. The cancel func closes
+// the write half with an error, which is what unblocks a Read parked on the
+// pipe — the same shape as a transport failing a read on context cancellation.
+func newPipeIdleReader(t *testing.T, cfg idleReaderConfig) (*idleReader, *io.PipeWriter) {
+	t.Helper()
+	pr, pw := io.Pipe()
+	var once sync.Once
+	cancel := func() {
+		once.Do(func() { _ = pw.CloseWithError(errWatchdogCanceled) })
+	}
+	r := newIdleReader(pr, cancel, cfg)
+	t.Cleanup(func() { _ = r.Close() })
+	return r, pw
+}
+
+type readResult struct {
+	n   int
+	err error
+}
+
+// readWithin runs one Read off-goroutine so a watchdog that never fires shows up
+// as a fast, legible failure instead of a ten-minute package timeout.
+func readWithin(t *testing.T, r io.Reader, limit time.Duration) (readResult, bool) {
+	t.Helper()
+	ch := make(chan readResult, 1)
+	go func() {
+		buf := make([]byte, 256)
+		n, err := r.Read(buf)
+		ch <- readResult{n: n, err: err}
+	}()
+	select {
+	case res := <-ch:
+		return res, true
+	case <-time.After(limit):
+		return readResult{}, false
+	}
+}
+
+// countingBody records how many times Close was called on it.
+type countingBody struct {
+	r      io.Reader
+	closes atomic.Int32
+}
+
+func (c *countingBody) Read(p []byte) (int, error) { return c.r.Read(p) }
+func (c *countingBody) Close() error {
+	c.closes.Add(1)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// T1 — idle window
+// ---------------------------------------------------------------------------
+
+func TestIdleReader_IdleWindow(t *testing.T) {
+	t.Run("bytes_then_silence_yields_ErrIdleTimeout", func(t *testing.T) {
+		const idle = 80 * time.Millisecond
+		r, pw := newPipeIdleReader(t, idleReaderConfig{
+			TTFT: 2 * time.Second,
+			Idle: idle,
+			Tick: 5 * time.Millisecond,
+		})
+
+		go func() {
+			for i := 0; i < 3; i++ {
+				if _, err := pw.Write([]byte("chunk")); err != nil {
+					return
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			// Then go silent, holding the pipe open. This is the S2 hang.
+		}()
+
+		for i := 0; i < 3; i++ {
+			res, ok := readWithin(t, r, 2*time.Second)
+			if !ok {
+				t.Fatalf("chunk %d: Read did not return within 2s", i)
+			}
+			if res.err != nil {
+				t.Fatalf("chunk %d: unexpected error: %v", i, res.err)
+			}
+			if res.n == 0 {
+				t.Fatalf("chunk %d: expected bytes, got 0", i)
+			}
+		}
+
+		start := time.Now()
+		res, ok := readWithin(t, r, 3*time.Second)
+		if !ok {
+			t.Fatal("Read never returned: the idle watchdog did not fire")
+		}
+		if res.err == nil {
+			t.Fatal("expected an idle timeout error, got nil")
+		}
+		if !errors.Is(res.err, ErrIdleTimeout) {
+			t.Fatalf("expected ErrIdleTimeout, got %v", res.err)
+		}
+		if elapsed := time.Since(start); elapsed > idle+2*time.Second {
+			t.Fatalf("idle timeout fired far too late: %v (window %v)", elapsed, idle)
+		}
+	})
+
+	t.Run("generic_transport_error_is_not_surfaced", func(t *testing.T) {
+		r, pw := newPipeIdleReader(t, idleReaderConfig{
+			TTFT: 2 * time.Second,
+			Idle: 60 * time.Millisecond,
+			Tick: 5 * time.Millisecond,
+		})
+		go func() { _, _ = pw.Write([]byte("x")) }()
+
+		if res, ok := readWithin(t, r, 2*time.Second); !ok || res.err != nil {
+			t.Fatalf("first read: ok=%v err=%v", ok, res.err)
+		}
+		res, ok := readWithin(t, r, 3*time.Second)
+		if !ok {
+			t.Fatal("Read never returned: the idle watchdog did not fire")
+		}
+		if errors.Is(res.err, errWatchdogCanceled) {
+			t.Fatalf("raw transport error leaked to the caller: %v", res.err)
+		}
+		if !errors.Is(res.err, ErrIdleTimeout) {
+			t.Fatalf("expected ErrIdleTimeout, got %v", res.err)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// T2 — TTFT window
+// ---------------------------------------------------------------------------
+
+func TestIdleReader_TTFTWindow(t *testing.T) {
+	t.Run("silence_over_idle_but_under_ttft_completes", func(t *testing.T) {
+		r, pw := newPipeIdleReader(t, idleReaderConfig{
+			TTFT: 600 * time.Millisecond,
+			Idle: 60 * time.Millisecond, // deliberately shorter than the wait below
+			Tick: 5 * time.Millisecond,
+		})
+
+		go func() {
+			time.Sleep(200 * time.Millisecond) // > idle, < TTFT
+			_, _ = pw.Write([]byte("first token"))
+		}()
+
+		res, ok := readWithin(t, r, 3*time.Second)
+		if !ok {
+			t.Fatal("Read never returned")
+		}
+		if res.err != nil {
+			t.Fatalf("pre-first-byte silence inside the TTFT window must not fail; got %v", res.err)
+		}
+		if res.n == 0 {
+			t.Fatal("expected the first token to be delivered")
+		}
+	})
+
+	t.Run("silence_over_ttft_yields_ErrTTFTTimeout", func(t *testing.T) {
+		r, _ := newPipeIdleReader(t, idleReaderConfig{
+			TTFT: 80 * time.Millisecond,
+			Idle: 2 * time.Second, // idle must not be what fires here
+			Tick: 5 * time.Millisecond,
+		})
+
+		res, ok := readWithin(t, r, 3*time.Second)
+		if !ok {
+			t.Fatal("Read never returned: the TTFT watchdog did not fire")
+		}
+		if res.err == nil {
+			t.Fatal("expected a TTFT timeout error, got nil")
+		}
+		if !errors.Is(res.err, ErrTTFTTimeout) {
+			t.Fatalf("expected ErrTTFTTimeout, got %v", res.err)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// T3 — which window fired is preserved
+// ---------------------------------------------------------------------------
+
+func TestIdleReader_WhichWindowFiredIsPreserved(t *testing.T) {
+	fireTTFT := func(t *testing.T) error {
+		t.Helper()
+		r, _ := newPipeIdleReader(t, idleReaderConfig{
+			TTFT: 60 * time.Millisecond,
+			Idle: 5 * time.Second,
+			Tick: 5 * time.Millisecond,
+		})
+		res, ok := readWithin(t, r, 3*time.Second)
+		if !ok {
+			t.Fatal("TTFT case: Read never returned")
+		}
+		return res.err
+	}
+
+	fireIdle := func(t *testing.T) error {
+		t.Helper()
+		r, pw := newPipeIdleReader(t, idleReaderConfig{
+			TTFT: 5 * time.Second,
+			Idle: 60 * time.Millisecond,
+			Tick: 5 * time.Millisecond,
+		})
+		go func() { _, _ = pw.Write([]byte("token")) }()
+		if res, ok := readWithin(t, r, 2*time.Second); !ok || res.err != nil {
+			t.Fatalf("idle case: priming read failed ok=%v err=%v", ok, res.err)
+		}
+		res, ok := readWithin(t, r, 3*time.Second)
+		if !ok {
+			t.Fatal("idle case: Read never returned")
+		}
+		return res.err
+	}
+
+	fireDeadline := func(t *testing.T) error {
+		t.Helper()
+		r, _ := newPipeIdleReader(t, idleReaderConfig{
+			TTFT: 5 * time.Second,
+			Idle: 5 * time.Second,
+			Hard: 60 * time.Millisecond,
+			Tick: 5 * time.Millisecond,
+		})
+		res, ok := readWithin(t, r, 3*time.Second)
+		if !ok {
+			t.Fatal("deadline case: Read never returned")
+		}
+		return res.err
+	}
+
+	var ttftErr, idleErr, deadlineErr error
+
+	t.Run("ttft_case_yields_ErrTTFTTimeout", func(t *testing.T) {
+		ttftErr = fireTTFT(t)
+		if !errors.Is(ttftErr, ErrTTFTTimeout) {
+			t.Fatalf("expected ErrTTFTTimeout, got %v", ttftErr)
+		}
+	})
+	t.Run("idle_case_yields_ErrIdleTimeout", func(t *testing.T) {
+		idleErr = fireIdle(t)
+		if !errors.Is(idleErr, ErrIdleTimeout) {
+			t.Fatalf("expected ErrIdleTimeout, got %v", idleErr)
+		}
+	})
+	t.Run("deadline_case_yields_ErrStreamDeadlineExceeded", func(t *testing.T) {
+		deadlineErr = fireDeadline(t)
+		if !errors.Is(deadlineErr, ErrStreamDeadlineExceeded) {
+			t.Fatalf("expected ErrStreamDeadlineExceeded, got %v", deadlineErr)
+		}
+	})
+
+	// The whole point: one generic error for all three must NOT pass.
+	t.Run("the_three_sentinels_are_pairwise_distinct", func(t *testing.T) {
+		if ttftErr == nil || idleErr == nil || deadlineErr == nil {
+			t.Fatalf("a prior subtest produced no error: ttft=%v idle=%v deadline=%v",
+				ttftErr, idleErr, deadlineErr)
+		}
+		cases := []struct {
+			name string
+			err  error
+			not  []error
+		}{
+			{"ttft", ttftErr, []error{ErrIdleTimeout, ErrStreamDeadlineExceeded}},
+			{"idle", idleErr, []error{ErrTTFTTimeout, ErrStreamDeadlineExceeded}},
+			{"deadline", deadlineErr, []error{ErrTTFTTimeout, ErrIdleTimeout}},
+		}
+		for _, c := range cases {
+			for _, other := range c.not {
+				if errors.Is(c.err, other) {
+					t.Errorf("%s error %v must NOT match %v", c.name, c.err, other)
+				}
+			}
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// T4 — leak-free, idempotent Close
+// ---------------------------------------------------------------------------
+
+func TestIdleReader_CloseStopsWatchdogAndIsIdempotent(t *testing.T) {
+	const payload = "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n"
+
+	body := &countingBody{r: strings.NewReader(payload)}
+	// Windows generous enough that nothing fires during the happy path.
+	r := newIdleReader(body, func() { t.Error("cancel must not fire on the happy path") },
+		idleReaderConfig{TTFT: 5 * time.Second, Idle: 5 * time.Second, Tick: 50 * time.Millisecond})
+
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("happy-path stream failed: %v", err)
+	}
+	if string(got) != payload {
+		t.Fatalf("payload mismatch:\n got %q\nwant %q", got, payload)
+	}
+
+	t.Run("close_shuts_the_watchdog_down_within_100ms", func(t *testing.T) {
+		if err := r.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		select {
+		case <-r.watchdogDone():
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("watchdog goroutine still running 100ms after Close")
+		}
+	})
+
+	t.Run("close_closes_the_underlying_body_exactly_once", func(t *testing.T) {
+		if n := body.closes.Load(); n != 1 {
+			t.Fatalf("underlying body Close count = %d, want 1", n)
+		}
+	})
+
+	t.Run("second_close_is_a_no_op", func(t *testing.T) {
+		if err := r.Close(); err != nil {
+			t.Fatalf("second Close returned %v, want nil", err)
+		}
+		if n := body.closes.Load(); n != 1 {
+			t.Fatalf("underlying body Close count after second Close = %d, want 1", n)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// T5 — hard-deadline resolver
+// ---------------------------------------------------------------------------
+
+func TestOllamaStreamHardDeadline(t *testing.T) {
+	const key = "AILANG_OLLAMA_HTTP_TIMEOUT_SEC"
+
+	tests := []struct {
+		name    string
+		set     bool
+		value   string
+		want    time.Duration
+		wantErr error
+	}{
+		{name: "unset_defaults_to_3600s", set: false, want: 3600 * time.Second},
+		{name: "7200_is_honoured", set: true, value: "7200", want: 7200 * time.Second},
+		{name: "zero_is_rejected", set: true, value: "0", wantErr: ErrStreamDeadlineInvalid},
+		{name: "negative_is_rejected", set: true, value: "-1", wantErr: ErrStreamDeadlineInvalid},
+		{name: "garbage_is_rejected", set: true, value: "banana", wantErr: ErrStreamDeadlineInvalid},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// t.Setenv registers the restore; unsetting after it gives a truly
+			// absent variable for the default row.
+			t.Setenv(key, "placeholder")
+			if tc.set {
+				t.Setenv(key, tc.value)
+			} else if err := os.Unsetenv(key); err != nil {
+				t.Fatalf("unsetenv: %v", err)
+			}
+
+			got, err := ollamaStreamHardDeadline()
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("want error %v, got %v", tc.wantErr, err)
+				}
+				if got != 0 {
+					t.Fatalf("want zero duration on rejection, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("want %v, got %v", tc.want, got)
+			}
+		})
+	}
+
+	// The legacy resolver keeps its own semantics; this file must not have
+	// changed it. "0" means "disabled" there and "invalid" here, on purpose.
+	t.Run("legacy_ollamaV1Timeout_still_treats_0_as_disabled", func(t *testing.T) {
+		t.Setenv(key, "0")
+		if d := ollamaV1Timeout(); d != 0 {
+			t.Fatalf("ollamaV1Timeout() with %s=0 = %v, want 0 (disabled)", key, d)
+		}
+	})
+}
+
+func TestOllamaSoftWindowResolvers(t *testing.T) {
+	t.Run("idle_defaults_to_120s", func(t *testing.T) {
+		t.Setenv("AILANG_OLLAMA_IDLE_TIMEOUT_SEC", "")
+		if got := ollamaIdleTimeout(); got != 120*time.Second {
+			t.Fatalf("got %v, want 120s", got)
+		}
+	})
+	t.Run("idle_override_is_honoured", func(t *testing.T) {
+		t.Setenv("AILANG_OLLAMA_IDLE_TIMEOUT_SEC", "45")
+		if got := ollamaIdleTimeout(); got != 45*time.Second {
+			t.Fatalf("got %v, want 45s", got)
+		}
+	})
+	t.Run("ttft_defaults_to_600s", func(t *testing.T) {
+		t.Setenv("AILANG_OLLAMA_TTFT_TIMEOUT_SEC", "")
+		if got := ollamaTTFTTimeout(); got != 600*time.Second {
+			t.Fatalf("got %v, want 600s", got)
+		}
+	})
+	t.Run("ttft_override_is_honoured", func(t *testing.T) {
+		t.Setenv("AILANG_OLLAMA_TTFT_TIMEOUT_SEC", "900")
+		if got := ollamaTTFTTimeout(); got != 900*time.Second {
+			t.Fatalf("got %v, want 900s", got)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// T6 — transport construction
+// ---------------------------------------------------------------------------
+
+type stubRoundTripper struct {
+	resp *http.Response
+	err  error
+}
+
+func (s *stubRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return s.resp, s.err
+}
+
+func TestIdleTimeoutTransport(t *testing.T) {
+	t.Run("wraps_the_response_body_in_the_watchdog_reader", func(t *testing.T) {
+		body := &countingBody{r: strings.NewReader("payload")}
+		rt := &idleTimeoutTransport{
+			base: &stubRoundTripper{resp: &http.Response{StatusCode: 200, Body: body}},
+			cfg:  idleReaderConfig{TTFT: 5 * time.Second, Idle: 5 * time.Second, Tick: time.Second},
+		}
+		req, err := http.NewRequest(http.MethodGet, "http://example.invalid/v1/chat/completions", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		resp, err := rt.RoundTrip(req)
+		if err != nil {
+			t.Fatalf("RoundTrip: %v", err)
+		}
+		wrapped, ok := resp.Body.(*idleReader)
+		if !ok {
+			t.Fatalf("response body is %T, want *idleReader", resp.Body)
+		}
+		if err := wrapped.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		if n := body.closes.Load(); n != 1 {
+			t.Fatalf("underlying body Close count = %d, want 1", n)
+		}
+	})
+
+	t.Run("transport_errors_pass_through_unwrapped", func(t *testing.T) {
+		want := errors.New("dial failed")
+		rt := &idleTimeoutTransport{base: &stubRoundTripper{err: want}}
+		req, err := http.NewRequest(http.MethodGet, "http://example.invalid/", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		if _, err := rt.RoundTrip(req); !errors.Is(err, want) {
+			t.Fatalf("got %v, want %v", err, want)
+		}
+	})
+
+	t.Run("base_transport_is_built_once_cloned_and_does_not_mutate_the_default", func(t *testing.T) {
+		a := streamBaseTransport()
+		b := streamBaseTransport()
+		if a != b {
+			t.Fatal("streamBaseTransport must return the same instance (sync.Once)")
+		}
+		def, ok := http.DefaultTransport.(*http.Transport)
+		if !ok {
+			t.Skip("http.DefaultTransport is not an *http.Transport in this build")
+		}
+		if a == def {
+			t.Fatal("streamBaseTransport must be a clone, not http.DefaultTransport itself")
+		}
+		if def.ResponseHeaderTimeout != 0 {
+			t.Fatalf("http.DefaultTransport was mutated: ResponseHeaderTimeout=%v", def.ResponseHeaderTimeout)
+		}
+		if a.ResponseHeaderTimeout <= 0 {
+			t.Fatalf("clone must carry a TTFT ResponseHeaderTimeout, got %v", a.ResponseHeaderTimeout)
+		}
+		if a.IdleConnTimeout != def.IdleConnTimeout {
+			t.Fatalf("clone lost the inherited IdleConnTimeout: got %v, want %v",
+				a.IdleConnTimeout, def.IdleConnTimeout)
+		}
+		if a.IdleConnTimeout == 0 {
+			t.Fatal("IdleConnTimeout is unlimited; idle connections would accumulate forever")
+		}
+	})
+
+	t.Run("newIdleTimeoutTransport_delegates_to_the_shared_base", func(t *testing.T) {
+		rt := newIdleTimeoutTransport(func() {}, idleReaderConfig{})
+		if rt.base != nil {
+			t.Fatalf("per-request wrapper must not carry its own transport, got %T", rt.base)
+		}
+	})
+}


### PR DESCRIPTION
**#618 M1** — the deadline-resetting stream reader M2 will wire into the `/v1` streaming branch.
**Zero call sites, so runtime behaviour is unchanged by construction.**

A streaming response stalls in three distinct ways needing three distinct diagnoses: **TTFT** (no
first byte — cold load, GPU contention), **IDLE** (bytes flowed then stopped — the hang we actually
see), **HARD** (alive but past its total budget). A blocked `Read` cannot interrupt itself, so a
watchdog samples last-activity and calls a supplied `context.CancelFunc`; which window fired is
recorded via an atomic CAS (first writer wins), so the caller gets a typed sentinel rather than a
bare `context canceled`.

It is a **ReadCloser, not a Reader**, on purpose: `StreamStep`'s `defer httpResp.Body.Close()`
(`openai/streamstep.go:100`) is what stops the watchdog.

`ollamaStreamHardDeadline()` is deliberately **not** `ollamaV1Timeout()` — the legacy resolver maps
`"0"` to *no timeout at all* and `TestOllamaV1Timeout` pins that (it passes unmodified). An
unbounded *stream* is the exact failure this sprint removes, so here `<= 0` and non-integers are
rejected with a typed error. The base transport is cloned from `http.DefaultTransport` **once** via
`sync.Once` (not mutated — process-global; not rebuilt per call — a bare transport has
`IdleConnTimeout: 0`, and the `/v1` client is built per request).

### Executor deviation — adjudicated ACCEPTABLE by measurement in BOTH arms

The plan puts the hard deadline in M2 (R4), which left M1 with no path able to produce
`ErrStreamDeadlineExceeded` — AC-M1.3's third sentinel would have shipped **dead and untestable**.
The executor added an optional in-reader budget (`idleReaderConfig.Hard`, `0` = disabled).

- **Forward arm**: neutering the branch reds **only** the deadline case + the pairwise-distinct assertion.
- **Inverse arm**: with it neutered and that test skipped, the rest of the package is **rc=0** — TTFT/idle
  behaviour is untouched, so the addition is **strict**.

M2's context still does the real cancelling; this only adds attribution.

### Controller mutation drill

Each asserted **LANDED** (sha256) and **BUILDS** (`go build ./internal/...` rc=0) *before* its result
was read, each scoped with `-run`, each restored from a `cp` backup and verified byte-identical.

| # | Mutation | Result |
|---|---|---|
| C1 | watchdog shutdown in `Close()` neutered | **KILLED** by the Close/idempotence test |
| C2 | hard-deadline branch neutered | **KILLED**, deadline case only (see above) |
| C3 | three sentinels collapsed to one | **KILLED** by the which-window test |

### Gates — controller-run, outside any sandbox

`go build ./internal/... ./cmd/ailang` · `go test ./internal/ai/{ollama,openai}` · `go test -race` ·
`go vet` · `gofmt` · `make test` · `check-file-sizes` · `check-boundaries` · `check-changelog` ·
`check-skills` · `fmt-check` · `vet` · `check-golden-drift` · `test-regression-guards` — **all rc=0**.

**Anti-vacuity**: the ollama package goes **23 → 30** top-level `--- PASS` (35 → 67 counting
subtests). At base, `-run TestIdleReader` is rc=0 with **zero** `=== RUN`, so a bare "rc=0" gate
would have passed after deleting the tests.

`go build ./...` is **rc=1 AT BASE** (`cmd/wasm`, `gen/main` have no native `main`) and is not an
acceptance gate anywhere in this sprint.

No changelog entry: M1 has no user-visible surface — it lands with M2, where
`AILANG_OLLAMA_V1_STREAM` becomes reachable.

Refs #618

🤖 Generated with [Claude Code](https://claude.com/claude-code)
