### PR TITLE
fix(security): bump project toolchain go 1.26.5 → 1.26.6 (7 reachable stdlib advisories)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v7
       with:
-        go-version: '1.26.5'
+        go-version: '1.26.6'
 
     # uv pins the Python runtime for eval-harness tests. The harness invokes
     # `uv run --python <PinnedPythonVersion>` and fails loudly if uv is missing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v7
       with:
-        go-version: '1.26.5'
+        go-version: '1.26.6'
         cache: true
 
     # uv pins the Python runtime for eval-harness tests (and the weekly eval
@@ -304,7 +304,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v7
       with:
-        go-version: '1.26.5'
+        go-version: '1.26.6'
         cache: true
 
     - name: Set up uv (provides Python for eval-harness Python runner tests)
@@ -392,7 +392,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v7
       with:
-        go-version: '1.26.5'
+        go-version: '1.26.6'
         cache: true
     
     - name: Build binary
@@ -436,7 +436,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v7
       with:
-        go-version: '1.26.5'
+        go-version: '1.26.6'
         cache: true
 
     - name: Check code formatting
@@ -483,7 +483,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v7
       with:
-        go-version: '1.26.5'
+        go-version: '1.26.6'
 
     - name: Install govulncheck
       # Pinned (was @latest): govulncheck v1.4.0 started crashing on `./...`
@@ -512,7 +512,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v7
       with:
-        go-version: '1.26.5'
+        go-version: '1.26.6'
 
     - name: Go Dependency Submission
       uses: actions/go-dependency-submission@v2.0.3

--- a/.github/workflows/docusaurus-deploy.yml
+++ b/.github/workflows/docusaurus-deploy.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Install jq for stats generation
         run: sudo apt-get update && sudo apt-get install -y jq

--- a/.github/workflows/eval-weekly.yml
+++ b/.github/workflows/eval-weekly.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v7
       with:
-        go-version: '1.26.5'
+        go-version: '1.26.6'
         cache: true
 
     # uv pins the Python runtime so baselines are comparable across runs and

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v7
       with:
-        go-version: '1.26.5'
+        go-version: '1.26.6'
 
     - name: Get dependencies
       run: go mod download
@@ -111,7 +111,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v7
       with:
-        go-version: '1.26.5'
+        go-version: '1.26.6'
 
     - name: Get dependencies
       run: go mod download
@@ -188,7 +188,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v7
       with:
-        go-version: '1.26.5'
+        go-version: '1.26.6'
 
     - name: Get dependencies
       run: go mod download
@@ -242,7 +242,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v7
       with:
-        go-version: '1.26.5'
+        go-version: '1.26.6'
 
     - name: Get dependencies
       run: go mod download

--- a/.github/workflows/test-game-codegen.yml
+++ b/.github/workflows/test-game-codegen.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Build AILANG compiler
         run: make build

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,37 @@
 
 ## [Unreleased]
 
+### Security — project toolchain go 1.26.5 → 1.26.6 (7 stdlib advisories)
+
+The `govulncheck` gate went red on `dev` with **7 unallowlisted findings**, all of them Go
+**standard library** advisories and all reporting the same `fixed` version, `1.26.6`:
+
+| ID | CVE | Package |
+|---|---|---|
+| GO-2026-5026 | CVE-2026-39821 | `net/http` (x/net/idna punycode) |
+| GO-2026-5972 | CVE-2026-33818 | `encoding/asn1` |
+| GO-2026-6088 | CVE-2026-56859 | `encoding/xml` |
+| GO-2026-6089 | CVE-2026-56853 | `net/http` |
+| GO-2026-6090 | CVE-2026-56862 | `crypto/tls` |
+| GO-2026-6091 | CVE-2026-56858 | `html/template` |
+| GO-2026-6218 | CVE-2026-56860 | `net/url` |
+
+Every one is reported **reachable** from AILANG's own call graph (`net/http.Do`,
+`crypto/tls.Handshake`, `net/url.Parse`, `encoding/xml.Token`, …), so this is a real upgrade
+rather than an allowlist case — no `.govulncheck-allow.yml` entry was added.
+
+Bumped the toolchain at **16 sites**: the `go` directive in `go.mod`, all **14** workflow
+`go-version` pins (`build.yml`, `ci.yml` ×6, `release.yml` ×4, `docusaurus-deploy.yml`,
+`eval-weekly.yml`, `test-game-codegen.yml`), and the hardcoded `go 1.26.5` in the external-module
+fixture at `serveapi/serveapi_external_test.go:95`. That last one is load-bearing: the fixture
+declares its own `go.mod` and `replace`s it onto this repo, so a fixture below the repo's `go`
+directive fails with `requires go >= 1.26.6`. Its drift was predicted in
+[#586](https://github.com/sunholo-data/ailang/issues/586) (NB-3) and has now materialised.
+
+Measured before and after on the same tree: `govulncheck -format json ./... | govulncheck-filter`
+→ **7 unallowlisted, rc=1** on 1.26.5, and **0 unallowlisted / 8 allowlisted-and-unexpired,
+rc=0** on 1.26.6. The 8 that remain are the pre-existing Ollama entries, unchanged.
+
 ### Tests — telemetry remote-write guard coverage
 
 Added deterministic mutation-killing coverage for pinned stage IDs and for four reachable

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -21,19 +21,38 @@ The `govulncheck` gate went red on `dev` with **7 unallowlisted findings**, all 
 
 Every one is reported **reachable** from AILANG's own call graph (`net/http.Do`,
 `crypto/tls.Handshake`, `net/url.Parse`, `encoding/xml.Token`, …), so this is a real upgrade
-rather than an allowlist case — no `.govulncheck-allow.yml` entry was added.
+rather than an allowlist case — no `.govulncheck-allow.yml` entry was added. The bump in fact
+clears an **eighth** stdlib advisory the gate never counted, `GO-2026-5942` (SVCB/HTTPS RR parse
+panic in `x/net/dns/dnsmessage`, also `fixed: 1.26.6`); it is invisible to the "7" because it
+reaches no traced function — see the caveat below.
 
-Bumped the toolchain at **16 sites**: the `go` directive in `go.mod`, all **14** workflow
-`go-version` pins (`build.yml`, `ci.yml` ×6, `release.yml` ×4, `docusaurus-deploy.yml`,
+Bumped the toolchain at **16 patch-pinned sites**: the `go` directive in `go.mod`, all **14**
+workflow `go-version` pins (`build.yml`, `ci.yml` ×6, `release.yml` ×4, `docusaurus-deploy.yml`,
 `eval-weekly.yml`, `test-game-codegen.yml`), and the hardcoded `go 1.26.5` in the external-module
-fixture at `serveapi/serveapi_external_test.go:95`. That last one is load-bearing: the fixture
-declares its own `go.mod` and `replace`s it onto this repo, so a fixture below the repo's `go`
-directive fails with `requires go >= 1.26.6`. Its drift was predicted in
-[#586](https://github.com/sunholo-data/ailang/issues/586) (NB-3) and has now materialised.
+fixture at `serveapi/serveapi_external_test.go:95`. "16 sites" counts *patch pins* only — the 8
+`docker/Dockerfile.*` files reference the floating `golang:1.26-bookworm` tag, which tracks the
+latest patch on its own and needs no edit.
+
+The fixture edit is **drift hygiene, not a required fix**, and an earlier draft of this entry
+overstated it. Measured: reverting only that literal, with the active toolchain at 1.26.6
+(what `actions/setup-go` installs), leaves the test `rc=0` — outcome-identical to the unmutated
+arm. The `requires go >= X` failure is real but needs the *active* toolchain to be below the
+requirement, which cannot happen here because all 14 workflow pins move in lockstep with
+`go.mod`. It is still worth doing: the literal was predicted to drift in
+[#586](https://github.com/sunholo-data/ailang/issues/586) (NB-3), and this is that prediction
+coming true.
 
 Measured before and after on the same tree: `govulncheck -format json ./... | govulncheck-filter`
 → **7 unallowlisted, rc=1** on 1.26.5, and **0 unallowlisted / 8 allowlisted-and-unexpired,
-rc=0** on 1.26.6. The 8 that remain are the pre-existing Ollama entries, unchanged.
+rc=0** on 1.26.6. The 8 that remain are the pre-existing Ollama entries, unchanged, none expiring
+before 2026-10-29.
+
+⚠ **Caveat found while verifying this, filed separately:** `govulncheck-filter` only considers
+findings that reach a traced *function*, so a module-level finding is reported in **neither** the
+unallowlisted list nor the allowlisted count — it is silently dropped. Four are being dropped
+today, and one of them, `GO-2026-5750` (`CVE-2026-7020`, Ollama path traversal, no upstream fix),
+is a real published advisory that is **not** in the allowlist. Unchanged by this PR and present
+identically before it.
 
 ### Tests — telemetry remote-write guard coverage
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sunholo-data/ailang
 
-go 1.26.5
+go 1.26.6
 
 require (
 	cloud.google.com/go/firestore v1.24.0

--- a/serveapi/serveapi_external_test.go
+++ b/serveapi/serveapi_external_test.go
@@ -92,7 +92,7 @@ func TestExternalModuleCanImportFacadeButNotInternal(t *testing.T) {
 	root := filepath.Dir(filepath.Dir(currentFile))
 	dir := t.TempDir()
 	t.Logf("external fixture directory: %s", dir)
-	goMod := fmt.Sprintf("module externalfixture\n\ngo 1.26.5\n\nrequire github.com/sunholo-data/ailang v0.0.0\nreplace github.com/sunholo-data/ailang => %s\n", root)
+	goMod := fmt.Sprintf("module externalfixture\n\ngo 1.26.6\n\nrequire github.com/sunholo-data/ailang v0.0.0\nreplace github.com/sunholo-data/ailang => %s\n", root)
 	writeFixtureFile(t, filepath.Join(dir, "go.mod"), []byte(goMod))
 	sum, err := os.ReadFile(filepath.Join(root, "go.sum"))
 	if err != nil {


### PR DESCRIPTION
## Why

`dev` is red on the `govulncheck (vuln gate)` job with **7 unallowlisted findings**. Every one is a Go **standard library** advisory, and every one reports the same fixed version — **1.26.6**. The repo is on **1.26.5**.

| ID | CVE | Package | Reachable via |
|---|---|---|---|
| GO-2026-5026 | CVE-2026-39821 | `net/http` (x/net idna punycode) | `Do`, `Get`, `Post`, `RoundTrip` |
| GO-2026-5972 | CVE-2026-33818 | `encoding/asn1` | `Unmarshal` |
| GO-2026-6088 | CVE-2026-56859 | `encoding/xml` | `Token` |
| GO-2026-6089 | CVE-2026-56853 | `net/http` | `Serve`, `ListenAndServe` |
| GO-2026-6090 | CVE-2026-56862 | `crypto/tls` | `Handshake`, `Read`, `Write` |
| GO-2026-6091 | CVE-2026-56858 | `html/template` | `Execute`, `ExecuteTemplate` |
| GO-2026-6218 | CVE-2026-56860 | `net/url` | `Parse`, `ResolveReference` |

All seven are reported **reachable from AILANG's own call graph**, and a fix exists — so this is an upgrade, not an allowlist case. `.govulncheck-allow.yml` is untouched.

## Attribution — this is a time-based red, not a regression

`govulncheck` was `success` on the three preceding `dev` commits (`644cf178a` 16:46Z, `8e8447f51` 21:24Z, `fc357a045` 21:48Z) and `failure` at 23:55Z. The commit at dev's head, `d53352af0`, changed **one markdown file** (a skill), so nothing in the diff could produce a vuln finding. New advisories, published in that window.

⚠ **It was invisible.** `d53352af0` merged at `22:18:30Z` and GitHub recorded **no PushEvent** for it — `actions/runs?head_sha=<full-40>` returned `total=0`, and there were **0** workflow runs repo-wide after 22:00Z against **20** in the hour before. Actions is `enabled`; a `workflow_dispatch` on `dev` created a run that acquired `jobs=7` in 12s. So the merge push event was dropped, and the dropped event concealed a real red for ~5.5h. Firing that dispatch is how this was found.

## What changed — 16 sites

Enumerated with a **widened** matcher, not a `1.26.5` grep (a literal grep is blind to any pin spelled differently; `grep -rn go-version .github/workflows/` finds **14**, and a truncated `1.26.5` listing had shown 11):

- `go.mod` — the `go` directive
- **14** workflow `go-version` pins: `build.yml`, `ci.yml` ×6, `release.yml` ×4, `docusaurus-deploy.yml`, `eval-weekly.yml`, `test-game-codegen.yml`
- `serveapi/serveapi_external_test.go:95` — a hardcoded `go 1.26.5` inside a generated fixture `go.mod`

That last one is load-bearing rather than cosmetic: the fixture declares its own module and `replace`s it onto this repo, so a fixture below the repo's `go` directive fails `requires go >= 1.26.6`. Its drift was **predicted** as #586 NB-3 and has now materialised.

## Evidence

Before and after on the same tree:

```
govulncheck -format json ./... | ./bin/govulncheck-filter
  go 1.26.5 → "govulncheck-filter: 7 unallowlisted finding(s)"          rc=1
  go 1.26.6 → "govulncheck-filter: 8 finding(s), all allowlisted and unexpired"  rc=0
```

The 8 that remain are the pre-existing Ollama entries, unchanged.

## Gates — **darwin/arm64 only**

`go test -timeout 300s ./...` **rc=0**, **108** `ok`, **0** `FAIL` (non-vacuous) · `go vet` rc=0 · `gofmt -l` empty · `check-changelog`, `check-file-sizes`, `check-boundaries`, `check-skills`, `verify-no-shim` all rc=0 · the external-module fixture test **PASS**.

`go build ./...` is **rc=1 both before and after**, byte-identical `cmd/wasm: function main is undeclared` — a pre-existing base failure, measured on the pristine tree rather than assumed.

**Windows and ubuntu legs are unrun locally.** A toolchain bump is exactly the change whose meaning is per-platform, so this PR's local green speaks for darwin/arm64 and no further; Gate 3b's matrix is the instrument that covers the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Post-review corrections (evaluator sonnet, **PASS 93/100**, zero blocking)

The independent judge **refuted one of my claims** and found the work better than I described it in another. All three reproduced first-party before being applied; changelog corrected in `106d8b847`.

1. **REFUTED — the serveapi fixture edit is drift hygiene, not "load-bearing".** Reverting only that literal, with the active toolchain at 1.26.6 (what `actions/setup-go` installs), leaves the test **rc=0** — outcome-identical to the unmutated arm. The `requires go >= X` failure needs the *active* toolchain below the requirement, which cannot happen here because all 14 workflow pins move in lockstep with `go.mod`. ⚠ My own first attempt to check this returned **rc=1 in exactly the direction I predicted, for the wrong reason**: the local `go` shim is 1.26.4, so `GOTOOLCHAIN=local` refused at the **main module** and the fixture was never reached. The edit is still worth keeping (it is #586 NB-3's prediction coming true), but the rationale was overstated.
2. **Better than claimed — the bump clears an *eighth* stdlib advisory**, `GO-2026-5942` (SVCB/HTTPS RR parse panic in `x/net/dns/dnsmessage`, also `fixed: 1.26.6`), invisible to the "7" because it reaches no traced function.
3. **"16 sites" counts patch pins only.** The 8 `docker/Dockerfile.*` files use the floating `golang:1.26-bookworm` tag — invisible to both of my matchers, and correctly needing no edit.

**Filed separately as #703:** `govulncheck-filter` only considers function-reaching findings, so module-level findings appear in **neither** the unallowlisted list nor the allowlisted count. Four are dropped today, one of which — `GO-2026-5750` / `CVE-2026-7020`, Ollama path traversal, no upstream fix — is a real published advisory **absent from the allowlist**. Pre-existing and unchanged by this PR.
