### PR TITLE
feat(testing): #517 Lane B1 M4 — derive generators for ADTs, with bounded recursion and a size budget

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -273,6 +273,31 @@
   `AILANG_OLLAMA_HTTP_TIMEOUT_SEC` semantics are documented in
   `docs/docs/guides/debugging.md`.
 
+- **Property tests now derive generators for ADTs, with bounded recursion and a
+  size budget** — Lane B1 milestone M4 of
+  [#517](https://github.com/sunholo-data/ailang/issues/517). A contract property
+  over a same-file algebraic type now runs its 100 cases instead of reporting a
+  vacuous `no generator` skip: each constructor becomes an `ADTGenerator` and the
+  type derives as a choice over all of them. If **any** field of **any**
+  constructor is underivable the whole type refuses (`nil` generator, loud skip)
+  rather than silently dropping that constructor, which would have biased the
+  generated distribution invisibly. `TypeApp` over a user type substitutes its
+  arguments into the declaration's type parameters before deriving, and the
+  existing `list` arm still matches first.
+
+  Recursion is bounded two ways, because a depth budget alone does not bound
+  cost. At the depth bound the choice is restricted to **non-recursive**
+  constructors (recursiveness computed once per declaration and memoised), and a
+  type with no non-recursive constructor (`type Endless = Wrap(Endless)`) derives
+  to nothing — an honest vacuous skip rather than a hang. Separately, list
+  lengths *inside* a derivation are capped by the remaining depth instead of
+  `MaxSize`; top-level `list[<scalar>]` deliberately keeps its `0..MaxSize`
+  behaviour so existing measured results are unchanged. Measured on the contracts
+  corpus: `park.ail` goes 6 vacuous → 0 and rc 1 → 0, and the mutually-recursive
+  `record_adt_cycle_verify.ail` goes 1 vacuous → 0 and rc 1 → 0, completing well
+  inside a 60 s bound; `hof_verify.ail` and `list_verify.ail` are byte-for-byte
+  unchanged, including the latter's one deliberate failure.
+
 - **Property tests now derive generators for records, tuples, unit and type
   aliases** — Lane B1 milestone M3 of
   [#517](https://github.com/sunholo-data/ailang/issues/517). A contract property

--- a/cmd/ailang/test_json_output_test.go
+++ b/cmd/ailang/test_json_output_test.go
@@ -14,11 +14,16 @@ test "passes" { true }
 `
 
 // The vacuous vehicle must be a type the runner cannot derive a generator
-// for. Records became derivable at Lane B1 M3 (#517), so the vehicle is an
-// ADT — underivable until M4, which will need to swap it again (F-M3-2).
+// for, and that target keeps moving as #517 lands: records became derivable at
+// Lane B1 M3, same-file ADTs at M4. The vehicle is now an UNRESOLVED type name,
+// which is the honest end of the line — B1 deliberately leaves imported and
+// refined types underivable (deferred to B2 on the evaluator fuel budget), so
+// unlike `Point` this one is not scheduled to become derivable underneath us.
+// If a future milestone does derive it, this test fails loudly rather than
+// silently ceasing to exercise the vacuous path — which is the whole point:
+// the assertion below is the ONLY end-to-end pin on `ailang test` exiting 1 for
+// a suite whose properties never ran.
 const mixedVacuousTestSource = `module mixed_vacuous_test
-
-export type Point = P | Q
 
 export func anchor(x: int) -> int ! {}
 ensures { result == x }
@@ -26,7 +31,7 @@ ensures { result == x }
   x
 }
 
-export func shiftX(p: Point, dx: int) -> int ! {}
+export func shiftX(p: ImportedPoint, dx: int) -> int ! {}
 ensures { result == dx }
 {
   dx
@@ -88,7 +93,7 @@ func TestTestCommand_MixedVacuousSuiteExitSemantics(t *testing.T) {
 	if humanExit != 1 {
 		t.Fatalf("human mode expected exit 1, got %d", humanExit)
 	}
-	if !strings.Contains(human, "no generator for parameter p: Point") {
+	if !strings.Contains(human, "no generator for parameter p: ImportedPoint") {
 		t.Fatalf("human output missing exact skip reason:\n%s", human)
 	}
 	if strings.Contains(human, "All tests passed!") {

--- a/internal/testing/derive.go
+++ b/internal/testing/derive.go
@@ -23,15 +23,22 @@ const maxDeriveDepth = 3
 // M4's derivation-internal list cap (F-4); top-level list[<scalar>] keeps
 // today's 0..MaxSize so Lane A's measured behaviour is unchanged.
 type deriveCtx struct {
-	depth      int
-	sizeBudget int
+	depth         int
+	sizeBudget    int
+	substitutions map[string]ast.Type
+	recursionMemo map[*ast.TypeDecl][]bool
 }
 
 // newDeriveCtx returns the root derivation context: the max derivation depth
 // and the default generation size budget.
 func newDeriveCtx() deriveCtx {
 	config := DefaultConfig()
-	return deriveCtx{depth: maxDeriveDepth, sizeBudget: config.MaxSize}
+	return deriveCtx{
+		depth:         maxDeriveDepth,
+		sizeBudget:    config.MaxSize,
+		substitutions: make(map[string]ast.Type),
+		recursionMemo: make(map[*ast.TypeDecl][]bool),
+	}
 }
 
 // descend returns the context for one derivation step deeper, decrementing the
@@ -71,9 +78,19 @@ func (r *Runner) deriveType(typ ast.Type, ctx deriveCtx) (Generator, Shrinker) {
 	if ctx.exhausted() {
 		return nil, nil
 	}
+	if typeVar, ok := typ.(*ast.TypeVar); ok {
+		replacement, found := ctx.substitutions[typeVar.Name]
+		if !found {
+			return nil, nil
+		}
+		return r.deriveType(replacement, ctx)
+	}
 
 	// Check for simple types
 	if simpleType, ok := typ.(*ast.SimpleType); ok {
+		if replacement, ok := ctx.substitutions[simpleType.Name]; ok {
+			return r.deriveType(replacement, ctx)
+		}
 		switch simpleType.Name {
 		case "int":
 			config := DefaultConfig()
@@ -128,8 +145,23 @@ func (r *Runner) deriveType(typ ast.Type, ctx deriveCtx) (Generator, Shrinker) {
 		if elemGen == nil {
 			return nil, nil
 		}
-		config := DefaultConfig()
-		return NewListGenerator(elemGen, 0, config.MaxSize), NewListShrinker(elemShrink)
+		return NewListGenerator(elemGen, 0, listMaxLen(ctx, app.Args[0])), NewListShrinker(elemShrink)
+	}
+
+	// A user type application substitutes its arguments for the declaration's
+	// type parameters before deriving the definition. The builtin list arm must
+	// remain above this lookup.
+	if app, ok := typ.(*ast.TypeApp); ok {
+		decl := r.findTypeDecl(app.Constructor)
+		if decl == nil || len(decl.TypeParams) != len(app.Args) {
+			return nil, nil
+		}
+		next := ctx.descend()
+		next.substitutions = cloneSubstitutions(ctx.substitutions)
+		for i, param := range decl.TypeParams {
+			next.substitutions[param] = app.Args[i]
+		}
+		return r.deriveTypeDef(decl, next)
 	}
 
 	// Check for list types [a]
@@ -139,12 +171,47 @@ func (r *Runner) deriveType(typ ast.Type, ctx deriveCtx) (Generator, Shrinker) {
 		if elemGen == nil {
 			return nil, nil
 		}
-		config := DefaultConfig()
-		return NewListGenerator(elemGen, 0, config.MaxSize), NewListShrinker(elemShrink)
+		return NewListGenerator(elemGen, 0, listMaxLen(ctx, listType.Element)), NewListShrinker(elemShrink)
 	}
 
 	// Unsupported type
 	return nil, nil
+}
+
+func cloneSubstitutions(src map[string]ast.Type) map[string]ast.Type {
+	dst := make(map[string]ast.Type, len(src))
+	for name, typ := range src {
+		dst[name] = typ
+	}
+	return dst
+}
+
+func listMaxLen(ctx deriveCtx, elem ast.Type) int {
+	config := DefaultConfig()
+	if ctx.depth == maxDeriveDepth && isScalarType(elem) {
+		return config.MaxSize
+	}
+	maxLen := ctx.depth
+	if maxLen > ctx.sizeBudget {
+		maxLen = ctx.sizeBudget
+	}
+	if maxLen < 0 {
+		return 0
+	}
+	return maxLen
+}
+
+func isScalarType(typ ast.Type) bool {
+	simple, ok := typ.(*ast.SimpleType)
+	if !ok {
+		return false
+	}
+	switch simple.Name {
+	case "int", "float", "bool", "string", "()":
+		return true
+	default:
+		return false
+	}
 }
 
 // deriveRecordType derives a record generator over per-field derived
@@ -174,17 +241,22 @@ func (r *Runner) deriveNamedType(name string, ctx deriveCtx) (Generator, Shrinke
 	if ctx.exhausted() {
 		return nil, nil
 	}
-	if r.executor == nil || r.executor.sourceFile == nil {
-		return nil, nil
-	}
-	for _, node := range r.executor.sourceFile.Decls {
-		decl, ok := node.(*ast.TypeDecl)
-		if !ok || decl.Name != name {
-			continue
-		}
+	if decl := r.findTypeDecl(name); decl != nil {
 		return r.deriveTypeDef(decl, ctx)
 	}
 	return nil, nil
+}
+
+func (r *Runner) findTypeDecl(name string) *ast.TypeDecl {
+	if r.executor == nil || r.executor.sourceFile == nil {
+		return nil
+	}
+	for _, node := range r.executor.sourceFile.Decls {
+		if decl, ok := node.(*ast.TypeDecl); ok && decl.Name == name {
+			return decl
+		}
+	}
+	return nil
 }
 
 // deriveTypeDef derives a generator from a TypeDecl's Definition.
@@ -203,8 +275,117 @@ func (r *Runner) deriveTypeDef(decl *ast.TypeDecl, ctx deriveCtx) (Generator, Sh
 	case *ast.TypeAlias:
 		// Recurse on the alias target.
 		return r.deriveType(def.Target, ctx.descend())
+	case *ast.AlgebraicType:
+		return r.deriveAlgebraicType(decl, def, ctx)
 	default:
 		// AlgebraicType and anything else: M4.
 		return nil, nil
 	}
+}
+
+func (r *Runner) deriveAlgebraicType(decl *ast.TypeDecl, def *ast.AlgebraicType, ctx deriveCtx) (Generator, Shrinker) {
+	recursive, ok := ctx.recursionMemo[decl]
+	if !ok {
+		recursive = make([]bool, len(def.Constructors))
+		for i, ctor := range def.Constructors {
+			for _, field := range ctor.Fields {
+				if r.typeReferencesDecl(field.Type, decl.Name, map[string]bool{}) {
+					recursive[i] = true
+					break
+				}
+			}
+		}
+		ctx.recursionMemo[decl] = recursive
+	}
+
+	modulePath := ""
+	if r.executor != nil && r.executor.sourceFile != nil && r.executor.sourceFile.Module != nil {
+		modulePath = r.executor.sourceFile.Module.Path
+	}
+	constructors := make([]Generator, 0, len(def.Constructors))
+	for i, ctor := range def.Constructors {
+		if ctx.depth <= 1 && recursive[i] {
+			continue
+		}
+		fieldCtx := ctx.descend()
+		if ctx.depth <= 1 {
+			fieldCtx = ctx
+		}
+		fieldGens := make([]Generator, 0, len(ctor.Fields))
+		for _, field := range ctor.Fields {
+			fieldGen, _ := r.deriveType(field.Type, fieldCtx)
+			if fieldGen == nil {
+				return nil, nil
+			}
+			fieldGens = append(fieldGens, fieldGen)
+		}
+		constructors = append(constructors,
+			NewADTGenerator(ctor.Name, fieldGens, true, modulePath, decl.Name))
+	}
+	if len(constructors) == 0 {
+		return nil, nil
+	}
+	return NewOneOfGenerator(constructors...), NewNoOpShrinker()
+}
+
+func (r *Runner) typeReferencesDecl(typ ast.Type, target string, visiting map[string]bool) bool {
+	switch t := typ.(type) {
+	case *ast.SimpleType:
+		if t.Name == target {
+			return true
+		}
+		if visiting[t.Name] {
+			return false
+		}
+		decl := r.findTypeDecl(t.Name)
+		if decl == nil {
+			return false
+		}
+		visiting[t.Name] = true
+		found := r.typeDefReferencesDecl(decl.Definition, target, visiting)
+		delete(visiting, t.Name)
+		return found
+	case *ast.TypeApp:
+		if t.Constructor == target {
+			return true
+		}
+		for _, arg := range t.Args {
+			if r.typeReferencesDecl(arg, target, visiting) {
+				return true
+			}
+		}
+	case *ast.ListType:
+		return r.typeReferencesDecl(t.Element, target, visiting)
+	case *ast.RecordType:
+		for _, field := range t.Fields {
+			if r.typeReferencesDecl(field.Type, target, visiting) {
+				return true
+			}
+		}
+	case *ast.TupleType:
+		for _, elem := range t.Elements {
+			if r.typeReferencesDecl(elem, target, visiting) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (r *Runner) typeDefReferencesDecl(def ast.TypeDef, target string, visiting map[string]bool) bool {
+	switch d := def.(type) {
+	case *ast.TypeAlias:
+		return r.typeReferencesDecl(d.Target, target, visiting)
+	case *ast.RecordType:
+		return r.typeReferencesDecl(d, target, visiting)
+	case *ast.AlgebraicType:
+		for _, ctor := range d.Constructors {
+			for _, field := range ctor.Fields {
+				if r.typeReferencesDecl(field.Type, target, visiting) {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }

--- a/internal/testing/derive_adt_test.go
+++ b/internal/testing/derive_adt_test.go
@@ -215,3 +215,34 @@ export func main() -> int ! {} { 0 }
 			"the derivable constructors, biasing the distribution invisibly)", gen, shrink)
 	}
 }
+
+// TestM4_IndirectRecursionThroughNamedTypeIsBounded covers the indirect arm of
+// the recursion detector (typeDefReferencesDecl). B1-9's Doc/Block fixture
+// recurses through an INLINE anonymous record, so it reaches the target through
+// typeReferencesDecl's RecordType arm and never consults a named intermediary —
+// leaving the whole named-type path at 0% coverage while looking well tested.
+//
+// Here Branch's field is a NAMED type whose own definition points back at Node.
+// If that indirection is not followed, Branch is classified non-recursive, the
+// depth bound never restricts it, and derivation runs away. The size assertion
+// is what catches that: it is downstream of the classification, not adjacent to
+// it. Neutering typeDefReferencesDecl to `return false` reds this test.
+func TestM4_IndirectRecursionThroughNamedTypeIsBounded(t *testing.T) {
+	r, _ := parseDeriveFixture(t, `module indirect_rec
+export type Node = Leaf | Branch(Wrapper)
+export type Wrapper = { node: Node }
+export func main() -> int ! {} { 0 }
+`)
+	gen, _ := r.createGeneratorForType(&ast.SimpleType{Name: "Node"})
+	if gen == nil {
+		t.Fatal("Node generator is nil: an ADT recursive through a named type must still derive")
+	}
+	rng := newRNG(7)
+	for i := 0; i < 200; i++ {
+		if n := derivedValueNodes(gen.Generate(rng)); n > maxDerivedDocNodes {
+			t.Fatalf("draw %d has %d nodes, limit is %d — indirect recursion through a "+
+				"named type was not detected, so the depth bound never restricted Branch",
+				i, n, maxDerivedDocNodes)
+		}
+	}
+}

--- a/internal/testing/derive_adt_test.go
+++ b/internal/testing/derive_adt_test.go
@@ -1,0 +1,188 @@
+package testing
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/ast"
+	"github.com/sunholo-data/ailang/internal/eval"
+	"github.com/sunholo-data/ailang/internal/lexer"
+	"github.com/sunholo-data/ailang/internal/parser"
+)
+
+func parseDeriveFixture(t *testing.T, src string) (*Runner, *ast.File) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fixture.ail")
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	p := parser.New(lexer.New(src, path))
+	file := p.ParseFile()
+	if errs := p.Errors(); len(errs) != 0 {
+		t.Fatalf("parse fixture: %v", errs)
+	}
+	r := NewRunner(path)
+	r.executor.SetSourceFile(file)
+	return r, file
+}
+
+func TestM4B1_6_ADTConstructorCoverage(t *testing.T) {
+	r, _ := parseDeriveFixture(t, `module examples/runnable/contracts/park
+export type Season = LOW_SEASON | HIGH_SEASON
+export func main() -> int ! {} { 0 }
+`)
+	gen, _ := r.createGeneratorForType(&ast.SimpleType{Name: "Season"})
+	if gen == nil {
+		t.Fatal("Season generator is nil")
+	}
+	seen := map[string]bool{}
+	rng := newRNG(42)
+	for i := 0; i < 100; i++ {
+		value, ok := gen.Generate(rng).(*eval.TaggedValue)
+		if !ok {
+			t.Fatalf("draw %d: expected TaggedValue", i)
+		}
+		seen[value.CtorName] = true
+	}
+	for _, ctor := range []string{"LOW_SEASON", "HIGH_SEASON"} {
+		if !seen[ctor] {
+			t.Errorf("constructor %s was never generated; seen=%v", ctor, seen)
+		}
+	}
+}
+
+func TestM4B1_7_NullaryAndNarySplice(t *testing.T) {
+	result := runEnsuresFromSource(t, `module shade_splice
+export type Shade = Light | Dark(int)
+export func valid(s: Shade) -> bool ! {}
+ensures { result == true } {
+  match s { Light => true, Dark(level) => level == level }
+}
+export func main() -> int ! {} { 0 }
+`)
+	property := propertyByName(t, result, "valid_property_1")
+	if property.Status != StatusPass || property.TestsRun != 100 {
+		t.Fatalf("property=%+v, want 100-case pass", property)
+	}
+}
+
+const maxDerivedDocNodes = 40
+
+func TestM4B1_9_MutualRecursionSizeBound(t *testing.T) {
+	r, _ := parseDeriveFixture(t, `module doc_cycle
+export type Block = Para(string) | Container({ blocks: list[Block], kind: string })
+export type Doc = { title: string, blocks: list[Block] }
+export func main() -> int ! {} { 0 }
+`)
+	gen, _ := r.createGeneratorForType(&ast.SimpleType{Name: "Doc"})
+	if gen == nil {
+		t.Fatal("Doc generator is nil")
+	}
+	rng := newRNG(42)
+	for i := 0; i < 200; i++ {
+		n := derivedValueNodes(gen.Generate(rng))
+		if n > maxDerivedDocNodes {
+			t.Fatalf("draw %d has %d nodes, limit is %d", i, n, maxDerivedDocNodes)
+		}
+	}
+}
+
+func derivedValueNodes(value eval.Value) int {
+	switch v := value.(type) {
+	case *eval.ListValue:
+		n := 1
+		for _, elem := range v.Elements {
+			n += derivedValueNodes(elem)
+		}
+		return n
+	case *eval.RecordValue:
+		n := 1
+		for _, field := range v.Fields {
+			n += derivedValueNodes(field)
+		}
+		return n
+	case *eval.TupleValue:
+		n := 1
+		for _, elem := range v.Elements {
+			n += derivedValueNodes(elem)
+		}
+		return n
+	case *eval.TaggedValue:
+		n := 1
+		for _, field := range v.Fields {
+			n += derivedValueNodes(field)
+		}
+		return n
+	default:
+		return 1
+	}
+}
+
+func TestM4B1_12_EndlessADTIsNoGenerator(t *testing.T) {
+	result := runEnsuresFromSource(t, `module endless
+export type Endless = Wrap(Endless)
+export func impossible(x: Endless) -> bool ! {}
+ensures { result == true } { true }
+export func main() -> int ! {} { 0 }
+`)
+	property := propertyByName(t, result, "impossible_property_1")
+	if property.Status != StatusSkip || property.SkipKind != SkipKindNoGenerator {
+		t.Fatalf("property=%+v, want no_generator skip", property)
+	}
+}
+
+func TestM4B1_13_TopLevelScalarListPreserved(t *testing.T) {
+	result := runEnsuresFromSource(t, `module lane_a_list
+export func same(xs: list[int]) -> bool ! {}
+ensures { result == true } { true }
+export func main() -> int ! {} { 0 }
+`)
+	property := propertyByName(t, result, "same_property_1")
+	if property.Status != StatusPass || property.TestsRun != 100 {
+		t.Fatalf("property=%+v, want exact 100-case pass", property)
+	}
+	r := NewRunner("list.ail")
+	gen, _ := r.createGeneratorForType(&ast.TypeApp{
+		Constructor: "list",
+		Args:        []ast.Type{&ast.SimpleType{Name: "int"}},
+	})
+	rng := newRNG(42)
+	maxLen := 0
+	for i := 0; i < 100; i++ {
+		length := len(gen.Generate(rng).(*eval.ListValue).Elements)
+		if length > maxLen {
+			maxLen = length
+		}
+	}
+	if maxLen <= maxDeriveDepth {
+		t.Fatalf("top-level list range was depth-capped: max length=%d", maxLen)
+	}
+}
+
+func TestM4_ADTGeneratorCarriesRealIdentity(t *testing.T) {
+	gen := NewADTGenerator("Some", []Generator{NewIntGenerator(1, 1)}, true,
+		"pkg/example", "Option")
+	value := gen.Generate(newRNG(42)).(*eval.TaggedValue)
+	if value.ModulePath != "pkg/example" || value.TypeName != "Option" {
+		t.Fatalf("identity=%s/%s, want pkg/example/Option", value.ModulePath, value.TypeName)
+	}
+}
+
+func TestM4_TypeAppSubstitution(t *testing.T) {
+	r, _ := parseDeriveFixture(t, `module generic_box
+export type Box[a] = Boxed(a)
+export func main() -> int ! {} { 0 }
+`)
+	gen, _ := r.createGeneratorForType(&ast.TypeApp{
+		Constructor: "Box",
+		Args:        []ast.Type{&ast.SimpleType{Name: "int"}},
+	})
+	if gen == nil {
+		t.Fatal("Box[int] generator is nil")
+	}
+	value := gen.Generate(newRNG(42)).(*eval.TaggedValue)
+	if _, ok := value.Fields[0].(*eval.IntValue); !ok {
+		t.Fatalf("substituted field type=%T, want IntValue", value.Fields[0])
+	}
+}

--- a/internal/testing/derive_adt_test.go
+++ b/internal/testing/derive_adt_test.go
@@ -67,7 +67,15 @@ export func main() -> int ! {} { 0 }
 	}
 }
 
-const maxDerivedDocNodes = 40
+// maxDerivedDocNodes bounds B1-9's size assertion. The draw sequence below is
+// fully deterministic (newRNG(42), a fixed 200 draws), so this can be tight
+// without flaking: the measured max over that exact sequence is 7. It is
+// deliberately NOT set to a round "obviously safe" number — at 40 the assertion
+// still caught the plan's named mutation (restoring unlimited MaxSize inside a
+// derivation, which reaches 197) but sailed past a modest one: widening the
+// per-level cap to ctx.depth+3 tops out at 13 and would have passed unnoticed.
+// A bound that only catches the catastrophic regression is not a size budget.
+const maxDerivedDocNodes = 10
 
 func TestM4B1_9_MutualRecursionSizeBound(t *testing.T) {
 	r, _ := parseDeriveFixture(t, `module doc_cycle
@@ -184,5 +192,26 @@ export func main() -> int ! {} { 0 }
 	value := gen.Generate(newRNG(42)).(*eval.TaggedValue)
 	if _, ok := value.Fields[0].(*eval.IntValue); !ok {
 		t.Fatalf("substituted field type=%T, want IntValue", value.Fields[0])
+	}
+}
+
+// TestM4_UnderivableConstructorRefusesWholeADT pins plan §3 M4 change 1: if ANY
+// field of ANY constructor is underivable, the WHOLE type refuses. Dropping just
+// the offending constructor would still produce a working generator — one that
+// silently draws from a biased sub-distribution, never emitting Bad. That is the
+// one defect in this milestone with no visible symptom: every other test still
+// passes, the corpus still runs, and the property tests quietly stop covering a
+// constructor. Mutating the refusal to `continue` past the bad constructor leaves
+// the entire package green without this test.
+func TestM4_UnderivableConstructorRefusesWholeADT(t *testing.T) {
+	r, _ := parseDeriveFixture(t, `module mixed_ctors
+export type Mix = Good(int) | Bad(ImportedThing)
+export func main() -> int ! {} { 0 }
+`)
+	gen, shrink := r.createGeneratorForType(&ast.SimpleType{Name: "Mix"})
+	if gen != nil || shrink != nil {
+		t.Fatalf("a constructor with an underivable field must refuse the whole ADT, "+
+			"got generator=%T shrinker=%T (a non-nil generator here draws only from "+
+			"the derivable constructors, biasing the distribution invisibly)", gen, shrink)
 	}
 }

--- a/internal/testing/derive_test.go
+++ b/internal/testing/derive_test.go
@@ -250,14 +250,12 @@ export func main() -> int ! {} { 0 }
 }
 
 // TestDerive_UnderivableFieldKillsWholeRecord pins the nil-on-any-underivable-
-// field rule: an ADT field (M4 territory) makes the entire record underivable
+// field rule: an unresolved imported field makes the entire record underivable
 // rather than silently substituting the other fields.
 func TestDerive_UnderivableFieldKillsWholeRecord(t *testing.T) {
 	src := `module derive_underv
 
-export type Shade = Light | Dark(level: int)
-
-export type Rec = { ok: int, shade: Shade }
+export type Rec = { ok: int, shade: ImportedShade }
 
 export func main() -> int ! {} { 0 }
 `
@@ -268,9 +266,8 @@ export func main() -> int ! {} { 0 }
 	}
 }
 
-// TestDerive_ADTIsM4 pins that AlgebraicType definitions do NOT derive in M3 —
-// they stay honest vacuous skips until M4's arm lands.
-func TestDerive_ADTIsM4(t *testing.T) {
+// TestDerive_ADT derives a same-file algebraic type after M4.
+func TestDerive_ADT(t *testing.T) {
 	src := `module derive_adt_m4
 
 export type Shade = Light | Dark(level: int)
@@ -278,14 +275,14 @@ export type Shade = Light | Dark(level: int)
 export func main() -> int ! {} { 0 }
 `
 	r := deriveRunnerFromSource(t, src)
-	gen, shrink := r.createGeneratorForType(&ast.SimpleType{Name: "Shade"})
-	if gen != nil || shrink != nil {
-		t.Fatalf("expected nil, nil for ADT at M3, got generator=%T shrinker=%T", gen, shrink)
+	_, val := deriveOnce(t, r, &ast.SimpleType{Name: "Shade"})
+	if _, ok := val.(*eval.TaggedValue); !ok {
+		t.Fatalf("expected TaggedValue for ADT, got %T", val)
 	}
 }
 
 // TestDerive_ListArmPreserved pins that the Lane A list arm is untouched:
-// list[int] still derives, list[Shade] (ADT element, M4) still fails.
+// list[int] still derives and list[Shade] derives through M4's ADT arm.
 func TestDerive_ListArmPreserved(t *testing.T) {
 	src := `module derive_list
 
@@ -305,8 +302,8 @@ export func main() -> int ! {} { 0 }
 		Constructor: "list",
 		Args:        []ast.Type{&ast.SimpleType{Name: "Shade"}},
 	})
-	if gen != nil {
-		t.Fatal("expected list[Shade] to stay underivable at M3 (ADT element)")
+	if gen == nil {
+		t.Fatal("expected list[Shade] to derive through the M4 ADT arm")
 	}
 }
 
@@ -335,14 +332,12 @@ export func main() -> int ! {} { 0 }
 func TestDerive_UnderivableElemKillsWholeTuple(t *testing.T) {
 	src := `module derive_tuple_refuse
 
-export type Color = Red | Green
-
 export func main() -> int ! {} { 0 }
 `
 	r := deriveRunnerFromSource(t, src)
 	typ := &ast.TupleType{Elements: []ast.Type{
 		&ast.SimpleType{Name: "int"},
-		&ast.SimpleType{Name: "Color"},
+		&ast.SimpleType{Name: "ImportedColor"},
 	}}
 	gen, shrink := r.createGeneratorForType(typ)
 	if gen != nil || shrink != nil {

--- a/internal/testing/generator_advanced.go
+++ b/internal/testing/generator_advanced.go
@@ -149,16 +149,28 @@ type ADTGenerator struct {
 	tag          string
 	fieldGens    []Generator
 	constructTag bool // If true, wrap in TaggedValue
+	modulePath   string
+	typeName     string
 }
 
 // NewADTGenerator creates a generator for ADT values.
 // If constructTag is true, wraps result in TaggedValue.
-func NewADTGenerator(tag string, fieldGens []Generator, constructTag bool) *ADTGenerator {
-	return &ADTGenerator{
+// identity optionally supplies module path and type name. Keeping it optional
+// preserves the test-helper API while production-derived ADTs carry their real
+// diagnostic identity.
+func NewADTGenerator(tag string, fieldGens []Generator, constructTag bool, identity ...string) *ADTGenerator {
+	gen := &ADTGenerator{
 		tag:          tag,
 		fieldGens:    fieldGens,
 		constructTag: constructTag,
+		modulePath:   "test",
+		typeName:     "ADT",
 	}
+	if len(identity) >= 2 {
+		gen.modulePath = identity[0]
+		gen.typeName = identity[1]
+	}
+	return gen
 }
 
 // Generate produces an ADT value.
@@ -171,8 +183,8 @@ func (g *ADTGenerator) Generate(rng *rand.Rand) eval.Value {
 
 	if g.constructTag {
 		return &eval.TaggedValue{
-			ModulePath: "test", // Test module
-			TypeName:   "ADT",  // Generic ADT type for testing
+			ModulePath: g.modulePath,
+			TypeName:   g.typeName,
 			CtorName:   g.tag,  // Constructor name (e.g., "Some", "None")
 			Fields:     fields, // Constructor fields
 		}

--- a/internal/testing/runner_seed_test.go
+++ b/internal/testing/runner_seed_test.go
@@ -217,9 +217,7 @@ func TestRunner_MasterSeedChangesEveryStream(t *testing.T) {
 func TestRunProperty_SeedSetEvenOnSkip(t *testing.T) {
 	src := `module skip_seed
 
-type Tree = TreeNode | TreeLeaf
-
-export pure func walk(t: Tree) -> int
+export pure func walk(t: ImportedTree) -> int
   ensures { result >= 0 }
 {
   0

--- a/internal/testing/runner_skip_kind_test.go
+++ b/internal/testing/runner_skip_kind_test.go
@@ -63,9 +63,7 @@ func TestRunProperty_SkipTaxonomyIsTotal(t *testing.T) {
 func TestRunContractProperties_SkipKinds(t *testing.T) {
 	src := `module skip_kinds
 
-type Point = P | Q
-
-export pure func unsupported(p: Point) -> int
+export pure func unsupported(p: ImportedPoint) -> int
   requires { true }
   ensures { result > 0 }
 {


### PR DESCRIPTION
Lane B1 milestone **M4** of #517 — ADTs, recursion depth budget, size budget, `TypeApp` substitution.
Plan: `design_docs/planned/v0_31_0/m-property-generator-coverage-lane-b1-sprint-plan.md` §3 M4.

## What changed
A contract property over a same-file algebraic type now runs its cases instead of a vacuous
`no generator` skip. Each constructor becomes an `ADTGenerator`; the type derives as a choice over
all of them. **If any field of any constructor is underivable the whole type refuses** rather than
silently dropping that constructor — dropping would bias the generated distribution invisibly.

Recursion is bounded twice, because a depth budget alone does not bound cost (plan F-4):
- at the depth bound the choice is restricted to **non-recursive** constructors (memoised per decl);
  a type with no non-recursive constructor (`type Endless = Wrap(Endless)`) derives to nothing — an
  honest vacuous skip, not a hang;
- list lengths **inside** a derivation are capped by remaining depth. Top-level `list[<scalar>]`
  deliberately keeps `0..MaxSize`, so Lane A's measured behaviour is unchanged (B1-13).

## Corpus, measured before/after on a pristine tree
| file | before | after |
|---|---|---|
| `park.ail` | rc 1, 1/0/7, vac **6** | rc 0, 4/0/4, vac **0** |
| `record_adt_cycle_verify.ail` | rc 1, 0/0/1, vac **1** | rc 0, 1/0/0, vac **0**, inside 60 s |
| `hof_verify.ail` | rc 0, 2 pass | **unchanged** |
| `list_verify.ail` | rc 1, 5 pass + 1 deliberate fail | **unchanged** |

Package `--- PASS`: **265 → 272**.

## Mutation drill (controller-run, outside the executor's sandbox)
Every mutant asserted **LANDED** (differing sha256) and **BUILDS** (`go build` rc 0) *before* its
result was read, then restored byte-identical from a `cp` backup.

| AC | mutation | target `-run` | package `-skip` target |
|---|---|---|---|
| B1-6 | keep only `constructors[0]` | rc 1 — `HIGH_SEASON was never generated` | rc 0 → sole killer |
| B1-9 | restore `MaxSize` inside derivation | rc 1 — `draw 0 has 197 nodes, limit is 40` | rc 0 → sole killer |
| B1-12 | neuter the non-recursive restriction at the bound | rc 1 — stack overflow | **rc 1** |

**Correction to the executor's own evidence table**: B1-12 is *not* the sole killer of its mutation —
`TestM4B1_9_MutualRecursionSizeBound` also reds under it. That is redundant coverage, not vacuity, but
the row as reported overstated it. Likewise the executor self-reported that B1-7's mutation is also
killed by two existing M1 splice tests.

## Deviations, adjudicated by measurement (both arms)
`runner_seed_test.go` and `runner_skip_kind_test.go` swap a local ADT for an unresolved imported type.
M4 makes local ADTs derivable, so those fixtures no longer exercised the `no_generator` path.
Reverting the swap fails with `expected skip, got pass` — so this **preserves** the original assertion
rather than weakening it. The assertions themselves are untouched.

## Gates (controller-run, outside any sandbox)
`go build ./internal/... ./cmd/ailang` · `go test ./internal/testing/ -count=1` · `go vet` ·
`gofmt -l` (0) · `check-boundaries` · `check-changelog` · `check-file-sizes` · `check-skills` ·
`fmt-check` · `check-golden-drift` · `test-regression-guards` · `verify-examples` — **all rc 0**.
(`go build ./...` is red at base and is barred as a gate — plan §1.7.)

Refs #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)