### PR TITLE
fix(cli): batch mode flushes attributable Debug output per item (#692)

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -6771,3 +6771,10 @@ Patch release on top of v0.18.0's M-MOTOKO-EXECUTOR-ADAPTER. Local smoke testing
   suppressing individual model-outcome filings. Invalid-run notifications now name
   the dominant unmeasured category, backed by frozen real-night replay fixtures and
   a Go/Python taxonomy drift guard (#551).
+
+### Fixed — batch runs flush attributable Debug output (#692)
+
+Batch execution now flushes each input's collected Debug ghost-effect logs on
+both success and failure, with an input-derived label that remains visible under
+`--quiet`. Single-file Debug output keeps its existing unlabelled format, and
+batch output continues to respect `--log-level` severity filtering.

--- a/cmd/ailang/main_run_batch_debug_test.go
+++ b/cmd/ailang/main_run_batch_debug_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sunholo-data/ailang/internal/testutil"
+)
+
+const batchDebugProgram = `module main
+
+import std/debug as Debug
+import std/env (getArgs)
+import std/io (exit)
+
+export func main() -> () ! {IO, Env} =
+  match getArgs() {
+    [a] => let _ = Debug.log("DEBUG-${a}") in
+           if a == "FIRST_FAIL" then exit(1) else ()
+    _ => ()
+  }
+`
+
+// batchSeverityProgram emits one message BELOW the --log-level threshold and one
+// ABOVE it. Both halves are load-bearing: without the high-severity line this
+// fixture could only assert an ABSENCE, which a batch path that flushes nothing
+// at all satisfies just as well as a working filter.
+const batchSeverityProgram = `module main
+
+import std/debug as Debug
+
+export func main() -> () =
+  let _ = Debug.log("{\"severity\":\"DEBUG\",\"message\":\"LOW-SEVERITY-BATCH\"}") in
+  Debug.log("{\"severity\":\"ERROR\",\"message\":\"HIGH-SEVERITY-BATCH\"}")
+`
+
+func runDebugFixture(t *testing.T, program string, flags []string, programArgs ...string) (string, int) {
+	t.Helper()
+
+	ailangBin := testutil.FindAilangBinary(t)
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "debug.ail")
+	if err := os.WriteFile(src, []byte(program), 0o644); err != nil {
+		t.Fatalf("write debug fixture: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	cmdArgs := append([]string{"run"}, flags...)
+	cmdArgs = append(cmdArgs, src)
+	cmdArgs = append(cmdArgs, programArgs...)
+	cmd := exec.CommandContext(ctx, ailangBin, cmdArgs...)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("debug fixture timed out; output: %s", out)
+	}
+	if err == nil {
+		return string(out), 0
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("run %v: %v (output: %s)", cmdArgs, err, out)
+	}
+	return string(out), exitErr.ExitCode()
+}
+
+func TestBatchDebugOutput_TwoItemsAttributedWhenQuiet(t *testing.T) {
+	out, code := runDebugFixture(t, batchDebugProgram,
+		[]string{"--quiet", "--caps", "IO,Env", "--entry", "main", "--batch"}, "FIRST", "SECOND")
+	if code != 0 {
+		t.Fatalf("batch exit code = %d, want 0; output:\n%s", code, out)
+	}
+	for _, want := range []string{"[FIRST] DEBUG-FIRST", "[SECOND] DEBUG-SECOND"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("quiet batch output missing attributable debug line %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestSingleFileDebugOutput_RemainsUnlabelled(t *testing.T) {
+	out, code := runDebugFixture(t, batchDebugProgram,
+		[]string{"--quiet", "--caps", "IO,Env", "--entry", "main"}, "SINGLE")
+	if code != 0 {
+		t.Fatalf("single-file exit code = %d, want 0; output:\n%s", code, out)
+	}
+	foundExact := false
+	for _, line := range strings.Split(strings.TrimSuffix(out, "\n"), "\n") {
+		if line == "DEBUG-SINGLE" {
+			foundExact = true
+		} else if strings.Contains(line, "DEBUG-SINGLE") {
+			t.Errorf("single-file debug output gained a prefix or suffix: %q\nfull output:\n%s", line, out)
+		}
+	}
+	if !foundExact {
+		t.Fatalf("single-file output has no exact unlabelled DEBUG-SINGLE line; output:\n%s", out)
+	}
+}
+
+func TestBatchDebugOutput_FailingItemFlushesAndBatchContinues(t *testing.T) {
+	out, code := runDebugFixture(t, batchDebugProgram,
+		[]string{"--quiet", "--caps", "IO,Env", "--entry", "main", "--batch"}, "FIRST_FAIL", "SECOND")
+	if code != 1 {
+		t.Fatalf("batch exit code = %d, want 1; output:\n%s", code, out)
+	}
+	if !strings.Contains(out, "[FIRST_FAIL] DEBUG-FIRST_FAIL") {
+		t.Errorf("failing first item's debug output was not flushed with attribution:\n%s", out)
+	}
+	if !strings.Contains(out, "[SECOND] DEBUG-SECOND") {
+		t.Errorf("second item did not run and flush after first item failed:\n%s", out)
+	}
+}
+
+// TestBatchDebugOutput_SeverityFilterApplies pins that a batch item's flush goes
+// THROUGH the shared debugLogLevel filter rather than around it.
+//
+// The known-positive control is not optional here. As first written this test
+// asserted only that the DEBUG-severity line was absent, and it SURVIVED the
+// mutation that neuters the per-item flush entirely (measured: rc=0 with
+// `if false { flushDebugOutput(effCtx, input) }`) — an absence is satisfied
+// just as well by "the filter worked" as by "nothing was ever emitted". The
+// high-severity assertion below is what makes the absence mean something: it
+// fails if the flush is removed, so the two arms together can only pass when
+// the flush ran AND the filter suppressed the low-severity line.
+func TestBatchDebugOutput_SeverityFilterApplies(t *testing.T) {
+	out, code := runDebugFixture(t, batchSeverityProgram,
+		[]string{"--quiet", "--log-level", "warn", "--entry", "main", "--batch"}, "ONLY")
+	if code != 0 {
+		t.Fatalf("batch exit code = %d, want 0; output:\n%s", code, out)
+	}
+	// Known-positive control: ERROR (3) >= warn (2), so this line MUST survive
+	// the filter — and it can only appear if the batch item flushed at all.
+	if !strings.Contains(out, "[ONLY] ") || !strings.Contains(out, "HIGH-SEVERITY-BATCH") {
+		t.Fatalf("instrument failure: the above-threshold line never reached stderr, "+
+			"so the absence assertion below proves nothing:\n%s", out)
+	}
+	if strings.Contains(out, "LOW-SEVERITY-BATCH") {
+		t.Errorf("DEBUG-severity message escaped --log-level warn filter:\n%s", out)
+	}
+}

--- a/cmd/ailang/main_run_exec.go
+++ b/cmd/ailang/main_run_exec.go
@@ -571,7 +571,7 @@ func runFile(filename string, programArgs []string, trace bool, seed int, virtua
 			stdoutBuf.Flush()
 
 			// Flush Debug ghost effect output to stderr
-			flushDebugOutput(effCtx)
+			flushDebugOutput(effCtx, "")
 
 			// M-TRACE-EXPORT: Record module end with duration
 			if effCtx.Trace != nil && effCtx.Trace.Enabled() {

--- a/cmd/ailang/run_helpers.go
+++ b/cmd/ailang/run_helpers.go
@@ -582,6 +582,9 @@ func executeBatchItem(ctx context.Context, result pipeline.Result, input string,
 
 	// Each input gets its own args: the input path is the sole program argument
 	effCtx := effects.NewEffContext([]string{input})
+	defer func() {
+		flushDebugOutput(effCtx, input)
+	}()
 	grantCapabilities(effCtx, caps)
 
 	effCtx.GoCtx = ctx
@@ -754,10 +757,15 @@ func extractSeverity(msg string) string {
 }
 
 // flushDebugOutput collects Debug effect logs and prints them to stderr.
-// Respects debugLogLevel for severity filtering. Called after execution completes.
-func flushDebugOutput(effCtx *effects.EffContext) {
+// Respects debugLogLevel for severity filtering. A non-empty label prefixes
+// each emitted line so batch output remains attributable even under --quiet.
+func flushDebugOutput(effCtx *effects.EffContext, label string) {
 	if effCtx == nil || effCtx.Debug == nil {
 		return
+	}
+	prefix := ""
+	if label != "" {
+		prefix = "[" + label + "] "
 	}
 	out := effCtx.Debug.Collect()
 	for _, log := range out.Logs {
@@ -768,11 +776,11 @@ func flushDebugOutput(effCtx *effects.EffContext) {
 				continue
 			}
 		}
-		fmt.Fprintf(os.Stderr, "%s\n", log.Message)
+		fmt.Fprintf(os.Stderr, "%s%s\n", prefix, log.Message)
 	}
 	for _, a := range out.Assertions {
 		if !a.Passed {
-			fmt.Fprintf(os.Stderr, "[ASSERT FAIL] %s at %s\n", a.Message, a.Location)
+			fmt.Fprintf(os.Stderr, "%s[ASSERT FAIL] %s at %s\n", prefix, a.Message, a.Location)
 		}
 	}
 }


### PR DESCRIPTION
## What

`flushDebugOutput` had exactly one call site in `cmd/ailang/` — `main_run_exec.go:574`, inside the
single-file branch. `executeBatchItem` never called it, so every Debug ghost-effect log produced by
a batch item was collected into that item's effect context and discarded when the context went out
of scope. Debug output worked when you ran a file directly and vanished silently when you ran the
same file in a batch — the worst shape for a debugging facility, since batch is exactly when you
need it. Same guard-the-helper-miss-the-call-site shape as #607.

**Measured at `6dd525c58`** with a fixture calling `std/debug.log("HELLO-FROM-DEBUG")`:

| command | occurrences |
|---|---|
| `ailang run --debug --entry main dbg.ail` | **1** |
| `ailang run --debug --entry main --batch dbg.ail in1 in2` | **0** (while reporting `Batch complete: 2/2 succeeded`) |

## How

- The flush is **deferred immediately after `effCtx` is constructed**, so it runs on every exit path
  from `executeBatchItem` — including the handler-setup error returns and the `exit()` sentinel that
  #607's recover converts into a per-item error. A failing item's Debug logs are exactly the ones
  worth keeping.
- **Attribution does not lean on the batch header.** `─── [i/n] <input>` is printed inside
  `if !quiet` and Debug shares its stream (stderr), so under `--quiet` an unlabelled per-item flush
  would produce an unattributable stream of N items' logs. The flush takes an explicit label and
  emits `[<input>] <message>`.
- **Single-file output is byte-unchanged**: that call site passes the empty label, which reproduces
  today's exact bytes. Pinned by a test asserting an *exact* unprefixed line.
- The batch path goes **through** the shared `debugLogLevel` severity filter, not around it.

## Tests

Four subprocess tests in `cmd/ailang/main_run_batch_debug_test.go`, reusing the #607 harness in
`main_run_batch_exit_test.go` (`testutil.FindAilangBinary`, `t.TempDir`, `exec.CommandContext`).
An in-process unit test cannot see this defect — it is a missing call site, not a broken function.

## Mutation drill

Mutant `if false { flushDebugOutput(effCtx, input) }` — asserted **LANDED**
(`b7e4b950…` → `83f78ec6…`) and **BUILDS** (`go build ./cmd/ailang` rc=0), with the binary rebuilt
before each arm (these tests shell out, so a stale binary makes the drill vacuous — and
`FindAilangBinary` *skips* rather than fails on a stale one).

- 3 of 4 tests go **RED**. `TestSingleFileDebugOutput_RemainsUnlabelled` correctly does not: it pins
  a path the mutant does not touch.
- **Inverse arm**: `go test ./cmd/ailang -skip '<the four>'` under the same mutant is **rc=0, 0 FAIL**
  — so the new tests are the killers, not bystanders.
- Restored via `cp` (never `git checkout --`, which would delete uncommitted work); sha256 verified
  byte-identical.

**One repaired row.** The severity-filter test as first written *survived* that mutant: it asserted
only that the below-threshold line was **absent**, which "nothing was ever flushed" satisfies just as
well as "the filter worked". It now carries a known-positive control — an `ERROR`-severity line that
must survive `--log-level warn`, and can only appear if the flush ran at all — and reds under the
mutant on that assertion. The filter's own negative control was measured separately: at
`--log-level debug` the low-severity line *does* appear, so the absence is the filter's doing.

## Gates

All re-run **outside the codex sandbox** by the controller (mandatory for a `cmd/*` diff; the
executor reported the full package gate and the inverse arm as `UNINFORMATIVE UNDER SANDBOX` on a
loopback-bind denial):

`go build ./cmd/ailang` rc=0 · `go vet ./cmd/ailang` rc=0 · `go test ./cmd/ailang -count=1` rc=0
(**0 FAIL, 0 SKIP**) · `gofmt -l` clean · `git diff --check` rc=0 · `make check-file-sizes`,
`make check-boundaries`, `make fmt-check`, `make vet`, `make check-golden-drift`,
`make check-changelog`, `make lint` all rc=0.

Baselined on the pristine tree first (rule 3e): build/vet/test were all rc=0 at base, so a red would
have been ours.

**Platform**: green on darwin/arm64; the windows and ubuntu legs are unrun locally and are Gate 3b's
to report. This diff does not touch anything per-GOOS.

Fixes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)
