### PR TITLE
fix(embed): exit() in an embedded module no longer panics the host (#691)

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,41 @@
 
 ## [Unreleased]
 
+### Fixed — `exit()` in an embedded module no longer panics the host (#691)
+
+`exit()` raises a `*eval.EvalExitCode` sentinel panic (`internal/effects/io.go:145`). The CLI's
+two consumers recover it — the single-file path (`cmd/ailang/main_run_exec.go`) and the batch
+path (`recoverBatchItemExit`, added by #607). `internal/embed`, the sanctioned host → compiler
+bridge, did **not**: `Engine.Call` and `Engine.CallPreserveFloats` called
+`runtime.CallEntrypoint` directly, so an embedded module calling `exit()` took the **host
+process** down with a raw Go stack. For a long-lived host (the dashboard/observatory) that is a
+crash, not an exit code. Reproduced first-party before the fix, frame-for-frame as filed.
+
+This is the same defect class as #607, one layer down — the repo's recurring
+guard-the-helper-miss-the-call-site shape. `runtime.CallEntrypoint` itself is deliberately left
+panic-based: the CLI *needs* the sentinel to reach its own recover so it can map onto `os.Exit`,
+so the shared primitive stays neutral and each consumer supplies its own contract.
+
+**Contract decision.** An embedding host has no process exit to map onto, so `exit(N)` is now
+surfaced as a typed `*embed.ExitError{Code: N}` from `Call`, `CallPreserveFloats` and
+(transitively) `CallJSON`. `exit(0)` is reported as an `ExitError` too, **not** as a nil error —
+unlike the batch runner, which owns a process and can treat `exit(0)` as success. A nil error
+here would be indistinguishable from a function that returned unit normally, discarding
+information the caller cannot recover; hosts wanting batch semantics branch on `Code == 0`.
+
+Two residuals are declared in code rather than left implicit: `Engine.Eval` is UNINFORMATIVE
+(GAP-5 makes standalone expressions unreachable — its existing tests are skipped), and
+`GetCallValue`/`GetCallValueN` hand the evaluator's own handles to the host unwrapped, which is
+harmless for the in-evaluator use (the panic unwinds into the enclosing `Call`) but not for a
+host that invokes them outside one.
+
+Guarded by 8 arms in `internal/embed/exit_test.go`, both call sites pinned separately. Mutation
+drill, one neutering mutation per branch, each asserted LANDED (sha256) and BUILDS (`go build`
+rc=0): the exit-mapping, re-panic and passthrough branches each red only their own arms, and
+unwiring either call site leaves the *other* site's arm passing. Inverse arm: with both guards
+removed and the new tests deleted, `internal/embed` is **rc=0 / 60 PASS / 0 FAIL** — the defect
+shipped entirely undetected by the existing suite.
+
 ### Security — project toolchain go 1.26.5 → 1.26.6 (7 stdlib advisories)
 
 The `govulncheck` gate went red on `dev` with **7 unallowlisted findings**, all of them Go

--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -233,8 +233,10 @@ func (e *Engine) Call(modulePath, funcName string, args ...interface{}) (eval.Va
 		ailangArgs[i] = converted
 	}
 
-	// Call the function
-	return runtime.CallEntrypoint(e.runtime, inst, funcName, ailangArgs)
+	// Call the function. exit() in the module must not panic the host (#691).
+	return recoverProgramExit(func() (eval.Value, error) {
+		return runtime.CallEntrypoint(e.runtime, inst, funcName, ailangArgs)
+	})
 }
 
 // CallPreserveFloats is like Call but preserves Go float64 values as AILANG FloatValue,
@@ -310,8 +312,10 @@ func (e *Engine) CallPreserveFloats(modulePath, funcName string, args ...interfa
 		ailangArgs[i] = converted
 	}
 
-	// Call the function
-	return runtime.CallEntrypoint(e.runtime, inst, funcName, ailangArgs)
+	// Call the function. exit() in the module must not panic the host (#691).
+	return recoverProgramExit(func() (eval.Value, error) {
+		return runtime.CallEntrypoint(e.runtime, inst, funcName, ailangArgs)
+	})
 }
 
 // CallJSON is a convenience method that accepts JSON input and returns JSON output.
@@ -407,6 +411,14 @@ func (e *Engine) SetEffContext(ctx interface{}) {
 // GetCallValue returns the evaluator's CallValue function, which can be used
 // to invoke AILANG function values from Go code (e.g., for stream event handlers).
 // Returns a function with signature: func(fn eval.Value, arg eval.Value) (eval.Value, error)
+//
+// DECLARED RESIDUAL (#691): the returned handle is the evaluator's own, so it is
+// NOT wrapped by recoverProgramExit. A callback that reaches exit() still raises
+// the *eval.EvalExitCode sentinel. That is harmless for the in-evaluator use
+// (effCtx.FnCaller), where the panic unwinds into the enclosing Call and is
+// recovered there; a host that invokes this handle OUTSIDE any Call is on its own.
+// Wrapping is deliberately not done here because it would change the callback
+// identity these consumers pass into the effect context.
 func (e *Engine) GetCallValue() func(eval.Value, eval.Value) (eval.Value, error) {
 	return e.runtime.GetEvaluator().CallValue
 }

--- a/internal/embed/exit.go
+++ b/internal/embed/exit.go
@@ -1,0 +1,58 @@
+package embed
+
+import (
+	"fmt"
+
+	"github.com/sunholo-data/ailang/internal/eval"
+)
+
+// ExitError reports that an embedded AILANG program called exit(code).
+//
+// The exit() builtin raises a *eval.EvalExitCode sentinel panic
+// (internal/effects/io.go). The CLI recovers it and maps it onto os.Exit;
+// an embedding host has no process exit to map onto, so the embed layer
+// surfaces it as this typed error instead. Callers that want the CLI's
+// batch semantics can branch on Code:
+//
+//	if ee := new(ExitError); errors.As(err, &ee) && ee.Code == 0 {
+//	    // program terminated normally
+//	}
+//
+// Note that Code 0 is reported as an ExitError too, not as a nil error:
+// the host cannot otherwise distinguish "the function returned unit" from
+// "the program called exit(0) and never reached its return". Collapsing
+// exit(0) to nil would discard information the caller cannot recover.
+type ExitError struct {
+	// Code is the argument the program passed to exit().
+	Code int
+}
+
+func (e *ExitError) Error() string {
+	return fmt.Sprintf("program called exit(%d)", e.Code)
+}
+
+// recoverProgramExit runs one entrypoint call and maps the exit() sentinel
+// panic onto a typed *ExitError, so that an embedded module calling exit()
+// cannot take the host process down with it.
+//
+// Three branches, each independently pinned by internal/embed/exit_test.go:
+//   - call returns without panicking: its value and error pass through unchanged
+//   - the panic is *eval.EvalExitCode: reported as *ExitError, host survives
+//   - any other panic: re-raised unchanged, so a real crash stays loud
+//
+// Split out from the Call methods so every branch is reachable from a unit
+// test without standing up a module runtime.
+func recoverProgramExit(call func() (eval.Value, error)) (val eval.Value, err error) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+		ec, ok := r.(*eval.EvalExitCode)
+		if !ok {
+			panic(r) // re-panic: not an exit(), so it is a real crash
+		}
+		val, err = nil, &ExitError{Code: ec.Code}
+	}()
+	return call()
+}

--- a/internal/embed/exit_test.go
+++ b/internal/embed/exit_test.go
@@ -1,0 +1,191 @@
+package embed
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/effects"
+	"github.com/sunholo-data/ailang/internal/eval"
+)
+
+// newExitTestEngine returns an engine rooted at the repo, with the IO
+// capability granted so that exit() is reachable at all.
+//
+// Without the grant the effect layer refuses before ioExit is entered
+// ("effect 'IO' requires capability"), which would make every arm below pass
+// for the wrong reason — the sentinel would never be raised.
+func newExitTestEngine(t *testing.T) *Engine {
+	t.Helper()
+
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolving repo root: %v", err)
+	}
+	t.Setenv("AILANG_STDLIB_PATH", root)
+
+	engine := New(root)
+	t.Cleanup(func() { _ = engine.Close() })
+
+	effCtx := effects.NewEffContext(nil)
+	effCtx.Grant(effects.NewCapability("IO"))
+	engine.runtime.GetEvaluator().SetEffContext(effCtx)
+
+	return engine
+}
+
+// TestCallReportsExitAsTypedError is the headline arm for #691: an embedded
+// module calling exit(1) must not take the host down. Before the fix this did
+// not fail — it panicked the test binary through embed.go's CallEntrypoint.
+func TestCallReportsExitAsTypedError(t *testing.T) {
+	engine := newExitTestEngine(t)
+
+	val, err := engine.Call("internal/embed/testdata/exit_nonzero", "main")
+	if err == nil {
+		t.Fatal("Call on a module calling exit(1) returned nil error; want *ExitError")
+	}
+
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("Call error = %T (%v); want *ExitError", err, err)
+	}
+	if exitErr.Code != 1 {
+		t.Errorf("ExitError.Code = %d, want 1", exitErr.Code)
+	}
+	if val != nil {
+		t.Errorf("Call value = %v, want nil on exit", val)
+	}
+}
+
+// TestCallPreserveFloatsReportsExitAsTypedError covers the SECOND call site.
+// This repo's named recurring failure shape is guard-the-helper-miss-the-
+// call-site, so the two entry points are pinned separately rather than
+// assumed equivalent.
+func TestCallPreserveFloatsReportsExitAsTypedError(t *testing.T) {
+	engine := newExitTestEngine(t)
+
+	val, err := engine.CallPreserveFloats("internal/embed/testdata/exit_nonzero", "main")
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("CallPreserveFloats error = %T (%v); want *ExitError", err, err)
+	}
+	if exitErr.Code != 1 {
+		t.Errorf("ExitError.Code = %d, want 1", exitErr.Code)
+	}
+	if val != nil {
+		t.Errorf("CallPreserveFloats value = %v, want nil on exit", val)
+	}
+}
+
+// TestCallJSONReportsExitAsTypedError pins the transitive consumer: CallJSON
+// delegates to Call, so it inherits the contract rather than needing its own
+// recover. Asserted rather than assumed.
+func TestCallJSONReportsExitAsTypedError(t *testing.T) {
+	engine := newExitTestEngine(t)
+
+	out, err := engine.CallJSON("internal/embed/testdata/exit_nonzero", "main", nil)
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("CallJSON error = %T (%v); want *ExitError", err, err)
+	}
+	if exitErr.Code != 1 {
+		t.Errorf("ExitError.Code = %d, want 1", exitErr.Code)
+	}
+	if out != nil {
+		t.Errorf("CallJSON output = %q, want nil on exit", out)
+	}
+}
+
+// TestCallReportsExitZeroAsTypedError pins the contract DECISION for #691:
+// exit(0) is an *ExitError too, not a nil error. The CLI's batch path maps
+// exit(0) onto success because it owns a process; the embed layer does not,
+// and a nil error here would be indistinguishable from a unit return.
+func TestCallReportsExitZeroAsTypedError(t *testing.T) {
+	engine := newExitTestEngine(t)
+
+	_, err := engine.Call("internal/embed/testdata/exit_zero", "main")
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("Call error = %T (%v); want *ExitError", err, err)
+	}
+	if exitErr.Code != 0 {
+		t.Errorf("ExitError.Code = %d, want 0", exitErr.Code)
+	}
+}
+
+// TestCallWithoutExitIsUnaffected is the mechanism-removed control (rule 3d).
+// Same engine, same call shape, exit() removed: a green here is what makes the
+// arms above evidence about exit() rather than about the harness.
+func TestCallWithoutExitIsUnaffected(t *testing.T) {
+	engine := newExitTestEngine(t)
+
+	val, err := engine.Call("internal/embed/testdata/no_exit", "main")
+	if err != nil {
+		t.Fatalf("Call on an exit-free module errored: %v", err)
+	}
+	got, err := ToInt(val)
+	if err != nil {
+		t.Fatalf("ToInt: %v", err)
+	}
+	if got != 42 {
+		t.Errorf("Call value = %d, want 42", got)
+	}
+}
+
+// --- recoverProgramExit branch arms (unit-level, no module runtime) ---
+
+// TestRecoverProgramExitPassesThroughValueAndError covers the no-panic branch.
+func TestRecoverProgramExitPassesThroughValueAndError(t *testing.T) {
+	want := &eval.IntValue{Value: 7}
+	wantErr := errors.New("ordinary failure")
+
+	val, err := recoverProgramExit(func() (eval.Value, error) { return want, wantErr })
+	if val != want {
+		t.Errorf("value = %v, want %v", val, want)
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("error = %v, want %v", err, wantErr)
+	}
+}
+
+// TestRecoverProgramExitMapsSentinel covers the exit branch in isolation.
+func TestRecoverProgramExitMapsSentinel(t *testing.T) {
+	val, err := recoverProgramExit(func() (eval.Value, error) {
+		panic(&eval.EvalExitCode{Code: 3})
+	})
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("error = %T (%v); want *ExitError", err, err)
+	}
+	if exitErr.Code != 3 {
+		t.Errorf("ExitError.Code = %d, want 3", exitErr.Code)
+	}
+	if val != nil {
+		t.Errorf("value = %v, want nil", val)
+	}
+	if got, want := exitErr.Error(), "program called exit(3)"; got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+// TestRecoverProgramExitReRaisesOtherPanics covers the third branch: a real
+// crash must stay loud and arrive unchanged, not be swallowed into an error.
+// Identity is asserted, not just non-nil-ness — a recover that re-panicked a
+// wrapped or substituted value would still "panic" and pass a weaker check.
+func TestRecoverProgramExitReRaisesOtherPanics(t *testing.T) {
+	sentinel := fmt.Errorf("a real crash")
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("a non-exit panic was swallowed; want it re-raised")
+		}
+		if r != any(sentinel) {
+			t.Fatalf("re-raised panic value = %#v, want the original %#v", r, sentinel)
+		}
+	}()
+
+	_, _ = recoverProgramExit(func() (eval.Value, error) { panic(sentinel) })
+	t.Fatal("unreachable: recoverProgramExit returned instead of re-panicking")
+}

--- a/internal/embed/testdata/exit_nonzero.ail
+++ b/internal/embed/testdata/exit_nonzero.ail
@@ -1,0 +1,10 @@
+-- exit_nonzero.ail: fixture for #691 — an embedded module that calls exit(1).
+--
+-- Used by internal/embed's host-survival tests. Calling this through
+-- Engine.Call must surface a typed *ExitError to the host, never panic
+-- the host process with the raw *eval.EvalExitCode sentinel.
+
+module internal/embed/testdata/exit_nonzero
+import std/io (exit)
+
+export func main() -> () ! {IO} = exit(1)

--- a/internal/embed/testdata/exit_zero.ail
+++ b/internal/embed/testdata/exit_zero.ail
@@ -1,0 +1,10 @@
+-- exit_zero.ail: fixture for #691 — an embedded module that calls exit(0).
+--
+-- Pins the contract decision that exit(0) is reported as *ExitError{Code: 0}
+-- rather than collapsed to a nil error: the host cannot otherwise tell it
+-- apart from a function that returned unit normally.
+
+module internal/embed/testdata/exit_zero
+import std/io (exit)
+
+export func main() -> () ! {IO} = exit(0)

--- a/internal/embed/testdata/no_exit.ail
+++ b/internal/embed/testdata/no_exit.ail
@@ -1,0 +1,9 @@
+-- no_exit.ail: fixture for #691 — the mechanism-removed control.
+--
+-- Identical call shape to exit_nonzero.ail with the exit() removed, so a
+-- green here proves the exit arms fail for the exit() and not for the
+-- fixture, the engine setup, or the test harness.
+
+module internal/embed/testdata/no_exit
+
+export func main() -> int = 42


### PR DESCRIPTION
## What

`exit()` in an **embedded** AILANG module panicked the **host process** with a raw Go stack. This is #607's defect class one layer down.

`exit()` raises a `*eval.EvalExitCode` sentinel panic (`internal/effects/io.go:145`). The CLI's two consumers recover it — the single-file path and `recoverBatchItemExit` (#607). `internal/embed`, the sanctioned host → compiler bridge, did **not**: `Engine.Call` (`embed.go:237`) and `Engine.CallPreserveFloats` (`embed.go:314`) called `runtime.CallEntrypoint` directly. For a long-lived host (dashboard/observatory) that is a crash, not an exit code.

**Reproduced first-party before fixing**, frame-for-frame as filed:
```
panic: (*eval.EvalExitCode) [recovered, repanicked]
  effects.ioExit          internal/effects/io.go:145
  runtime.CallEntrypoint  internal/runtime/entrypoint.go:112
  embed.(*Engine).Call    internal/embed/embed.go:237
```

## Why not fix `runtime.CallEntrypoint`

Deliberate. The CLI *needs* the sentinel to reach its own recover so it can map onto `os.Exit`; recovering inside the shared primitive would break that and churn the freshly-landed, mutation-guarded #607 path. The primitive stays neutral, each consumer supplies its own contract.

## Contract decision (this is the part worth reviewing)

An embedding host has no process exit to map onto, so `exit(N)` is surfaced as a typed `*embed.ExitError{Code: N}` from `Call`, `CallPreserveFloats` and transitively `CallJSON`.

**`exit(0)` is an `ExitError` too, not a nil error** — unlike the batch runner, which owns a process and treats `exit(0)` as success. A nil error here would be indistinguishable from a function that returned unit normally, discarding information the caller cannot recover. Hosts wanting batch semantics branch on `Code == 0`.

## Declared residuals (in code, not implicit)

- `Engine.Eval` — **UNINFORMATIVE**: GAP-5 makes standalone expressions unreachable; its existing tests are `t.Skip`ped.
- `GetCallValue`/`GetCallValueN` — hand the evaluator's own handles to the host unwrapped. Harmless for the in-evaluator use (`effCtx.FnCaller`), where the panic unwinds into the enclosing `Call`; a host invoking them outside any `Call` is on its own. Wrapping would change the callback identity these consumers pass into the effect context.

## Mutation drill — one per branch (rule 3j)

Each mutant asserted **LANDED** (sha256 changed) and **BUILDS** (`go build ./internal/embed/` rc=0) before its result was read, and restored from a `cp` backup (never `git checkout --` — these files are untracked).

| mutation | reds |
|---|---|
| exit-mapping neutered | the 4 exit arms + the sentinel unit arm |
| re-panic neutered | **only** `ReRaisesOtherPanics` |
| passthrough neutered | **only** the control arm + the passthrough arm |
| call site 1 unwired | site-1 arm dies; **site-2 arm still PASSES** |
| call site 2 unwired | site-2 arm dies; **site-1 arm still PASSES** |

The last two are the point: this repo's named recurring shape is guard-the-helper-miss-the-call-site, so the two entry points are pinned *independently* rather than assumed equivalent.

**Inverse arm**: both guards removed **and** `exit_test.go` deleted → `internal/embed` is **rc=0, 60 PASS, 0 FAIL**. The defect shipped entirely undetected by the existing suite. (68 PASS with the 8 new arms.)

The re-raise arm asserts panic-value **identity**, not just that *something* panicked — a recover that re-panicked a wrapped value would pass a weaker check.

## Gates

⚠ **darwin/arm64 only — the windows and ubuntu legs are unrun locally** (rule 3b(viii)). The new test resolves paths and sets an env var, so the matrix legs are informative here, not noise.

`go test ./... ` **rc=0 (108 ok, 0 FAIL)** · `vet` rc=0 · `fmt-check` rc=0 · `check-boundaries` rc=0 · `check-file-sizes` rc=0 · `check-changelog` rc=0 · `check-golden-drift` rc=0 · `verify-examples` rc=0

Two **BASE** failures, confirmed not attributable to this diff (rule 3e):
- `go build ./...` rc=1 — `cmd/wasm`, no native `main`; identical on the pristine tree.
- `make fmt-check-ail` rc=2 — **opt-in, not in CI** (zero hits in `.github/workflows/`); flags 3 pre-existing `examples/` files, and its enumerator `find examples stdlib` cannot even see this diff's `.ail` files (`stdlib/` does not exist in this repo; the real path is `std/`).

Fixes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)
