### PR TITLE
fix(ci): govulncheck-filter reports module-level findings instead of silently dropping them (#703)

### DIFF
--- a/.govulncheck-allow.yml
+++ b/.govulncheck-allow.yml
@@ -36,6 +36,9 @@ allow:
   # another 90 days rather than papered over. Next reviewer: re-run the
   # three checks above before bumping again — if any entry gains a fixed
   # version, upgrade the dependency instead of extending this date.
+  - id: GO-2026-5750
+    reason: Ollama path-traversal (CVE-2026-7020, GHSA-x99g-8v8j-25j2), module-level / not function-reaching in AILANG's call graph; client-side use only; no upstream fix as of 2026-07-27. Tracked via Dependabot with the other Ollama advisories.
+    expires: 2026-10-29
   - id: GO-2025-4251
     reason: Ollama upstream unpatched (re-verified 2026-07-31, no fixed version published); tracked via Dependabot. AILANG only invokes the client side; daemon-side issues need an upstream Ollama release.
     expires: 2026-10-29

--- a/tools/govulncheck-filter/main.go
+++ b/tools/govulncheck-filter/main.go
@@ -37,10 +37,8 @@ type allowlist struct {
 	Allow []allowEntry `yaml:"allow"`
 }
 
-// govulncheck JSON streams a sequence of objects, one per line. We
-// only care about the "finding" frames where Trace[0].Module is
-// non-empty (those are real reachable findings — symbol-level rather
-// than module-level scan artifacts).
+// govulncheck JSON streams a sequence of objects, one per line. Finding
+// frames may be function-reaching or module-level scan artifacts.
 type vulnFrame struct {
 	Finding *struct {
 		OSV   string `json:"osv"`
@@ -72,7 +70,7 @@ func main() {
 		byID[e.ID] = e
 	}
 
-	findings, err := readFindings(os.Stdin)
+	reaching, moduleOnly, err := readFindings(os.Stdin)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "govulncheck-filter: parse stdin: %v\n", err)
 		os.Exit(2)
@@ -85,10 +83,7 @@ func main() {
 		seen     = map[string]bool{}
 	)
 
-	for _, id := range findings {
-		if seen[id] {
-			continue
-		}
+	for _, id := range reaching {
 		seen[id] = true
 
 		entry, ok := byID[id]
@@ -106,6 +101,9 @@ func main() {
 			expired = append(expired, fmt.Sprintf("%s (expired %s)", id, entry.Expires))
 		}
 	}
+	for _, id := range moduleOnly {
+		seen[id] = true
+	}
 
 	// Surface allowlist entries that no longer match any finding —
 	// they're dead weight and should be removed.
@@ -121,8 +119,9 @@ func main() {
 	sort.Strings(stale)
 
 	if len(blocking) == 0 && len(expired) == 0 {
-		fmt.Printf("govulncheck-filter: %d finding(s), all allowlisted and unexpired.\n",
-			len(findings))
+		fmt.Printf("govulncheck-filter: %d reachable finding(s), all allowlisted and unexpired.\n",
+			len(reaching))
+		printModuleOnly(os.Stdout, moduleOnly, byID)
 		if len(stale) > 0 {
 			fmt.Printf("Note: %d stale allowlist entr(ies) — consider removing: %v\n",
 				len(stale), stale)
@@ -148,7 +147,22 @@ func main() {
 		fmt.Fprintln(os.Stderr,
 			"Re-evaluate: bump expires forward, fix the underlying issue, or remove the dependency.")
 	}
+	printModuleOnly(os.Stderr, moduleOnly, byID)
 	os.Exit(1)
+}
+
+func printModuleOnly(w io.Writer, ids []string, byID map[string]allowEntry) {
+	if len(ids) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "govulncheck-filter: %d module-level finding(s) (not function-reaching, not gating):\n", len(ids))
+	for _, id := range ids {
+		status := "NOT allowlisted"
+		if _, ok := byID[id]; ok {
+			status = "allowlisted"
+		}
+		fmt.Fprintf(w, "  - %s [%s]\n", id, status)
+	}
 }
 
 func loadAllowlist(path string) (*allowlist, error) {
@@ -163,7 +177,8 @@ func loadAllowlist(path string) (*allowlist, error) {
 	return &a, nil
 }
 
-// readFindings extracts unique OSV IDs from a govulncheck JSON stream.
+// readFindings extracts unique OSV IDs from a govulncheck JSON stream,
+// partitioned into function-reaching and module-only findings.
 // Each finding object has an "osv" field naming the vulnerability;
 // govulncheck emits multiple frames per OSV (one per call trace) — we
 // dedup at the OSV level since the allowlist is OSV-keyed.
@@ -171,31 +186,39 @@ func loadAllowlist(path string) (*allowlist, error) {
 // Note: govulncheck's JSON output is a stream of pretty-printed
 // objects (NOT JSON Lines), so we use json.Decoder which handles
 // arbitrary whitespace between top-level values.
-func readFindings(r io.Reader) ([]string, error) {
+func readFindings(r io.Reader) (reaching, moduleOnly []string, err error) {
 	dec := json.NewDecoder(r)
-	seen := map[string]bool{}
-	var ids []string
+	reachesFunction := map[string]bool{}
 	for {
 		var frame vulnFrame
 		if err := dec.Decode(&frame); err != nil {
 			if err == io.EOF {
 				break
 			}
-			return nil, err
+			return nil, nil, err
 		}
 		if frame.Finding == nil {
 			continue
 		}
-		// Module-level frames have empty Trace[0].Function — those are
-		// false positives at the symbol level. Keep only frames whose
-		// trace reaches a function (= reachable finding).
-		if len(frame.Finding.Trace) == 0 || frame.Finding.Trace[0].Function == "" {
-			continue
+		id := frame.Finding.OSV
+		if _, exists := reachesFunction[id]; !exists {
+			reachesFunction[id] = false
 		}
-		if !seen[frame.Finding.OSV] {
-			seen[frame.Finding.OSV] = true
-			ids = append(ids, frame.Finding.OSV)
+		for _, trace := range frame.Finding.Trace {
+			if trace.Function != "" {
+				reachesFunction[id] = true
+				break
+			}
 		}
 	}
-	return ids, nil
+	for id, reaches := range reachesFunction {
+		if reaches {
+			reaching = append(reaching, id)
+		} else {
+			moduleOnly = append(moduleOnly, id)
+		}
+	}
+	sort.Strings(reaching)
+	sort.Strings(moduleOnly)
+	return reaching, moduleOnly, nil
 }

--- a/tools/govulncheck-filter/main_test.go
+++ b/tools/govulncheck-filter/main_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestReadFindingsClassifiesModuleOnlyAndReaching(t *testing.T) {
+	input := strings.NewReader(`
+{"config":{"protocol_version":"v1.0.0"}}
+{"finding":{"osv":"GO-2026-5750","trace":[{"module":"github.com/ollama/ollama","function":""}]}}
+{"progress":{"message":"Scanning your code..."}}
+{"finding":{"osv":"GO-2026-6218","trace":[{"module":"example.com/dependency","function":""},{"module":"example.com/ailang","function":"main.run"}]}}
+`)
+
+	reaching, moduleOnly, err := readFindings(input)
+	if err != nil {
+		t.Fatalf("readFindings() error = %v", err)
+	}
+	assertStringsEqual(t, "moduleOnly", moduleOnly, []string{"GO-2026-5750"})
+	assertStringsEqual(t, "reaching", reaching, []string{"GO-2026-6218"})
+
+	// Mutation killed: reverting readFindings to skip non-function traces
+	// (the pre-#703 `Function == ""` continue) empties moduleOnly and reds this test.
+}
+
+func assertStringsEqual(t *testing.T, name string, got, want []string) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("%s = %v, want %v", name, got, want)
+	}
+}


### PR DESCRIPTION
## Summary

`tools/govulncheck-filter` classified findings by `Trace[0].Function` only, so an OSV whose every trace is module-level (no function in our call graph) was reported in **neither** output list — not as unallowlisted (gate red), not in the `all allowlisted` count. It was **silently dropped** — the vacuous-green CLAUDE.md §2 forbids. One dropped finding, **GO-2026-5750** (a real, published, unallowlisted Ollama path-traversal advisory), was invisible.

## Change
- `readFindings` now partitions OSVs into **reaching** vs **module-only** across **all** frames (also fixes a second latent bug: the old `Trace[0]`-only check dropped an OSV reachable via a *later* trace element).
- **Gating is unchanged** and applies only to reaching findings. Module-only findings are **always reported** in a third named bucket (with allowlist status) on both the pass and fail paths — so the count is always complete and never gates on the unreachable.
- Adds **GO-2026-5750** to `.govulncheck-allow.yml` with a reason + expiry `2026-10-29` (co-reviews with the Ollama batch).
- New test pins the classification; the pre-#703 skip mutation reds it (verified by hand + by the independent evaluator).

## Verification
- Controller gates outside sandbox: `go build`/`go vet`/`go test`/`gofmt -l` all rc=0.
- Functional: a reaching unallowlisted finding still reds the gate (exit 1); the previously-dropped GO-2026-5750 now appears in the module-level bucket.
- Independent sonnet evaluator **96/100 PASS, zero blocking** — reproduced the mutation drill (builds, reds under mutant, restored byte-identical) and confirmed the pre-fix binary was *worse than silent* (it listed GO-2026-5750 as a 'stale' entry to delete).

Non-blocking follow-up (filed separately): `printModuleOnly` does not annotate expiry for module-only allowlist entries.

Fixes #703
Found by the iteration-196 sprint-evaluator while reviewing #702.

🤖 Generated with [Claude Code](https://claude.com/claude-code)