### PR TITLE
feat(ollama): #618 M2 — flag-gated /v1 streaming with a mandatory total-time bound

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -114,6 +114,28 @@
 
 ### Added
 
+- **Opt-in streaming for Ollama's OpenAI-compatible `/v1` tool-calling path, with a
+  mandatory total-time bound** — milestone M2 of
+  [#618](https://github.com/sunholo-data/ailang/issues/618). Set
+  `AILANG_OLLAMA_V1_STREAM=1` to route `Step`'s `/v1` call through
+  `openai.StreamStep`, wrapped in the idle/TTFT/hard-deadline reader landed by M1.
+  A stalled stream now fails in seconds with a typed `ErrIdleTimeout` /
+  `ErrTTFTTimeout` instead of burning the whole 300s client cap, and a stream that
+  emits keep-alives forever is bounded by a hard deadline (`ErrStreamDeadlineExceeded`)
+  rather than resetting the idle timer indefinitely. **Default OFF and byte-identical
+  when unset** — with the flag absent the request carries no `stream`, no
+  `stream_options` and no `text/event-stream` `Accept`, pinned by a test that captures
+  the raw wire body.
+
+  Two semantics worth knowing. `AILANG_OLLAMA_HTTP_TIMEOUT_SEC` now means different
+  things per path: on the legacy buffered path `0` still means "uncapped", while on the
+  streaming path `0` or a negative value is a **configuration error**
+  (`ErrStreamDeadlineInvalid`) refused before any request leaves — a stream with no
+  total bound is the failure this milestone exists to remove. And the streaming branch
+  derives its deadline from the context captured *before* the buffered path's 300s
+  wrap; deriving it after would have silently capped every stream at 300s and shipped
+  the feature inert.
+
 - **Property tests now derive generators for records, tuples, unit and type
   aliases** — Lane B1 milestone M3 of
   [#517](https://github.com/sunholo-data/ailang/issues/517). A contract property

--- a/internal/ai/ollama/step.go
+++ b/internal/ai/ollama/step.go
@@ -261,6 +261,13 @@ func (c *Client) Step(ctx context.Context, req *ai.Request) (*ai.Response, error
 	// is how we diff what each harness actually sends to the model.
 	logOllamaRequest(req)
 
+	// Capture the context BEFORE ollamaCallContext's wrap. The streaming /v1
+	// branch derives its own (much longer) hard deadline from THIS context —
+	// see streamCallContext for why deriving from the wrapped ctx would cap
+	// every stream at the buffered path's 300s default and make the feature
+	// inert. Every other path below keeps using the wrapped ctx unchanged.
+	outerCtx := ctx
+
 	// Bound the whole call (native /api/chat has no client timeout — see
 	// ollamaCallContext). Covers the /v1 delegation and Generate fallback too.
 	ctx, cancel := ollamaCallContext(ctx)
@@ -281,6 +288,14 @@ func (c *Client) Step(ctx context.Context, req *ai.Request) (*ai.Response, error
 	// pointed at the Ollama host's /v1 (dummy key; Ollama ignores auth). Set
 	// AILANG_OLLAMA_NATIVE_TOOLS=1 to force the legacy native /api/chat tool path.
 	if len(req.Tools) > 0 && os.Getenv("AILANG_OLLAMA_NATIVE_TOOLS") != "1" {
+		// M-OLLAMA-V1-STREAMING-IDLE-TIMEOUT (ailang#618): opt-in streaming
+		// variant of exactly this call. Default-OFF — with the flag unset the
+		// buffered request built below is byte-identical to today's, which is
+		// why this is an early return rather than a restructure.
+		if ollamaStreamEnabled() {
+			return c.stepV1Stream(outerCtx, req)
+		}
+
 		// CRITICAL: bound the call with an HTTP timeout. The /v1 Step path is
 		// non-streaming (io.ReadAll of the full body) and openai.NewClient
 		// defaults to http.DefaultClient (Timeout: 0). On a single shared local

--- a/internal/ai/ollama/streambranch_test.go
+++ b/internal/ai/ollama/streambranch_test.go
@@ -1,0 +1,670 @@
+package ollama
+
+// streambranch_test.go — acceptance tests for M2 of
+// M-OLLAMA-V1-STREAMING-IDLE-TIMEOUT (ailang#618).
+//
+// A separate file from step_test.go on purpose: AC-M2.1 requires that the
+// existing bodies in step_test.go stay UNMODIFIED, and a new file makes that
+// property hold by construction rather than by review.
+//
+// Window granularity note: the two soft windows are configured through env
+// vars that take whole SECONDS, so the plan's "500ms idle / 900ms delay" shapes
+// are realised here as "1s idle / 1.5s delay". The ORDERING the plan relies on
+// (emission interval < idle window < delay < TTFT window < hard deadline) is
+// preserved exactly; only the scale moves.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sunholo-data/ailang/internal/ai"
+)
+
+// --- fake /v1 server --------------------------------------------------------
+
+// fakeV1 is an Ollama-compatible /v1 endpoint under test control. It counts
+// requests (AC-M2.3 needs "exactly zero requests left the process") and
+// captures the raw request bytes + headers (AC-M2.1 needs the wire shape).
+type fakeV1 struct {
+	srv      *httptest.Server
+	requests atomic.Int32
+	stop     chan struct{}
+
+	mu     sync.Mutex
+	body   []byte
+	header http.Header
+	path   string
+}
+
+// newFakeV1 starts the server and registers cleanups so a handler that is
+// deliberately stalling cannot wedge srv.Close(). Cleanups run LIFO, so the
+// stop channel is closed BEFORE the server is closed.
+func newFakeV1(t *testing.T, h func(f *fakeV1, w http.ResponseWriter, r *http.Request)) *fakeV1 {
+	t.Helper()
+	f := &fakeV1{stop: make(chan struct{})}
+	f.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.requests.Add(1)
+		b, _ := io.ReadAll(r.Body)
+		f.mu.Lock()
+		f.body = b
+		f.header = r.Header.Clone()
+		f.path = r.URL.Path
+		f.mu.Unlock()
+		h(f, w, r)
+	}))
+	t.Cleanup(f.srv.Close)
+	t.Cleanup(func() { close(f.stop) })
+	return f
+}
+
+func (f *fakeV1) capturedBody() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return string(f.body)
+}
+
+func (f *fakeV1) capturedHeader(k string) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.header == nil {
+		return ""
+	}
+	return f.header.Get(k)
+}
+
+// sseHeaders writes the SSE response header and flushes it, so the response
+// HEADERS are always on the wire immediately. Everything the tests delay is
+// therefore a BODY delay, which is what the TTFT/idle windows measure.
+func sseHeaders(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.WriteHeader(http.StatusOK)
+	flush(w)
+}
+
+func flush(w http.ResponseWriter) {
+	if fl, ok := w.(http.Flusher); ok {
+		fl.Flush()
+	}
+}
+
+// sseWrite returns false once the client has gone away, so a "forever" handler
+// terminates instead of spinning.
+func sseWrite(w http.ResponseWriter, s string) bool {
+	if _, err := io.WriteString(w, s); err != nil {
+		return false
+	}
+	flush(w)
+	return true
+}
+
+func sseData(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err) // test-only: the literals below are always marshalable
+	}
+	return "data: " + string(b) + "\n\n"
+}
+
+func contentChunk(text string) string {
+	return sseData(map[string]any{
+		"id": "chatcmpl-1", "object": "chat.completion.chunk", "model": "qwen3.6",
+		"choices": []any{map[string]any{"index": 0, "delta": map[string]any{"content": text}}},
+	})
+}
+
+// toolFragChunk emits ONE tool_calls fragment and nothing else — no content,
+// no reasoning. This is the shape that fires zero onChunk callbacks
+// (streamstep.go has no tool-call callback site), which is exactly why the
+// idle clock has to live at the READ level.
+func toolFragChunk(name, args string) string {
+	fn := map[string]any{}
+	if name != "" {
+		fn["name"] = name
+	}
+	if args != "" {
+		fn["arguments"] = args
+	}
+	return sseData(map[string]any{
+		"id": "chatcmpl-1", "object": "chat.completion.chunk", "model": "qwen3.6",
+		"choices": []any{map[string]any{"index": 0, "delta": map[string]any{
+			"tool_calls": []any{map[string]any{
+				"index": 0, "id": "call_1", "type": "function", "function": fn,
+			}},
+		}}},
+	})
+}
+
+func finishChunk(reason string) string {
+	return sseData(map[string]any{
+		"id": "chatcmpl-1", "object": "chat.completion.chunk", "model": "qwen3.6",
+		"choices": []any{map[string]any{"index": 0, "delta": map[string]any{}, "finish_reason": reason}},
+	})
+}
+
+const doneChunk = "data: [DONE]\n\n"
+
+// --- harness ----------------------------------------------------------------
+
+// streamEnv puts the process in "streaming /v1, no native tools" mode.
+func streamEnv(t *testing.T, endpoint string) {
+	t.Helper()
+	t.Setenv("AILANG_OLLAMA_NATIVE_TOOLS", "")
+	t.Setenv("AILANG_OLLAMA_V1_STREAM", "1")
+	t.Setenv("OLLAMA_HOST", endpoint)
+}
+
+func toolReq() *ai.Request {
+	return &ai.Request{
+		Model:    "ollama:qwen3.6",
+		Messages: []ai.Message{{Role: "user", Content: "write x.ail"}},
+		Tools: []ai.ToolSchema{{
+			Name: "write_file", Description: "write a file",
+			Parameters: `{"type":"object","properties":{"path":{"type":"string"}}}`,
+		}},
+	}
+}
+
+func newTestClient(t *testing.T, endpoint string) *Client {
+	t.Helper()
+	c, err := NewClient(WithEndpoint(endpoint))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c
+}
+
+type stepResult struct {
+	resp *ai.Response
+	err  error
+}
+
+// stepWithin runs Step on a goroutine and fails the test if it has not
+// returned within limit. Every timeout AC needs this: the failure mode of a
+// broken watchdog is an infinite block, and a bare synchronous call would
+// surface that as a 10-minute package timeout rather than a named failure.
+func stepWithin(t *testing.T, c *Client, req *ai.Request, limit time.Duration) stepResult {
+	t.Helper()
+	done := make(chan stepResult, 1)
+	go func() {
+		resp, err := c.Step(context.Background(), req)
+		done <- stepResult{resp, err}
+	}()
+	select {
+	case r := <-done:
+		return r
+	case <-time.After(limit):
+		t.Fatalf("Step did not return within %v — the watchdog/deadline never fired", limit)
+		return stepResult{}
+	}
+}
+
+// --- AC-M2.1 — default-off is byte-identical (doc S5) ------------------------
+
+// TestStreamBranch_DefaultOffIsByteIdentical pins the release-gating property:
+// with AILANG_OLLAMA_V1_STREAM unset, the /v1 request is the buffered one, with
+// no streaming markers anywhere on the wire.
+//
+// The flag_on_control subtest is the anti-vacuity arm: it proves the three
+// assertions can SEE a streaming request, so their absence in the flag-off arm
+// is a measurement rather than a broken instrument.
+func TestStreamBranch_DefaultOffIsByteIdentical(t *testing.T) {
+	t.Run("flag_unset_sends_a_buffered_request", func(t *testing.T) {
+		f := newFakeV1(t, func(_ *fakeV1, w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"id":"chatcmpl-1","object":"chat.completion","model":"qwen3.6","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+		})
+		t.Setenv("AILANG_OLLAMA_NATIVE_TOOLS", "")
+		t.Setenv("AILANG_OLLAMA_V1_STREAM", "") // the default: unset
+		t.Setenv("OLLAMA_HOST", f.srv.URL)
+
+		c := newTestClient(t, f.srv.URL)
+		resp, err := c.Step(context.Background(), toolReq())
+		if err != nil {
+			t.Fatalf("Step: %v", err)
+		}
+		if resp.Text != "ok" {
+			t.Errorf("Text = %q, want %q", resp.Text, "ok")
+		}
+		body := f.capturedBody()
+		if strings.Contains(body, `"stream":true`) {
+			t.Errorf("flag-off request set stream:true; body = %s", body)
+		}
+		if strings.Contains(body, "stream_options") {
+			t.Errorf("flag-off request carried stream_options; body = %s", body)
+		}
+		if got := f.capturedHeader("Accept"); got == "text/event-stream" {
+			t.Errorf("flag-off request asked for SSE: Accept = %q", got)
+		}
+	})
+
+	t.Run("flag_on_control_the_assertions_can_see_a_stream", func(t *testing.T) {
+		f := newFakeV1(t, func(_ *fakeV1, w http.ResponseWriter, _ *http.Request) {
+			sseHeaders(w)
+			sseWrite(w, contentChunk("ok"))
+			sseWrite(w, finishChunk("stop"))
+			sseWrite(w, doneChunk)
+		})
+		streamEnv(t, f.srv.URL)
+		c := newTestClient(t, f.srv.URL)
+		if _, err := c.Step(context.Background(), toolReq()); err != nil {
+			t.Fatalf("Step: %v", err)
+		}
+		body := f.capturedBody()
+		if !strings.Contains(body, `"stream":true`) {
+			t.Errorf("CONTROL FAILED: flag-on request has no stream:true, so the flag-off assertion proves nothing; body = %s", body)
+		}
+		if !strings.Contains(body, "stream_options") {
+			t.Errorf("CONTROL FAILED: flag-on request has no stream_options; body = %s", body)
+		}
+		if got := f.capturedHeader("Accept"); got != "text/event-stream" {
+			t.Errorf("CONTROL FAILED: flag-on Accept = %q, want text/event-stream", got)
+		}
+	})
+}
+
+// --- AC-M2.2 — the MANDATORY hard deadline (doc S8) --------------------------
+
+// TestStreamBranch_HardDeadlineBeatsKeepAlive is the highest-risk requirement
+// in the sprint: a server that emits keep-alive BYTES forever but never a
+// parseable chunk defeats an idle-only guard completely, because every
+// keep-alive resets the idle clock. Only a total budget terminates it.
+//
+// Interval (100ms) << idle window (1s) << hard deadline (2s): the idle timer is
+// provably reset throughout and provably never fires, so the terminating error
+// can only have come from the deadline. The !ErrIdleTimeout assertion pins
+// which of the two racing clocks is reported.
+func TestStreamBranch_HardDeadlineBeatsKeepAlive(t *testing.T) {
+	f := newFakeV1(t, func(f *fakeV1, w http.ResponseWriter, r *http.Request) {
+		sseHeaders(w)
+		tick := time.NewTicker(100 * time.Millisecond)
+		defer tick.Stop()
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-f.stop:
+				return
+			case <-tick.C:
+				if !sseWrite(w, ": keep-alive\n") {
+					return
+				}
+			}
+		}
+	})
+	streamEnv(t, f.srv.URL)
+	t.Setenv("AILANG_OLLAMA_IDLE_TIMEOUT_SEC", "1")
+	t.Setenv("AILANG_OLLAMA_HTTP_TIMEOUT_SEC", "2") // the hard deadline
+
+	c := newTestClient(t, f.srv.URL)
+	start := time.Now()
+	got := stepWithin(t, c, toolReq(), 3*time.Second)
+	elapsed := time.Since(start)
+
+	if got.err == nil {
+		t.Fatalf("expected a hard-deadline error from an infinite keep-alive stream, got resp=%+v", got.resp)
+	}
+	if !errors.Is(got.err, ErrStreamDeadlineExceeded) {
+		t.Fatalf("err = %v, want errors.Is(err, ErrStreamDeadlineExceeded)", got.err)
+	}
+	if errors.Is(got.err, ErrIdleTimeout) {
+		t.Errorf("err reported as idle timeout, but bytes flowed every 100ms under a 1s idle window: %v", got.err)
+	}
+	if elapsed < 1500*time.Millisecond {
+		t.Errorf("returned after %v — too early for a 2s deadline; something other than the deadline fired", elapsed)
+	}
+}
+
+// --- AC-M2.3 — a configured 0 is REJECTED, not "disabled" (doc S8) -----------
+
+// TestStreamBranch_ZeroDeadlineIsRejectedBeforeAnyRequest pins the semantics
+// split. For the legacy buffered resolver, AILANG_OLLAMA_HTTP_TIMEOUT_SEC=0
+// means "no cap" and TestOllamaV1Timeout pins that. For the streaming path an
+// uncapped stream is the hang the feature exists to prevent, so the same value
+// is a configuration ERROR — and the request-counter assertion is what stops an
+// implementation that merely fails "eventually" from passing.
+func TestStreamBranch_ZeroDeadlineIsRejectedBeforeAnyRequest(t *testing.T) {
+	for _, v := range []string{"0", "-1"} {
+		t.Run("value_"+v, func(t *testing.T) {
+			f := newFakeV1(t, func(_ *fakeV1, w http.ResponseWriter, _ *http.Request) {
+				sseHeaders(w)
+				sseWrite(w, contentChunk("should never be reached"))
+				sseWrite(w, doneChunk)
+			})
+			streamEnv(t, f.srv.URL)
+			t.Setenv("AILANG_OLLAMA_HTTP_TIMEOUT_SEC", v)
+
+			c := newTestClient(t, f.srv.URL)
+			_, err := c.Step(context.Background(), toolReq())
+			if err == nil {
+				t.Fatal("expected ErrStreamDeadlineInvalid, got nil")
+			}
+			if !errors.Is(err, ErrStreamDeadlineInvalid) {
+				t.Fatalf("err = %v, want errors.Is(err, ErrStreamDeadlineInvalid)", err)
+			}
+			if n := f.requests.Load(); n != 0 {
+				t.Fatalf("server saw %d requests, want 0 — the refusal must happen before anything leaves the process", n)
+			}
+		})
+	}
+
+	// The mirror case: the SAME value keeps its legacy meaning on the buffered
+	// path, so this change is a split of semantics and not a redefinition.
+	t.Run("flag_off_zero_still_means_uncapped_on_the_legacy_path", func(t *testing.T) {
+		f := newFakeV1(t, func(_ *fakeV1, w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"id":"c","object":"chat.completion","model":"qwen3.6","choices":[{"index":0,"message":{"role":"assistant","content":"legacy"},"finish_reason":"stop"}]}`)
+		})
+		t.Setenv("AILANG_OLLAMA_NATIVE_TOOLS", "")
+		t.Setenv("AILANG_OLLAMA_V1_STREAM", "")
+		t.Setenv("OLLAMA_HOST", f.srv.URL)
+		t.Setenv("AILANG_OLLAMA_HTTP_TIMEOUT_SEC", "0")
+
+		if got := ollamaV1Timeout(); got != 0 {
+			t.Fatalf("ollamaV1Timeout() = %v, want 0 (legacy 'disabled') — the legacy resolver must not change", got)
+		}
+		c := newTestClient(t, f.srv.URL)
+		resp, err := c.Step(context.Background(), toolReq())
+		if err != nil {
+			t.Fatalf("legacy buffered path failed with the same value that the stream rejects: %v", err)
+		}
+		if resp.Text != "legacy" {
+			t.Errorf("Text = %q, want %q", resp.Text, "legacy")
+		}
+	})
+}
+
+// --- AC-M2.4 — the outer 300s deadline must not survive (REFUTATION #1) ------
+
+// readStreamMetrics returns the single stream_metrics record from the ollama
+// debug log at path.
+func readStreamMetrics(t *testing.T, path string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read debug log: %v", err)
+	}
+	var found []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("debug log line is not JSON: %v (%s)", err, line)
+		}
+		if rec["kind"] == "stream_metrics" {
+			found = append(found, rec)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("found %d stream_metrics records, want exactly 1 (log: %s)", len(found), raw)
+	}
+	return found[0]
+}
+
+// TestStreamBranch_EffectiveDeadlineIsNotTheOuter300s is the gate on
+// REFUTATION #1. Step wraps the whole call in ollamaCallContext (300s default)
+// BEFORE the /v1 branch is reached; a streaming branch derived from that
+// context is capped at 300s no matter what the hard deadline says, and the
+// feature ships inert with the rig reproducing today's ~4m59s signature.
+//
+// Why the deadline VALUE and not a wall clock: both clocks read the same env
+// var, so whenever it is set they are equal and no elapsed-time test can tell
+// them apart. They differ only in their DEFAULTS — 300s vs 3600s — so the env
+// is left unset here and the discriminating observation is the effective
+// deadline read back from streamCtx.Deadline().
+func TestStreamBranch_EffectiveDeadlineIsNotTheOuter300s(t *testing.T) {
+	f := newFakeV1(t, func(_ *fakeV1, w http.ResponseWriter, _ *http.Request) {
+		sseHeaders(w)
+		sseWrite(w, contentChunk("hi"))
+		sseWrite(w, finishChunk("stop"))
+		sseWrite(w, doneChunk)
+	})
+	streamEnv(t, f.srv.URL)
+	t.Setenv("AILANG_OLLAMA_HTTP_TIMEOUT_SEC", "") // UNSET: the defaults diverge
+	logPath := t.TempDir() + "/ollama.jsonl"
+	t.Setenv("AILANG_OLLAMA_LOG_REQUESTS", logPath)
+
+	c := newTestClient(t, f.srv.URL)
+	if _, err := c.Step(context.Background(), toolReq()); err != nil {
+		t.Fatalf("Step: %v", err)
+	}
+
+	rec := readStreamMetrics(t, logPath)
+	eff, ok := rec["effective_deadline_sec"].(float64)
+	if !ok {
+		t.Fatalf("stream_metrics has no numeric effective_deadline_sec: %+v", rec)
+	}
+	if eff < 3500 {
+		t.Fatalf("effective deadline = %.0fs, want >= 3500s. "+
+			"~300s means the streaming branch inherited ollamaCallContext's wrap "+
+			"instead of the pre-wrap context, and the feature is inert. (record: %+v)", eff, rec)
+	}
+	if hard, ok := rec["hard_deadline_sec"].(float64); !ok || hard != 3600 {
+		t.Errorf("hard_deadline_sec = %v, want 3600 (the configured default)", rec["hard_deadline_sec"])
+	}
+	// The falsifier fields for Design Freeze #1/#2/#3 must all be present.
+	for _, k := range []string{"ttft_ms", "max_gap_ms", "total_ms", "effective_deadline_sec"} {
+		if _, ok := rec[k]; !ok {
+			t.Errorf("stream_metrics is missing %q — AC-M4.2 reads this on the rig", k)
+		}
+	}
+}
+
+// --- AC-M2.5 — tool-call-only streams must not starve the clock (doc S1) -----
+
+// TestStreamBranch_ToolCallOnlyStreamDoesNotStarve pins the property that makes
+// read-level placement of the idle clock correct by construction: a stream of
+// pure tool_calls fragments fires the onChunk callback ZERO times (streamstep.go
+// has no tool-call callback site), so a callback-level clock would starve and
+// kill a perfectly healthy turn.
+//
+// Fragments arrive every 300ms for ~3s under a 1s idle window and a 2s TTFT
+// window; the call must COMPLETE with correctly assembled arguments.
+func TestStreamBranch_ToolCallOnlyStreamDoesNotStarve(t *testing.T) {
+	frags := []string{`{"pa`, `th":"`, `a.ail`, `"}`}
+	f := newFakeV1(t, func(f *fakeV1, w http.ResponseWriter, r *http.Request) {
+		sseHeaders(w)
+		// 10 emissions at 300ms => ~3s of stream, all tool_calls, no content.
+		send := func(s string) bool {
+			select {
+			case <-r.Context().Done():
+				return false
+			case <-f.stop:
+				return false
+			case <-time.After(300 * time.Millisecond):
+				return sseWrite(w, s)
+			}
+		}
+		if !send(toolFragChunk("write_file", "")) {
+			return
+		}
+		for _, fr := range frags {
+			if !send(toolFragChunk("", fr)) {
+				return
+			}
+		}
+		for i := 0; i < 5; i++ {
+			if !send(toolFragChunk("", "")) { // keep-alive-shaped tool frags
+				return
+			}
+		}
+		if !send(finishChunk("tool_calls")) {
+			return
+		}
+		sseWrite(w, doneChunk)
+	})
+	streamEnv(t, f.srv.URL)
+	t.Setenv("AILANG_OLLAMA_IDLE_TIMEOUT_SEC", "1")
+	t.Setenv("AILANG_OLLAMA_TTFT_TIMEOUT_SEC", "2")
+
+	c := newTestClient(t, f.srv.URL)
+	got := stepWithin(t, c, toolReq(), 8*time.Second)
+	if got.err != nil {
+		t.Fatalf("a progressing tool-call-only stream was killed: %v", got.err)
+	}
+	if len(got.resp.ToolCalls) != 1 {
+		t.Fatalf("ToolCalls = %+v, want exactly 1", got.resp.ToolCalls)
+	}
+	tc := got.resp.ToolCalls[0]
+	if tc.Name != "write_file" {
+		t.Errorf("tool call name = %q, want write_file", tc.Name)
+	}
+	if want := strings.Join(frags, ""); tc.Arguments != want {
+		t.Errorf("arguments = %q, want %q (fragments not concatenated)", tc.Arguments, want)
+	}
+	if got.resp.FinishReason != "tool_calls" {
+		t.Errorf("FinishReason = %q, want tool_calls", got.resp.FinishReason)
+	}
+}
+
+// --- AC-M2.6 — idle window at branch level (doc S2) -------------------------
+
+// TestStreamBranch_IdleTimeoutFiresMidStream is the failure this whole line of
+// work exists to catch: bytes flow, then the model goes silent forever.
+func TestStreamBranch_IdleTimeoutFiresMidStream(t *testing.T) {
+	f := newFakeV1(t, func(f *fakeV1, w http.ResponseWriter, r *http.Request) {
+		sseHeaders(w)
+		for i := 0; i < 3; i++ {
+			if !sseWrite(w, contentChunk(fmt.Sprintf("chunk%d ", i))) {
+				return
+			}
+		}
+		select { // then silence, forever
+		case <-r.Context().Done():
+		case <-f.stop:
+		}
+	})
+	streamEnv(t, f.srv.URL)
+	t.Setenv("AILANG_OLLAMA_IDLE_TIMEOUT_SEC", "1")
+
+	c := newTestClient(t, f.srv.URL)
+	got := stepWithin(t, c, toolReq(), 5*time.Second)
+	if got.err == nil {
+		t.Fatalf("expected ErrIdleTimeout from a stream that went silent, got resp=%+v", got.resp)
+	}
+	if !errors.Is(got.err, ErrIdleTimeout) {
+		t.Fatalf("err = %v, want errors.Is(err, ErrIdleTimeout)", got.err)
+	}
+	if errors.Is(got.err, ErrTTFTTimeout) {
+		t.Errorf("bytes had already flowed, so this is not a TTFT failure: %v", got.err)
+	}
+}
+
+// --- AC-M2.7 — TTFT window at branch level (doc S3) -------------------------
+
+// TestStreamBranch_TTFTWindowIsSeparateFromIdle pins that the two windows are
+// genuinely two windows. A cold 35B load legitimately produces nothing for
+// minutes; if the (short) idle window were armed from t=0, every cold start
+// would be killed. The first subtest is red under collapsing the windows into
+// one; the second is red if the TTFT window never fires at all.
+func TestStreamBranch_TTFTWindowIsSeparateFromIdle(t *testing.T) {
+	t.Run("slow_first_byte_within_ttft_completes", func(t *testing.T) {
+		f := newFakeV1(t, func(f *fakeV1, w http.ResponseWriter, r *http.Request) {
+			sseHeaders(w) // headers immediately; the DELAY is body-side
+			select {
+			case <-r.Context().Done():
+				return
+			case <-f.stop:
+				return
+			case <-time.After(1500 * time.Millisecond): // > idle 1s, < TTFT 3s
+			}
+			sseWrite(w, contentChunk("late"))
+			sseWrite(w, finishChunk("stop"))
+			sseWrite(w, doneChunk)
+		})
+		streamEnv(t, f.srv.URL)
+		t.Setenv("AILANG_OLLAMA_IDLE_TIMEOUT_SEC", "1")
+		t.Setenv("AILANG_OLLAMA_TTFT_TIMEOUT_SEC", "3")
+
+		c := newTestClient(t, f.srv.URL)
+		got := stepWithin(t, c, toolReq(), 6*time.Second)
+		if got.err != nil {
+			t.Fatalf("a 1.5s pre-first-byte wait under a 3s TTFT window was killed: %v", got.err)
+		}
+		if got.resp.Text != "late" {
+			t.Errorf("Text = %q, want %q", got.resp.Text, "late")
+		}
+	})
+
+	t.Run("first_byte_past_ttft_fires_the_ttft_sentinel", func(t *testing.T) {
+		f := newFakeV1(t, func(f *fakeV1, w http.ResponseWriter, r *http.Request) {
+			sseHeaders(w)
+			select { // never send a body byte
+			case <-r.Context().Done():
+			case <-f.stop:
+			}
+		})
+		streamEnv(t, f.srv.URL)
+		t.Setenv("AILANG_OLLAMA_IDLE_TIMEOUT_SEC", "1")
+		t.Setenv("AILANG_OLLAMA_TTFT_TIMEOUT_SEC", "2")
+
+		c := newTestClient(t, f.srv.URL)
+		got := stepWithin(t, c, toolReq(), 6*time.Second)
+		if got.err == nil {
+			t.Fatalf("expected ErrTTFTTimeout, got resp=%+v", got.resp)
+		}
+		if !errors.Is(got.err, ErrTTFTTimeout) {
+			t.Fatalf("err = %v, want errors.Is(err, ErrTTFTTimeout)", got.err)
+		}
+		if errors.Is(got.err, ErrIdleTimeout) {
+			t.Errorf("no byte ever arrived, so this is not an idle failure: %v", got.err)
+		}
+	})
+}
+
+// --- AC-M2.8 — long but progressing beats the old client timeout (doc S4) ----
+
+// TestStreamBranch_LongProgressingStreamCompletes is the V12 trap in its pure
+// form. A whole-call http.Client.Timeout cannot distinguish "still producing
+// tokens" from "wedged": here the stream drips for 2.5s under a 4s budget and
+// must COMPLETE. Any client-level timer shorter than the total stream duration
+// interrupts the body read mid-stream and fails this.
+func TestStreamBranch_LongProgressingStreamCompletes(t *testing.T) {
+	const n = 12
+	f := newFakeV1(t, func(f *fakeV1, w http.ResponseWriter, r *http.Request) {
+		sseHeaders(w)
+		for i := 0; i < n; i++ {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-f.stop:
+				return
+			case <-time.After(200 * time.Millisecond):
+			}
+			if !sseWrite(w, contentChunk(fmt.Sprintf("t%d ", i))) {
+				return
+			}
+		}
+		sseWrite(w, finishChunk("stop"))
+		sseWrite(w, doneChunk)
+	})
+	streamEnv(t, f.srv.URL)
+	t.Setenv("AILANG_OLLAMA_HTTP_TIMEOUT_SEC", "4") // > the ~2.5s stream
+
+	var want strings.Builder
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&want, "t%d ", i)
+	}
+
+	c := newTestClient(t, f.srv.URL)
+	got := stepWithin(t, c, toolReq(), 8*time.Second)
+	if got.err != nil {
+		t.Fatalf("a 2.5s progressing stream under a 4s budget was killed: %v", got.err)
+	}
+	if got.resp.Text != want.String() {
+		t.Errorf("Text = %q, want %q", got.resp.Text, want.String())
+	}
+}

--- a/internal/ai/ollama/streamstep.go
+++ b/internal/ai/ollama/streamstep.go
@@ -1,0 +1,318 @@
+package ollama
+
+// streamstep.go — M2 of M-OLLAMA-V1-STREAMING-IDLE-TIMEOUT (ailang#618).
+//
+// Split out of step.go rather than appended to it so the flag-off diff to
+// Step is exactly two hunks (the outerCtx capture and one early return), and
+// so M3's response-parity work has room without crossing the 800-line gate.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sunholo-data/ailang/internal/ai"
+	"github.com/sunholo-data/ailang/internal/ai/openai"
+)
+
+// --- Streaming /v1 path (M-OLLAMA-V1-STREAMING-IDLE-TIMEOUT, ailang#618 M2) ---
+//
+// The buffered /v1 path above reads the whole response with io.ReadAll under a
+// single whole-call clock. That clock cannot tell "the model is thinking hard"
+// from "the connection is wedged", so it is either too short (a long-but-healthy
+// turn is killed at 4m59.97s) or too long (a wedged stream hangs for hours).
+//
+// The streaming path replaces one coarse clock with three sharp ones:
+// TTFT (silence before the first byte), IDLE (silence between bytes) and a
+// MANDATORY hard deadline (total budget). The first two live in the response
+// body wrapper (idlereader.go); the third is the request context.
+
+// ollamaStreamEnabled reports whether the flag-gated streaming /v1 path is on.
+//
+// Exactly "1" opts in. Deliberately NOT `!= "0"`: default-off is a contract
+// (doc S5 — with the flag unset the wire bytes must be identical to today's),
+// so this must be an opt-IN test, not an opt-out one.
+func ollamaStreamEnabled() bool {
+	return os.Getenv("AILANG_OLLAMA_V1_STREAM") == "1"
+}
+
+// streamCallContext derives the streaming call's context from outer — the
+// context as it was BEFORE Step's ollamaCallContext wrap — and returns the
+// resolved hard deadline alongside it.
+//
+// Deriving from outer is the entire point of Step's outerCtx capture.
+// ollamaCallContext bounds the buffered paths at AILANG_OLLAMA_HTTP_TIMEOUT_SEC
+// with a 300s default. A streaming branch derived from THAT context would be
+// capped at 300s no matter how large the new hard deadline was configured to
+// be: the effective bound is the minimum of the two, so the feature would ship
+// inert and every long turn would still die at ~4m59s — the exact signature
+// this work exists to remove.
+//
+// The hard deadline is MANDATORY. A <= 0 or unparseable configuration is
+// REJECTED here, before any HTTP request is made, rather than silently meaning
+// "unbounded" (which is what the same value means to the legacy resolver
+// ollamaV1Timeout, whose semantics TestOllamaV1Timeout pins and which this
+// must not change). An unbounded stream is the hang the guard exists to stop.
+func streamCallContext(outer context.Context) (context.Context, context.CancelFunc, time.Duration, error) {
+	hard, err := ollamaStreamHardDeadline()
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	base, stopHard := outer, context.CancelFunc(func() {})
+	if hard > 0 {
+		base, stopHard = context.WithTimeout(outer, hard)
+	}
+	// A cancellable child of the hard-deadline context so the TTFT/idle
+	// watchdog can fail a pending Read immediately instead of waiting out the
+	// total budget. Cancelling the child leaves the parent's deadline intact,
+	// so streamCtx.Deadline() still reads back the hard deadline.
+	ctx, cancel := context.WithCancel(base)
+	return ctx, func() { cancel(); stopHard() }, hard, nil
+}
+
+// streamMetrics is the per-request falsifier record for Design Freeze #1/#2/#3:
+// the observed TTFT and max inter-chunk gap are what say whether the 600s/120s
+// window defaults are right, and the read-back effective deadline is what says
+// whether the hard deadline actually reached the wire.
+//
+// Read-level timings (ttft, maxGap, bytes) are recorded by meteredReader;
+// delta counts come from the StreamStep callback. In M2 the callback only
+// counts — M3 gives it the response-parity job.
+type streamMetrics struct {
+	mu             sync.Mutex
+	start          time.Time
+	ttft           time.Duration
+	lastRead       time.Time
+	maxGap         time.Duration
+	bytes          int64
+	sawFirst       bool
+	contentDeltas  int
+	thinkingDeltas int
+}
+
+// observe records a non-empty read: TTFT on the first one, the running maximum
+// inter-read gap thereafter.
+func (m *streamMetrics) observe(n int) {
+	now := time.Now()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.bytes += int64(n)
+	if !m.sawFirst {
+		m.sawFirst = true
+		m.ttft = now.Sub(m.start)
+	} else if gap := now.Sub(m.lastRead); gap > m.maxGap {
+		m.maxGap = gap
+	}
+	m.lastRead = now
+}
+
+// onChunk is the StreamStep callback. Non-nil on purpose: it is the seam M3
+// uses to recover Response.Reasoning without touching the shared SSE parser.
+// In M2 it only counts deltas for the debug log.
+func (m *streamMetrics) onChunk(chunk ai.StreamChunk) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	switch chunk.(type) {
+	case ai.StreamContentDelta:
+		m.contentDeltas++
+	case ai.StreamThinkingDelta:
+		m.thinkingDeltas++
+	}
+}
+
+// meteredReader times reads without touching the watchdog wrapper it sits on
+// top of. Placed OUTSIDE the idleReader so it observes exactly the reads the
+// SSE scanner performs, and so idlereader.go stays a pure M1 artifact.
+type meteredReader struct {
+	inner io.ReadCloser
+	m     *streamMetrics
+}
+
+var _ io.ReadCloser = (*meteredReader)(nil)
+
+func (r *meteredReader) Read(p []byte) (int, error) {
+	n, err := r.inner.Read(p)
+	if n > 0 {
+		r.m.observe(n)
+	}
+	return n, err
+}
+
+func (r *meteredReader) Close() error { return r.inner.Close() }
+
+// streamWatchTransport wraps the per-request idleTimeoutTransport so the caller
+// can ask, after the fact, WHICH window fired.
+//
+// It is needed because the typed sentinel the idleReader returns from Read is
+// consumed by bufio.Scanner inside ParseChatStepSSEStream and re-wrapped as an
+// *ai.AIError, which errors.Is cannot see through. Holding the reader lets the
+// error mapping below reconstruct the typed sentinel from the wrapper's own
+// first-writer-wins CAS rather than sniffing error strings.
+type streamWatchTransport struct {
+	inner http.RoundTripper
+	m     *streamMetrics
+
+	mu     sync.Mutex
+	reader *idleReader
+}
+
+var _ http.RoundTripper = (*streamWatchTransport)(nil)
+
+func (t *streamWatchTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.inner.RoundTrip(req)
+	if resp == nil || resp.Body == nil {
+		return resp, err
+	}
+	if ir, ok := resp.Body.(*idleReader); ok {
+		t.mu.Lock()
+		t.reader = ir
+		t.mu.Unlock()
+	}
+	resp.Body = &meteredReader{inner: resp.Body, m: t.m}
+	return resp, err
+}
+
+// firedError returns the typed sentinel for the window that fired, or nil if
+// none did. cause is kept as context so the transport-level error is not lost.
+func (t *streamWatchTransport) firedError(cause error) error {
+	t.mu.Lock()
+	r := t.reader
+	t.mu.Unlock()
+	if r == nil {
+		return nil
+	}
+	code := r.fired.Load()
+	if code == firedNone {
+		return nil
+	}
+	return r.sentinel(code, cause)
+}
+
+// stepV1Stream is the streaming twin of Step's buffered /v1 delegation.
+//
+// outerCtx is Step's PRE-ollamaCallContext context; see streamCallContext.
+func (c *Client) stepV1Stream(outerCtx context.Context, req *ai.Request) (*ai.Response, error) {
+	streamCtx, cancel, hard, cfgErr := streamCallContext(outerCtx)
+	if cfgErr != nil {
+		// Refuse before anything leaves the process. Returning the error here
+		// rather than after a request is what makes "0 is rejected, not
+		// disabled" observable: the server sees zero requests.
+		return nil, ai.NewProviderError("ollama", 0, cfgErr.Error(), cfgErr)
+	}
+	defer cancel()
+
+	metrics := &streamMetrics{start: time.Now()}
+	// cancel is the watchdog's escape hatch: a blocked Read cannot interrupt
+	// itself, so the watchdog cancels the request context and the transport
+	// fails the pending Read.
+	//
+	// Hard is deliberately left at 0 here: the total budget is enforced ONCE,
+	// by streamCtx. Arming the reader's hard window with the same value would
+	// be a second timer for the same budget, and a redundant guard is one that
+	// no test can hold accountable — neutering either half would leave every
+	// deadline test green. The typed ErrStreamDeadlineExceeded still reaches
+	// the caller, via rule (b) in streamStepError.
+	watch := &streamWatchTransport{
+		m: metrics,
+		inner: newIdleTimeoutTransport(cancel, idleReaderConfig{
+			TTFT: ollamaTTFTTimeout(),
+			Idle: ollamaIdleTimeout(),
+		}),
+	}
+
+	v1 := openai.NewClient("ollama",
+		openai.WithBaseURL(strings.TrimRight(c.endpoint, "/")+"/v1"),
+		// Timeout: 0 on purpose. A whole-call client timeout is exactly the
+		// trap this path removes — it fires mid-stream on a long but healthily
+		// progressing response, which is indistinguishable to the caller from
+		// a wedge. The bound is streamCtx's hard deadline plus the per-read
+		// TTFT/idle watchdogs in the transport.
+		openai.WithHTTPClient(&http.Client{Timeout: 0, Transport: watch}),
+	)
+
+	// Same request shaping as the buffered branch. Deliberately duplicated
+	// rather than factored out: the flag-off diff to Step must stay reviewable
+	// as "one early return", with no edits to the code it guards.
+	r2 := *req
+	r2.Model = bareModel(req.Model)
+	r2.Temperature = resolveOllamaTemperature(req.Temperature)
+	r2.MaxTokens = resolveOllamaMaxTokens(req.MaxTokens)
+
+	resp, err := v1.StreamStep(streamCtx, &r2, metrics.onChunk)
+	logOllamaStreamMetrics(metrics, streamCtx, hard, err)
+	if err != nil {
+		return nil, streamStepError(err, watch, streamCtx)
+	}
+	logOllamaResponse(resp)
+	return resp, nil
+}
+
+// streamStepError maps a StreamStep failure to a typed error with EXPLICIT
+// precedence. Precedence matters because when the hard deadline expires the
+// idle timer is usually racing it, and a caller asking "was this idle?" must
+// not get a yes from a deadline.
+//
+//	(a) a window fired  -> that window's sentinel (first-writer-wins CAS)
+//	(b) the context hit its deadline -> ErrStreamDeadlineExceeded
+//	(c) anything else   -> StreamStep's own classification, unchanged
+//
+// The typed sentinel is carried by an *ai.ProviderError so errors.Is still
+// finds it (ai.AIError cannot wrap a sentinel from outside its own package),
+// and the message embeds the sentinel text so string-based retry classifiers
+// downstream keep seeing "timeout".
+func streamStepError(err error, watch *streamWatchTransport, streamCtx context.Context) error {
+	if fired := watch.firedError(err); fired != nil {
+		return ai.NewProviderError("ollama", 0, fired.Error(), fired)
+	}
+	if errors.Is(streamCtx.Err(), context.DeadlineExceeded) {
+		hardErr := fmt.Errorf("%w (transport: %v)", ErrStreamDeadlineExceeded, err)
+		return ai.NewProviderError("ollama", 0, hardErr.Error(), hardErr)
+	}
+	return err
+}
+
+// logOllamaStreamMetrics appends the per-request stream record to the same
+// JSONL sink as logOllamaRequest/logOllamaResponse (AILANG_OLLAMA_LOG_REQUESTS,
+// or the HOME sentinel that reaches harnesses which drop our env).
+//
+// effective_deadline_sec is READ BACK from streamCtx.Deadline() rather than
+// reported from the configured value. That distinction is the whole point: a
+// configured 3600s that arrives on the wire as 300s because an outer context
+// deadline survived is precisely the inert-feature bug, and only the read-back
+// value can see it. Compare it with hard_deadline_sec: if they disagree,
+// something upstream is capping the stream.
+func logOllamaStreamMetrics(m *streamMetrics, streamCtx context.Context, hard time.Duration, err error) {
+	m.mu.Lock()
+	rec := map[string]any{
+		"kind":              "stream_metrics",
+		"ts":                time.Now().UTC().Format(time.RFC3339Nano),
+		"ttft_ms":           m.ttft.Milliseconds(),
+		"max_gap_ms":        m.maxGap.Milliseconds(),
+		"total_ms":          time.Since(m.start).Milliseconds(),
+		"bytes":             m.bytes,
+		"content_deltas":    m.contentDeltas,
+		"thinking_deltas":   m.thinkingDeltas,
+		"hard_deadline_sec": hard.Seconds(),
+		"idle_window_sec":   ollamaIdleTimeout().Seconds(),
+		"ttft_window_sec":   ollamaTTFTTimeout().Seconds(),
+		"saw_first_byte":    m.sawFirst,
+		"effective_deadline_sec": func() float64 {
+			dl, ok := streamCtx.Deadline()
+			if !ok {
+				return 0
+			}
+			return dl.Sub(m.start).Seconds()
+		}(),
+	}
+	m.mu.Unlock()
+	if err != nil {
+		rec["error"] = err.Error()
+	}
+	appendOllamaLog(rec)
+}


### PR DESCRIPTION
Milestone **M2** of the `#618` ollama streaming sprint (M1 landed as #647 / `752f997d1`).

Adds an opt-in streaming variant of the `/v1` tool-calling call (`AILANG_OLLAMA_V1_STREAM=1`), wrapped in M1's idle/TTFT/hard-deadline reader, so a stalled local-model stream fails in seconds with a typed sentinel instead of burning the whole 300s client cap.

### The load-bearing change is two lines

The streaming branch derives its deadline from the context captured **before** `ollamaCallContext`'s wrap at `step.go:266`. The `/v1` branch sits 17 lines below it, so deriving from the wrapped `ctx` would cap every stream at the buffered path's 300s default and ship the feature **inert** — reproducing the exact `took=4m59.97x` signature the sprint exists to remove. That is planner refutation R1, and **AC-M2.4 is its gate**: with the capture moved below the wrap (mutant LANDED by sha256, BUILDS rc=0) the effective deadline reads back `299.999963583s` against a configured `3600s` and the test reds; `-skip` that one test and the package is rc=0, so it is the **sole killer**.

### Default-OFF is byte-identical, not merely equivalent

With the flag unset the request carries no `"stream"`, no `"stream_options"` and no `text/event-stream` `Accept`, asserted against the captured raw wire body. `step_test.go` and `idlereader.go` are sha256-identical to HEAD. The `step.go` diff is **+15/−0** — two additive hunks, zero deletions.

`AILANG_OLLAMA_HTTP_TIMEOUT_SEC` gains split semantics: `0` still means "uncapped" on the legacy path, but is a configuration error (`ErrStreamDeadlineInvalid`) refused **before any request leaves** on the streaming path.

### Two executor deviations, both adjudicated by controller measurement in both arms

- **Controller ruling E-3's behavioural arm for AC-M2.4 is impossible, not merely weaker — and the ruling was the controller's own.** Precedence rule (b) maps any `streamCtx` `DeadlineExceeded` to `ErrStreamDeadlineExceeded` regardless of provenance, so the error *type* cannot discriminate: under the R1 defect above, `TestStreamBranch_HardDeadlineBeatsKeepAlive` still passes rc=0. Only the read-back value discriminates.
- **`idleReaderConfig.Hard` stays 0 in production.** Measured: with only `streamCtx` armed, neutering it reds AC-M2.2 **and** AC-M2.4; with **both** armed the same neuter leaves AC-M2.2 **green**. A redundant guard is one no test can hold accountable.

### Verification

All gates rc=0: `build` · `test ./internal/ai/...` · `vet` · `gofmt` · `check-file-sizes` · `check-boundaries` · `check-changelog` · `check-golden-drift` · `check-skills` · `fmt-check` · `test-regression-guards`. Anti-vacuity: ollama package **30 → 38** top-level `--- PASS`, one per AC, 0 FAIL.

Evaluator (sonnet, ≠ the opus executor) **97/100 PASS, zero blocking**: reproduced both adjudications independently, refuted the `sync.Once`-freeze vacuity risk (TTFT is read fresh per call, bypassing the frozen shared transport), and killed all six in-scope named mutations with each AC's own test.

Closes part of #618.

🤖 Generated with [Claude Code](https://claude.com/claude-code)