### PR TITLE
feat(ollama): #618 M4 — fixture replay pin, stopgap removal, docs (+ the stopgap's second delivery site)

### DIFF
--- a/.claude/rules/dev-workflow.md
+++ b/.claude/rules/dev-workflow.md
@@ -39,11 +39,39 @@ make check-file-sizes     # Fails if >800 lines
 | `AILANG_TRACE_MAX_SPANS=N` | Per-trace span budget (default 500). Overflow emits `trace.truncated` rollup |
 | `AILANG_NO_TRACE=1` | Back-compat alias for `AILANG_TRACE=off` |
 | `AILANG_EVAL_MAX_RSS=8G` | Eval memory cap per generated-code run (process-group RSS, default 8G, `off` disables). Breach → tree killed, banked as `resource_limit` |
+| `AILANG_OLLAMA_V1_STREAM=1` | Opt into the streaming ollama `/v1` path (v0.34.0, default **off**). Exactly `"1"` opts in — flag-off wire bytes are unchanged. Changes what `AILANG_OLLAMA_HTTP_TIMEOUT_SEC` means (see below) |
+| `AILANG_OLLAMA_IDLE_TIMEOUT_SEC=120` | Streaming only. Max silence **between** bytes before the stream is failed with a typed `idle-timeout`. Default 120. Unparseable/`<= 0` falls back to the default |
+| `AILANG_OLLAMA_TTFT_TIMEOUT_SEC=600` | Streaming only. Max silence **before the first byte** (cold 35B load under GPU contention). Default 600. Unparseable/`<= 0` falls back to the default |
+| `AILANG_OLLAMA_HTTP_TIMEOUT_SEC` | **Semantics depend on the flag.** Flag-off (buffered `/v1`): HTTP client + whole-call cap, default **300**, `0` means *no timeout*. Flag-on (streaming): the **mandatory hard deadline** on the whole stream, default **3600**, and `0`/negative/unparseable is **REJECTED** at construction (typed error, no request sent) rather than meaning unbounded. **Two delivery sites on the rig** — see below |
 | `--trace-tier off\|standard\|deep` | Tracing tier CLI flag (overrides env) |
 | `--timeout 30s` | Compilation timeout with stack dump (CLI flag) |
 | `--debug-compile` | Phase timing breakdown (CLI flag) |
 | `-cpuprofile FILE` | Write Go CPU profile (CLI flag) |
 | `-memprofile FILE` | Write memory allocation profile (CLI flag) |
+
+**Rig gotcha — `AILANG_OLLAMA_*` reaches a launchd job by TWO paths.** The plist's
+`EnvironmentVariables` block, *and* the launchd **user-domain global** set by `launchctl setenv`.
+No plist edit touches the global, and no `grep` over the repo can see it. Audit the live value with
+a control, never the plist alone:
+
+```bash
+launchctl getenv AILANG_OLLAMA_HTTP_TIMEOUT_SEC   # empty == not pinned
+launchctl getenv AILANG_NOT_A_REAL_VAR            # control: also empty, so empty is a measurement
+```
+
+Measured 2026-08-11: both repo plists were cleaned and every grep read green while the domain
+global still held `1800`, so streamed requests kept logging `effective_deadline_sec = 1800` instead
+of the 3600s default. A grep-over-files criterion cannot see site 2 — that is a property of the
+instrument, not of the config.
+
+**Two more things that bite in this order.** The repo plists are *source*: the installed copies in
+`~/Library/LaunchAgents/` are regular files (not symlinks), updated by a manual
+`cp` + `launchctl load` (`tools/launchd/nightly-eval.sh:19-21`), so **editing the repo changes
+nothing on the rig**. And clearing site 2 is **ordered** — while `AILANG_OLLAMA_V1_STREAM` is off,
+the buffered path's `ollamaV1Timeout()` falls back to **300s** and the global is the only thing
+raising it, so `launchctl unsetenv` *before* the flag-on plists are installed re-creates the
+#618 defect (895 retries / ~74.6 GPU-hours, `b67d415cd`). Install the flag-on plists first,
+`launchctl unsetenv` second.
 
 **Full guide**: See `docs/docs/guides/debugging.md`
 

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -150,6 +150,47 @@
   three-case streamed-≡-buffered parity table asserting `Text`, `ToolCalls` (order,
   IDs, assembled arguments), `FinishReason` and `Reasoning` are byte-identical.
 
+- **The rig now opts into Ollama `/v1` streaming, and the 1800s timeout stopgap is
+  gone** — milestone M4 of
+  [#618](https://github.com/sunholo-data/ailang/issues/618), which closes the
+  sprint. Both eval launchd plists (`dev.ailang.os-rotation-filler`,
+  `dev.ailang.nightly-eval`) drop the 2026-08-07 `AILANG_OLLAMA_HTTP_TIMEOUT_SEC=1800`
+  pin and set `AILANG_OLLAMA_V1_STREAM=1` in the same edit. Removing the pin is
+  **mandatory, not tidy-up**: flag-on, that same variable stops being an HTTP client
+  timeout and becomes the stream's hard deadline, and 1800s sits *below* the computed
+  worst-case legitimate request (~2941s) — leaving it would have re-created the
+  `took=4m59.97` failure at a larger scale. Unset, the hard deadline defaults to
+  3600s and hangs are caught by the sharper idle (120s) and TTFT (600s) windows.
+
+  **The pin had a second delivery site, and the plist edit does not reach it.** On the
+  rig, `AILANG_OLLAMA_HTTP_TIMEOUT_SEC=1800` was *also* a launchd **user-domain
+  global** (`launchctl setenv`), inherited by every job in the domain, invisible to
+  any grep over the repo, and untouched by editing `EnvironmentVariables`. With both
+  plists already clean, streamed requests still logged `hard_deadline_sec = 1800` and
+  `effective_deadline_sec = 1800` rather than the 3600s default — caught only because
+  `effective_deadline_sec` is **read back** from the request context instead of
+  reported from the configured value. Clearing it needs
+  `launchctl unsetenv AILANG_OLLAMA_HTTP_TIMEOUT_SEC`; audit with
+  `launchctl getenv …` against a known-unset control name.
+
+  Note the ordering, because the obvious cleanup order is the harmful one: the
+  global is **load-bearing until the flag is on**. The repo plists are source — the
+  installed copies under `~/Library/LaunchAgents/` are regular files updated by a
+  manual `cp` + `launchctl load` — so with the flag not yet installed the buffered
+  path runs, `ollamaV1Timeout()` falls back to **300s**, and the global is the only
+  thing raising it. Install the flag-on plists **first**, clear the global
+  **second**; the reverse order re-creates the very defect this milestone closes.
+  Documented in `docs/docs/guides/debugging.md` and `.claude/rules/dev-workflow.md`.
+
+  Also adds a replay regression pin over **real ollama wire bytes**: the committed
+  `ollama_v1_stream_toolcall.sse` capture (a qwen3.6:35b tool-calling turn — 48
+  `reasoning` deltas with empty `content`, then one chunk carrying the whole tool
+  call) is parsed through `ParseChatStepSSEStream` and asserted end to end, so a
+  future ollama emission change or parser regression fails a sub-second unit test
+  instead of a GPU run. The three streaming knobs and the split
+  `AILANG_OLLAMA_HTTP_TIMEOUT_SEC` semantics are documented in
+  `docs/docs/guides/debugging.md`.
+
 - **Property tests now derive generators for records, tuples, unit and type
   aliases** — Lane B1 milestone M3 of
   [#517](https://github.com/sunholo-data/ailang/issues/517). A contract property

--- a/design_docs/planned/m-ollama-v1-streaming-idle-timeout.md
+++ b/design_docs/planned/m-ollama-v1-streaming-idle-timeout.md
@@ -334,7 +334,10 @@ reassembly that already exists):**
   `ollamaV1Timeout()`.
 - `internal/ai/ollama/step_test.go`: fake-SSE-server tests (M2 below), including the
   tool-call-only starvation gate.
-- `internal/ai/openai/streamstep_test.go` (M3): replay the **already-committed** ollama `/v1`
+- `internal/ai/openai/step.go` (M3): export `ExtractHermesToolCalls` so the ollama streaming
+  branch can reuse the Hermes recovery rather than duplicating its regex (ruling E-2). The
+  recovery and the `Reasoning` accumulation themselves land in `internal/ai/ollama/streamstep.go`.
+- `internal/ai/openai/streamstep_test.go` (M4): replay the **already-committed** ollama `/v1`
   fixture (`internal/ai/ollama/testdata/ollama_v1_stream_toolcall.sse` — real wire bytes from the
   2026-08-10 rig probe, V21, not a hand-written mock) through `ParseChatStepSSEStream` — coverage
   widening only, no source change. The capture itself is DONE; only the replay test remains.
@@ -397,6 +400,24 @@ grammar/type conflict surface. Runtime risks:
   the existing code verbatim (moved into an `else` — indentation-only diff) with the existing
   300s-default total cap: byte-identical requests on the wire, proven by S5 below and by the
   unchanged existing `step_test.go` suite.
+- ⚠️ **THE STOPGAP HAS TWO DELIVERY SITES, AND EDITING THE REPO REACHES NEITHER OF THEM**
+  (measured 2026-08-11, iteration 175; this paragraph previously described only the plists, and
+  followed literally it produces the exact failure the next bullet warns about). **(i)** the two
+  plists below — but `tools/launchd/*.plist` is *source*: the rig runs
+  `~/Library/LaunchAgents/*.plist`, which are **regular files, not symlinks**, installed by a
+  manual `cp` + `launchctl load` (`tools/launchd/nightly-eval.sh:19-21`). **(ii)** a launchd
+  **user-domain global** — `launchctl getenv AILANG_OLLAMA_HTTP_TIMEOUT_SEC` returns `1800`, set
+  by `launchctl setenv` when the stopgap landed (`b67d415cd` says so in its own body: *"pinned in
+  both rig plists (also set live via launchctl setenv)"*). Controls: an unset variable and
+  `AILANG_OLLAMA_V1_STREAM` both return empty, so the reading discriminates. A grep over the
+  plists cannot see (ii) at all.
+  **The rollout is therefore ORDERED, and the obvious order is the harmful one.** Install the
+  flag-on, pin-free plists and `launchctl load` them **first**; clear the global **second**.
+  Reversed, the flag is still off everywhere installed, so the buffered path runs and
+  `ollamaV1Timeout()` falls to its **300s** default (`step.go:24`) for every invocation the
+  plists do not cover — reintroducing `#618` at its measured cost of 895 retries / ~74.6
+  GPU-hours. The stopgap is load-bearing until the flag is on. Full arms and controls in the
+  sprint plan's AC-M4.3.
 - The rig opts in via the launchd plists that today pin the `AILANG_OLLAMA_HTTP_TIMEOUT_SEC=1800`
   stopgap (`dev.ailang.os-rotation-filler.plist`, `dev.ailang.nightly-eval.plist`) — replace the
   stopgap pin with `AILANG_OLLAMA_V1_STREAM=1` in the same edit, so the band-aid is removed by
@@ -406,9 +427,11 @@ grammar/type conflict surface. Runtime risks:
   4m59.97 failure at a larger scale. Note the semantics split: flag-off, `0` still means "no
   timeout" (legacy `ollamaV1Timeout()`, `step.go:29-39`); flag-on, `0` is a loud construction
   error.
-- Default flips on in v0.35.0 only if the M3 rig validation held for the release cycle (no
-  idle/TTFT false-trips on passing runs — checkable from the per-request max-gap/TTFT debug logs
-  added in M2).
+- Default flips on in v0.35.0 only if **both** the M3 response-parity work and the **M4** rig
+  validation held for the release cycle (no idle/TTFT false-trips on passing runs — checkable
+  from the per-request max-gap/TTFT debug logs added in M2). Parity alone is not sufficient
+  evidence to flip a default on the rig. (Milestones were renumbered on 2026-08-10 when the
+  parity milestone was inserted as M3; the rig-validation milestone this sentence means is M4.)
 
 ## Success Criteria (each names the mutation that turns it red)
 
@@ -445,7 +468,7 @@ grammar/type conflict surface. Runtime risks:
   and once as SSE (via the streaming branch) yields identical `Response.Text`,
   `Response.ToolCalls` (order, IDs, assembled arguments), and `FinishReason`. **Red under:**
   fragment-ordering or concatenation regressions in assembly.
-- [ ] **S7 — Field validation (M3, on the rig).** With the flag on, `docx_reimplement` produces an
+- [ ] **S7 — Field validation (M4, on the rig).** With the flag on, `docx_reimplement` produces an
   end-to-end X/17 grade, and the per-request debug logs show max inter-chunk gap, TTFT, and total
   request duration for every request (the falsifiers for Design Freeze #1/#2/#3). **Red under:**
   any false idle/TTFT trip on a progressing run, or a run lost to `context deadline exceeded` at
@@ -496,22 +519,46 @@ tests in `step_test.go` covering S1–S6 and S8 — S1 (tool-call-only starvatio
 (keep-alive-forever bounded) are the non-negotiable gates. *Acceptance: S1–S6 + S8 green;
 existing tests untouched and green; flag-off diff is indentation-only.*
 
-**M3 — Fixture replay + rig validation + docs (RE-SCOPED 2026-08-10: the capture task is DONE).**
-The original M3 task "capture a real streamed response in a test fixture" was completed **before
-the sprint** by the controller's 2026-08-10 rig probe: real wire bytes — not a hand-written mock
-— are committed at `internal/ai/ollama/testdata/ollama_v1_stream_toolcall.sse` (13,077 B,
-52 events; provenance in V21, contents re-derived locally in V22). What remains in M3: write the
-replay test through `ParseChatStepSSEStream` (added to `streamstep_test.go` — coverage only, no
-source change); flip the rig plists to `AILANG_OLLAMA_V1_STREAM=1` (removing the 1800s stopgap
-pin in the same edit — V19); run `docx_reimplement` end-to-end; record the observed TTFT /
-max-gap distributions against the freeze defaults. Add the three env knobs to the debug-flags
-table in `.claude/rules/dev-workflow.md` + `docs/docs/guides/debugging.md`. *Acceptance: S7
-green; fixture-replay test green; freeze-default falsifier data recorded in the PR description.*
+**M3 — Response parity: `Reasoning` + Hermes tool-call recovery (ADDED by the sprint plan,
+2026-08-10).** This milestone did not exist in the first draft of this doc, which assumed
+`StreamStep` was response-*equivalent* to `Step` and that "everything downstream is unchanged".
+Planning refuted that: `ParseChatStepSSEStream` never sets `out.Reasoning`, and — far more
+seriously — it has no equivalent of the buffered path's Hermes tool-call recovery
+(`openai/step.go:610-616`), which exists precisely because Ollama's `/v1` sometimes fails to lift
+a `<tool_call>` block out of a **Qwen3 thinking model's** reasoning text into `tool_calls`. Swapping
+to streaming without this would trade a timeout bug for the *disengagement* bug this whole line of
+work exists to fight. So: export `extractHermesToolCalls`, accumulate `StreamThinkingDelta` text
+through a **non-nil** `onChunk` (reversing this doc's earlier `v1.StreamStep(ctx, &r2, nil)` — the
+only seam that recovers `Reasoning` without editing `streamstep.go`, which the non-goals forbid),
+set `resp.Reasoning`, and run the identical zero-native-tool-calls recovery.
+*Acceptance: S6, strengthened into a three-case streamed-≡-buffered table — native single-chunk
+tool call, tool call fragmented across 3 chunks, and Hermes block in `reasoning` with zero native
+tool calls. S6 as originally written would have passed green while the regression shipped.*
 
-## Timeline (realistic; ~1–2 days total under V8/V9)
-- Day 1 AM: M1. Day 1 PM: M2 (the branch is ~40–60 LOC; the tests are the bulk).
-- Day 2: M3 (rig time dominates; the docx run is wall-clock-bound — the fixture capture is
-  already done, which shortens M3's code-bound portion to the replay test + plist flip).
+**M4 — Fixture replay + rig validation + stopgap removal + docs (RE-SCOPED 2026-08-10: the capture
+task is DONE).** The original "capture a real streamed response in a test fixture" task was
+completed **before** the sprint by the controller's 2026-08-10 rig probe: real wire bytes — not a
+hand-written mock — are committed at `internal/ai/ollama/testdata/ollama_v1_stream_toolcall.sse`
+(13,077 B, 52 events; provenance in V21, contents re-derived locally in V22). What remains in M4:
+write the replay test through `ParseChatStepSSEStream` (added to `streamstep_test.go` — coverage
+only, no source change); flip the rig plists to `AILANG_OLLAMA_V1_STREAM=1` (removing the 1800s
+stopgap pin in the same edit — V19, and mandatory, not tidy-up); run `docx_reimplement`
+end-to-end; record the observed TTFT / max-gap distributions against the freeze defaults. Add the
+three env knobs, and the changed `AILANG_OLLAMA_HTTP_TIMEOUT_SEC` semantics, to the debug-flags
+table in `.claude/rules/dev-workflow.md` + `docs/docs/guides/debugging.md`. *Acceptance: S7 green;
+fixture-replay test green; freeze-default falsifier data recorded in the PR description.*
+
+## Timeline (revised 2026-08-10: 3 days, not 1–2)
+- Day 1: M1, and start M2.
+- Day 2: finish M2, then M3.
+- Day 3: M4 (rig-lock window + docs). The docx run is wall-clock-bound; the fixture capture is
+  already done, which shortens M4's code-bound portion to the replay test + plist flip.
+
+The earlier "~1–2 days" estimate was downstream of the premise that the buffered→streaming swap
+was semantically free. M3 is work that premise hid, and it cannot be dropped without shipping a
+disengagement regression. Rollout note: the v0.35.0 default flip requires **both** M3 parity
+**and** M4 rig validation to have held — the "M3 rig validation" phrasing in Rollout above predates
+this renumbering and now means **M4**.
 
 ## Related Documents
 - [m-eval-stream-health-retry](v0_24_0/m-eval-stream-health-retry.md) (neural 0.48) — **distinct**: that covers eval-harness-level stream health + retry policy; this is the ollama client's per-call timeout semantics underneath it. Complementary.

--- a/design_docs/planned/v1_0_0/m-ollama-v1-streaming-idle-timeout-sprint-plan.md
+++ b/design_docs/planned/v1_0_0/m-ollama-v1-streaming-idle-timeout-sprint-plan.md
@@ -140,6 +140,21 @@ report UNINFORMATIVE and let the controller re-run outside.
 | `grep -c AILANG_OLLAMA_HTTP_TIMEOUT_SEC tools/launchd/dev.ailang.{os-rotation-filler,nightly-eval}.plist` | **1** each — **correctly red**, must reach **0** |
 | `grep -c AILANG_OLLAMA tools/launchd/dev.ailang.{os-rotation-filler,nightly-eval}.plist` | **1** each — anti-vacuity **control fires** |
 | `grep -rc AILANG_OLLAMA_V1_STREAM tools/launchd/*.plist` | **0** everywhere — must reach ≥1 in both |
+| `launchctl getenv AILANG_OLLAMA_HTTP_TIMEOUT_SEC` | **`1800`** — **SECOND DELIVERY SITE, missed by this table's first draft.** See below |
+| `launchctl getenv AILANG_OLLAMA_V1_STREAM` · `launchctl getenv AILANG_NOT_A_REAL_VAR` | **empty** each — the anti-vacuity control pair: the instrument discriminates set from unset, so the `1800` above is a measurement |
+| `test -L ~/Library/LaunchAgents/dev.ailang.{nightly-eval,os-rotation-filler}.plist` | **not symlinks** — both are regular files. The repo copies are *source*, not the running config |
+| `diff -q ~/Library/LaunchAgents/dev.ailang.*.plist` vs `git show HEAD:tools/launchd/…` | **identical** — the installed files match repo HEAD, i.e. pre-M4. Install is a manual `cp` + `launchctl load` (`tools/launchd/nightly-eval.sh:19-21`), so **a repo edit reaches the rig only when a human copies it** |
+
+**The stopgap has TWO delivery sites and the three rows above this one only measure ONE.**
+`AILANG_OLLAMA_HTTP_TIMEOUT_SEC=1800` is also a launchd **user-domain global**, set by
+`launchctl setenv`, which **no plist edit touches**. The stopgap commit says so in its own body —
+`git log -1 b67d415cd`: *"pinned in both rig plists (**also set live via launchctl setenv**)"* —
+and this table's first draft measured only the plists. Consequence: the grep criterion can go fully
+GREEN while the hazard stays live, and it did. Measured on the controller's in-flight GPU run with
+the flag on and both plists already edited: every streamed request logged
+`hard_deadline_sec = 1800` **and** `effective_deadline_sec = 1800`, not the 3600 default — i.e. the
+inherited global became the hard deadline, which is the exact ~2941s-worst-case hazard AC-M4.3
+exists to remove, one level up from where the criterion was looking. AC-M4.3 gains a fourth arm.
 
 ### 2.5 Load-bearing code facts, re-verified first-party at `3e1f63f7a`
 
@@ -179,10 +194,37 @@ block, because a mutant that fails to compile reds for the wrong reason.
 | R7 | Streaming branch selected only when flag set | `if false && os.Getenv("AILANG_OLLAMA_V1_STREAM") == "1" {` | AC-M2.1 (S5, inverted: flag-ON case) |
 | R8 | Hermes recovery on zero native tool calls | `if false && len(resp.ToolCalls) == 0 {` | **AC-M3.1** |
 | R9 | Reasoning accumulation from thinking deltas | `if false && d.Text != "" { rb.WriteString(d.Text) }` | AC-M3.2 |
-| R10 | Tool-call argument fragment concatenation | `if false && tcFrag.Function.Arguments != "" {` (`streamstep.go:299`) | AC-M4.1 |
+| R10 | Tool-call argument fragment concatenation | `if false && tcFrag.Function.Arguments != "" {` (`streamstep.go:`**`298`**) | AC-M4.1 |
+| R11 | Usage mapping from the final chunk | `if false && chunk.Usage.PromptTokens > 0 {` (`streamstep.go:248`) | AC-M4.1 (controller-added) |
+| R12b | **Fixture** tool-call arguments: line 97 `Paris` → `Berlin` | not an `if false &&` — the mutation target is the captured wire bytes, not a branch | AC-M4.1 (controller-added) |
 
 R10 is a mutation of *existing* code, used only to prove the M4 replay test actually reads the
 assembly path. It is a verification step, not a change to ship.
+
+**R10's line number was wrong in this register's first draft** — it said `streamstep.go:299`, but
+`:299` is the `WriteString` body; the predicate is at **`:298`**. Measured independently by the
+executor and the controller.
+
+**Finding (2026-08-11): R10 is NOT discriminating for AC-M4.1; R12b is.** Executed results:
+
+| Mutation | Landed (sha256 differs) | Builds | Arm A — target test alone | Arm B — package `-skip` target |
+|---|---|---|---|---|
+| R10 | yes | rc=0 | **rc=1**, `Arguments = "{}"` | **rc=1** — pre-existing `TestStreamStep_ParsesToolCallFragments` also dies |
+| R11 | yes | rc=0 | **rc=1**, `InputTokens = 0, want 294` | **rc=1** — pre-existing `TestStreamStep_ParsesContentAndUsage` also dies |
+| R12b | yes, *and asserted to have landed on the mechanism* | n/a (data) | **rc=1**, `=== RUN` 1, `Arguments = "{\"city\":\"Berlin\"}"` | **rc=0** — **UNIQUE killer** |
+
+**Why arm B failing is expected rather than a defect in the M4 test.** No mutation of
+`openai/streamstep.go` can be unique to the replay test, because the package's existing tests
+already cover parse, assembly and usage on hand-written SSE. AC-M4.1's object is the **captured
+wire shape** — that today's real ollama emission still parses to `get_weather{"city":"Paris"}` with
+usage `294/80/374` — so the discriminating mutation is one on the **fixture**, which is what R12b
+is. The earlier instruction "arm B must stay rc=0 under R10" was an over-specification: this plan
+only ever claimed R10 proves the test reaches the assembly path, which it does.
+
+**Methodology note carried by R12b, worth more than the result.** The controller's first R12b
+attempt edited line 17 — thinking text, not the tool call — and the test correctly stayed green.
+A mutation must be asserted to have landed **on the mechanism under test**, not merely to have
+changed the file's bytes; a sha256 diff proves the edit happened, not that it was aimed correctly.
 
 ---
 
@@ -504,6 +546,61 @@ is default-off and no default behaviour changes — but turning it on early woul
   doc's computed worst-case legitimate request (~2941s) — it would re-create the `4m59.97` failure at
   a larger scale.
   **RED UNDER**: leaving either pin in place.
+
+  **FOURTH ARM (added 2026-08-11, after the first three passed while the hazard stayed live).**
+  The stopgap has **two** delivery sites and the three arms above measure only one. The launchd
+  user-domain global is set by `launchctl setenv`, survives every plist edit, and is invisible to
+  any grep over the repo; §2.4 records the commit that says so and the in-flight rig measurement
+  (`effective_deadline_sec = 1800`) that caught it. A criterion that greens on the plists alone is
+  measuring the *file*, not the process environment the rig job actually inherits.
+
+  > ### ⚠️ THIS ARM IS RIG-STATE ROLLOUT — **NOT** PART OF M4's REPO DELIVERABLE
+  >
+  > **M4's repo work is complete when the files change.** The plists in `tools/launchd/` are
+  > *source*; the rig runs `~/Library/LaunchAgents/`. Measured 2026-08-11: both installed files are
+  > **regular files, not symlinks**, and were **byte-identical to repo HEAD** — installation is a
+  > manual `cp` + `launchctl load`, documented at `tools/launchd/nightly-eval.sh:19-21`. Editing
+  > this repo therefore changes **nothing** on the rig. Steps 1–2 below are a separate,
+  > human-sequenced action with its own ordering hazard, and no executor should perform them as
+  > "finishing the milestone".
+
+  **The rollout is ORDERED. Flag ON first, clear the global SECOND.**
+
+  1. **Install the flag-on, pin-free plists**, then reload them:
+     `cp tools/launchd/dev.ailang.{nightly-eval,os-rotation-filler}.plist ~/Library/LaunchAgents/`
+     followed by `launchctl unload && launchctl load` on each. Verify with
+     `grep -c AILANG_OLLAMA_V1_STREAM ~/Library/LaunchAgents/dev.ailang.*.plist` → ≥1 each
+     (base: **0** each, so the check discriminates).
+  2. **Only then** `launchctl unsetenv AILANG_OLLAMA_HTTP_TIMEOUT_SEC`, asserted by
+     `launchctl getenv AILANG_OLLAMA_HTTP_TIMEOUT_SEC` returning **empty**, paired in the same call
+     with a **firing control** — a known-set variable returning non-empty — so an empty result is a
+     measurement and not a broken call. (At base the target itself reads `1800` while
+     `launchctl getenv AILANG_OLLAMA_V1_STREAM` and `launchctl getenv AILANG_NOT_A_REAL_VAR` read
+     empty, which is the same discrimination in the other direction.)
+
+  **HAZARD OF THE REVERSE ORDER — do not "tidy up" the global first.** Until step 1 is installed,
+  `AILANG_OLLAMA_V1_STREAM` is unset **everywhere installed**, so the streaming branch is OFF and
+  the buffered path is live. On the buffered path `ollamaV1Timeout()` (`step.go:28-39`) falls back
+  to `defaultOllamaV1TimeoutSec = 300` (`step.go:24`), and the domain global is the **only** thing
+  raising it for any invocation not covered by a plist's own `EnvironmentVariables`. Clearing the
+  global before the flag is on therefore drops those invocations straight back to 300s and
+  **reintroduces the exact defect #618 exists to fix** — the one that cost 895 retries /
+  ~74.6 GPU-hours over 43 days, 80 runs lost (`b67d415cd`). **The stopgap is load-bearing until the
+  flag is on.** Step 2 before step 1 is not a cosmetic mistake; it is a regression to the original
+  bug at full cost.
+
+  **RED UNDER**: editing the plists (or even installing them) without clearing the domain global —
+  the three grep arms pass and step 2 fails, which is precisely the state that shipped. Also red,
+  in the opposite and more expensive direction, under performing step 2 before step 1.
+
+  **Known limitation of arms 1–3, stated so the next person does not read it as an oversight**:
+  the instrument is a raw `grep -c` over the **whole file**, not a plist-key query, so the criterion
+  forbids naming `AILANG_OLLAMA_HTTP_TIMEOUT_SEC` anywhere in either file — including in a comment
+  explaining why the pin was removed. The M4 executor hit this: an explanatory removal comment held
+  the count at 1 and read red. The comments therefore describe it as "the 1800s total-timeout pin"
+  without the literal token, and the variable name lives in git history. Do not "fix" this by
+  matching a partial token; that games the instrument. If a future revision wants the name back in
+  prose, change the arm to a key-level query (e.g. `plutil -extract EnvironmentVariables …`) first.
 
 **Milestone boundary (not acceptance criteria — these gate the repo, not the feature):**
 `go build ./internal/... ./cmd/ailang` · `go test -count=1 ./internal/ai/...` ·

--- a/docs/docs/guides/debugging.md
+++ b/docs/docs/guides/debugging.md
@@ -155,6 +155,117 @@ $ DEBUG_PARSER=1 ailang run test.ail
 | `DEBUG_OPERATOR_LOWERING=1` | Operator resolution | Dispatch issues | Builtin selection |
 | `DEBUG_PARSER=1` | Token position tracing | Parser bugs | Token flow |
 
+### Ollama Streaming Timeouts (v0.34.0)
+
+Local-model turns on the eval rig are long: a `qwen3.6:35b` thinking turn can run
+well past the buffered path's 300s default cap. A single total-duration clock
+cannot tell **"the model is thinking hard"** from **"the connection is wedged"**,
+so it is either too short (a healthy turn is killed at 4m59.97s) or too long
+(a wedged stream hangs for hours). The streaming `/v1` path replaces one coarse
+clock with three sharp ones.
+
+| Flag | Purpose | Use When | Default |
+|------|---------|----------|---------|
+| `AILANG_OLLAMA_V1_STREAM=1` | Opt into the streaming ollama `/v1` path. Exactly `"1"` opts in — anything else keeps today's buffered path with byte-identical requests | Long local-model turns timing out mid-generation | **off** |
+| `AILANG_OLLAMA_IDLE_TIMEOUT_SEC` | Max silence **between** bytes. Trips a typed `idle-timeout` — this is the "wedged" detector | A hung stream should fail fast instead of burning the whole budget | `120` |
+| `AILANG_OLLAMA_TTFT_TIMEOUT_SEC` | Max silence **before the first byte**. Long on purpose: a cold 35B load under GPU contention legitimately takes minutes | Cold-start false trips | `600` |
+| `AILANG_OLLAMA_HTTP_TIMEOUT_SEC` | Total budget for the whole call — **but its meaning changes with the flag**, see below | Bounding worst-case wall clock | `300` off / `3600` on |
+
+:::warning `AILANG_OLLAMA_HTTP_TIMEOUT_SEC` means two different things
+
+- **Flag off (buffered `/v1`)** — an HTTP client timeout and whole-call cap,
+  default **300s**, where `0` (or negative) means *no timeout at all*.
+- **Flag on (streaming `/v1`)** — the **mandatory hard deadline** on the stream,
+  default **3600s**, where `0`, a negative, or an unparseable value is
+  **rejected at client construction** with a typed configuration error and **no
+  HTTP request is sent**. An unbounded stream is precisely the hang the guard
+  exists to prevent, so there is deliberately no "disabled" setting here.
+
+The practical consequence: a value that was a safe raise on the buffered path
+becomes a **ceiling** on the streaming path. Auditing a config, read the flag
+first. This is why the rig's launchd plists dropped their `1800` stopgap pin in
+the same edit that added the flag — 1800s sits below the worst-case legitimate
+request and would have re-created the timeout it was added to fix.
+:::
+
+:::danger Two delivery sites — clearing one does not clear the other
+
+On the eval rig this variable reaches a job by **two independent paths**, and
+they must be audited separately:
+
+1. **The plist**, via `EnvironmentVariables` in `tools/launchd/*.plist`.
+2. **The launchd user-domain global**, set once by `launchctl setenv` and
+   inherited by every job in the domain. **No plist edit touches it**, it
+   survives reboots of the job, and it is invisible to any `grep` over the repo.
+
+Editing the plists alone is therefore *not* enough to remove a pin — it silently
+keeps applying from site 2. Check the live value before trusting a config:
+
+```bash
+launchctl getenv AILANG_OLLAMA_HTTP_TIMEOUT_SEC   # empty == not pinned
+launchctl getenv AILANG_NOT_A_REAL_VAR            # control: also empty
+```
+
+Pair the check with a known-unset name as above, so an empty answer is a
+measurement rather than a broken command.
+
+**Clearing site 2 is ordered, and the wrong order is expensive.** Site 2 is
+load-bearing while the streaming flag is off: with the flag unset the buffered
+path runs, `ollamaV1Timeout()` falls back to its **300s** default, and the domain
+global is the only thing raising it for invocations a plist does not cover. So
+turn the flag on **first** — the plists in `tools/launchd/` are *source*, and the
+installed copies under `~/Library/LaunchAgents/` are regular files updated by a
+manual `cp` + `launchctl load`, so editing the repo changes nothing on the rig —
+and only then:
+
+```bash
+launchctl unsetenv AILANG_OLLAMA_HTTP_TIMEOUT_SEC
+```
+
+Doing it the other way round drops those calls back to 300s and re-creates the
+timeout the pin was added to fix.
+
+This is not hypothetical. Both plists were cleaned up and every grep read green
+while the domain global still held `1800`, so streamed requests kept logging
+`hard_deadline_sec = 1800` / `effective_deadline_sec = 1800` instead of the 3600s
+default. The `effective_deadline_sec` read-back is what exposed it — which is
+exactly why that field is read back from the context rather than reported from
+the configured value.
+:::
+
+When request logging is enabled — `AILANG_OLLAMA_LOG_REQUESTS=<path>`, or a path
+written to the `~/.ailang/state/ollama-log-requests` **sentinel file** whose
+contents are the dump path (it exists because harnesses like motoko's
+`bun`→`ailang` process chain drop our custom env, but `HOME` always propagates)
+— each streaming request appends a `"kind":"stream_metrics"` JSONL record with
+`ttft_ms`, `max_gap_ms`, `total_ms`, `bytes`, the delta counts, and both
+`hard_deadline_sec` (configured) and `effective_deadline_sec` (**read back** from
+the request context). Those numbers are the evidence for whether the three
+defaults above are right. If the two deadline fields disagree, something upstream
+is capping the stream — a run killed at ~300s with the flag on means the deadline
+never reached the wire, which is a harness bug, not a model one.
+
+:::caution The sentinel makes the log a shared global sink
+
+Because the sentinel is keyed on `HOME`, **every** `ailang` process on the machine
+writes to the same file — including `go test ./internal/ai/...`, whose `httptest`
+fake servers emit real `stream_metrics` records. A unit-test run during a field
+capture therefore pollutes the capture. This happened on 2026-08-11: 10
+test-generated records landed in the middle of a live rig measurement.
+
+They were separable only by their **window fields**: tests use non-production
+values (`idle_window_sec: 1`, `ttft_window_sec: 2` or `3`) against a real run's
+`120` / `600`. Filter on those before analysing a capture:
+
+```bash
+jq -c 'select(.kind=="stream_metrics" and .idle_window_sec==120)' "$LOG"
+```
+
+Prefer an explicit `AILANG_OLLAMA_LOG_REQUESTS=<path>` per capture where the
+harness propagates env; reach for the sentinel only when it does not, and remove
+it when the capture ends.
+:::
+
 ### CLI Flags
 
 | Flag | Purpose | Use When |

--- a/internal/ai/openai/streamstep_test.go
+++ b/internal/ai/openai/streamstep_test.go
@@ -2,9 +2,13 @@ package openai
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -343,5 +347,113 @@ func TestStreamStep_HTTPError(t *testing.T) {
 	}
 	if !strings.Contains(aiErr.Message, "Incorrect API key") {
 		t.Errorf("AIError.Message = %q, want it to contain 'Incorrect API key'", aiErr.Message)
+	}
+}
+
+// TestParseChatStepSSEStream_OllamaV1Fixture replays REAL ollama /v1 wire bytes
+// through the shared SSE parser (M-OLLAMA-V1-STREAMING-IDLE-TIMEOUT, ailang#618
+// AC-M4.1).
+//
+// The fixture is not a hand-written mock: it is the verbatim capture of a
+// qwen3.6:35b-a3b-mxfp8 tool-calling turn recorded off the rig on 2026-08-10 and
+// committed at internal/ai/ollama/testdata/ollama_v1_stream_toolcall.sse. Its
+// shape — 48 `delta.reasoning` chunks with `content:""`, then ONE chunk carrying
+// the whole tool call, then a bare `finish_reason:"tool_calls"` chunk, then a
+// choices-empty usage chunk, then `[DONE]` — is what the ollama streaming branch
+// actually has to survive. Pinning it here means a future ollama emission change
+// (or a parser regression) fails a sub-second unit test instead of a GPU run.
+//
+// Every asserted value below was read out of the fixture first, not copied from
+// the design doc: `wc -c` = 13077 B / 104 lines; the tool call is on line 97; the
+// finish reason on line 99; the usage block on line 101.
+//
+// This test reads the committed fixture in place (the ollama package's testdata
+// dir) rather than duplicating it, so there is exactly one copy of the wire bytes
+// in the repo and no way for the two to drift apart.
+func TestParseChatStepSSEStream_OllamaV1Fixture(t *testing.T) {
+	fixture := filepath.Join("..", "ollama", "testdata", "ollama_v1_stream_toolcall.sse")
+	f, err := os.Open(fixture) //nolint:gosec // fixed test fixture path
+	if err != nil {
+		t.Fatalf("open fixture %s: %v", fixture, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// onChunk is non-nil: the streaming ollama branch passes a real callback
+	// (controller ruling E-1), so exercise the nil-check-free path here too.
+	var thinking, content int
+	resp, aiErr := ParseChatStepSSEStream(f, "requested-model-should-be-overridden", func(chunk ai.StreamChunk) {
+		switch chunk.(type) {
+		case ai.StreamThinkingDelta:
+			thinking++
+		case ai.StreamContentDelta:
+			content++
+		}
+	})
+	if aiErr != nil {
+		t.Fatalf("ParseChatStepSSEStream returned error: %v", aiErr)
+	}
+
+	// --- Tool call: exactly one, fully assembled ---
+	if len(resp.ToolCalls) != 1 {
+		t.Fatalf("ToolCalls len = %d, want 1", len(resp.ToolCalls))
+	}
+	tc := resp.ToolCalls[0]
+	if tc.Name != "get_weather" {
+		t.Errorf("ToolCall.Name = %q, want get_weather", tc.Name)
+	}
+	if tc.ID != "call_1p3mekpr" {
+		t.Errorf("ToolCall.ID = %q, want call_1p3mekpr (fixture line 97)", tc.ID)
+	}
+	// JSON-equal, not string-equal: key order is not part of the contract, but
+	// the assembled *content* is. Under mutation R10 (dropping the argument
+	// fragment concatenation in streamstep.go) this collapses to `{}` and fails,
+	// which is what proves this test reads the assembly path and not just the
+	// parser.
+	var gotArgs, wantArgs map[string]any
+	if err := json.Unmarshal([]byte(tc.Arguments), &gotArgs); err != nil {
+		t.Fatalf("ToolCall.Arguments %q is not valid JSON: %v", tc.Arguments, err)
+	}
+	if err := json.Unmarshal([]byte(`{"city":"Paris"}`), &wantArgs); err != nil {
+		t.Fatalf("want-arguments literal is not valid JSON: %v", err)
+	}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Errorf("ToolCall.Arguments = %q, want JSON-equal to {\"city\":\"Paris\"}", tc.Arguments)
+	}
+
+	// --- Finish reason: mapped from the wire's "tool_calls" ---
+	if resp.FinishReason != "tool_calls" {
+		t.Errorf("FinishReason = %q, want tool_calls (fixture line 99)", resp.FinishReason)
+	}
+
+	// --- Usage: from the choices-empty final chunk (fixture line 101) ---
+	if resp.InputTokens != 294 {
+		t.Errorf("InputTokens = %d, want 294", resp.InputTokens)
+	}
+	if resp.OutputTokens != 80 {
+		t.Errorf("OutputTokens = %d, want 80", resp.OutputTokens)
+	}
+	if resp.TotalTokens != 374 {
+		t.Errorf("TotalTokens = %d, want 374", resp.TotalTokens)
+	}
+
+	// --- Shape of the turn, as measured from the fixture ---
+	// 48 reasoning deltas and ZERO content deltas: every `content` field in the
+	// fixture is the empty string. This is the exact shape that motivated the
+	// M3 reasoning-parity work — the model's whole visible output is reasoning
+	// text, which the streamed path would otherwise discard. Asserted here so
+	// that a future re-capture with a different shape is a loud test failure
+	// rather than a silent change of what this fixture is evidence for.
+	if thinking != 48 {
+		t.Errorf("thinking deltas = %d, want 48", thinking)
+	}
+	if content != 0 {
+		t.Errorf("content deltas = %d, want 0 (every content field in the fixture is \"\")", content)
+	}
+	if resp.Text != "" {
+		t.Errorf("Response.Text = %q, want empty (the fixture carries no content)", resp.Text)
+	}
+	// The model name is lifted off the wire, overriding the requested one.
+	if resp.Model != "qwen3.6:35b-a3b-mxfp8" {
+		t.Errorf("Model = %q, want qwen3.6:35b-a3b-mxfp8", resp.Model)
 	}
 }

--- a/tools/launchd/dev.ailang.nightly-eval.plist
+++ b/tools/launchd/dev.ailang.nightly-eval.plist
@@ -52,13 +52,17 @@
         <key>HOME</key>
         <string>/Users/voightkampff</string>
 
-        <!-- STOPGAP (2026-08-07): see the note in
-             dev.ailang.os-rotation-filler.plist. The 300s default in
-             internal/ai/ollama/step.go kills long-but-healthy local-model turns.
-             Remove once the idle/TTFT timeout lands
-             (design_docs/planned/m-ollama-v1-streaming-idle-timeout.md). -->
-        <key>AILANG_OLLAMA_HTTP_TIMEOUT_SEC</key>
-        <string>1800</string>
+        <!-- The 2026-08-07 stopgap (a 1800s total-timeout pin on the buffered
+             /v1 path) is REMOVED here and replaced by the streaming opt-in
+             below — ailang#618 M4, 2026-08-11. Full rationale in
+             dev.ailang.os-rotation-filler.plist. In short: flag-on, that same
+             env var becomes the stream's hard deadline rather than an HTTP
+             client timeout, and 1800s sits BELOW the worst-case legitimate
+             request (~2941s), so leaving it would re-create the failure it was
+             meant to prevent. Unset, the hard deadline is 3600s and "hung" is
+             caught by the idle (120s) / TTFT (600s) windows. -->
+        <key>AILANG_OLLAMA_V1_STREAM</key>
+        <string>1</string>
 
         <!-- Inherit OPENROUTER_API_KEY from ~/.config/ailang/secrets.env via the script -->
     </dict>

--- a/tools/launchd/dev.ailang.os-rotation-filler.plist
+++ b/tools/launchd/dev.ailang.os-rotation-filler.plist
@@ -51,17 +51,26 @@
         <key>PATH</key>
         <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
 
-        <!-- STOPGAP (2026-08-07): the 300s default in internal/ai/ollama/step.go
-             is shorter than a qwen3.6:35b thinking turn on long benchmarks, so
-             motoko retried the deadline until the wall clock killed it — 895
-             retries / ~74.6 GPU-hours burned over 43 days, 80 runs lost. 1800s
-             unblocks the rotation; it does NOT fix the real problem, which is
-             that a TOTAL-duration cap cannot tell "hung" from "slow". The robust
-             fix is the idle/TTFT timeout in
-             design_docs/planned/m-ollama-v1-streaming-idle-timeout.md — REMOVE
-             this line once that lands. -->
-        <key>AILANG_OLLAMA_HTTP_TIMEOUT_SEC</key>
-        <string>1800</string>
+        <!-- The 2026-08-07 stopgap (a 1800s total-timeout pin on the buffered
+             /v1 path) is REMOVED here and replaced by the streaming opt-in
+             below — ailang#618 M4, 2026-08-11.
+
+             Why the stopgap existed: the 300s default in
+             internal/ai/ollama/step.go is shorter than a qwen3.6:35b thinking
+             turn, so motoko retried the deadline until the wall clock killed
+             it — 895 retries / ~74.6 GPU-hours over 43 days, 80 runs lost.
+             1800s unblocked the rotation but did not fix the real problem: a
+             TOTAL-duration cap cannot tell "hung" from "slow".
+
+             Why removing it is MANDATORY, not tidy-up: with the flag below on,
+             that same env var stops being an HTTP client timeout and BECOMES
+             the stream's hard deadline. 1800s sits BELOW the computed
+             worst-case legitimate request (~2941s), so leaving it in would
+             re-create the 4m59.97 failure at a larger scale. Left unset, the
+             hard deadline defaults to 3600s, and "hung" is caught by the
+             sharper idle (120s) / TTFT (600s) windows instead. -->
+        <key>AILANG_OLLAMA_V1_STREAM</key>
+        <string>1</string>
     </dict>
 </dict>
 </plist>


### PR DESCRIPTION
Closes the last milestone of the `#618` sprint (M1 `752f997d1`, M2 `ff1fa0760`, M3 `86f7f1c32`).

## AC-M4.1 — fixture replay pin
`TestParseChatStepSSEStream_OllamaV1Fixture` replays the committed 13,077-byte ollama `/v1` SSE capture through `ParseChatStepSSEStream`. Every plan-claimed value was re-measured against the fixture first and **confirmed**: 1 tool call (`get_weather`, `{"city":"Paris"}`), `finish_reason: tool_calls`, usage `294/80/374`. Three values the plan did not state are now pinned too — **48 thinking deltas, 0 content deltas, empty `Text`** — which is precisely the shape that motivated M3's reasoning parity.

Anti-vacuity: base was rc=0 with **0** `=== RUN` (`[no tests to run]`); now **rc=0, 1 RUN, 1 PASS**. No change to `internal/ai/openai/streamstep.go` source (plan §5) — the diff has exactly one Go file and it is a `_test.go`.

## AC-M4.3 — stopgap removal, and the site the plan missed

Six grep counts, both plists: `AILANG_OLLAMA_HTTP_TIMEOUT_SEC` **1 → 0**, `AILANG_OLLAMA_V1_STREAM` **0 → 1**, anti-vacuity control `AILANG_OLLAMA` staying **1**. Repo-wide: **0** pins left across all 8 plists.

**The stopgap has two delivery sites and the plan named one.** `launchctl getenv AILANG_OLLAMA_HTTP_TIMEOUT_SEC` → **1800**: a launchd user-domain global that no plist edit touches. `b67d415cd` says so in its own body — *"pinned in both rig plists (**also set live via launchctl setenv**)"*. Controls: `AILANG_NOT_A_REAL_VAR` and `AILANG_OLLAMA_V1_STREAM` both return empty, so the instrument discriminates. The plan's grep criterion would have gone green with the hazard live.

**And the obvious cleanup order is the harmful one.** Clearing the global *before* the flag-on plists are installed drops any invocation not covered by a plist to the 300s buffered default (`step.go:24`) — reintroducing `#618` at its full measured cost (895 retries, ~74.6 GPU-hours). AC-M4.3 now carries an **ordered** two-step rollout (install + load, *then* `unsetenv`) with the reverse-order hazard spelled out, and that rollout is explicitly marked **not part of M4's repo deliverable**: `~/Library/LaunchAgents/*.plist` are regular files, currently byte-identical to HEAD, so this PR changes nothing on the rig until someone deliberately copies and loads them.

## AC-M4.2 — field validation on the rig (**GPU**, controller-run under the eval-suite rig lock)

`docx_reimplement` × `motoko-local-qwen3-6-35b-a3b-mxfp8` with `AILANG_OLLAMA_V1_STREAM=1`. Field arm discriminated from concurrent unit-test records by the production windows (`idle_window_sec==120 && ttft_window_sec==600`); negative control — every excluded record carries `idle_window_sec: 1` and `ttft_window_sec: 2|3`, max 2,101 bytes, 0 thinking deltas.

| metric | median | max | window | headroom |
|---|---|---|---|---|
| TTFT | 1,062 ms | 25,520 ms | 600,000 ms | **23.5×** |
| max inter-chunk gap | 1,742 ms | 30,896 ms | 120,000 ms | **3.9×** |
| total | 4,534 ms | 378,968 ms | 1,800,000 ms | **4.7×** |

- **`effective_deadline_sec = 1800` on every request, exactly matching the configured value** — the read-back that `REFUTATION #1` exists to expose shows **no 300s cap leaking through**. M2's fix holds in the field, not just in `httptest`.
- **Zero idle/TTFT trips, `saw_first_byte` true on every request** — AC-M4.2's RED condition is not met.
- 23,658 thinking deltas against 162 content deltas, max response 4.9 MB: the reasoning-heavy shape M3's parity work targets.
- Design Freeze falsifiers: **#2 (TTFT 600s)** and **#3 (hard deadline)** have wide margins; **#1 (idle 120s)** is the tightest at 3.9× and is the one to watch.

## Mutation register

R10's line corrected to `:298`. **R11** (neuter the usage mapping) and **R12b** (mutate the fixture's tool-call arguments) added, each asserted LANDED by sha256 and BUILDS rc=0 before its result was read, each restored from a `cp` backup and verified byte-identical.

The generalisation: **no mutation of `openai/streamstep.go` can be unique to the replay test**, because AC-M4.1's object is the captured *wire shape*, not the parser — R10 and R11 are both also killed by pre-existing tests. **R12b reds the new test alone (arm B rc=0)**, so it is the discriminating instrument. Also recorded, because it nearly produced a false all-clear: a sha256 diff proves an edit *happened*, not that it was aimed at the mechanism under test — the first R12 attempt landed on line 17's thinking text and the test correctly stayed green.

## Gates (controller-run outside any sandbox)

`go build ./internal/... ./cmd/ailang` · `go test -count=1 ./internal/ai/...` · `go vet ./internal/ai/...` · `gofmt -l internal/ai` → 0 · `check-file-sizes` · `check-boundaries` · `check-changelog` · `check-skills` — **all rc=0**. (`go build ./...` is rc=1 at base and is not a gate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)