### PR TITLE
fix(#505): fixed-length list patterns must match exactly n under --bytecode

### DIFF
--- a/.ailang/state/sprints/sprint_M-BYTECODE-PATTERN-ARITY-FIX.json
+++ b/.ailang/state/sprints/sprint_M-BYTECODE-PATTERN-ARITY-FIX.json
@@ -1,0 +1,135 @@
+{
+  "sprint_id": "M-BYTECODE-PATTERN-ARITY-FIX",
+  "status": "planned",
+  "created": "2026-08-12T00:00:00Z",
+  "design_doc": "design_docs/planned/v1_0_0/m-bytecode-pattern-arity-fix.md",
+  "sprint_plan": "design_docs/planned/v1_0_0/m-bytecode-pattern-arity-fix-sprint-plan.md",
+  "github_issues": [505],
+  "metadata": {
+    "planner-model": "claude-opus-5",
+    "base_commit": "8a859d6a2",
+    "base_of_base": "8ecebc0e1",
+    "worktree": "/Users/voightkampff/dev/sunholo-data/.wt-iter187",
+    "branch": "sprint/iter187-bytecode-pattern-arity",
+    "scope": "ONE branch change in internal/gen/lower/match.go:lowerPatternCond — a core.ListPattern with Tail == nil lowers its length guard to stmt.OpEq instead of stmt.OpGte. Root cause is already pinned and mutation-proven by the design doc (V-C/V-E/V-I); this sprint does NOT re-derive it. The work is overwhelmingly test work: build guards that have teeth and prove they have teeth. NON-SCOPE: the closure-dispatch family (array_basic/array_grid/module_let_helpers, parent doc B1/B3); the parity harness classification scheme (A1/A2, parked); the unsafe-effect-replay policy (B4, parked); M-BYTECODE-2E bridge gaps; and nested tail sub-patterns (lowerPatternCond never recurses into p.Tail, so ::(x, []) stays len >= 1 after this fix — a documented residual, not a regression, follow-up doc only).",
+    "estimated_effort": "1 day (M1 0.25d red-first, M2 0.25d fix + AC1/AC3, M3 0.5d drills + blast radius + gates)",
+    "premises_verified_live": true,
+    "verification_binary": "built from base in the worktree (make build -> bin/ailang, v0.33.0-179-g8a859d6a2); probe applied and restored byte-identically, final sha256 internal/gen/lower/match.go = fd1d890e7d3e1ed58211c0fec4eab41640aad7d8274ca31b09d25b6aa87500a2, git status and git diff --stat both empty",
+    "verification_date": "2026-08-12",
+    "read_only_git": true,
+    "ac_numbering": "AC1/AC2/AC3 exactly as the design doc numbers them; no renumbering, no added milestones beyond doc scope",
+    "caps_requirement": "EVERY acceptance/blast-radius command passes --caps IO. Without it the run errors with \"effect 'IO' requires capability\" and the bytecode path falls back to the evaluator, masking the bug entirely.",
+    "hashing_tool": "shasum -a 256 (md5 does not exist on this machine)",
+    "test_home_correction": "The design doc says to commit the .ail repro under tests/golden/bytecode/. VERIFIED: that path is a Go test package (package bytecode_golden_test; golden_test.go, probe_test.go, bench_test.go, io_test.go), its .ail fixtures live in tests/golden/codegen/ loaded by name from a hard-coded goldenSpecs() list, and it drives pipeline->lower->compiler->vm IN-PROCESS so it cannot observe CLI stderr, --caps IO, or exit code. AC1 and AC3 are therefore unimplementable there. Resolution: .ail fixture at tests/golden/bytecode/pattern_arity.ail (honours the stated location; verified inert - go test ./tests/golden/bytecode/ stays ok with it present, and no Glob/WalkDir exists over that dir), and ALL THREE ACs as CLI tests appended to cmd/ailang/run_bytecode_test.go.",
+    "wiring_verdict": "ALREADY GATED — no new make target and no new CI job needed. .github/workflows/ci.yml runs `go test -timeout 300s ./...`, which covers ./cmd/ailang, ./tests/golden/bytecode and ./internal/gen/.... Measured at base: `go test -count=1 -run TestCLI_RunBytecode ./cmd/ailang` = 5/5 PASS in 6.35s; `go test ./tests/golden/bytecode/` = ok. This differs from iteration 183's gap, which was specific to `ailang test`-driven .ail suites having no runner at all; these are Go tests.",
+    "do_not_place_in_examples": "scripts/verify_bytecode_parity.go:85 globs examples/runnable/*.ail. Putting the repro there would silently mutate the very corpus used as the blast-radius control and would enter the make verify-examples manifest.",
+    "changelog_target": "changelogs/v0.18-current.md under ## [Unreleased] -> ### Fixed. NEVER root CHANGELOG.md — scripts/check_changelog.sh fails on any ### Fixed heading there (root is an index only). make check-changelog measured rc=0 at base."
+  },
+  "discrepancies_found": [
+    {
+      "id": "D-A",
+      "doc_claim": "Commit a minimal failing .ail repro under tests/golden/bytecode/",
+      "finding": "tests/golden/bytecode/ is a Go test package (4 .go files, package bytecode_golden_test), not a fixture directory. Its .ail fixtures live in tests/golden/codegen/ and are loaded BY NAME from a hard-coded goldenSpecs() list (tryCompileAILFile -> filepath.Join(\"..\",\"codegen\",name)); there is no Glob or WalkDir over either directory. More importantly the harness runs pipeline.Run -> lower.LowerProgram -> compiler.Compile -> vm.NewVM in-process, so it can never observe the `falling back to evaluator` stderr line (emitted at cmd/ailang/run_helpers.go:376), --caps IO grants, or process exit code. AC1 and AC3 are unimplementable there.",
+      "action": "Place the .ail fixture at tests/golden/bytecode/pattern_arity.ail (honours the doc's stated location; verified inert w.r.t. the Go package). Implement AC1, AC2 and AC3 as CLI tests appended to cmd/ailang/run_bytecode_test.go, which already shells out via runCLI -> testutil.RunBounded(t, projectRoot, 120s, \"go\", \"run\", \"./cmd/ailang\", ...) and already carries the exact AC3 assertion at line 63. Already covered by `go test ./...` in CI."
+    },
+    {
+      "id": "D-B",
+      "doc_claim": "AC3: the minimal quicksort repro passes under --bytecode with no fallback (stderr asserted free of \"falling back to evaluator\")",
+      "finding": "The stderr clause is ALREADY TRUE AT HEAD on the broken binary. Measured: `ailang run --bytecode --caps IO examples/runnable/recursion_quicksort.ail` prints the WRONG answer (Quicksort: [3] / sortBy:    [3]) with rc=0 and stderr containing only `✓ Running ... via bytecode VM` — no `falling back` line at all. As an independent observable the clause is set alongside the mechanism rather than by it, i.e. decorative.",
+      "action": "Keep the clause — it rules out a 'fix' that gets the right answer by bailing to the evaluator — but ONLY as a conjunction with the stdout assertion inside a single test, and give it its own mutation (drill D4: neuter the guard at cmd/ailang/run_helpers.go:376 to `if true || vmErr != nil` and require the test to red ON THE STDERR ASSERTION SPECIFICALLY). If it reds only on stdout, the stderr clause is unwired."
+    },
+    {
+      "id": "D-C",
+      "doc_claim": "Conflict Surface names four must-still-work programs (cons_expression, block_recursion, adt_list_fields, effectful_list)",
+      "finding": "Correct — and all four are MATCH at HEAD as well as under the probe, with identical hash prefixes (2230a604cb25, d4295f6e4c13, 5430d1a50e8f, 69fd90893805), so this is a genuine before/after control. But the three most list-pattern-dense examples in the corpus are unnamed: list_pattern_cons (3d9a0ed566bd), list_patterns (ec1c27cb21d0), list_pattern_records (316ab9a842c6). All three also MATCH at HEAD and under the probe.",
+      "action": "Blast-radius set widened from 4 to 7 examples. All seven must read MATCH after the change."
+    },
+    {
+      "id": "D-D",
+      "doc_claim": "(not addressed) — the doc treats Tail != nil as uniformly 'at least n' and stops there",
+      "finding": "lowerPatternCond never recurses into p.Tail. It builds one length guard from len(p.Elements) plus tag checks for constructor sub-patterns at each index, then returns. So a nested tail sub-pattern such as ::(x, []) still lowers to `len >= 1` after this fix and does not enforce its inner fixed-length tail.",
+      "action": "Documented as an explicit residual in the plan's scope-boundaries section. It is NOT a regression introduced by this change and is NOT covered by AC1-AC3. Flag for a follow-up doc; do not fix in this sprint."
+    },
+    {
+      "id": "D-E",
+      "doc_claim": "(controller-prescribed non-vacuity drill) assert each mutation BUILDS via `go build ./...` rc=0",
+      "finding": "CONTRADICTS a controller VERIFIED-BY-ME instruction. `go build ./...` is RED AT BASE on darwin/arm64 in this worktree: `# github.com/sunholo-data/ailang/cmd/wasm` / `runtime.main_main·f: function main is undeclared in the main package`. cmd/wasm only builds under GOOS=js GOARCH=wasm. Using it would report EVERY mutation as 'failed to build' and make the drill uninterpretable (rule 3e: a command already red at base measures the repo, not the change).",
+      "action": "All mutation drills use `go build ./internal/... ./cmd/ailang` instead — measured rc=0 at base. Do not add `go build ./...` to the gate sweep."
+    },
+    {
+      "id": "D-F",
+      "doc_claim": "Run the whole-corpus parity harness (go run ./scripts/verify_bytecode_parity.go) before/after as the blast-radius check",
+      "finding": "Sound as a check, but the harness is NOT byte-stable across runs: xml_walk_perf.ail embeds wall-clock time_ms in its output, tar_gzip_reader.ail depends on a /tmp/tar_smoke fixture that may not exist, and claude_haiku_call.ail hits the network. Measured base = MATCH 151 / NON_DET 2 / DIVERGE 6 / EVAL_SKIP 16 of 175; probe = MATCH 152 / NON_DET 2 / DIVERGE 5 / EVAL_SKIP 16. Delta is exactly one file.",
+      "action": "Compare bucket COUNTS and the DIVERGE NAME SET only, never raw output diffs. Expected delta: recursion_quicksort.ail moves DIVERGE -> MATCH and nothing else moves. Residual DIVERGE (all out of scope): array_basic (closure-dispatch, parent B1/B3); pattern_sugar (the parent doc's A1 — note the EVALUATOR is the wrong one there, printing <*eval.TupleValue> where the VM correctly prints (a, 1)); claude_haiku_call (network); tar_gzip_reader (missing fixture); xml_walk_perf (timing). Report deviations as findings, not as build failures."
+    }
+  ],
+  "velocity": {
+    "target_loc_per_day": 205,
+    "estimated_total_loc": 205,
+    "estimated_days": 1,
+    "loc_note": "205 = sum of the three milestone estimates (125 + 50 + 30). Only ~6 of those are PRODUCTION lines (one branch in internal/gen/lower/match.go, net -4). The rest is ~55 LOC of .ail fixture, ~115 LOC of Go CLI tests, and ~30 LOC of drill/changelog bookkeeping. Deliberately ~20:1 test-to-production: the root cause is already mutation-proven by the design doc, so the entire risk of this sprint lives in whether the guards have teeth, not in whether the fix works."
+  },
+  "features": [
+    {
+      "id": "M1_RED_FIRST_AC2",
+      "description": "RED FIRST — land the pattern-arity .ail fixture and the AC2 table-driven CLI test against the UNFIXED lowering, and prove the test fails. No production code changes in this milestone. Deliverables: tests/golden/bytecode/pattern_arity.ail (module tests/golden/bytecode/pattern_arity — resolves canonically, NO --relax-modules needed, measured) with five isolated functions arity1/arity2/arity3 (each a single fixed arm plus a [p, ...rest] fallback so no shorter arm can intercept, per V-H), tail2 ([a,b,...rest]) and consForm (::(h,t)); plus TestCLI_ListPatternArity_Bytecode appended to cmd/ailang/run_bytecode_test.go asserting BOTH (a) cross-engine parity: stdout of `run --caps IO` byte-identical to `run --bytecode --caps IO`, AND (b) an absolute 15-line golden — parity alone is satisfiable by breaking both engines identically. Also assert exitCode==0 and stderr contains 'via bytecode VM' (anti-bridging sanity check).",
+      "estimated_loc": 125,
+      "dependencies": [],
+      "acceptance_criteria": [
+        "AC2 (doc numbering): fixed-length list-pattern arity under --bytecode for n=1, 2 and 3, in all three directions — exact-length matches, LONGER list does NOT match (the bug), SHORTER list does NOT match (the over-correction guard) — plus the tailed [a,b,...rest] and cons ::(h,t) arms which must keep 'at least n'.",
+        "`go test -count=1 -run 'TestCLI_ListPatternArity_Bytecode' ./cmd/ailang` exits NON-ZERO at HEAD (this milestone is DONE when the test is RED).",
+        "The failure output names EXACTLY THREE wrong rows: `arity1 [7,8]` (got n1, want other), `arity2 [7,8,9]` (got n2, want other), `arity3 [7,8,9,10]` (got n3, want other). Fewer than three means the fixture is being bridged to the evaluator or an arm is intercepting; more than three means the expected table is wrong.",
+        "The red-first failure output is recorded verbatim in the milestone commit message.",
+        "`go test -count=1 ./tests/golden/bytecode/` stays rc=0 with the new .ail file present (measured ok at base).",
+        "STOP CONDITION: if the test is GREEN at HEAD, do not proceed — the test is vacuous and must be reworked."
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": null
+    },
+    {
+      "id": "M2_FIX_AC1_AC3",
+      "description": "Land the one-branch fix and the flagship-symptom goldens. internal/gen/lower/match.go lowerPatternCond case *core.ListPattern: replace the if/else at lines 412-427 with a single operator selection — `lenOp := stmt.OpGte; if p.Tail == nil { lenOp = stmt.OpEq }` — then one BinOp{Op: lenOp, Left: lenExpr, Right: LitInt{int64(len(p.Elements))}}. This SUBSUMES rather than deletes the empty-list special case: (0 elems, Tail nil) -> len == 0, identical to before; (n elems, Tail nil) -> len == n, the fix; (n elems, Tail non-nil) -> len >= n, unchanged; (0 elems, Tail non-nil) -> len >= 0, always true, identical. Plus TestCLI_RunBytecode_QuicksortArity appended to cmd/ailang/run_bytecode_test.go covering AC1 and AC3 in ONE run (they are the same invocation; splitting doubles a ~4s `go run` for no extra signal). Do NOT pass --relax-modules — the example resolves canonically.",
+      "estimated_loc": 50,
+      "dependencies": ["M1_RED_FIRST_AC2"],
+      "acceptance_criteria": [
+        "AC1 (doc numbering): `ailang run --bytecode --caps IO examples/runnable/recursion_quicksort.ail` stdout contains exactly `Quicksort: [1, 1, 2, 3, 4, 5, 6, 9]` AND `sortBy:    [1, 1, 2, 3, 4, 5, 6, 9]` (three spaces after `sortBy:` — the source is column-aligned; copy the literal, do not retype).",
+        "AC3 (doc numbering): the same run exits 0, stderr does NOT contain `falling back to evaluator`, and stderr DOES contain `via bytecode VM`.",
+        "`go test -count=1 -run 'TestCLI_RunBytecode_QuicksortArity|TestCLI_ListPatternArity_Bytecode' ./cmd/ailang` rc=0 — M1's previously-red test is now GREEN under the same command.",
+        "`go test -count=1 ./internal/gen/...` rc=0 (base measured rc=0 across 5 packages: block, emitgo, golang, lower, stmt).",
+        "Regression arm, UNDERFLOW direction: `arity2 [7]` and `arity3 [7,8]` still return `other` — a fix that over-corrects into rejecting shorter lists incorrectly is caught here.",
+        "Regression arm, TAILED direction: `tail2 [7,8,9]` still returns `tail2` and `cons [7,8]` still returns `cons` — [p, ...rest] and the :: cons form (per V-I always Tail != nil) must keep 'at least n'.",
+        "internal/gen/lower/match.go stays under 800 lines (566 at base, net -4)."
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": null
+    },
+    {
+      "id": "M3_DRILLS_BLAST_RADIUS_GATES",
+      "description": "Prove every guard has teeth, measure blast radius in both directions, sweep the local gates, and update the changelog. Mutation protocol for EVERY drill row: (1) shasum -a 256 the file, record BEFORE; (2) apply the mutation, preferring neutering (`if false && cond` / `if true || cond`) over deletion so imports stay used; (3) shasum again, ASSERT IT DIFFERS — a mutation that did not land makes the subsequent red meaningless; (4) assert it BUILDS with `go build ./internal/... ./cmd/ailang` (NOT `go build ./...`, which is red at base — see D-E); (5) run the row's command and assert it reds, naming the expected rows; (6) restore from backup and assert shasum equals BEFORE.",
+      "estimated_loc": 30,
+      "dependencies": ["M2_FIX_AC1_AC3"],
+      "acceptance_criteria": [
+        "Drill D1 (kills AC2 overflow / the fix itself): neuter the discriminator in internal/gen/lower/match.go to `if false && p.Tail == nil` so lenOp stays OpGte unconditionally -> TestCLI_ListPatternArity_Bytecode reds on exactly arity1 [7,8], arity2 [7,8,9], arity3 [7,8,9,10].",
+        "Drill D2 (kills AC2 TAILED arm — the over-correction guard): force `lenOp := stmt.OpEq` unconditionally, i.e. OpEq even when Tail != nil -> the same test reds on tail2 [7,8,9] and cons [7,8] (they become `other`). This is the ONLY drill that exercises those rows: under D1 they stay green, so without D2 the tailed arm is unproven decoration.",
+        "Drill D3 (kills AC1): same mutation as D1 -> TestCLI_RunBytecode_QuicksortArity reds with `Quicksort: [3]`.",
+        "Drill D4 (kills AC3's stderr clause — the decorative one, see D-B): at cmd/ailang/run_helpers.go:376 neuter the fallback guard to `if true || vmErr != nil` so the top-level fallback always fires -> TestCLI_RunBytecode_QuicksortArity must red ON THE STDERR ASSERTION SPECIFICALLY (`falling back to evaluator` present). If it reds only on stdout, the stderr clause is unwired — fix the test, not the mutation.",
+        "Drill D5 (kills AC2's absolute-golden clause): corrupt one expected line in the test (e.g. `n2` -> `nX`) -> test reds naming that row, proving the golden is compared rather than merely computed.",
+        "Drill D6 (kills AC2's parity clause): set `evalStdout := vmStdout` in the test -> the parity clause can no longer fire; re-run D1 and RECORD WHICH CLAUSE fired, proving the evaluator run is a real second measurement and not a self-comparison.",
+        "Every drill records BEFORE sha256, AFTER sha256 (asserted different), `go build ./internal/... ./cmd/ailang` rc=0, the observed red, and the restore-hash equality.",
+        "Blast radius: all SEVEN examples read MATCH (cons_expression, block_recursion, adt_list_fields, effectful_list, list_pattern_cons, list_patterns, list_pattern_records) via `./bin/ailang run --caps IO` vs `--bytecode --caps IO`, comparing shasum -a 256 of the last 20 output lines. Expected prefixes: 2230a604cb25, d4295f6e4c13, 5430d1a50e8f, 69fd90893805, 3d9a0ed566bd, ec1c27cb21d0, 316ab9a842c6.",
+        "Parity harness `go run ./scripts/verify_bytecode_parity.go` before/after: bucket counts move 151->152 MATCH and 6->5 DIVERGE of 175, and the DIVERGE name-set delta is EXACTLY recursion_quicksort.ail leaving. This is a REGRESSION CHECK, NOT A GATE — this doc does not own the harness's bucket definitions. Compare counts and names only (the harness is not byte-stable: xml_walk_perf embeds time_ms, tar_gzip_reader needs a /tmp fixture, claude_haiku_call hits the network). Report any other movement as a finding.",
+        "Local gate sweep, all rc=0: `go test -timeout 300s ./...`; `go test -count=1 ./internal/gen/...`; `go test -count=1 ./tests/golden/bytecode/`; `go test -count=1 -run 'TestCLI_RunBytecode|TestCLI_ListPatternArity' -v ./cmd/ailang`; `make test-lowering`; `make test-stdlib-ail`; `make check-file-sizes`; `make check-boundaries`; `make check-changelog`; `make check-golden-drift`; `make test-regression-guards`; `make verify-examples`; `make fmt-check`; `make vet`; `make lint`.",
+        "Changelog entry added to changelogs/v0.18-current.md under ## [Unreleased] -> ### Fixed, referencing #505. NOT root CHANGELOG.md.",
+        "docs/LIMITATIONS.md checked for a fixed-length-list-pattern-under---bytecode caveat: remove it if present, add nothing if absent."
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": null
+    }
+  ]
+}

--- a/.ailang/state/sprints/sprint_M-BYTECODE-PATTERN-ARITY-FIX.json
+++ b/.ailang/state/sprints/sprint_M-BYTECODE-PATTERN-ARITY-FIX.json
@@ -102,10 +102,10 @@
         "Regression arm, TAILED direction: `tail2 [7,8,9]` still returns `tail2` and `cons [7,8]` still returns `cons` — [p, ...rest] and the :: cons form (per V-I always Tail != nil) must keep 'at least n'.",
         "internal/gen/lower/match.go stays under 800 lines (566 at base, net -4)."
       ],
-      "passes": null,
-      "started": null,
-      "completed": null,
-      "notes": null
+      "passes": true,
+      "started": "2026-08-12T20:45:16Z",
+      "completed": "2026-08-12T20:46:18Z",
+      "notes": "Tail-discriminated list-length lowering implemented. AC1/AC3 quicksort CLI test added; combined CLI tests, internal/gen suite, and corrected build scope all passed."
     },
     {
       "id": "M3_DRILLS_BLAST_RADIUS_GATES",

--- a/.ailang/state/sprints/sprint_M-BYTECODE-PATTERN-ARITY-FIX.json
+++ b/.ailang/state/sprints/sprint_M-BYTECODE-PATTERN-ARITY-FIX.json
@@ -1,6 +1,6 @@
 {
   "sprint_id": "M-BYTECODE-PATTERN-ARITY-FIX",
-  "status": "in_progress",
+  "status": "completed",
   "created": "2026-08-12T00:00:00Z",
   "design_doc": "design_docs/planned/v1_0_0/m-bytecode-pattern-arity-fix.md",
   "sprint_plan": "design_docs/planned/v1_0_0/m-bytecode-pattern-arity-fix-sprint-plan.md",
@@ -126,10 +126,10 @@
         "Changelog entry added to changelogs/v0.18-current.md under ## [Unreleased] -> ### Fixed, referencing #505. NOT root CHANGELOG.md.",
         "docs/LIMITATIONS.md checked for a fixed-length-list-pattern-under---bytecode caveat: remove it if present, add nothing if absent."
       ],
-      "passes": null,
-      "started": null,
-      "completed": null,
-      "notes": null
+      "passes": true,
+      "started": "2026-08-12T20:46:19Z",
+      "completed": "2026-08-12T20:57:30Z",
+      "notes": "D1-D6 mutation drills produced behavioral reds and all mutants built; seven-example blast radius and 175-example parity observation matched expected results; changelog updated; all targeted gates passed. Full go test ./... rc=1 is UNINFORMATIVE UNDER SANDBOX due forbidden httptest socket binds and denied home/cache access, requiring controller rerun. D1/D3 used the exact pre-fix branch because the prescribed false-and mutant did not reproduce #505; D4 neutered the current ranOnVM guard because the cited vmErr guard no longer exists."
     }
   ]
 }

--- a/.ailang/state/sprints/sprint_M-BYTECODE-PATTERN-ARITY-FIX.json
+++ b/.ailang/state/sprints/sprint_M-BYTECODE-PATTERN-ARITY-FIX.json
@@ -1,6 +1,6 @@
 {
   "sprint_id": "M-BYTECODE-PATTERN-ARITY-FIX",
-  "status": "planned",
+  "status": "in_progress",
   "created": "2026-08-12T00:00:00Z",
   "design_doc": "design_docs/planned/v1_0_0/m-bytecode-pattern-arity-fix.md",
   "sprint_plan": "design_docs/planned/v1_0_0/m-bytecode-pattern-arity-fix-sprint-plan.md",
@@ -83,10 +83,10 @@
         "`go test -count=1 ./tests/golden/bytecode/` stays rc=0 with the new .ail file present (measured ok at base).",
         "STOP CONDITION: if the test is GREEN at HEAD, do not proceed — the test is vacuous and must be reworked."
       ],
-      "passes": null,
-      "started": null,
-      "completed": null,
-      "notes": null
+      "passes": true,
+      "started": "2026-08-12T20:40:00Z",
+      "completed": "2026-08-12T20:45:15Z",
+      "notes": "Red-first AC2 fixture and CLI parity/absolute-golden test added. Intended behavioral failure rc=1 named exactly the three overflow rows; fixture check and bytecode golden package passed."
     },
     {
       "id": "M2_FIX_AC1_AC3",

--- a/.claude/skills/mission-control/SKILL.md
+++ b/.claude/skills/mission-control/SKILL.md
@@ -1208,6 +1208,41 @@ the Repo Profile above):
    mutant, and require rc=0 — that is what proves *your* test is the killer rather than a
    bystander. The tell: a milestone's headline verb is "reject", "refuse", "validate" or "exit
    non-zero", and your mutation list has one entry.
+   **AND A GATE'S COVERAGE IS A PROPERTY OF ITS *ENUMERATOR*, ONE LEVEL BELOW ITS BRANCHES — SO
+   EVERY BRANCH CAN BE PINNED AND THE GATE STILL SEE NOTHING** (added 2026-08-12 V1 iteration 187;
+   proposed by `mission-world` iter-77 with a first-party instance, corroborated in V1's own
+   checkout before adoption per the sibling-claim ghost discipline). Everything above asks *how
+   many ways can this mechanism refuse*, and iter-75's dual asks *how many ways can the forbidden
+   thing be spelled*. Neither asks **who decides what counts as an input at all**. An enumerator's
+   blind spot is invisible to every downstream assertion **by construction**, which is exactly why
+   a full set of arms, mutations and a high evaluator score all agree: the input never reached the
+   branches. World's instance: a gate refusing any `.ail` module outside an allowlist, four
+   refusal branches all mutation-killed, five committed arms, ten mutations, evaluator 93/100 —
+   defeated by `SNEAKY.AIL`, because the enumerator is `find -name '*.ail'` and `-name` is
+   case-sensitive. The gate exited **rc=0** and printed its own success line **byte-identical to
+   the pristine baseline's**; same-call control, `-name` saw **4** files, `-iname` saw **5**.
+   **V1's corroborating instance is a different mechanism — wrong SCOPE, not wrong case — and a
+   live 46-file hole.** `make fmt-check-ail` (`make/code-health.mk:28-39`) advertises "examples/ +
+   stdlib/" and enumerates `find examples stdlib -name '*.ail' 2>/dev/null`. **`stdlib/` has never
+   existed in this repo** (`test -d stdlib` → NO; the real path is `std/`, → YES), `find` reports
+   that only on stderr, and the `2>/dev/null` swallows it. Measured in one call: as-written
+   **400** files, `find examples std` **446**. So 46 stdlib `.ail` files sit outside a gate that
+   still prints `✓ All .ail files are canonical`. Worse, its empty-enumeration branch prints a
+   **GREEN checkmark and `exit 0`** — the anti-vacuity floor iteration 183 added to
+   `test-stdlib-ail` is absent here. Note this is the *same wrong path* rule 3a(i-d) already
+   records from iteration 181, now inside a gate rather than inside a controller probe: a repo
+   with one wrong-path habit will grow enumerators around it.
+   **Rule.** Before trusting any set-compare, allowlist, manifest or sweep gate, ask what its
+   enumerator **cannot see** — case, symlinks, extension variants, roots that do not exist,
+   permissions, build tags, ignore files, `head`/`tail` limiters. Pair the enumeration with a
+   deliberately **widened** control in the same call (`-iname` beside `-name`, `find` beside
+   `go list`, the parent directory beside the named one) and require the two counts to agree, or
+   record the delta as a declared limitation. Assert the roots exist (`test -d`) rather than
+   reading their emptiness, since a missing root returns zero exactly like a clean one — that is
+   rule 3a(i-d)'s scope trap, aimed at a committed gate instead of at your own probe. And any
+   enumerator-fed gate needs an anti-vacuity floor: an empty set must FAIL LOUDLY, never print a
+   checkmark. The tell: you are about to trust a gate whose branches you have all mutation-killed,
+   and you have never asked what feeds it.
 3k. **IF THE PRODUCT HANDS A HUMAN SOMETHING TO RUN, A TEST MUST RUN EXACTLY THAT — A TEST THAT
    REBUILDS THE SAME COMMAND BY A SECOND ROUTE VERIFIES YOUR ARITHMETIC, NEVER YOUR ARTIFACT**
    (added 2026-08-08 iteration 166). Rules 3a–3j police claims about the codebase, about a check's

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -169,6 +169,11 @@
 
 ### Fixed
 
+- **Fixed-length list patterns now enforce exact arity in the bytecode VM (#505).** Closed
+  patterns such as `[x]` and `[a, b]` no longer match longer lists and silently discard the
+  remaining elements. Tailed patterns (`[x, ...rest]`) and `::` cons patterns retain their
+  intentional “at least n” behavior.
+
 - **Strict `take` after `flatMap` or an allocating `map` no longer has to materialise every
   unvisited output.** `std/list` now exposes the existing fused `takeFlatMap(n, f, xs)` and
   `takeMap(n, f, xs)` builtins, with the strict-evaluation limitation and remaining memory

--- a/cmd/ailang/run_bytecode_test.go
+++ b/cmd/ailang/run_bytecode_test.go
@@ -214,3 +214,25 @@ func listPatternProgramOutput(t *testing.T, stdout string) string {
 	}
 	return stdout[start:]
 }
+
+func TestCLI_RunBytecode_QuicksortArity(t *testing.T) {
+	src := filepath.Join("examples", "runnable", "recursion_quicksort.ail")
+	stdout, stderr, exitCode := runCLI(t, "run", "--bytecode", "--caps", "IO", src)
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d\nstderr=%s", exitCode, stderr)
+	}
+	for _, want := range []string{
+		"Quicksort: [1, 1, 2, 3, 4, 5, 6, 9]",
+		"sortBy:    [1, 1, 2, 3, 4, 5, 6, 9]",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("expected stdout to contain %q, got %q", want, stdout)
+		}
+	}
+	if strings.Contains(stderr, "falling back to evaluator") {
+		t.Errorf("expected no fallback to evaluator, got stderr=%q", stderr)
+	}
+	if !strings.Contains(stderr, "via bytecode VM") {
+		t.Errorf("expected stderr to mention bytecode VM run, got %q", stderr)
+	}
+}

--- a/cmd/ailang/run_bytecode_test.go
+++ b/cmd/ailang/run_bytecode_test.go
@@ -162,3 +162,55 @@ export func main() -> () ! {IO} = println("nope")
 		t.Errorf("expected strict-bytecode failure message, got %q", stderr)
 	}
 }
+
+func TestCLI_ListPatternArity_Bytecode(t *testing.T) {
+	src := filepath.Join("tests", "golden", "bytecode", "pattern_arity.ail")
+	evalStdout, evalStderr, evalExit := runCLI(t, "run", "--caps", "IO", src)
+	if evalExit != 0 {
+		t.Fatalf("evaluator path exited %d\nstderr=%s", evalExit, evalStderr)
+	}
+
+	vmStdout, vmStderr, vmExit := runCLI(t, "run", "--bytecode", "--caps", "IO", src)
+	if vmExit != 0 {
+		t.Fatalf("bytecode path exited %d\nstderr=%s", vmExit, vmStderr)
+	}
+	if !strings.Contains(vmStderr, "via bytecode VM") {
+		t.Errorf("expected --bytecode run to mention VM dispatch, got %q", vmStderr)
+	}
+	evalStdout = listPatternProgramOutput(t, evalStdout)
+	vmStdout = listPatternProgramOutput(t, vmStdout)
+
+	want := strings.Join([]string{
+		"arity1 []      = other",
+		"arity1 [7]     = n1",
+		"arity1 [7,8]   = other",
+		"arity2 [7]     = other",
+		"arity2 [7,8]   = n2",
+		"arity2 [7,8,9] = other",
+		"arity3 [7,8]   = other",
+		"arity3 [7,8,9] = n3",
+		"arity3 [7,8,9,10] = other",
+		"tail2  [7]     = other",
+		"tail2  [7,8]   = tail2",
+		"tail2  [7,8,9] = tail2",
+		"cons   []      = other",
+		"cons   [7]     = cons",
+		"cons   [7,8]   = cons",
+	}, "\n") + "\n"
+	if vmStdout != evalStdout {
+		t.Errorf("stdout parity mismatch:\nevaluator:\n%s\nbytecode:\n%s", evalStdout, vmStdout)
+	}
+	if vmStdout != want {
+		t.Errorf("bytecode stdout mismatch:\ngot:\n%swant:\n%s", vmStdout, want)
+	}
+}
+
+func listPatternProgramOutput(t *testing.T, stdout string) string {
+	t.Helper()
+	const firstRow = "arity1 []      = "
+	start := strings.Index(stdout, firstRow)
+	if start < 0 {
+		t.Fatalf("program output did not contain first arity row: %q", stdout)
+	}
+	return stdout[start:]
+}

--- a/design_docs/planned/v1_0_0/m-bytecode-pattern-arity-fix-sprint-plan.md
+++ b/design_docs/planned/v1_0_0/m-bytecode-pattern-arity-fix-sprint-plan.md
@@ -431,17 +431,20 @@ Notes:
 
 ## 8. Success metrics
 
-- [ ] AC1 green: quicksort under `--bytecode --caps IO` prints both correct lines.
-- [ ] AC2 green: all 15 fixture rows match the evaluator **and** the absolute golden, for n=1,2,3,
+- [x] AC1 green: quicksort under `--bytecode --caps IO` prints both correct lines.
+- [x] AC2 green: all 15 fixture rows match the evaluator **and** the absolute golden, for n=1,2,3,
       in the overflow, exact **and** underflow directions, plus the tailed and cons arms.
-- [ ] AC3 green: rc=0, stderr free of `falling back to evaluator`, stderr contains `via bytecode VM`.
-- [ ] M1's red-first failure output recorded in the commit message (exactly three wrong rows).
-- [ ] Six mutation drills D1-D6 executed; each recorded with before/after sha256, build rc, and the
+- [x] AC3 green: rc=0, stderr free of `falling back to evaluator`, stderr contains `via bytecode VM`.
+- [x] M1's red-first failure output recorded in sprint state and the executor report (exactly three
+      wrong rows); the controller owns the milestone commit per the no-git-write rule.
+- [x] Six mutation drills D1-D6 executed; each recorded with before/after sha256, build rc, and the
       observed red.
-- [ ] All seven blast-radius examples MATCH.
-- [ ] Parity harness delta is exactly `recursion_quicksort.ail` DIVERGE → MATCH.
-- [ ] Full §7 gate sweep rc=0.
-- [ ] Changelog entry in `changelogs/v0.18-current.md`.
+- [x] All seven blast-radius examples MATCH.
+- [x] Parity harness delta is exactly `recursion_quicksort.ail` DIVERGE → MATCH.
+- [ ] Full §7 gate sweep rc=0 — `go test -timeout 300s ./...` is **UNINFORMATIVE UNDER
+      SANDBOX** because `httptest` cannot bind (`operation not permitted`) and home/cache writes
+      are denied; every other §7 gate returned rc=0. Controller rerun required outside sandbox.
+- [x] Changelog entry in `changelogs/v0.18-current.md`.
 
 ## 9. Scope boundaries (do not cross)
 

--- a/design_docs/planned/v1_0_0/m-bytecode-pattern-arity-fix-sprint-plan.md
+++ b/design_docs/planned/v1_0_0/m-bytecode-pattern-arity-fix-sprint-plan.md
@@ -1,0 +1,495 @@
+# Sprint Plan: M-BYTECODE-PATTERN-ARITY-FIX
+
+**Design doc**: [m-bytecode-pattern-arity-fix.md](m-bytecode-pattern-arity-fix.md) (quorum-resolved 2026-08-12, committed `8a859d6a2`)
+**Issue**: [#505](https://github.com/sunholo-data/ailang/issues/505)
+**Base**: `origin/dev` @ `8ecebc0e1`; worktree branch `sprint/iter187-bytecode-pattern-arity`
+**Planner verification**: all rows below measured live in this worktree on 2026-08-12 (see §7).
+
+## Summary
+
+One-branch change in `internal/gen/lower/match.go:lowerPatternCond`: a `core.ListPattern` with
+`Tail == nil` must lower its length guard to `OpEq`, not `OpGte`. The root cause is already pinned
+and mutation-proven by the design doc (V-C, V-E, V-I); this sprint does **not** re-derive it. The
+work is almost entirely *test* work — building guards that have teeth, and proving they have teeth.
+
+**Duration**: 1 day (3 milestones, ~205 LOC of which only ~6 are production)
+**Dependencies**: none. Explicitly NOT blocked on the parent doc's parked A1/A2/B3/B4.
+**Risk Level**: Low for the change itself; **Medium for test vacuity** — the two ACs most likely to
+ship as decoration are AC3 (its stderr clause is already true on the broken binary) and AC2 (its
+fixture can be silently bridged to the evaluator and pass for the wrong reason). Both are handled
+by an explicit red-first gate in M1 and a mutation drill in M3.
+
+## 1. The change
+
+`internal/gen/lower/match.go`, `lowerPatternCond` (declared line 390), `case *core.ListPattern`
+(line 410), length guard at lines 412-427.
+
+Current (verified live; file sha256 `fd1d890e7d3e1ed58211c0fec4eab41640aad7d8274ca31b09d25b6aa87500a2`):
+
+```go
+var cond stmt.Expr
+if len(p.Elements) == 0 && p.Tail == nil {
+    cond = stmt.BinOp{Op: stmt.OpEq,  Left: lenExpr, Right: stmt.LitInt{Value: 0}}
+} else {
+    cond = stmt.BinOp{Op: stmt.OpGte, Left: lenExpr, Right: stmt.LitInt{Value: int64(len(p.Elements))}}
+}
+```
+
+Target — collapse both branches into one operator selection driven by `p.Tail`:
+
+```go
+var cond stmt.Expr
+lenOp := stmt.OpGte
+if p.Tail == nil {
+    lenOp = stmt.OpEq
+}
+cond = stmt.BinOp{
+    Op:    lenOp,
+    Left:  lenExpr,
+    Right: stmt.LitInt{Value: int64(len(p.Elements))},
+}
+```
+
+**Why the collapse is safe rather than merely equivalent-looking** — the four `(len(Elements), Tail)`
+quadrants, exhaustively:
+
+| case | before | after | verdict |
+|---|---|---|---|
+| `[]` — 0 elems, `Tail == nil` | `len == 0` | `len == 0` | identical |
+| `[a,b]` — n elems, `Tail == nil` | `len >= n` **(the bug)** | `len == n` | **fixed** |
+| `[a, ...rest]` — n elems, `Tail != nil` | `len >= n` | `len >= n` | unchanged |
+| `[...rest]` — 0 elems, `Tail != nil` | `len >= 0` (always true) | `len >= 0` (always true) | identical |
+
+So the empty-list special case at line 414 is *subsumed*, not deleted: it is exactly the
+`Tail == nil, n = 0` instance of the general rule. The `Tail == nil ⟺ exactly-n` invariant is
+established over the whole codebase, not just the struct, by V-I (exactly two construction sites,
+both in `internal/elaborate/patterns.go`).
+
+Expected diff: **~6 net LOC** in one file. Nothing in `internal/vm` or `internal/bytecode` is
+touched (V-D: zero `Pattern` occurrences there).
+
+## 2. Where the tests live — CORRECTED from the design doc
+
+The design doc says: *"Commit a minimal failing `.ail` repro under `tests/golden/bytecode/`."*
+I verified this before prescribing it, and it needs two corrections.
+
+**Correction A — `tests/golden/bytecode/` is a Go test package, not a fixture directory.**
+It contains exactly four files, all `.go`, all `package bytecode_golden_test`:
+`golden_test.go`, `probe_test.go`, `bench_test.go`, `io_test.go`. Its `.ail` fixtures live one
+directory over in `tests/golden/codegen/`, loaded **by name** from a hard-coded `goldenSpecs()`
+list (`tryCompileAILFile` → `filepath.Join("..", "codegen", name)`). There is no `Glob`/`WalkDir`
+over either directory, so dropping a `.ail` file in will not be auto-discovered by anything.
+
+**Correction B — AC1 and AC3 are not implementable in that package at all.**
+`tests/golden/bytecode` drives `pipeline.Run` → `lower.LowerProgram` → `compiler.Compile` →
+`vm.NewVM` **in-process**. It never runs the CLI, so it cannot observe:
+- the `falling back to evaluator` stderr line that AC3 asserts on (emitted at
+  `cmd/ailang/run_helpers.go:376`, i.e. in the CLI run path, not in the VM);
+- `--caps IO` capability grants;
+- process exit code.
+
+**Chosen homes:**
+
+| artifact | path | rationale |
+|---|---|---|
+| the `.ail` repro | `tests/golden/bytecode/pattern_arity.ail` | honours the doc's stated location; verified inert w.r.t. the Go package (`go test ./tests/golden/bytecode/` stays `ok` with the file present) |
+| AC1, AC2, AC3 tests | `cmd/ailang/run_bytecode_test.go` (append) | the only existing harness that shells out to the real CLI |
+
+`cmd/ailang/run_bytecode_test.go` is exactly the right host: it is 164 LOC, has five passing
+`TestCLI_RunBytecode_*` tests, drives the CLI through `runCLI` →
+`testutil.RunBounded(t, projectRoot, 120s, "go", "run", "./cmd/ailang", …)` with cwd = repo root,
+and **already contains the precise AC3 assertion** at line 63:
+
+```go
+if strings.Contains(stderr, "falling back to evaluator") {
+```
+
+**Wiring verdict: already gated, no new target or job needed.** This is the point the design doc's
+"golden file that no target runs is decoration" worry is aimed at, and here it does not bite —
+because these are Go tests, not `ailang test` `.ail` suites. `.github/workflows/ci.yml` runs
+`go test -timeout 300s ./...`, which covers `./cmd/ailang`, `./tests/golden/bytecode` and
+`./internal/gen/...`. Measured at base: `go test -count=1 -run 'TestCLI_RunBytecode' ./cmd/ailang`
+→ 5/5 PASS in 6.35s; `go test ./tests/golden/bytecode/` → ok. Contrast with iteration 183's gap,
+which was specific to `ailang test`-driven `.ail` suites having no runner — not the case here.
+
+**Do NOT put the repro in `examples/runnable/`.** `scripts/verify_bytecode_parity.go:85` globs
+`examples/runnable/*.ail`, so a fixture there would silently mutate the very corpus we use as the
+blast-radius control, and would also enter the `make verify-examples` manifest.
+
+## 3. The AC2 fixture (verified red at HEAD, verified green under the probe)
+
+`tests/golden/bytecode/pattern_arity.ail`. Shaped after V-H — each fixed arity is tested in an
+**isolated** function so no shorter arm can intercept and hide it (the arm-ordering artifact the
+round-2 quorum correctly refused). Module decl matches the canonical path, so **no
+`--relax-modules` is needed** (measured).
+
+```ailang
+module tests/golden/bytecode/pattern_arity
+
+import std/io (println)
+
+// n=1 fixed arm, isolated: only the tailed fallback can catch anything else.
+func arity1(xs: [int]) -> string =
+  match xs {
+    [] => "other",
+    [a] => "n1",
+    [p, ...rest] => "other"
+  }
+
+// n=2 fixed arm, isolated.
+func arity2(xs: [int]) -> string =
+  match xs {
+    [] => "other",
+    [a, b] => "n2",
+    [p, ...rest] => "other"
+  }
+
+// n=3 fixed arm, isolated.
+func arity3(xs: [int]) -> string =
+  match xs {
+    [] => "other",
+    [a, b, c] => "n3",
+    [p, ...rest] => "other"
+  }
+
+// Tailed pattern MUST keep "at least 2" semantics.
+func tail2(xs: [int]) -> string =
+  match xs {
+    [a, b, ...rest] => "tail2",
+    _ => "other"
+  }
+
+// Cons form: per V-I always Tail != nil, so "at least 1" must survive.
+func consForm(xs: [int]) -> string =
+  match xs {
+    ::(h, t) => "cons",
+    _ => "other"
+  }
+
+export func main() -> () ! {IO} {
+  println("arity1 []      = ${arity1([])}");
+  println("arity1 [7]     = ${arity1([7])}");
+  println("arity1 [7,8]   = ${arity1([7, 8])}");
+  println("arity2 [7]     = ${arity2([7])}");
+  println("arity2 [7,8]   = ${arity2([7, 8])}");
+  println("arity2 [7,8,9] = ${arity2([7, 8, 9])}");
+  println("arity3 [7,8]   = ${arity3([7, 8])}");
+  println("arity3 [7,8,9] = ${arity3([7, 8, 9])}");
+  println("arity3 [7,8,9,10] = ${arity3([7, 8, 9, 10])}");
+  println("tail2  [7]     = ${tail2([7])}");
+  println("tail2  [7,8]   = ${tail2([7, 8])}");
+  println("tail2  [7,8,9] = ${tail2([7, 8, 9])}");
+  println("cons   []      = ${consForm([])}");
+  println("cons   [7]     = ${consForm([7])}");
+  println("cons   [7,8]   = ${consForm([7, 8])}")
+}
+```
+
+Measured behaviour (planner, live). `→`/`✓` status lines stripped:
+
+| row | direction | evaluator (control) | `--bytecode` @ HEAD | `--bytecode` @ probe |
+|---|---|---|---|---|
+| `arity1 []` | exact n=0 | other | other | other |
+| `arity1 [7]` | exact n=1 | n1 | n1 | n1 |
+| **`arity1 [7,8]`** | **overflow n=1** | other | **n1 ✗** | other ✓ |
+| `arity2 [7]` | **underflow n=2** | other | other | other |
+| `arity2 [7,8]` | exact n=2 | n2 | n2 | n2 |
+| **`arity2 [7,8,9]`** | **overflow n=2** | other | **n2 ✗** | other ✓ |
+| `arity3 [7,8]` | **underflow n=3** | other | other | other |
+| `arity3 [7,8,9]` | exact n=3 | n3 | n3 | n3 |
+| **`arity3 [7,8,9,10]`** | **overflow n=3** | other | **n3 ✗** | other ✓ |
+| `tail2 [7]` | tailed, below | other | other | other |
+| `tail2 [7,8]` | tailed, at | tail2 | tail2 | tail2 |
+| `tail2 [7,8,9]` | **tailed, above — must stay ≥** | tail2 | tail2 | tail2 |
+| `cons []` | cons, empty | other | other | other |
+| `cons [7]` | cons, at | cons | cons | cons |
+| `cons [7,8]` | **cons, above — must stay ≥** | cons | cons | cons |
+
+Three rows diverge at HEAD and only those three; the fix flips exactly those three and nothing
+else. Crucially the divergence **also proves these functions really execute in the VM** rather
+than being bridged back to the evaluator — a fixture that were silently bridged would show zero
+divergence and pass at HEAD, i.e. be vacuous.
+
+## 4. Milestones
+
+### M1 — Red first: land the fixture and AC2 **against the unfixed lowering** (~0.25d)
+
+**Goal**: prove the guard has teeth *before* the thing it guards exists. No production code changes
+in this milestone.
+
+**Deliverables**
+- `tests/golden/bytecode/pattern_arity.ail` exactly as §3.
+- `TestCLI_ListPatternArity_Bytecode` appended to `cmd/ailang/run_bytecode_test.go` (~70 LOC).
+  Shape — a **two-clause** assertion, both clauses required:
+  1. **cross-engine parity**: run the fixture under `ailang run --caps IO` and under
+     `ailang run --bytecode --caps IO`; stdout must be byte-identical.
+  2. **absolute golden**: bytecode stdout must equal the 15 expected lines verbatim (table §3,
+     evaluator column). Parity alone is satisfiable by breaking *both* engines identically;
+     the absolute golden is what stops that.
+  Also assert `exitCode == 0` and `strings.Contains(vmStderr, "via bytecode VM")` — the latter is
+  the anti-bridging sanity check that the run actually took the VM path.
+
+**Acceptance (this milestone is DONE when the test is RED)**
+```
+go test -count=1 -run 'TestCLI_ListPatternArity_Bytecode' ./cmd/ailang
+```
+must exit **non-zero**, and the failure output must name **exactly three** wrong rows:
+`arity1 [7,8]`, `arity2 [7,8,9]`, `arity3 [7,8,9,10]`. Fewer than three ⇒ the fixture is being
+bridged or an arm is intercepting; more than three ⇒ the expected table is wrong. **Record the
+failure output in the commit message.** If it is green at HEAD, STOP — the test is vacuous and
+must be reworked, not proceeded past.
+
+**Risk**: fixture gets silently bridged to the evaluator and passes at HEAD.
+**Mitigation**: that is precisely what the red-first gate detects; it cannot be skipped.
+
+---
+
+### M2 — The fix, plus AC1 and AC3 (~0.25d)
+
+**Goal**: land the one-branch change and the flagship-symptom goldens.
+
+**Deliverables**
+- `internal/gen/lower/match.go` — the §1 change (~6 net LOC).
+- `TestCLI_RunBytecode_QuicksortArity` appended to `cmd/ailang/run_bytecode_test.go` (~45 LOC),
+  covering **AC1 and AC3 in one test** (they are the same run; splitting them would double a
+  ~4s `go run` for no signal):
+  - **AC1**: `ailang run --bytecode --caps IO examples/runnable/recursion_quicksort.ail` stdout
+    contains `Quicksort: [1, 1, 2, 3, 4, 5, 6, 9]` **and** `sortBy:    [1, 1, 2, 3, 4, 5, 6, 9]`
+    (note: three spaces after `sortBy:` — copy the literal from the doc, it is column-aligned).
+  - **AC3**: same run, `exitCode == 0`, `!strings.Contains(stderr, "falling back to evaluator")`,
+    and `strings.Contains(stderr, "via bytecode VM")`.
+  - Do **not** pass `--relax-modules`: the example resolves canonically (measured).
+
+**Acceptance**
+```
+go test -count=1 -run 'TestCLI_RunBytecode_QuicksortArity|TestCLI_ListPatternArity_Bytecode' ./cmd/ailang
+go test -count=1 ./internal/gen/...
+```
+first rc=0 (M1's test must now be **green** — the same binary, the same command that was red);
+second rc=0 (base measured rc=0, 5 packages).
+
+**⚠ AC3's stderr clause is decorative on its own — measured.** At HEAD the quicksort run prints the
+*wrong* answer with `rc=0` and stderr containing only `✓ Running … via bytecode VM`; there is **no**
+`falling back to evaluator` line. So `!Contains(stderr, "falling back")` is already true on the
+broken binary — it is set alongside the mechanism, not by it. It earns its place only as a
+conjunction with the stdout assertion (it rules out a "fix" that got the right answer by bailing
+to the evaluator), and it needs its own mutation (D4, §5) to prove it is wired to anything at all.
+
+**Risk**: over-correcting into the underflow direction, or breaking tailed patterns.
+**Mitigation**: M1's `arity2 [7]` / `arity3 [7,8]` rows are the underflow arm; `tail2 [7,8,9]` and
+`cons [7,8]` are the tailed arm. Both directions are already in the fixture and both were measured
+unchanged under the probe.
+
+---
+
+### M3 — Prove the guards have teeth; blast radius; gates; changelog (~0.5d)
+
+**Goal**: mutation drills, whole-corpus regression check, full local gate sweep, docs.
+
+**Deliverables**
+- Mutation drill table (§5) executed, with before/after sha256 + build rc recorded per row.
+- Blast-radius results (§6) recorded.
+- Changelog entry in **`changelogs/v0.18-current.md`** under `## [Unreleased]` → `### Fixed`.
+  **NOT** root `CHANGELOG.md` — `make check-changelog` (`scripts/check_changelog.sh`) fails on any
+  `### Fixed` heading there; root is an index only.
+- `docs/LIMITATIONS.md`: if it carries a "fixed-length list patterns under `--bytecode`" caveat,
+  remove it; if not, add nothing. (Check, don't assume.)
+
+**Acceptance**: the §7 gate sweep, all rc=0.
+
+## 5. Non-vacuity drill — one mutation per test-plan row
+
+**Protocol for every row.** Prefer neutering over deletion so imports stay used.
+1. `shasum -a 256 <file>` → record **before**.
+2. Apply the mutation.
+3. `shasum -a 256 <file>` → record **after**; assert it **differs**. A mutation that did not land
+   makes the subsequent red meaningless.
+4. Assert it **builds** — see the build-command correction immediately below.
+5. Run the row's command; assert it goes **red**, and that the red names the expected rows.
+6. Restore from backup; `shasum -a 256` must equal the **before** value.
+
+**⚠ CORRECTION to the prescribed drill command — `go build ./...` is RED AT BASE.**
+Measured in this worktree on the pristine tree:
+```
+$ go build ./...
+# github.com/sunholo-data/ailang/cmd/wasm
+runtime.main_main·f: function main is undeclared in the main package
+```
+`cmd/wasm` only builds under `GOOS=js GOARCH=wasm`, so `go build ./...` never returns rc=0 on
+darwin/arm64 — it would report every mutation as "failed to build" and the drill would be
+uninterpretable (rule 3e: a command already red at base measures the repo, not the change).
+**Use instead** (measured rc=0 at base):
+```
+go build ./internal/... ./cmd/ailang
+```
+
+| # | row it kills | mutation | file | expected red |
+|---|---|---|---|---|
+| D1 | **AC2 overflow** (the fix itself) | revert §1: force `lenOp := stmt.OpGte` unconditionally, i.e. `if false && p.Tail == nil {` | `internal/gen/lower/match.go` | `TestCLI_ListPatternArity_Bytecode` fails on exactly `arity1 [7,8]`, `arity2 [7,8,9]`, `arity3 [7,8,9,10]` |
+| D2 | **AC2 tailed arm** (over-correction guard) | invert the discriminator: `lenOp := stmt.OpEq` unconditionally (i.e. `OpEq` even when `Tail != nil`) | `internal/gen/lower/match.go` | same test fails on `tail2 [7,8,9]` and `cons [7,8]` (they become `other`). **This is the row that proves the tailed arm is not decoration** — under D1 those rows stay green, so only D2 exercises them. |
+| D3 | **AC1** | in the fixture-independent path: change the AC1 expectation source — mutate `internal/gen/lower/match.go` as D1 | `internal/gen/lower/match.go` | `TestCLI_RunBytecode_QuicksortArity` fails with `Quicksort: [3]` |
+| D4 | **AC3 stderr clause** (the decorative one) | force the top-level fallback: at `cmd/ailang/run_helpers.go:376`, neuter the guard so the fallback branch always runs (`if true || vmErr != nil {`) | `cmd/ailang/run_helpers.go` | `TestCLI_RunBytecode_QuicksortArity` fails **on the stderr assertion specifically** (`falling back to evaluator` present). If it fails only on stdout, the stderr clause is unwired — fix the test, not the mutation. |
+| D5 | **AC2 absolute-golden clause** | in the test, corrupt one expected line (e.g. `n2` → `nX`) — proves the golden is compared, not merely computed | `cmd/ailang/run_bytecode_test.go` | test fails naming that row |
+| D6 | **AC2 parity clause** | in the test, replace the evaluator-run stdout with the bytecode stdout (`evalStdout := vmStdout`) — proves the control is a real second measurement | `cmd/ailang/run_bytecode_test.go` | parity clause can no longer fail ⇒ re-run D1: if the test still reds it is because of the golden clause only. **Record which clause fired.** |
+
+**Rows deliberately NOT drilled**: the blast-radius examples and the parity harness (§6). They are
+regression *observations*, not gates — the doc explicitly declines to own the harness's bucket
+definitions. Do not manufacture a mutation for them.
+
+## 6. Blast radius (regression check, NOT a gate)
+
+**Named must-still-work programs.** All four are MATCH at HEAD **and** MATCH under the probe, with
+identical hashes — measured, so this is a genuine before/after control, not a restatement of V-F:
+
+| example | eval sha256[0:12] | bytecode sha256[0:12] | HEAD | probe |
+|---|---|---|---|---|
+| `cons_expression` | `2230a604cb25` | `2230a604cb25` | MATCH | MATCH |
+| `block_recursion` | `d4295f6e4c13` | `d4295f6e4c13` | MATCH | MATCH |
+| `adt_list_fields` | `5430d1a50e8f` | `5430d1a50e8f` | MATCH | MATCH |
+| `effectful_list` | `69fd90893805` | `69fd90893805` | MATCH | MATCH |
+
+I added three the doc does not name but which are the most list-pattern-dense examples in the
+corpus — all MATCH at HEAD and under the probe: `list_pattern_cons` (`3d9a0ed566bd`),
+`list_patterns` (`ec1c27cb21d0`), `list_pattern_records` (`316ab9a842c6`). Include them.
+
+Command (`md5` is absent on this machine — `shasum -a 256`):
+```
+for f in cons_expression block_recursion adt_list_fields effectful_list \
+         list_pattern_cons list_patterns list_pattern_records; do
+  e=$(./bin/ailang run --caps IO examples/runnable/$f.ail 2>/dev/null | tail -20 | shasum -a 256 | cut -c1-12)
+  b=$(./bin/ailang run --bytecode --caps IO examples/runnable/$f.ail 2>/dev/null | tail -20 | shasum -a 256 | cut -c1-12)
+  [ "$e" = "$b" ] && s=MATCH || s=DIVERGE
+  echo "$f  eval=$e  bc=$b  $s"
+done
+```
+All seven must read MATCH after the change. (`--caps IO` is mandatory: without it the run errors
+with `effect 'IO' requires capability` and the bytecode path falls back to the evaluator, which
+masks the bug entirely.)
+
+**Whole-corpus parity harness.** `go run ./scripts/verify_bytecode_parity.go`, before/after.
+Measured by the planner:
+
+| bucket | BASE (HEAD) | PROBE | delta |
+|---|---|---|---|
+| MATCH | 151 (86.3%) | **152 (86.9%)** | **+1** |
+| NON_DET | 2 | 2 | 0 |
+| DIVERGE | 6 (3.4%) | **5 (2.9%)** | **−1** |
+| EVAL_SKIP | 16 | 16 | 0 |
+| total | 175 | 175 | — |
+
+The delta is **exactly one file**: `recursion_quicksort.ail` leaves DIVERGE. Nothing else moves in
+either direction. Residual DIVERGE after the fix, all out of scope:
+- `array_basic.ail` — closure-dispatch family, parent doc B1/B3.
+- `pattern_sugar.ail` — the parent doc's **A1**. Worth stating precisely because it looks adjacent:
+  the divergence is `firstPair([("a",1),...])`, where the **evaluator** prints `<*eval.TupleValue>`
+  and the **VM prints the correct `(a, 1)`**. The evaluator is the wrong one. This fix neither
+  helps nor hurts it.
+- `claude_haiku_call.ail` (network), `tar_gzip_reader.ail` (missing `/tmp/tar_smoke` fixture),
+  `xml_walk_perf.ail` (wall-clock `time_ms` in output).
+
+**The harness is not byte-stable across runs** (the last two rows embed timings/IO state), so
+compare **bucket counts and the DIVERGE name set**, never raw output diffs. Treat any change other
+than `recursion_quicksort.ail` leaving DIVERGE as a finding to report — not as a build failure.
+
+## 7. Local gate sweep before pushing
+
+Derived from `.github/workflows/ci.yml` (the `test` job's steps and the lint job), filtered to what
+a diff touching `internal/gen/`, `cmd/ailang/` and `tests/` can plausibly break. Note CI has **no
+push paths filter**, so the full suite runs regardless.
+
+All of the following were measured rc=0 on the pristine tree, so a red is attributable to the
+change (rule 3e):
+
+```
+go test -timeout 300s ./...
+go test -count=1 ./internal/gen/...
+go test -count=1 ./tests/golden/bytecode/
+go test -count=1 -run 'TestCLI_RunBytecode|TestCLI_ListPatternArity' -v ./cmd/ailang
+make test-lowering
+make test-stdlib-ail
+make check-file-sizes
+make check-boundaries
+make check-changelog
+make check-golden-drift
+make test-regression-guards
+make verify-examples
+make fmt-check
+make vet
+make lint
+```
+
+Notes:
+- `make check-golden-drift` only diffs `internal/parser/testdata/parser/` — adding files under
+  `tests/golden/` does **not** trip it (verified by reading the target).
+- `make check-file-sizes` (800-line limit): `internal/gen/lower/match.go` is 566 lines and the
+  change is net **−4**; `cmd/ailang/run_bytecode_test.go` is 164 and grows to ~280. Both clear.
+- `make check-changelog` is the one that has bitten this loop before. Entry goes in
+  `changelogs/v0.18-current.md`, never root `CHANGELOG.md`.
+- `make verify-examples` runs the **evaluator** path, which this change does not touch; expect it
+  unchanged. Run it anyway — it is the examples job's real gate.
+- Do **not** add `go build ./...` — red at base (`cmd/wasm`, §5).
+
+## 8. Success metrics
+
+- [ ] AC1 green: quicksort under `--bytecode --caps IO` prints both correct lines.
+- [ ] AC2 green: all 15 fixture rows match the evaluator **and** the absolute golden, for n=1,2,3,
+      in the overflow, exact **and** underflow directions, plus the tailed and cons arms.
+- [ ] AC3 green: rc=0, stderr free of `falling back to evaluator`, stderr contains `via bytecode VM`.
+- [ ] M1's red-first failure output recorded in the commit message (exactly three wrong rows).
+- [ ] Six mutation drills D1-D6 executed; each recorded with before/after sha256, build rc, and the
+      observed red.
+- [ ] All seven blast-radius examples MATCH.
+- [ ] Parity harness delta is exactly `recursion_quicksort.ail` DIVERGE → MATCH.
+- [ ] Full §7 gate sweep rc=0.
+- [ ] Changelog entry in `changelogs/v0.18-current.md`.
+
+## 9. Scope boundaries (do not cross)
+
+Out of scope, per the design doc and Mark's option-C carve-out:
+- Closure-dispatch family (`array_basic`, `array_grid`, `module_let_helpers`) — parent B1/B3.
+- Parity-harness classification scheme (A1 eval tuple-show, A2 harness honesty) — parked.
+- Unsafe-effect-replay fallback policy (B4) — parked with A2.
+- M-BYTECODE-2E bridge gaps (Result.Ok/Err TaggedValue, MapValue, BytesValue).
+- **Nested tail sub-patterns.** `lowerPatternCond` does **not** recurse into `p.Tail`, so a pattern
+  like `::(x, [])` still lowers to `len >= 1` after this fix and does not enforce its inner
+  fixed-length tail. This is a real residual, it is **not** a regression introduced here, and it is
+  not in AC1-AC3. Flag it for a follow-up doc; do not fix it in this sprint.
+
+## 10. Open questions / discrepancies found
+
+| id | design-doc claim | finding | resolution |
+|---|---|---|---|
+| **D-A** | "Commit a minimal failing `.ail` repro under `tests/golden/bytecode/`" implies a fixture directory with a runner | That path is a **Go test package** (`package bytecode_golden_test`, 4 `.go` files); its `.ail` fixtures live in `tests/golden/codegen/` and are named in a hard-coded list. The package is in-process and **cannot** observe CLI stderr or `--caps IO`, so AC1/AC3 are unimplementable there. | `.ail` fixture at `tests/golden/bytecode/pattern_arity.ail` (honours the stated location, verified inert); **all three ACs** as CLI tests in `cmd/ailang/run_bytecode_test.go`. Already gated by `go test ./...` in CI — no new make target or CI job required. |
+| **D-B** | AC3: "no fallback (stderr asserted free of `falling back to evaluator`)" reads as an independent observable | **Already true at HEAD on the broken binary** — quicksort prints `[3]`, rc=0, stderr has only `✓ Running … via bytecode VM`. The clause is set alongside the mechanism, not by it. | Keep it (it rules out a fix that bails to the evaluator), but only as a conjunction with the stdout assertion, and drill it separately (D4). |
+| **D-C** | Conflict Surface names four must-still-work programs | Correct, and all four MATCH at HEAD as well as under the probe. But the three most list-pattern-dense examples (`list_pattern_cons`, `list_patterns`, `list_pattern_records`) are unnamed. | Added to the blast-radius set; all MATCH before and after. |
+| **D-D** | (not addressed) `lowerPatternCond`'s handling of `p.Tail` sub-patterns | The function never recurses into `p.Tail`, so `::(x, [])` remains `len >= 1` after the fix. | Documented as an explicit residual in §9; follow-up doc, not this sprint. |
+| **D-E** | (controller-prescribed drill command) `go build ./...` rc=0 | **Red at base** on darwin/arm64 — `cmd/wasm` needs `GOOS=js GOARCH=wasm`. | Drills use `go build ./internal/... ./cmd/ailang` (rc=0 at base). |
+| **D-F** | Parity harness as before/after regression check | Sound, but the harness is **not byte-stable**: `xml_walk_perf.ail` embeds `time_ms`, `tar_gzip_reader.ail` depends on a `/tmp` fixture, `claude_haiku_call.ail` hits the network. | Compare bucket counts + DIVERGE name set only. Expected delta measured: `recursion_quicksort.ail` DIVERGE → MATCH, nothing else. |
+
+## 11. Planner verification log
+
+All measured in `/Users/voightkampff/dev/sunholo-data/.wt-iter187` on 2026-08-12, base `8a859d6a2`
+(= design doc commit on top of `8ecebc0e1`). The probe was applied and restored; final
+`shasum -a 256 internal/gen/lower/match.go` = `fd1d890e7d3e1ed58211c0fec4eab41640aad7d8274ca31b09d25b6aa87500a2`
+(identical to the doc's V-E restore hash) and `git status --short` / `git diff --stat` are both empty.
+
+| ID | check | result |
+|---|---|---|
+| P-1 | `sed -n '386,432p' internal/gen/lower/match.go`; `sed -n '365,380p' internal/core/core.go` | Confirms every controller-VERIFIED fact: `lowerPatternCond` at 390, `case *core.ListPattern` at 410, `OpEq` empty special-case at 414, `OpGte` at 421-427; `ListPattern{Elements, Tail}` at core.go:370. |
+| P-2 | `ailang run --caps IO` vs `--bytecode --caps IO` on `recursion_quicksort.ail` | Evaluator (control): correct both lines. Bytecode: `Quicksort: [3]` / `sortBy:    [3]`, **rc=0**, stderr = `✓ Running … via bytecode VM` only, **no** `falling back`. Source of D-B. |
+| P-3 | §3 fixture, both engines, at HEAD | Exactly three rows diverge: `arity1 [7,8]`, `arity2 [7,8,9]`, `arity3 [7,8,9,10]`. Underflow, tailed and cons rows correct on **both** engines. Reproduces V-H independently and proves the fixture is VM-executed, not bridged. |
+| P-4 | probe applied (`lenOp` per §1); `shasum` before `fd1d890e…` → after `5142335d7e74…`; `go build ./internal/... ./cmd/ailang` rc=0; `make build` | Fixture byte-identical to evaluator on all 15 rows; quicksort prints both correct lines. |
+| P-5 | `go test ./internal/gen/...` | rc=0 at base (5 pkgs) **and** under the probe. Confirms the doc's V-G: the existing suite pins nothing in either direction, so AC2 is load-bearing. |
+| P-6 | 7 examples × 2 engines, `shasum -a 256` of last 20 lines, at HEAD and under probe | All 7 MATCH in both states; hash prefixes identical across states (see §6 table). |
+| P-7 | `go run ./scripts/verify_bytecode_parity.go` at base and under probe | 151→152 MATCH, 6→5 DIVERGE; delta = exactly `recursion_quicksort.ail`. Residual DIVERGE set enumerated in §6. |
+| P-8 | `ls tests/golden/bytecode/`; `head -3 tests/golden/bytecode/*.go`; `grep Glob\|WalkDir` | 4 `.go` files, all `package bytecode_golden_test`; no directory walk; fixtures loaded from `../codegen` by name. Source of D-A. |
+| P-9 | wrote fixture to `tests/golden/bytecode/pattern_arity.ail`, ran without `--relax-modules`, ran `go test ./tests/golden/bytecode/`, deleted it | Module `tests/golden/bytecode/pattern_arity` resolves canonically (no MOD010, no `--relax-modules`); Go package unaffected (`ok`). Tree left clean. |
+| P-10 | `go test -count=1 -run 'TestCLI_RunBytecode' -v ./cmd/ailang` | 5/5 `--- PASS` in 6.35s at base. Confirms the chosen host harness is green and fast. |
+| P-11 | `go build ./...` at base | **rc≠0**: `cmd/wasm: runtime.main_main·f: function main is undeclared in the main package`. Source of D-E. |
+| P-12 | `make check-file-sizes`, `make check-changelog`, `make vet`, `make fmt-check`, `go test ./tests/golden/bytecode/` at base | all rc=0. |
+| P-13 | read `check-golden-drift` target in `make/test.mk` | diffs only `internal/parser/testdata/parser/` — unaffected by `tests/golden/` additions. |
+| P-14 | `grep -rn "falling back to evaluator" --include=*.go` | Exactly two sites: emitter `cmd/ailang/run_helpers.go:376`; existing assertion `cmd/ailang/run_bytecode_test.go:63`. Basis for D4 and for the AC3 host choice. |
+
+---
+
+**Plan created**: 2026-08-12 · planner model `claude-opus-5` · read-only w.r.t. git (no add/commit/branch)

--- a/design_docs/planned/v1_0_0/m-bytecode-pattern-arity-fix.md
+++ b/design_docs/planned/v1_0_0/m-bytecode-pattern-arity-fix.md
@@ -1,6 +1,8 @@
 # M-BYTECODE-PATTERN-ARITY-FIX — fixed-length list patterns match longer lists under `--bytecode` (silent wrong result)
 
-**Status**: Planned — **UNBLOCKED**, ready to sprint. Spun out of
+**Status**: Planned — **QUORUM-RESOLVED 2026-08-12, ready to sprint.** Two blocked rounds, both on
+premise objections the controller then measured (see the Quorum verification log at the end);
+resolved via the narrow-refinement carve-out with V-H and V-I appended. Spun out of
 [m-bytecode-vm-parity-bugs.md](m-bytecode-vm-parity-bugs.md) (Milestones B1's quicksort half + B2)
 per Mark's 2026-08-04 decision on that doc's parked A2 question: **option C** — split the doc, land
 this P0 fix immediately since it does not depend on A2's harness-classification redesign at all.
@@ -19,32 +21,36 @@ question — that question is about the *parity harness's* classification scheme
 behavior directly; its acceptance criteria are golden-output tests, not harness bucket counts.
 **Filed bug**: [#505](https://github.com/sunholo-data/ailang/issues/505)
 
-## Root cause (already known — verified by the controller, see parent doc's Verification Log)
+## Root cause (localized and mutation-verified at HEAD `8ecebc0e1`)
 
-**The bytecode VM does not check the LENGTH of a fixed-length list pattern.** A pattern
+**The bytecode lowering path does not check the LENGTH of a fixed-length list pattern.** A pattern
 `[p1, …, pn]` matches any list of length **≥ n**, binding the first `n` elements and silently
 discarding the tail. The guard is `len >= n` where it must be `len == n`. Only the *overflow*
 direction is unchecked — a list **shorter** than the pattern correctly fails to match, which is why
 this survived so long.
 
-Minimal repro (`match` with arms `[] / [x] / [a,b] / [p, ...rest]`):
+Minimal repro (`match` with arms `[] / [x] / [a,b] / [a,b,c] / [p, ...rest]`):
 
 | input | `ailang run` (correct) | `ailang run --bytecode` |
 |---|---|---|
 | `[]` | `empty` | `empty` |
 | `[7]` | `one:7` | `one:7` |
 | `[7,8]` | `two:7,8` | **`one:7`** |
-| `[7,8,9]` | `many:7` | **`one:7`** |
+| `[7,8,9]` | `three:7,8,9` | **`one:7`** |
+| `[7,8,9,10]` | `many:7` | **`one:7`** |
 
-Confirmed general at n=1, 2 **and** 3 (`[a,b]` arm swallows `[7,8,9]` → `two:7,8`; `[a,b,c]` arm
-swallows `[7,8,9,10]` → `three:7,8,9`).
+The earliest non-empty fixed-length arm swallows every list at least that long. In this ordered
+repro, `[x]` therefore captures every non-empty input and the n=2 and n=3 arms are never reached.
+The same `len >= n` lowering applies at n=1, 2, and 3; an isolated n=2 or n=3 arm likewise accepts
+a longer list. AC2 tests each arity independently so arm ordering cannot hide that generality.
 
 This fully explains `recursion_quicksort.ail` (the flagship symptom): the `[x] => [x]` arm captures
 the whole 8-element input and returns the head as a singleton, so `ailang run --bytecode` silently
 prints `[3]` instead of the correct `[1, 1, 2, 3, 4, 5, 6, 9]`, exit 0, no error, no fallback
 warning on stderr. `sortBy`'s identical `[3]` is the same arm in `std/list`, not a second bug.
 `show`, `filter`, `concat`, recursion-as-argument, and closure capture of a pattern-bound variable
-were each ruled out (all MATCH under both engines) before landing on this cause.
+are not alternative fix sites: the mutation experiment in V-E changes only the list-pattern
+condition and makes both the minimal repro and flagship symptom byte-identical to the evaluator.
 
 **Impact is wider than one example**: every fixed-length list pattern in every `--bytecode` program
 can silently return a wrong answer.
@@ -63,10 +69,17 @@ can silently return a wrong answer.
 
 ## Fix location
 
-`internal/gen/lower/` / `internal/vm/` / `internal/bytecode/` — exact site to be confirmed by
-whoever picks this up (the parent doc's B1 milestone did not localize the opcode/function, only
-the semantic cause). `ailang disasm` the repro below and trace the list-pattern-match opcode's
-length check; compare against the evaluator's equivalent (which correctly requires `len == n`).
+The fix site is `internal/gen/lower/match.go`, function `lowerPatternCond` (declared at line 390),
+in `case *core.ListPattern` at lines 410–427. Line 414 special-cases the empty pattern to
+`stmt.OpEq`; lines 421–427 currently emit `stmt.OpGte` for every other list pattern. The existing
+node discriminator is `core.ListPattern.Tail` (`internal/core/core.go:370`):
+
+- `Tail == nil`: fixed-length pattern, emit `stmt.OpEq` (including the n=0 empty pattern).
+- `Tail != nil`: tailed pattern, emit `stmt.OpGte` because “at least n” is intentional.
+
+Pattern matching is lowered away in `internal/gen` before execution. `internal/vm` and
+`internal/bytecode` are not involved: neither contains a `Pattern` occurrence in any `.go` file,
+while the same search finds 13 files under `internal/gen` (V-D).
 
 ## Milestone — fix the pattern-arity bug (P0, ~0.5–1d)
 
@@ -92,13 +105,17 @@ above is already minimal — do not re-derive it).
 
 ## Conflict Surface
 
-- `internal/gen/lower/` / `internal/vm/` / `internal/bytecode/` (exact files unknown until the fix
-  site is located) — list/closure codegen is shared by *all* list-recursive programs, not just
-  `recursion_quicksort.ail`; run the whole-corpus parity harness (`go run
-  ./scripts/verify_bytecode_parity.go`) before/after as a blast-radius check even though this doc
+- `internal/gen/lower/match.go:lowerPatternCond` is the shared statement-IR lowering path for every
+  list pattern in every program using the bytecode pipeline. The real regression risks are (1)
+  over-correcting into the underflow direction so a fixed-length pattern accepts a shorter list,
+  and (2) changing a tailed pattern from `>= n` to `== n`. AC2 covers both boundaries and both
+  fixed arity outcomes; its tailed fallback also exercises the `Tail != nil` path. Run the
+  whole-corpus parity harness (`go run
+  ./scripts/verify_bytecode_parity.go`) before/after as the blast-radius check even though this doc
   does not depend on the harness's classification scheme.
 
-**Programs that MUST still work post-change (verified MATCH at parent-doc HEAD `33be8f5a7`):**
+**Programs that MUST still work post-change (verified MATCH under the probe at HEAD `8ecebc0e1`,
+V-F):**
 `examples/runnable/cons_expression.ail`, `examples/runnable/block_recursion.ail`,
 `examples/runnable/adt_list_fields.ail`, `examples/runnable/effectful_list.ail`.
 
@@ -107,6 +124,45 @@ above is already minimal — do not re-derive it).
 Golden: minimal repro + exact-output goldens (AC1–AC3) under `tests/golden/bytecode/`.
 Whole-corpus: full parity harness before/after, as a regression/blast-radius check (not a gate —
 this doc doesn't own the harness's bucket definitions).
+
+The existing generator suite does not pin this behavior in either direction: it remains green
+under the probe (`go test ./internal/gen/...`, rc=0; V-G). AC2 is therefore the regression test
+that will prevent a future return to unconditional `OpGte` lowering.
+
+## Verification Log
+
+All rows were measured by the controller on 2026-08-12 at HEAD `8ecebc0e1`. The probe mentioned
+below was restored byte-identically and is not committed.
+
+| ID | Command / check | Observed output |
+|---|---|---|
+| V-A | `ailang run --caps IO examples/runnable/recursion_quicksort.ail`; then `ailang run --bytecode --caps IO examples/runnable/recursion_quicksort.ail` | Evaluator (known-positive control): `Quicksort: [1, 1, 2, 3, 4, 5, 6, 9]` / `sortBy:    [1, 1, 2, 3, 4, 5, 6, 9]`. Bytecode: `Quicksort: [3]` / `sortBy:    [3]`, rc=0; stderr has no `falling back` line. |
+| V-B | Run the inline minimal repro with arms `[] / [x] / [a,b] / [a,b,c] / [p, ...rest]` and inputs `[]`, `[7]`, `[7,8]`, `[7,8,9]`, `[7,8,9,10]`, once with `ailang run` and once with `ailang run --bytecode` | Evaluator (known-positive control): `empty / one:7 / two:7,8 / three:7,8,9 / many:7`. Bytecode: `empty / one:7 / one:7 / one:7 / one:7`; the first non-empty fixed arm swallows all later non-empty inputs. |
+| V-C | `sed -n '390,430p' internal/gen/lower/match.go`; `sed -n '360,378p' internal/core/core.go` | `lowerPatternCond`, `case *core.ListPattern`, builds `OpEq` for empty at line 414 but `OpGte` for every non-empty pattern at lines 421–427. `core.ListPattern` has `Elements []CorePattern` and `Tail *CorePattern`; `Tail == nil` means exact length, `Tail != nil` means at least n. |
+| V-D | Search `.go` files under `internal/vm`, `internal/bytecode`, and control `internal/gen` for `Pattern` | `internal/vm` and `internal/bytecode`: zero occurrences. Known-positive control `internal/gen`: 13 matching files. Pattern matching is lowered before the VM sees it. |
+| V-E | Apply the probe at V-C (`OpEq` when `p.Tail == nil`, retain `OpGte` when non-nil); assert source hash changes; `go build`; run patched bytecode minimal repro and quicksort; run evaluator control; restore backup and hash again | Probe landed; build rc=0. Patched bytecode minimal repro: `empty / one:7 / two:7,8 / three:7,8,9 / many:7`, byte-identical to evaluator. Patched quicksort: exact V-A evaluator output. Evaluator unchanged. Restored SHA-256: `fd1d890e7d3e1ed58211c0fec4eab41640aad7d8274ca31b09d25b6aa87500a2`. This proves reachability and causation at the pinned site. |
+| V-F | Under the probe, run `cons_expression`, `block_recursion`, `adt_list_fields`, and `effectful_list` under both engines; compare SHA-256 of the last 20 output lines | All four engine pairs MATCH. Distinct hash prefixes: `2230a604cb25`, `d4295f6e4c13`, `5430d1a50e8f`, `69fd90893805`. Known-positive control: mutually distinct hashes show the instrument discriminates. Do not use `md5` on this machine; the unavailable command previously produced vacuous empty-string matches. |
+| V-G | With the probe applied: `go test ./internal/gen/...` | rc=0; `block`, `emitgo`, `golang`, `lower`, and `stmt` all pass. This green suite is the control showing the probe does not conflict with an existing expectation; it also contains no regression that catches unconditional `OpGte`, so AC2 is required. |
+| V-H | **Isolated-arm arity, both directions.** Two single-fixed-arm modules with only a `[p, ...rest] => "other"` fallback, so no shorter arm can intercept. n=2 arms `[a,b]`, inputs `[7]` / `[7,8]` / `[7,8,9]`; n=3 arms `[a,b,c]`, inputs `[7,8]` / `[7,8,9]` / `[7,8,9,10]`. Each run under `ailang run` and `ailang run --bytecode` | n=2 evaluator (known-positive control): `other / two:7,8 / other`. n=2 bytecode: `other / two:7,8 / `**`two:7,8`**. n=3 evaluator: `other / three:7,8,9 / other`. n=3 bytecode: `other / three:7,8,9 / `**`three:7,8,9`**. So **underflow is correct on both engines** (measured, previously only asserted) and the **overflow bug is confirmed independently at n=2 and n=3** with no arm-ordering masking. This row exists because V-B's combined block lets `[x]` intercept every non-empty input, which makes V-B silent about the n=2/n=3 arms — an ordering artifact the round-2 quorum correctly refused to accept as proof. |
+| V-I | **The `Tail` invariant the fix branches on, verified by exhaustive enumeration of construction sites** rather than from the struct definition. Search all non-test `.go` for `core.ListPattern{` / `&ListPattern{` | Exactly **two** construction sites exist, both in `internal/elaborate/patterns.go` (a third hit, `internal/core/gob.go:38`, is a `gob.Register` type registration, not a construction). **`:150`** is the `::` cons-constructor case: it always sets `Tail: &tailPat`, so `Tail != nil`, and "at least 1" is the intended semantics → `OpGte` stays correct there. **`:203`** is the `ast.ListPattern` case: `tail` is left `nil` unless the surface pattern has a `Rest` (`...rest`), so `Tail == nil` ⟺ the source pattern was a closed `[…]` with no rest → exactly-n. Known-positive control: the same search matches `ListPattern` across 10+ files, so it is not a broken pattern. **The invariant therefore holds over the whole codebase, not merely over the type declaration**, and the fix cannot silently reinterpret another list-pattern form because no other form is ever constructed. |
+
+## Quorum verification log
+
+- **Round 1 (2026-08-12T20:19:29Z) — BLOCKED.** Both reviewers raised the *same premise* objection:
+  the doc claimed a known root cause while leaving the fix site unlocalized across three packages,
+  and cited the parent doc's log rather than verifying anything here. Per the mission's rule 3f the
+  controller measured the premise instead of forwarding the objection; the result is V-A .. V-G,
+  and the localization shrank the fix site from three packages to one function and one operator.
+- **Round 2 (2026-08-12T20:25:02Z) — BLOCKED, and both objections were correct.**
+  `gpt5-6-sol`: the `Tail == nil` ⟺ exact-length invariant was read off the struct rather than
+  established across constructors. `gemini-3-1-pro`: V-B's ordered match block masks the n=2/n=3
+  arms, so both the underflow-correctness claim and the isolated overflow claim were asserted, not
+  proven. Neither objection disputed the design direction; both asked for a measurement.
+- **Resolution — narrow-refinement carve-out, bounded 2nd revision.** The controller ran both
+  checks and appended **V-H** (isolated-arm arity, both directions, both arities) and **V-I**
+  (exhaustive enumeration of `core.ListPattern` construction sites). Both objections are satisfied
+  by measurement rather than overridden. No design decision was made by the controller, and the
+  milestone, AC numbering, estimate and scope boundaries are unchanged from the pre-quorum doc.
 
 ## Related Documents
 

--- a/internal/gen/lower/match.go
+++ b/internal/gen/lower/match.go
@@ -411,19 +411,14 @@ func lowerPatternCond(scrutinee stmt.Expr, pat core.CorePattern) stmt.Expr {
 		// List pattern — check length + tag checks for constructor sub-patterns.
 		lenExpr := stmt.BuiltinCall{Name: "_len", Args: []stmt.Expr{scrutinee}}
 		var cond stmt.Expr
-		if len(p.Elements) == 0 && p.Tail == nil {
-			// Match empty list.
-			cond = stmt.BinOp{
-				Op:    stmt.OpEq,
-				Left:  lenExpr,
-				Right: stmt.LitInt{Value: 0},
-			}
-		} else {
-			cond = stmt.BinOp{
-				Op:    stmt.OpGte,
-				Left:  lenExpr,
-				Right: stmt.LitInt{Value: int64(len(p.Elements))},
-			}
+		lenOp := stmt.OpGte
+		if p.Tail == nil {
+			lenOp = stmt.OpEq
+		}
+		cond = stmt.BinOp{
+			Op:    lenOp,
+			Left:  lenExpr,
+			Right: stmt.LitInt{Value: int64(len(p.Elements))},
 		}
 		// Tag checks for constructor sub-patterns at each index.
 		for i, elem := range p.Elements {

--- a/tests/golden/bytecode/pattern_arity.ail
+++ b/tests/golden/bytecode/pattern_arity.ail
@@ -1,0 +1,59 @@
+module tests/golden/bytecode/pattern_arity
+
+import std/io (println)
+
+// n=1 fixed arm, isolated: only the tailed fallback can catch anything else.
+func arity1(xs: [int]) -> string =
+  match xs {
+    [] => "other",
+    [a] => "n1",
+    [p, ...rest] => "other"
+  }
+
+// n=2 fixed arm, isolated.
+func arity2(xs: [int]) -> string =
+  match xs {
+    [] => "other",
+    [a, b] => "n2",
+    [p, ...rest] => "other"
+  }
+
+// n=3 fixed arm, isolated.
+func arity3(xs: [int]) -> string =
+  match xs {
+    [] => "other",
+    [a, b, c] => "n3",
+    [p, ...rest] => "other"
+  }
+
+// Tailed pattern MUST keep "at least 2" semantics.
+func tail2(xs: [int]) -> string =
+  match xs {
+    [a, b, ...rest] => "tail2",
+    _ => "other"
+  }
+
+// Cons form: always tailed, so "at least 1" must survive.
+func consForm(xs: [int]) -> string =
+  match xs {
+    ::(h, t) => "cons",
+    _ => "other"
+  }
+
+export func main() -> () ! {IO} {
+  println("arity1 []      = ${arity1([])}");
+  println("arity1 [7]     = ${arity1([7])}");
+  println("arity1 [7,8]   = ${arity1([7, 8])}");
+  println("arity2 [7]     = ${arity2([7])}");
+  println("arity2 [7,8]   = ${arity2([7, 8])}");
+  println("arity2 [7,8,9] = ${arity2([7, 8, 9])}");
+  println("arity3 [7,8]   = ${arity3([7, 8])}");
+  println("arity3 [7,8,9] = ${arity3([7, 8, 9])}");
+  println("arity3 [7,8,9,10] = ${arity3([7, 8, 9, 10])}");
+  println("tail2  [7]     = ${tail2([7])}");
+  println("tail2  [7,8]   = ${tail2([7, 8])}");
+  println("tail2  [7,8,9] = ${tail2([7, 8, 9])}");
+  println("cons   []      = ${consForm([])}");
+  println("cons   [7]     = ${consForm([7])}");
+  println("cons   [7,8]   = ${consForm([7, 8])}")
+}


### PR DESCRIPTION
Closes #505.

## The bug

Under `--bytecode`, a fixed-length list pattern matched any **longer** list, binding the first `n` elements and silently discarding the tail. `recursion_quicksort.ail` printed `Quicksort: [3]` instead of `[1, 1, 2, 3, 4, 5, 6, 9]` — **rc=0, no error, no fallback warning**. A direct NO-SILENT-FALLBACKS and A1 (determinism) violation, and it affected every fixed-length list pattern in every `--bytecode` program.

## Root cause — one function, one operator

`internal/gen/lower/match.go`, `lowerPatternCond`, `case *core.ListPattern`: the empty pattern was special-cased to `OpEq` while every other list pattern got `OpGte`, tail or no tail.

The discriminator was already on the node. `core.ListPattern.Tail == nil` is a closed `[…]` pattern and must be `OpEq`; `Tail != nil` (a `...rest` pattern, or the `::` cons form) genuinely means at-least-n and keeps `OpGte`. The old empty-list case is just the `Tail == nil, n == 0` instance of that rule, so it collapses into it.

`internal/vm` and `internal/bytecode` are not involved — neither contains a single `Pattern` reference; matching is lowered away in `internal/gen`.

## Verification (controller-run, outside the executor sandbox)

- **AC1** — quicksort under `--bytecode` now prints the correct list.
- **AC3** — stderr has **0** `falling back to evaluator` lines (control: `bytecode VM` present = 1, so the grep works).
- **AC2** — isolated single-arm modules confirm overflow is now rejected at **n=2** and **n=3**, while underflow was already correct. Verified with the controller's own fixtures, independent of the shipped tests.
- Blast radius: seven examples MATCH across both engines; parity harness `MATCH 151 → 152`, `DIVERGE 6 → 5`, delta exactly `recursion_quicksort.ail`.
- Gates rc=0: `go build`, `go vet`, `go test ./internal/gen/... ./tests/golden/bytecode/ ./cmd/ailang`, `gofmt`, `check-file-sizes`, `check-boundaries`, `check-changelog`, `check-golden-drift`, `test-lowering`, `test-stdlib-ail`.

## The pin is real, not decorative

Restoring unconditional `OpGte` **LANDS** (sha256 `5142335d` → `fd282d4d`) and **BUILDS** (`go build` rc=0, so the red is behavioural, not a compile error), and reds both new tests with the right mechanism. The **inverse arm** — the same mutant with those two tests `-skip`'d — is **rc=0 across all of `./cmd/ailang`**. So the new tests are the sole killers; nothing else in the suite catches #505.

That run also confirmed the executor's self-reported deviation: the plan prescribed `if false && p.Tail == nil` as the drill mutant, which is **not** #505 — it makes the empty pattern match everything too, so quicksort prints `[]` rather than `[3]`. The executor spotted it and substituted the exact measured pre-fix lowering.

## Also in this PR

- The design doc gained a Verification Log (V-A..V-I) after a two-round quorum block; both rounds were premise objections the controller measured rather than forwarded, which shrank the fix site from three packages to one function.
- **Test location correction**: the doc prescribed `tests/golden/bytecode/`, but that is a Go test package driving `pipeline→lower→compiler→vm` in-process — it can never observe the CLI's stderr, `--caps IO` or exit code, so AC1 and AC3 were unimplementable there. The `.ail` fixture lives there; the tests that run it shell out from `cmd/ailang/run_bytecode_test.go`.
- A mission-control skill rule (enumerator blind spots) with its two supporting frictions, one of which is filed as #683.

🤖 Generated with [Claude Code](https://claude.com/claude-code)