### PR TITLE
fix(apiserver): exit(0) in a route/A2A/MCP handler is a success, not a 500 (#706)

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+### Fixed — clean handler exits now complete successfully (#706)
+
+`exit(0)` from serve-api routes, A2A tasks, and MCP tools now produces each
+protocol's existing unit-shaped success response. Non-zero exits remain errors
+with their existing response shapes and messages.
+
 ### Fixed — the motoko mission loop had no recovery watcher, so a refused fire cost 12 hours
 
 `mission-recovery.sh` has been mission-parameterized since it was written (#7d8db911f) — every

--- a/internal/apiserver/a2a.go
+++ b/internal/apiserver/a2a.go
@@ -229,7 +229,7 @@ func (s *Server) handleA2ATaskSend(w http.ResponseWriter, req *a2aRequest) {
 		taskID = fmt.Sprintf("task-%d", time.Now().UnixNano())
 	}
 
-	if callErr != nil {
+	if callErr != nil && !isCleanExit(callErr) {
 		a2aResult(w, req.ID, map[string]any{
 			"id":     taskID,
 			"status": map[string]any{"state": "failed", "message": callErr.Error()},
@@ -237,13 +237,17 @@ func (s *Server) handleA2ATaskSend(w http.ResponseWriter, req *a2aRequest) {
 		return
 	}
 
-	goResult, err := embed.ToGo(result)
-	if err != nil {
-		a2aResult(w, req.ID, map[string]any{
-			"id":     taskID,
-			"status": map[string]any{"state": "failed", "message": "result conversion: " + err.Error()},
-		})
-		return
+	var goResult any
+	if callErr == nil {
+		var err error
+		goResult, err = embed.ToGo(result)
+		if err != nil {
+			a2aResult(w, req.ID, map[string]any{
+				"id":     taskID,
+				"status": map[string]any{"state": "failed", "message": "result conversion: " + err.Error()},
+			})
+			return
+		}
 	}
 
 	resultJSON, _ := json.Marshal(goResult)

--- a/internal/apiserver/exit_status.go
+++ b/internal/apiserver/exit_status.go
@@ -1,0 +1,17 @@
+package apiserver
+
+import (
+	"errors"
+
+	"github.com/sunholo-data/ailang/internal/embed"
+)
+
+// isCleanExit reports whether an embedded handler deliberately called exit(0).
+//
+// D-17 resolves #706 by giving API hosts the same clean-exit semantics as the
+// CLI batch path. The embed layer deliberately preserves exit(0) as a typed
+// error (#691), so each host must classify it. Non-zero exits remain errors.
+func isCleanExit(err error) bool {
+	var exitErr *embed.ExitError
+	return errors.As(err, &exitErr) && exitErr.Code == 0
+}

--- a/internal/apiserver/exit_status_test.go
+++ b/internal/apiserver/exit_status_test.go
@@ -1,0 +1,165 @@
+package apiserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/effects"
+)
+
+const exitFixturePrefix = "internal/embed/testdata/"
+
+func newExitHandlerTestServer(t *testing.T) *Server {
+	t.Helper()
+
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolving repo root: %v", err)
+	}
+	t.Setenv("AILANG_STDLIB_PATH", root)
+
+	effCtx := effects.NewEffContext(nil)
+	effCtx.Grant(effects.NewCapability("IO"))
+	srv := New(root, Config{EffCtx: effCtx})
+	t.Cleanup(func() { _ = srv.Close() })
+
+	for _, fixture := range []string{"exit_zero.ail", "exit_nonzero.ail", "no_exit.ail"} {
+		if err := srv.LoadModules([]string{filepath.Join(root, exitFixturePrefix, fixture)}); err != nil {
+			t.Fatalf("LoadModules(%s): %v", fixture, err)
+		}
+	}
+	return srv
+}
+
+func callRouteFixture(t *testing.T, srv *Server, module string) (int, map[string]any) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/"+module+"/main", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.callFunction(w, req, module, "main")
+
+	var body map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decoding route response %q: %v", w.Body.String(), err)
+	}
+	return w.Code, body
+}
+
+func callA2AFixture(t *testing.T, srv *Server, module string) map[string]any {
+	t.Helper()
+	skillID := strings.ReplaceAll(module, "/", ".") + ".main"
+	body := `{"jsonrpc":"2.0","id":1,"method":"tasks/send","params":{"id":"exit-test","metadata":{"skill_id":"` + skillID + `"},"message":{"parts":[]}}}`
+	req := httptest.NewRequest(http.MethodPost, "/a2a/", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handleA2ATask(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("A2A HTTP status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+
+	var response map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("decoding A2A response %q: %v", w.Body.String(), err)
+	}
+	return response
+}
+
+func a2aTaskState(t *testing.T, response map[string]any) string {
+	t.Helper()
+	result, ok := response["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("A2A response has no task result: %#v", response)
+	}
+	status, ok := result["status"].(map[string]any)
+	if !ok {
+		t.Fatalf("A2A task has no status: %#v", result)
+	}
+	state, ok := status["state"].(string)
+	if !ok {
+		t.Fatalf("A2A task has no string state: %#v", status)
+	}
+	return state
+}
+
+func TestRoutesDispatchExitZeroSucceeds(t *testing.T) {
+	srv := newExitHandlerTestServer(t)
+	status, body := callRouteFixture(t, srv, exitFixturePrefix+"exit_zero")
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %#v", status, body)
+	}
+	if _, present := body["error"]; present {
+		t.Fatalf("clean exit response contains error: %#v", body)
+	}
+}
+
+func TestRoutesDispatchExitNonzeroFails(t *testing.T) {
+	srv := newExitHandlerTestServer(t)
+	status, body := callRouteFixture(t, srv, exitFixturePrefix+"exit_nonzero")
+	if status != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500: %#v", status, body)
+	}
+	if body["error"] != "program called exit(1)" {
+		t.Fatalf("error = %#v, want unchanged exit(1) message", body["error"])
+	}
+}
+
+func TestA2AExitZeroSucceeds(t *testing.T) {
+	srv := newExitHandlerTestServer(t)
+	response := callA2AFixture(t, srv, exitFixturePrefix+"exit_zero")
+	if state := a2aTaskState(t, response); state != "completed" {
+		t.Fatalf("task state = %q, want completed: %#v", state, response)
+	}
+}
+
+func TestA2AExitNonzeroFails(t *testing.T) {
+	srv := newExitHandlerTestServer(t)
+	response := callA2AFixture(t, srv, exitFixturePrefix+"exit_nonzero")
+	if state := a2aTaskState(t, response); state != "failed" {
+		t.Fatalf("task state = %q, want failed: %#v", state, response)
+	}
+}
+
+func TestMCPExitZeroSucceeds(t *testing.T) {
+	srv := newExitHandlerTestServer(t)
+	handler := NewMCPServer(srv).makeToolHandler(exitFixturePrefix+"exit_zero", "main", nil)
+	res, err := handler(context.Background(), mcpCallReq("main", `{}`))
+	if err != nil {
+		t.Fatalf("handler returned Go error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("clean exit returned MCP error: %s", mcpResultText(t, res))
+	}
+	if text := mcpResultText(t, res); text != "null" {
+		t.Fatalf("clean exit result = %q, want unit-shaped null", text)
+	}
+}
+
+func TestMCPExitNonzeroFails(t *testing.T) {
+	srv := newExitHandlerTestServer(t)
+	handler := NewMCPServer(srv).makeToolHandler(exitFixturePrefix+"exit_nonzero", "main", nil)
+	res, err := handler(context.Background(), mcpCallReq("main", `{}`))
+	if err != nil {
+		t.Fatalf("handler returned Go error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("exit(1) returned normal MCP result: %s", mcpResultText(t, res))
+	}
+	if text := mcpResultText(t, res); !strings.Contains(text, "function call failed: program called exit(1)") {
+		t.Fatalf("MCP error changed: %q", text)
+	}
+}
+
+func TestExitHandlerPositiveControl(t *testing.T) {
+	srv := newExitHandlerTestServer(t)
+	status, body := callRouteFixture(t, srv, exitFixturePrefix+"no_exit")
+	if status != http.StatusOK {
+		t.Fatalf("no-exit control status = %d, want 200: %#v", status, body)
+	}
+	if body["result"] != float64(42) {
+		t.Fatalf("no-exit control result = %#v, want 42", body["result"])
+	}
+}

--- a/internal/apiserver/exit_status_test.go
+++ b/internal/apiserver/exit_status_test.go
@@ -85,6 +85,28 @@ func a2aTaskState(t *testing.T, response map[string]any) string {
 	return state
 }
 
+// a2aTaskMessage returns the status message an A2A failure carries.
+//
+// Separate from a2aTaskState because the state is a three-value enum that
+// many unrelated failures share, so a state assertion cannot tell "exit(1)
+// was reported as an error" from "the call never reached exit() at all".
+func a2aTaskMessage(t *testing.T, response map[string]any) string {
+	t.Helper()
+	result, ok := response["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("A2A response has no task result: %#v", response)
+	}
+	status, ok := result["status"].(map[string]any)
+	if !ok {
+		t.Fatalf("A2A task has no status: %#v", result)
+	}
+	message, ok := status["message"].(string)
+	if !ok {
+		t.Fatalf("A2A task has no string message: %#v", status)
+	}
+	return message
+}
+
 func TestRoutesDispatchExitZeroSucceeds(t *testing.T) {
 	srv := newExitHandlerTestServer(t)
 	status, body := callRouteFixture(t, srv, exitFixturePrefix+"exit_zero")
@@ -93,6 +115,20 @@ func TestRoutesDispatchExitZeroSucceeds(t *testing.T) {
 	}
 	if _, present := body["error"]; present {
 		t.Fatalf("clean exit response contains error: %#v", body)
+	}
+	// Pin the whole shape, not just the absence of an error. D-17's contract
+	// is that a clean exit is indistinguishable from a unit return, and
+	// embed.ToGo maps UnitValue to nil, so "result" must be absent (it is
+	// omitempty) while the identifying fields are present. Measured against
+	// a live serve-api unit return: {"module":…,"func":…,"elapsed_ms":…}.
+	if _, present := body["result"]; present {
+		t.Fatalf("clean exit response carries a result: %#v", body)
+	}
+	if body["module"] != exitFixturePrefix+"exit_zero" || body["func"] != "main" {
+		t.Fatalf("clean exit response misidentifies the call: %#v", body)
+	}
+	if _, present := body["elapsed_ms"]; !present {
+		t.Fatalf("clean exit response has no elapsed_ms: %#v", body)
 	}
 }
 
@@ -120,6 +156,15 @@ func TestA2AExitNonzeroFails(t *testing.T) {
 	response := callA2AFixture(t, srv, exitFixturePrefix+"exit_nonzero")
 	if state := a2aTaskState(t, response); state != "failed" {
 		t.Fatalf("task state = %q, want failed: %#v", state, response)
+	}
+	// The state alone is NOT enough. Every failure mode reaches "failed" —
+	// including one where exit() never ran at all, e.g. the effect layer
+	// refusing the call for a missing IO capability. Asserting the message
+	// is what makes this arm depend on the mechanism under test: with the
+	// grant in newExitHandlerTestServer removed, the state check still
+	// passes and only this check fails.
+	if msg := a2aTaskMessage(t, response); msg != "program called exit(1)" {
+		t.Fatalf("task message = %q, want unchanged exit(1) message: %#v", msg, response)
 	}
 }
 

--- a/internal/apiserver/mcp.go
+++ b/internal/apiserver/mcp.go
@@ -238,14 +238,18 @@ func (ms *MCPServer) makeToolHandler(modulePath, funcName string, paramNames []s
 
 		// Call the AILANG function (preserve floats — JSON has no int/float distinction).
 		result, callErr := ms.server.engine.CallPreserveFloats(modulePath, funcName, args...)
-		if callErr != nil {
+		if callErr != nil && !isCleanExit(callErr) {
 			return mcpError(fmt.Sprintf("function call failed: %v", callErr)), nil
 		}
 
 		// Convert result to Go value.
-		goResult, err := embed.ToGo(result)
-		if err != nil {
-			return mcpError(fmt.Sprintf("result conversion failed: %v", err)), nil
+		var goResult any
+		if callErr == nil {
+			var err error
+			goResult, err = embed.ToGo(result)
+			if err != nil {
+				return mcpError(fmt.Sprintf("result conversion failed: %v", err)), nil
+			}
 		}
 
 		// Marshal to JSON for text content.

--- a/internal/apiserver/routes_dispatch.go
+++ b/internal/apiserver/routes_dispatch.go
@@ -143,6 +143,14 @@ func (s *Server) callFunction(w http.ResponseWriter, r *http.Request, modulePath
 	}
 
 	if callErr != nil {
+		if isCleanExit(callErr) {
+			writeJSON(w, http.StatusOK, FunctionCallResponse{
+				Module:    modulePath,
+				Func:      funcName,
+				ElapsedMs: elapsed,
+			})
+			return
+		}
 		log.Printf("[API] %s/%s failed: %v", modulePath, funcName, callErr)
 		writeJSON(w, http.StatusInternalServerError, FunctionCallResponse{
 			Module:    modulePath,


### PR DESCRIPTION
Fixes #706.

## The gap

`#691` made `exit()` in an embedded module surface as a typed `*embed.ExitError{Code}` instead of panicking the host, and its doc comment says a host wanting the CLI's batch semantics "can branch on `Code`". **No host in this repo did that branching.** All three production consumers of `Engine.Call`/`CallPreserveFloats` treated any non-nil error as a hard failure, so an `@route` handler calling `exit(0)` — a plausible "stop here cleanly" idiom, since `exit` is an ordinary `std/io` builtin — returned HTTP 500.

Not a regression: before `#691` that same handler crashed the whole serve-api process. This is the incomplete half of that improvement.

## Contract

Ratified by Mark as `D-17`, not re-litigated here:

- `exit(0)` from a route / A2A / MCP handler is a **success** response, matching the CLI batch path where `recoverBatchItemExit` maps `exit(0)` to success.
- `exit(N != 0)` **stays an error**, message unchanged. No response schema changes.
- `internal/embed/` is deliberately untouched — the embed contract is correct; the hosts were incomplete.

## Shape

One shared classifier (`isCleanExit`) **plus a separate branch at each of the three call sites**. This repo's recurring defect shape is guard-the-helper-miss-the-call-site — it is literally how `#706` arose from `#691`, and `#691` from `#607` — so a helper-only test would not be acceptance.

On a clean exit the engine returns a **nil** value, so `embed.ToGo(result)` is now guarded rather than called on nil in `a2a.go`/`mcp.go`. `ToGo` maps `UnitValue` to `nil`, so the clean-exit response is identical in shape to a unit return — measured, not assumed.

## Evidence

Live repro on the built binary at `66abbc660`, both arms in one run with `--caps IO`:

| route | before | after |
|---|---|---|
| unit return (control) | 200 | 200 |
| `exit(0)` | **500** `{"error":"program called exit(0)"}` | **200** `{"module":…,"func":…,"elapsed_ms":0}` |
| `exit(3)` (over-match control) | 500 | 500 `{"error":"program called exit(3)"}` |

Host survived in every case, and `#692`'s stdout/Debug flush still fires on the clean-exit path.

The control arm is load-bearing: on a first attempt without `--caps IO` **both** arms returned 500 for an unrelated capability reason, i.e. the subject would have "reproduced" for the wrong cause. Every test arm therefore grants IO and carries a positive control proving the grant took.

Six arms (`exit(0)` and `exit(1)` at each of the three sites) run against a **real engine** over the already-committed `internal/embed/testdata` fixtures.

## Mutation drill

Run per call site, one at a time, neutered with `if false && …` so every import stays used and "the mutant does not build" cannot masquerade as "the guard fired". Each site's arm fails alone under its own mutant; the inverse arm (new tests `-skip`ped) is rc=0, which is what proves the new tests are killers rather than bystanders.

## Gates

All re-run by the controller **outside** the executor sandbox, all rc=0: `go build ./internal/... ./cmd/ailang`, `go test ./internal/apiserver/ ./internal/embed/`, `go vet`, `gofmt -l` (empty), `make check-changelog`, `make check-file-sizes`, `make check-boundaries`.

Green on darwin/arm64 locally; the windows and ubuntu legs are unrun here and are CI's to report.

`go build ./...` is rc=1 on **pristine** `origin/dev` as well (`cmd/wasm`: `function main is undeclared in the main package`) — already red at base, not this change's doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
