### PR TITLE
fix(driver): the pin would have walked every fire into a probe-hang — gate on onboarding (#558)

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -573,6 +573,25 @@
   Stated plainly: this cannot help until the shared clone receives it once, and that first
   reconcile is human (Principle 0).
 
+  **Follow-up, and it is the reason the first cut would have taken the loop down.** A pin
+  worktree is by construction a path Claude Code has never seen, and an un-onboarded checkout
+  makes headless `claude -p` block on a trust dialog it cannot display — so *every* model probe
+  hangs to its timeout and the driver refuses with "NO usable model in prefs", indistinguishable
+  from a quota outage. That had just cost the motoko mission its entire first unattended fire
+  (charter V22, `76ee4056c`). The pin now checks
+  `projects[<wt>].hasCompletedProjectOnboarding` in `~/.claude.json` and **refuses to pin**
+  when it is absent or undeterminable, because stale-but-working strictly beats fresh-and-dead.
+  It reads the *measured* flag, not the `hasTrustDialogAccepted` the error text names —
+  `ailang-world` runs with trust=false/onboarded=true, the control proving the named flag is not
+  the gate. Consequence: reconciling is safe with no further action (the pin declines, loudly);
+  pinning switches on when a human runs `cd ~/.ailang-driver-pin/<mission> && claude` once.
+
+  The same pass fixed a latent one-shot bug the new tests caught: worktree existence was decided
+  by string-matching `git worktree list`, which never matches git's recorded realpath when any
+  path component is a symlink (`/var` → `/private/var`). Fire 1 would pin, fire 2 would hit
+  `worktree add` on an existing directory and refuse — a fix that disables itself after first
+  use while reporting loudly. Now decided by asking the worktree itself. 48 assertions.
+
 - **`dev.ailang.mission-recovery` — a probe-stall costs ~20 min of loop time instead of
   90.** When every controller probe times out the driver refuses, and with
   `StartInterval` at 5400s that slot is gone for a full 90 minutes even if the stall

--- a/design_docs/v1-mission.md
+++ b/design_docs/v1-mission.md
@@ -1677,6 +1677,15 @@ frozen; contracts projection live).
   `#666` FIRST, reconcile SECOND — reconciling first brings the lane fix but not the pin, and
   the clone simply starts drifting again.
 
+  **PER-CHECKOUT PREREQUISITE, and it applies to EVERY entry point that spawns `claude`:** a pin
+  worktree is a path Claude Code has never seen, and an un-onboarded checkout hangs every
+  headless probe (charter V22, `76ee4056c`). The pin now refuses rather than walking into it, so
+  a fire stays alive — but it stays *unpinned* until a human runs `cd
+  ~/.ailang-driver-pin/<mission> && claude` once. Budget one such action per pinned entry point
+  that runs `claude`, and **measure rather than assume which ones do**: `nightly-eval.sh` looks
+  exempt (it builds and runs the binary, not `claude`) but that has not been verified, and
+  assuming it would repeat exactly the mistake this row exists to prevent.
+
   **THE GATE (evidence, not a delay):** ≥3 consecutive V1 fires logging `driver pin: running
   committed origin/dev @ <sha>` with a normal iteration completing. Read it from
   `/tmp/ailang-mission-control.log`, not from the file's presence on disk — measuring the wrong

--- a/tools/launchd/lib/pin-root.sh
+++ b/tools/launchd/lib/pin-root.sh
@@ -131,11 +131,23 @@ pin_root_to_committed_ref() {
 
   # Refresh (or create) the pin worktree. It is a throwaway checkout with no user work in it,
   # kept outside every dev clone, so --force can never overwrite in-progress changes.
+  #
+  # Existence is decided by ASKING THE WORKTREE, not by string-matching `worktree list`. git
+  # records the resolved realpath, so on any tree reached through a symlink — /var -> /private/var
+  # on macOS being the everyday case — the recorded path never equals the one we computed, the
+  # match silently fails, and we take the `add` branch against a directory that already exists.
+  # That fails, which means the pin would have worked exactly ONCE and reported STALE on every
+  # fire afterwards: a self-disabling fix, loud but useless. Caught by test 7, not by review.
   git -C "$src" worktree prune >/dev/null 2>&1
-  if git -C "$src" worktree list --porcelain 2>/dev/null | grep -qx "worktree $wt"; then
+  if [ -e "$wt/.git" ] && git -C "$wt" rev-parse --git-dir >/dev/null 2>&1; then
     if ! git -C "$wt" checkout --quiet --detach --force "$target" 2>/dev/null; then
       _pin_stale "pin worktree checkout $short failed at $wt"; return 1
     fi
+  elif [ -d "$wt" ]; then
+    # Occupied but not a usable worktree. Deliberately NOT rm -rf'd: AILANG_DRIVER_PIN_DIR is
+    # caller-supplied, and silently deleting a caller-named directory is a worse failure than
+    # declining to pin. A human clears it; until then this is loud on every fire.
+    _pin_stale "$wt exists but is not a usable git worktree — refusing to pin; remove it to re-enable"; return 1
   else
     mkdir -p "$(dirname "$wt")"
     if ! git -C "$src" worktree add --quiet --detach --force "$wt" "$target" 2>/dev/null; then
@@ -147,6 +159,29 @@ pin_root_to_committed_ref() {
   # a pin into a silent no-run. Control for the whole worktree step in one assertion.
   if [ ! -f "$wt/tools/launchd/$script" ]; then
     _pin_stale "$ref has no tools/launchd/$script — refusing to re-exec into a missing driver"; return 1
+  fi
+
+  # ONBOARDING GATE — the one that makes this whole mechanism dangerous by default.
+  # A checkout Claude Code has never seen makes headless `claude -p` block on a trust dialog it
+  # cannot display, so EVERY model probe hangs to its timeout and the driver refuses with "NO
+  # usable model in prefs" — indistinguishable from a quota outage. That cost the motoko mission
+  # its entire first unattended fire (charter V22, commit 76ee4056c). A pin worktree is BY
+  # CONSTRUCTION a path Claude Code has never seen, so pinning into an un-onboarded one trades
+  # stale-but-working for fresh-and-dead. Staleness is the strictly smaller harm: refuse.
+  #
+  # `hasCompletedProjectOnboarding`, NOT the `hasTrustDialogAccepted` the error text names —
+  # 76ee4056c measured all three checkouts and ailang-world (trust=false, onboarded=true) WORKS,
+  # which is the control proving the flag the message points at is not the gate.
+  #
+  # Undeterminable is treated as un-onboarded, deliberately: pinning blind risks ~12 min of hung
+  # probes and a dead loop, refusing costs staleness that is already reported. jq lives at
+  # /usr/bin/jq, inside launchd's default PATH, so its absence means something is genuinely wrong.
+  if [ -n "${AILANG_DRIVER_SKIP_ONBOARD_CHECK:-}" ]; then
+    :
+  elif ! command -v jq >/dev/null 2>&1; then
+    _pin_stale "cannot verify Claude Code onboarding for $wt (jq not found) — refusing to pin into a possibly-unusable checkout"; return 1
+  elif [ "$(jq -r --arg p "$wt" '.projects[$p].hasCompletedProjectOnboarding // false' "$HOME/.claude.json" 2>/dev/null)" != "true" ]; then
+    _pin_stale "$wt is not onboarded in Claude Code — every model probe would hang there (charter V22). Run once, interactively: cd $wt && claude"; return 1
   fi
 
   # MISSION_WORKDIR moves too, and that is the point: mission-control.sh:40 reads it AHEAD of

--- a/tools/launchd/test_pin_root.sh
+++ b/tools/launchd/test_pin_root.sh
@@ -72,6 +72,15 @@ cd "$T"
 DRV="$T/clone/tools/launchd/fake-driver.sh"
 export AILANG_DRIVER_PIN_DIR="$T/pinwt"
 
+# Fake HOME carrying a synthetic ~/.claude.json, so the ONBOARDING GATE is exercised for real
+# rather than switched off for the happy path. Marking the pin path onboarded here is what makes
+# tests 1-5 meaningful: if the gate regressed to always-refuse they would go red, and if it
+# regressed to always-allow test 7 would.
+export HOME="$T/home"; mkdir -p "$HOME"
+cat > "$HOME/.claude.json" <<JSON
+{"projects": {"$T/pinwt": {"hasCompletedProjectOnboarding": true}}}
+JSON
+
 echo "== 1. happy path: stale clone re-execs into committed origin/dev =="
 OUT=$(/bin/bash "$DRV" alpha beta 2>&1)
 check "status is pinned"                 "$OUT" "STATUS=pinned"
@@ -80,6 +89,13 @@ check "ROOT moved to the pin worktree"   "$OUT" "REPO=$T/pinwt"
 check "reads FRESH content, not stale"   "$OUT" "MARKER=FRESH-CONTENT"
 checkno "stale content is NOT read"      "$OUT" "MARKER=STALE-CONTENT"
 check "args survive the re-exec"         "$OUT" "ARGS=alpha beta"
+
+# REGRESSION: the SECOND fire must pin too. The first implementation matched `worktree list`
+# by string, which never matches a realpath-resolved entry, so fire 2 hit `worktree add` on an
+# existing directory and refused. A one-shot fix that reports STALE forever after.
+OUT2=$(/bin/bash "$DRV" 2>&1)
+check "second consecutive fire pins"     "$OUT2" "STATUS=pinned"
+check "and still reads FRESH content"    "$OUT2" "MARKER=FRESH-CONTENT"
 
 echo "== 2. control: the clone really was stale (instrument check) =="
 CTL=$(AILANG_DRIVER_PIN=0 /bin/bash "$DRV" 2>&1)
@@ -118,6 +134,38 @@ cp "$T/clone/tools/launchd/fake-driver.sh" "$T/plain/tools/launchd/"
 NR=$(/bin/bash "$T/plain/tools/launchd/fake-driver.sh" 2>&1)
 check "non-repo is STALE"                "$NR" "STATUS=STALE"
 check "reason names the repo problem"    "$NR" "not a git repository"
+
+echo "== 7. un-onboarded pin target => REFUSE, do not exec into a probe-hang =="
+# The regression this exists for: a pin worktree is by construction a path Claude Code has never
+# seen, and pinning into one makes every model probe hang to its timeout, then the driver refuses
+# with "NO usable model in prefs" — reading as a quota outage. Cost motoko its whole first fire
+# (charter V22). Staleness is the strictly smaller harm, so the pin must decline.
+printf '{"projects":{}}' > "$HOME/.claude.json"
+UO=$(/bin/bash "$DRV" 2>&1)
+check "refuses to pin"                   "$UO" "STATUS=STALE"
+check "names the onboarding cause"       "$UO" "is not onboarded in Claude Code"
+check "gives the exact human fix"        "$UO" "&& claude"
+check "fire still runs, unpinned"        "$UO" "MARKER=STALE-CONTENT"
+checkno "never reports pinned"           "$UO" "STATUS=pinned"
+
+echo "== 8. the gate reads the MEASURED flag, not the one the error text names =="
+# 76ee4056c: ailang-world has trust=false / onboarded=true and WORKS. So trust alone must not
+# satisfy the gate, or we would be right by accident and wrong in the reason.
+printf '{"projects":{"%s":{"hasTrustDialogAccepted":true}}}' "$T/pinwt" > "$HOME/.claude.json"
+TR=$(/bin/bash "$DRV" 2>&1)
+check "trust flag alone does NOT satisfy" "$TR" "STATUS=STALE"
+printf '{"projects":{"%s":{"hasCompletedProjectOnboarding":true}}}' "$T/pinwt" > "$HOME/.claude.json"
+OB=$(/bin/bash "$DRV" 2>&1)
+check "onboarding flag DOES satisfy"      "$OB" "STATUS=pinned"
+
+echo "== 9. undeterminable (no jq) fails SAFE, not open =="
+mkdir -p "$T/nojq"
+for b in git mktemp date basename dirname cat rm sleep kill grep tr tail printf mkdir; do
+  p=$(command -v $b 2>/dev/null); [ -n "$p" ] && ln -sf "$p" "$T/nojq/$b"
+done
+NJ=$(PATH="$T/nojq" /bin/bash "$DRV" 2>&1)
+check "no jq => STALE, not pinned"       "$NJ" "STATUS=STALE"
+check "says it could not verify"         "$NJ" "cannot verify Claude Code onboarding"
 
 echo ""
 echo "==== $PASS passed, $FAIL failed ===="


### PR DESCRIPTION
Follow-up to #666. **Two defects, one of which would have taken the V1 loop down on the first fire after the reconcile.** Found by reading `76ee4056c`, which landed on dev while #666 was in review.

## Defect 1 — the pin walks into a dead checkout

A pin worktree is *by construction* a path Claude Code has never seen, and an un-onboarded checkout makes headless `claude -p` block on a trust dialog it cannot display. Every model probe then hangs to its timeout (120s × 2 × 3 models ≈ 12 min) and the driver refuses with `NO usable model in prefs` — which reads as a quota outage, not as the harness fault it is. That had just cost the motoko mission its entire first unattended fire (charter V22).

Measured before writing any code:

```
onboarded=true    /Users/voightkampff/dev/sunholo-data/ailang
onboarded=ABSENT  /Users/voightkampff/.ailang-driver-pin/v1     <- the pin target
```

So #666, the moment the shared clone received it, would have converted a working-but-stale loop into a dead one. **Stale-but-working strictly beats fresh-and-dead**, so the pin now refuses when `projects[<wt>].hasCompletedProjectOnboarding` is absent — reported on both human channels like every other pin failure, with the exact one-line fix in the message. Undeterminable (no `jq`) counts as un-onboarded on purpose: pinning blind risks 12 minutes of hung probes; refusing costs staleness that is already reported.

It gates on `hasCompletedProjectOnboarding`, **not** the `hasTrustDialogAccepted` the error text names — `76ee4056c` measured `ailang-world` at trust=false/onboarded=true and *working*, the control proving the named flag is not the gate. Test 8 pins both arms so a future edit cannot quietly switch to the wrong flag and stay green.

## Defect 2 — a fix that disables itself after one use

Worktree existence was decided by string-matching `git worktree list`, but git records the **resolved realpath**, so on any path reached through a symlink (`/var` → `/private/var`, the macOS everyday case) the match silently fails. Fire 1 pins; fire 2 hits `worktree add` on an existing directory and refuses — from then on, permanently. Loud, but useless. Now decided by asking the worktree itself.

Caught by the new repeat-fire test, not by review: the original suite only ever fired once.

## Consequence for deployment

Reconciling the shared clone is now **safe with no further action** — the pin declines and says why. Pinning switches on when a human runs, once per checkout:

```
cd ~/.ailang-driver-pin/<mission> && claude
```

## Testing

48 assertions (31 + 17), `make test-launchd-drivers`, bash 3.2.57, CI job on macOS. New coverage: un-onboarded → refuse + fire still runs + never reports pinned; trust-flag-alone does *not* satisfy while onboarding-flag does; no-`jq` fails safe; second consecutive fire pins.

The happy path runs against a synthetic `~/.claude.json` in a fake `HOME` rather than with the check disabled — so a gate regressed to always-refuse fails tests 1–6, and one regressed to always-allow fails test 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)