### PR TITLE
feat(testing): #517 Lane B1 M6 — corpus triage, shapes_verify example, closeout

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -169,6 +169,17 @@
 
 ### Fixed
 
+- **Structural contract generators now exercise record, ADT, tuple, and unit parameters**
+  ([#517](https://github.com/sunholo-data/ailang/issues/517), Lane B1). Across the contracts corpus,
+  **87 previously-never-executed properties in 15 examples now run**, reducing vacuous skips from
+  111 to 24. Eight files flip from exit 1 to exit 0: `access_control.ail`, `cross_function.ail`,
+  `nested_record_verify.ail`, `park.ail`, `record_adt_cycle_verify.ail`,
+  `record_adt_sort_verify.ail`, `record_discovery_verify.ail`, and
+  `record_pattern_verify.ail`. The 24 remaining skips are deliberately outside B1: imported types
+  in `cross_module_types.ail` and `inbox_v2_app.ail`, plus refined `string<email>` parameters in
+  the prompt-injection examples. Those require imported-type resolution and refinement-aware/B2
+  generation respectively.
+
 - **A contract property test could pass on a value the harness had silently
   invented.** When the generator produced a value kind the splicer had no arm
   for, `valueToLiteral` quietly substituted `()` and the property was then

--- a/design_docs/planned/v0_31_0/m-property-generator-coverage-lane-b1-sprint-plan.md
+++ b/design_docs/planned/v0_31_0/m-property-generator-coverage-lane-b1-sprint-plan.md
@@ -178,6 +178,19 @@ corpus occurrence**, so its acceptance is unit-level only — say so, do not cla
 
 ### 1.6 Bounded-wait recipe that actually works
 
+> **M6 correction (2026-08-11): do not pipe the watchdog command.** The watchdog subshell inherits
+> stdout, so `/tmp/bwait.sh 60 command | jq` keeps the pipe open for the full 60 seconds even when
+> `command` exits immediately. Redirect first, then inspect the completed file:
+>
+> ```bash
+> /tmp/bwait.sh 60 ./bin/ailang test --format json --no-color FILE > /tmp/out.json 2>/dev/null
+> jq ... /tmp/out.json
+> ```
+>
+> The CLI JSON schema is top-level: `.success`, `.total_tests`, `.passed_tests`, `.failed_tests`,
+> `.skipped_tests`, `.vacuous_skips`, and `.properties[]`; it has **no `.suites` key**. Failing
+> properties are selected with `.properties[] | select(.status == "fail")`.
+
 ```bash
 # /tmp/bwait.sh <seconds> <cmd...>
 lim=$1; shift

--- a/design_docs/planned/v0_31_0/m-property-generator-coverage.md
+++ b/design_docs/planned/v0_31_0/m-property-generator-coverage.md
@@ -1,6 +1,5 @@
 # M-PROPERTY-GENERATOR-COVERAGE: Vacuous-Pass Honesty + Structural Generator Derivation for Contract Property Tests
 
-**Status**: Planned
 **Target**: v0.31.0 (Lane A); Lane B may slip to a later minor without harming Lane A
 **Status**: Lane A and Lane B1 landed; Lane B2 remains deferred
 **Priority**: P2 (explicitly NOT a v1.0 bar item — sized accordingly)
@@ -734,6 +733,13 @@ properties had never executed. Lane B1 makes the demos demonstrate what they alw
   shape is unit-level only today.
 - Resolve imported types through the typechecker environment to unlock the remaining imported-type
   skips. Refinement-aware generation for `string<email>` remains B2.
+- **`ailang verify` cannot encode tuple patterns.** Surfaced by M6's new `shapes_verify.ail`:
+  `fst2` fails with `unsupported pattern type *core.TuplePattern in SMT encoding`. Measured in
+  both arms — the error comes from encoding the function **body**, so it is independent of the
+  `ensures` clause and was present before that clause was strengthened. Consequence: a
+  tuple-parameter contract is checkable by property testing (B1 derives its generator and runs
+  100 cases) but **not** by Z3, so the two checkers disagree in coverage for this one shape.
+  `shapes_verify.ail`'s header states the split explicitly rather than claiming a clean verify.
 
 M6 also corrected the measurement procedure in the sprint plan: watchdog output must be redirected
 before `jq`, and the CLI JSON schema has no `.suites` key. Finally,

--- a/design_docs/planned/v0_31_0/m-property-generator-coverage.md
+++ b/design_docs/planned/v0_31_0/m-property-generator-coverage.md
@@ -2,6 +2,7 @@
 
 **Status**: Planned
 **Target**: v0.31.0 (Lane A); Lane B may slip to a later minor without harming Lane A
+**Status**: Lane A and Lane B1 landed; Lane B2 remains deferred
 **Priority**: P2 (explicitly NOT a v1.0 bar item — sized accordingly)
 **Estimated**: Lane A ~0.5 day; Lane B = B1 only, ~1.5–2 days (independently shippable; Lane A first). B2 (user-supplied generators) **DEFERRED** — see Lane B2.
 **Dependencies**: Lane A and Lane B1: None. **Deferred B2: BLOCKED ON a deterministic evaluator fuel/step budget** (fuel charged per evaluation reduction and function application — see Future Work; quorum 2026-07-29). Related-but-independent: [m-forall-properties-direct-core-eval](../v1_1_0/m-forall-properties-direct-core-eval.md) (P3, parked)
@@ -304,6 +305,7 @@ export func genPoint(seed: int) -> Point ! {}
 **Lane B (B1 only — B2 file impact deferred with B2):**
 - `internal/testing/derive.go` (new, ~200 LOC) — type resolution, structural derivation, depth budget (`gen<TypeName>` lookup deferred with B2)
 - `internal/testing/runner.go` (+40/-10) — wire derivation; `valueToLiteral` record/tuple/tagged arms + loud default
+- `internal/testing/contract_domain.go` — wire derived generators and loud splice errors into the ensures path
 - `internal/testing/generator_advanced.go` (+15/-8) — parameterize ADTGenerator module/type
 - `internal/testing/shrink.go` (+80) — TupleShrinker, RecordShrinker
 - `internal/testing/derive_test.go` (new, ~300 LOC)
@@ -631,6 +633,111 @@ scope** in any case. Lane A remains unobjected across **both** rounds. This is n
 objection was overridden, and no controller-invented resolution was substituted for a reviewer's.
 
 ---
+
+## Lane B1 closeout (M6, 2026-08-11)
+
+Lane B1 has landed. The controller re-swept all 33 contract files with the repository binary built at
+`025588fe2`. The sweep confirms the intended payoff: **87 previously-never-executed properties across
+15 examples now run**, and vacuous skips fall **111 → 24**. The remaining 24 are exactly
+`cross_module_types` (4), `inbox_injection_v2` (10), and `inbox_v2_app` (10). They are imported or
+refined types and remain B2 by design. `p/f/s` below means passed/failed/skipped; “before vac” is the
+§1.4 baseline. `per_function_depth_verify` exceeded the 60-second bound and is deliberately reported
+as UNMEASURED, never pass or fail.
+
+| File | rc | success | total | p/f/s | vac | before vac | Δ vac | M6 result / triage |
+|---|---:|:---:|---:|---:|---:|---:|---:|---|
+| access_control | 0 | true | 4 | 2/0/2 | 0 | 4 | -4 | fixed; rc 1→0 |
+| basic | 1 | false | 8 | 3/2/3 | 0 | 0 | 0 | unchanged; 2 pre-existing failures |
+| cross_function | 0 | true | 5 | 4/0/1 | 0 | 5 | -5 | fixed; rc 1→0 |
+| cross_module_functions | 0 | true | 5 | 3/0/2 | 0 | 0 | 0 | false-red guard holds |
+| cross_module_functions_lib | 0 | true | 3 | 2/0/1 | 0 | 0 | 0 | false-red guard holds |
+| cross_module_types | 1 | false | 8 | 3/0/5 | 4 | 5 | -1 | unit now runs; 4 imported skips remain |
+| cross_module_types_lib | 1 | false | 0 | 0/0/0 | 0 | 0 | 0 | unchanged; no tests |
+| ensures_violation_demo | 1 | false | 2 | 1/1/0 | 0 | 0 | 0 | unchanged |
+| finance | 1 | false | 6 | 2/1/3 | 0 | 4 | -4 | pre-existing failure |
+| hof_verify | 0 | true | 2 | 2/0/0 | 0 | 0 | 0 | false-red guard holds |
+| inbox_injection | 1 | false | 10 | 3/1/6 | 0 | 0 | 0 | unchanged |
+| inbox_injection_v2 | 1 | false | 11 | 1/0/10 | 10 | 10 | 0 | F-1: refined types, B2 |
+| inbox_v2_app | 1 | false | 11 | 1/0/10 | 10 | 10 | 0 | F-1: imported/refined types, B2 |
+| inbox_v2_lib | 1 | false | 0 | 0/0/0 | 0 | 0 | 0 | unchanged; no tests |
+| insurance | 1 | false | 6 | 4/1/1 | 0 | 6 | -6 | **(a) deliberate:** `applyDiscount_property_2` |
+| invoice | 1 | false | 21 | 9/1/11 | 0 | 13 | -13 | pre-existing failure |
+| list_recursive_verify | 1 | false | 6 | 0/0/6 | 0 | 0 | 0 | unchanged |
+| list_verify | 1 | false | 7 | 5/1/1 | 0 | 0 | 0 | deliberate pre-existing fixture failure |
+| nested_record_verify | 0 | true | 5 | 2/0/3 | 0 | 5 | -5 | fixed; rc 1→0 |
+| park | 0 | true | 8 | 4/0/4 | 0 | 6 | -6 | fixed; rc 1→0 |
+| per_function_depth_verify | 137 | — | — | — | — | — | — | **UNMEASURED**; exceeds bound |
+| quantifier_verify | 1 | false | 7 | 2/1/4 | 0 | 0 | 0 | unchanged |
+| record_adt_cycle_verify | 0 | true | 1 | 1/0/0 | 0 | 1 | -1 | fixed; rc 1→0 |
+| record_adt_sort_verify | 0 | true | 1 | 1/0/0 | 0 | 1 | -1 | fixed; rc 1→0 |
+| record_discovery_verify | 0 | true | 10 | 5/0/5 | 0 | 6 | -6 | fixed; rc 1→0, better than §1.4 predicted |
+| record_pattern_verify | 0 | true | 5 | 2/0/3 | 0 | 5 | -5 | fixed; rc 1→0 |
+| record_verify | 1 | false | 15 | 4/1/10 | 0 | 15 | -15 | **(a) deliberate:** `brokenDistance_property_3` |
+| recursive_verify | 1 | false | 9 | 0/0/9 | 0 | 0 | 0 | unchanged |
+| scoring | 1 | false | 6 | 5/1/0 | 0 | 6 | -6 | **(a) deliberate:** `normalizedScore_property_1` |
+| showcase | 1 | false | 15 | 7/1/7 | 0 | 9 | -9 | pre-existing failure |
+| string_verify | 1 | false | 5 | 4/1/0 | 0 | 0 | 0 | unchanged |
+| temperature | 0 | true | 4 | 2/0/2 | 0 | 0 | 0 | false-red guard holds |
+| unencodable_callee_skip | 0 | true | 2 | 1/0/1 | 0 | 0 | 0 | false-red guard holds |
+
+Eight files flip rc 1 → 0: `access_control`, `cross_function`, `nested_record_verify`, `park`,
+`record_adt_cycle_verify`, `record_adt_sort_verify`, `record_discovery_verify`, and
+`record_pattern_verify`. The five false-red guards remain rc 0.
+
+### Newly-failing-property triage (B1-16)
+
+All three newly-failing properties are **(a) deliberate**; zero are (b) example bugs, zero are (c)
+B1 defects, and zero are unclassified:
+
+- `record_verify / brokenDistance_property_3`, counterexample `p={x: 152, y: 469}`. The header says
+  “Expect: 4 verified, 1 violation (brokenDistance)”; measured 4 pass / 1 fail.
+- `insurance / applyDiscount_property_2`, counterexample `age=ADULT, tier=LOW,
+  discountPercent=297`. The function comment explicitly calls the discount calculation intentionally
+  broken and says Z3 will find the breaking combination; measured 4 pass / 1 fail.
+- `scoring / normalizedScore_property_1`, counterexample `level=ADVANCED, perf=AVERAGE,
+  dept=RESEARCH, tenure=MID`. The function comment explicitly says department weights can push the
+  score above 100 and Z3 finds the combination; measured 5 pass / 1 fail.
+
+These examples were written to demonstrate Z3 catching contract violations, but the relevant
+properties had never executed. Lane B1 makes the demos demonstrate what they always claimed to.
+
+### Sprint findings F-1 through F-8
+
+- **F-1 (mission-visible): B1 does not fix the prompt-injection safety demos.**
+  `inbox_injection_v2` and `inbox_v2_app` are unchanged at 10 vacuous skips each. Their refined and
+  imported types are B2, so the original Success metric claiming B1 makes those properties run is
+  wrong. Lane A made them fail loudly; B1 does not make them execute.
+- **F-2:** generated ADT `TypeName`/`ModulePath` metadata is not downstream-observable on this path;
+  the evaluator reconstructs tagged values through constructor closures. Parameterisation is
+  diagnostic/cosmetic, not a prerequisite.
+- **F-3:** `RecordGenerator` map iteration made seeded generation nondeterministic. B1 now uses a
+  stable field order, preserving replayability.
+- **F-4:** recursion depth alone does not bound collection growth. B1 also scales list size by the
+  remaining derivation budget while preserving top-level scalar-list behavior.
+- **F-5:** derived record/tuple shrinkers have no downstream observable above a unit test because the
+  live contract paths discard the shrinker and the forall consumer is blocked by #624. M5 was
+  therefore descoped.
+- **F-6:** `perl alarm` does not bound the Go binary, and the replacement watchdog must not be piped:
+  its inherited stdout keeps the pipe open until the full timeout. Redirect watchdog output to a
+  file, then run `jq` on that file. The JSON has top-level counters and `.properties[]`, not
+  `.suites`.
+- **F-7:** `runEnsuresProperty` lives in `internal/testing/contract_domain.go`; the Lane B file list
+  above now includes it. Ensures and requires paths also have different out-of-contract text.
+- **F-8:** the earlier V34 corpus count was a lower bound: it missed `scoring.ail` and `showcase.ail`.
+  The M6 table is the complete 33-file accounting, with one bounded-time UNMEASURED fixture.
+
+### Follow-ups (not implemented in Lane B1)
+
+- Derived record and tuple shrinkers (descoped M5); revisit only when a live downstream consumer can
+  make their behavior observable.
+- Add corpus coverage for named aliases represented by `*ast.TypeAlias`; Lane B1 acceptance for this
+  shape is unit-level only today.
+- Resolve imported types through the typechecker environment to unlock the remaining imported-type
+  skips. Refinement-aware generation for `string<email>` remains B2.
+
+M6 also corrected the measurement procedure in the sprint plan: watchdog output must be redirected
+before `jq`, and the CLI JSON schema has no `.suites` key. Finally,
+`record_discovery_verify` reached rc 0 rather than the predicted rc 1 with two out-of-contract skips.
 
 ## References
 

--- a/examples/manifest.json
+++ b/examples/manifest.json
@@ -1629,6 +1629,19 @@
       "description": "Multi-factor scoring system \u2014 Z3 finds score exceeds 100 in specific enum combination"
     },
     {
+      "path": "runnable/contracts/shapes_verify.ail",
+      "status": "working",
+      "tags": [
+        "contracts",
+        "smt-verification",
+        "ailang-verify",
+        "records",
+        "adt",
+        "tuples"
+      ],
+      "description": "Structural contract generators \u2014 record, ADT, tuple, and scalar ensures parameters all execute property cases"
+    },
+    {
       "path": "runnable/contracts/showcase.ail",
       "status": "working",
       "tags": [
@@ -2670,11 +2683,11 @@
     }
   ],
   "statistics": {
-    "total": 192,
-    "working": 184,
+    "total": 193,
+    "working": 185,
     "aspirational": 4,
     "broken": 4,
-    "coverage": 0.9583333333333334,
+    "coverage": 0.9585492227979274,
     "experimental": 0
   },
   "milestones": {

--- a/examples/runnable/contracts/insurance.ail
+++ b/examples/runnable/contracts/insurance.ail
@@ -1,6 +1,7 @@
 -- examples/runnable/contracts/insurance.ail
 -- Complex insurance pricing with many interacting factors
 -- Demonstrates: contracts catching non-obvious bugs in branching logic
+-- Expect: 4 verified, 1 violation (applyDiscount)
 --
 -- WHY THIS IS HARD TO VERIFY BY HAND:
 -- 5 enum types × multiple branches = 50+ code paths

--- a/examples/runnable/contracts/scoring.ail
+++ b/examples/runnable/contracts/scoring.ail
@@ -1,6 +1,7 @@
 -- examples/runnable/contracts/scoring.ail
 -- Multi-factor scoring system with complex invariants
 -- Demonstrates: Z3 catching subtle bugs in scoring logic
+-- Expect: 5 verified, 1 violation (normalizedScore)
 --
 -- WHY THIS IS HARD TO VERIFY BY HAND:
 -- Multiple scoring dimensions combine non-linearly

--- a/examples/runnable/contracts/shapes_verify.ail
+++ b/examples/runnable/contracts/shapes_verify.ail
@@ -2,8 +2,15 @@
 -- Structural generator coverage for contract parameters
 -- Demonstrates: named records, ADTs, tuples, and scalar ensures parameters
 --
+-- Run:    ailang test   examples/runnable/contracts/shapes_verify.ail
+-- Expect: 4 properties, 100 cases each, 0 vacuous skips, 0 failures
+--
 -- Run:    ailang verify examples/runnable/contracts/shapes_verify.ail
--- Expect: 4 verified, 0 violations
+-- Expect: 3 verified, 1 encoding error (fst2)
+--         Z3 cannot yet encode tuple patterns (`unsupported pattern type
+--         *core.TuplePattern`), so a tuple-parameter contract is checkable by
+--         property testing but not by SMT. The error is a known language gap,
+--         not a violated contract — see the Lane B1 closeout follow-ups.
 
 module examples/runnable/contracts/shapes_verify
 

--- a/examples/runnable/contracts/shapes_verify.ail
+++ b/examples/runnable/contracts/shapes_verify.ail
@@ -1,0 +1,40 @@
+-- examples/runnable/contracts/shapes_verify.ail
+-- Structural generator coverage for contract parameters
+-- Demonstrates: named records, ADTs, tuples, and scalar ensures parameters
+--
+-- Run:    ailang verify examples/runnable/contracts/shapes_verify.ail
+-- Expect: 4 verified, 0 violations
+
+module examples/runnable/contracts/shapes_verify
+
+export type Point = { x: int, y: int }
+
+export type Shade = Light | Dark(level: int)
+
+export func shiftX(p: Point, dx: int) -> int ! {}
+ensures { result == p.x + dx } {
+  p.x + dx
+}
+
+export func level(s: Shade) -> int ! {}
+ensures { result >= 0 } {
+  match s {
+    Light => 0,
+    Dark(l) => if l >= 0 then l else 0
+  }
+}
+
+export func fst2(pair: (int, int)) -> int ! {}
+ensures { match pair { (a, _) => result == a } } {
+  match pair { (a, _) => a }
+}
+
+export func anchor(x: int) -> int ! {}
+ensures { result == x } {
+  x
+}
+
+export func main() -> int ! {} {
+  let p = { x: 3, y: 4 }
+  shiftX(p, level(Dark(2))) + fst2((5, 8)) + anchor(1)
+}


### PR DESCRIPTION
Final milestone of Lane B1 (`#517`). **M5 descoped** per the sprint plan's own §6 (F-5: both contract paths discard the shrinker, so there is no downstream observable above a unit test) — filed as a follow-up, not implemented.

## Corpus re-sweep — the payoff, measured
- **Vacuous skips 111 → 24**: **87 previously-never-executed contract properties across 15 examples now actually run.** Matches the plan's prediction exactly.
- **8 files flip exit 1 → 0**: `access_control`, `cross_function`, `nested_record_verify`, `park`, `record_adt_cycle_verify`, `record_adt_sort_verify`, `record_discovery_verify`, `record_pattern_verify`.
- **All 5 false-red guards hold exit 0** (B1-11): `cross_module_functions`, `cross_module_functions_lib`, `hof_verify`, `temperature`, `unencodable_callee_skip`.
- The surviving 24 are imported (`cross_module_types`, `inbox_v2_app`) and refined (`string<email>`) types — **B2 by design**.

## Triage (B1-16) — zero unclassified
All three newly-failing properties are **(a) deliberate**:
| File | Property | Evidence |
|---|---|---|
| `record_verify` | `brokenDistance_property_3` | header `:8` already declared "Expect: 4 verified, 1 violation"; measured 4/1 exactly |
| `insurance` | `applyDiscount_property_2` | `:114` "INTENTIONALLY BROKEN … Z3 will find the exact combination" |
| `scoring` | `normalizedScore_property_1` | `:139-142` "Z3 finds the exact combination that breaks `ensures { result <= 100 }`" |

**Zero** classify as example bugs (b) or B1 defects (c) — no contract logic changed. `insurance.ail` and `scoring.ail` gain the `Expect:` header line they lacked, so a reader running `ailang test` sees the failure is intended.

The finding worth stating plainly: **these files were written to demonstrate Z3 catching contract violations, and their properties had never executed.** The demos were vacuous. They now do what they always claimed.

## New example (B1-15)
`shapes_verify.ail` — record + ADT + tuple + scalar `ensures` params. All 4 properties run **100 cases each, zero vacuous skips**. Mutation drill: removing the manifest entry reds `make verify-examples` (rc 2), so the gate is non-vacuous.

## Controller correction to the executor's output
The tuple property shipped as `ensures { result == result }` — a tautology that **cannot fail**. Strengthened to `match pair { (a, _) => result == a } `. Both arms measured under a wrong-element mutation of `fst2`: strengthened → **rc 1**, tautological → **rc 0**. That vacuity is the exact class this sprint exists to remove.

## Also corrected
- The plan's §1.6 bounded-wait recipe holds a **pipe** open for its full limit (the watchdog subshell inherits stdout) — redirect to a file instead. Cost 13 min this iteration and nearly produced a false "these files are slow now" finding.
- The test JSON has no `.suites` key.

## Gates (controller-run, outside any sandbox)
`go build ./internal/... ./cmd/ailang/...` · `go test ./internal/testing/...` (311 PASS, 0 FAIL) · `go vet` · `make verify-examples` (rc 0, 187 modules) · `check-file-sizes` · `check-changelog` · `check-boundaries` · `gofmt -l` empty — **all rc 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)