### PR TITLE
fix(pkg): ailang install writes an idempotent upsert, not a duplicate TOML key (#718)

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -8,7 +8,11 @@
 
 Repeated `ailang install` and duplicate `init package --deps` declarations now
 replace the existing `[dependencies]` entry in place instead of emitting duplicate
-TOML keys. Package compilation also surfaces malformed `ailang.toml` and existing
+TOML keys. The writer handles a header carrying a trailing comment, a header that
+is the file's last line, keys inside multi-line strings, literal-quoted keys, and
+CRLF manifests; because it edits TOML as text, it also re-parses afterwards and
+rolls the write back rather than leaving a manifest less parseable than it found
+it. Package compilation additionally surfaces malformed `ailang.toml` and existing
 malformed `ailang.lock` files with their paths and underlying parse errors; bare
 projects and packages that have not generated a lock file retain legacy behavior.
 

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,14 @@
 
 ## [Unreleased]
 
+### Fixed — package dependency upserts and manifest parse diagnostics (#718)
+
+Repeated `ailang install` and duplicate `init package --deps` declarations now
+replace the existing `[dependencies]` entry in place instead of emitting duplicate
+TOML keys. Package compilation also surfaces malformed `ailang.toml` and existing
+malformed `ailang.lock` files with their paths and underlying parse errors; bare
+projects and packages that have not generated a lock file retain legacy behavior.
+
 ### Fixed — clean handler exits now complete successfully (#706)
 
 `exit(0)` from serve-api routes, A2A tasks, and MCP tools now produces each

--- a/cmd/ailang/pkg_commands.go
+++ b/cmd/ailang/pkg_commands.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/sunholo-data/ailang/internal/messaging"
@@ -149,23 +150,14 @@ func addGitDep(cwd string, manifest *pkg.PackageManifest, gitURL, tag, rev, subd
 }
 
 func appendGitDependencyToFile(dir, name string, parts []string, gitURL, tag, rev string) error {
-	path := dir + "/" + pkg.ManifestFile
+	path := filepath.Join(dir, pkg.ManifestFile)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
 
-	content := string(data)
-	depLine := fmt.Sprintf("\"%s\" = { %s }\n", name, strings.Join(parts, ", "))
-
-	if strings.Contains(content, "[dependencies]") {
-		idx := strings.Index(content, "[dependencies]")
-		lineEnd := strings.Index(content[idx:], "\n")
-		insertAt := idx + lineEnd + 1
-		content = content[:insertAt] + depLine + content[insertAt:]
-	} else {
-		content += "\n[dependencies]\n" + depLine
-	}
+	depLine := fmt.Sprintf("\"%s\" = { %s }", name, strings.Join(parts, ", "))
+	content, previous, replaced := upsertDependencyLine(string(data), name, depLine)
 
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		return err
@@ -177,13 +169,17 @@ func appendGitDependencyToFile(dir, name string, parts []string, gitURL, tag, re
 	} else {
 		label += "@" + rev[:12]
 	}
-	fmt.Printf("%s Added %s (git: %s)\n", green("✓"), name, label)
+	if replaced && previous != depLine {
+		fmt.Printf("%s Updated %s (%s -> git: %s)\n", green("✓"), name, previous, label)
+	} else {
+		fmt.Printf("%s Added %s (git: %s)\n", green("✓"), name, label)
+	}
 	return nil
 }
 
-// appendDependencyToFile appends a dependency line to ailang.toml.
+// appendDependencyToFile inserts or replaces a dependency line in ailang.toml.
 func appendDependencyToFile(dir, name, value string, isPath bool) error {
-	path := dir + "/" + pkg.ManifestFile
+	path := filepath.Join(dir, pkg.ManifestFile)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
@@ -193,22 +189,12 @@ func appendDependencyToFile(dir, name, value string, isPath bool) error {
 
 	var depLine string
 	if isPath {
-		depLine = fmt.Sprintf("\"%s\" = { path = %q }\n", name, value)
+		depLine = fmt.Sprintf("\"%s\" = { path = %q }", name, value)
 	} else {
-		depLine = fmt.Sprintf("\"%s\" = %q\n", name, value)
+		depLine = fmt.Sprintf("\"%s\" = %q", name, value)
 	}
 
-	// Find [dependencies] section and append
-	if strings.Contains(content, "[dependencies]") {
-		// Insert after [dependencies] line
-		idx := strings.Index(content, "[dependencies]")
-		lineEnd := strings.Index(content[idx:], "\n")
-		insertAt := idx + lineEnd + 1
-		content = content[:insertAt] + depLine + content[insertAt:]
-	} else {
-		// Add new [dependencies] section
-		content += "\n[dependencies]\n" + depLine
-	}
+	content, previous, replaced := upsertDependencyLine(content, name, depLine)
 
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		return err
@@ -218,8 +204,89 @@ func appendDependencyToFile(dir, name, value string, isPath bool) error {
 	if isPath {
 		label = fmt.Sprintf("path: %s", value)
 	}
-	fmt.Printf("%s Added %s (%s)\n", green("✓"), name, label)
+	if replaced && previous != depLine {
+		fmt.Printf("%s Updated %s (%s -> %s)\n", green("✓"), name, previous, label)
+	} else {
+		fmt.Printf("%s Added %s (%s)\n", green("✓"), name, label)
+	}
 	return nil
+}
+
+// upsertDependencyLine replaces an exact key inside [dependencies], preserving
+// its position, or inserts the line immediately after the section header.
+func upsertDependencyLine(content, name, depLine string) (updated, previous string, replaced bool) {
+	lines := strings.SplitAfter(content, "\n")
+	inDependencies := false
+	sectionHeader := -1
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") {
+			if inDependencies {
+				break
+			}
+			inDependencies = trimmed == "[dependencies]"
+			if inDependencies {
+				sectionHeader = i
+			}
+			continue
+		}
+		if inDependencies && dependencyLineKey(line) == name {
+			previous = strings.TrimSpace(strings.TrimSuffix(line, "\n"))
+			ending := "\n"
+			if !strings.HasSuffix(line, "\n") {
+				ending = ""
+			}
+			lines[i] = depLine + ending
+			return strings.Join(lines, ""), previous, true
+		}
+	}
+
+	if sectionHeader >= 0 {
+		insertAt := sectionHeader + 1
+		line := depLine + "\n"
+		lines = append(lines, "")
+		copy(lines[insertAt+1:], lines[insertAt:])
+		lines[insertAt] = line
+		return strings.Join(lines, ""), "", false
+	}
+
+	// A brand-new section is separated from the preceding one by a blank line,
+	// matching every manifest written before the upsert rewrite. Without the
+	// leading newline the header lands flush against the previous key — valid
+	// TOML, but a visible formatting regression in a file users read.
+	prefix := "\n"
+	if !strings.HasSuffix(content, "\n") {
+		prefix = "\n\n"
+	}
+	if content == "" {
+		prefix = ""
+	}
+	return content + prefix + "[dependencies]\n" + depLine + "\n", "", false
+}
+
+// dependencyLineKey extracts a quoted or bare TOML key only when the line is
+// a simple key/value entry. The exact returned token prevents prefix matches.
+func dependencyLineKey(line string) string {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+		return ""
+	}
+	if strings.HasPrefix(trimmed, `"`) {
+		end := strings.Index(trimmed[1:], `"`)
+		if end < 0 {
+			return ""
+		}
+		end++
+		if !strings.HasPrefix(strings.TrimSpace(trimmed[end+1:]), "=") {
+			return ""
+		}
+		return trimmed[1:end]
+	}
+	key, rest, ok := strings.Cut(trimmed, "=")
+	if !ok || strings.TrimSpace(rest) == "" {
+		return ""
+	}
+	return strings.TrimSpace(key)
 }
 
 func pkgLockCommand(args []string) error {

--- a/cmd/ailang/pkg_commands.go
+++ b/cmd/ailang/pkg_commands.go
@@ -159,7 +159,7 @@ func appendGitDependencyToFile(dir, name string, parts []string, gitURL, tag, re
 	depLine := fmt.Sprintf("\"%s\" = { %s }", name, strings.Join(parts, ", "))
 	content, previous, replaced := upsertDependencyLine(string(data), name, depLine)
 
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := writeManifestChecked(dir, path, data, content); err != nil {
 		return err
 	}
 
@@ -196,7 +196,7 @@ func appendDependencyToFile(dir, name, value string, isPath bool) error {
 
 	content, previous, replaced := upsertDependencyLine(content, name, depLine)
 
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := writeManifestChecked(dir, path, data, content); err != nil {
 		return err
 	}
 
@@ -214,13 +214,37 @@ func appendDependencyToFile(dir, name, value string, isPath bool) error {
 
 // upsertDependencyLine replaces an exact key inside [dependencies], preserving
 // its position, or inserts the line immediately after the section header.
+//
+// This is a line scanner over TOML text, so what it CANNOT see is the thing that
+// breaks it. Four shapes were found by mutation/adversarial review and are
+// handled explicitly below: a header carrying a trailing comment, a header that
+// is the file's last line with no newline after it, lines inside a multi-line
+// string that look like headers or keys, and single-quoted (literal) keys.
+// Anything still missed is bounded by writeManifestChecked, which refuses to
+// leave a manifest less parseable than it found it.
 func upsertDependencyLine(content, name, depLine string) (updated, previous string, replaced bool) {
 	lines := strings.SplitAfter(content, "\n")
 	inDependencies := false
 	sectionHeader := -1
+	// Open multi-line string delimiter (`"""` or `'''`), empty when outside one.
+	// A line inside such a string is TOML data, not structure — treating it as a
+	// header ends the scan early and silently re-inserts a key that was there.
+	openString := ""
 	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "[") {
+		body := stripLineComment(line)
+		trimmed := strings.TrimSpace(body)
+		if openString != "" {
+			if strings.Contains(line, openString) {
+				openString = ""
+			}
+			continue
+		}
+		if d := openMultilineString(line); d != "" {
+			openString = d
+			// The opening line may still carry the key it belongs to; fall through
+			// so a `key = """` line is matched as a key before we start skipping.
+		}
+		if openString == "" && strings.HasPrefix(trimmed, "[") {
 			if inDependencies {
 				break
 			}
@@ -230,18 +254,24 @@ func upsertDependencyLine(content, name, depLine string) (updated, previous stri
 			}
 			continue
 		}
-		if inDependencies && dependencyLineKey(line) == name {
-			previous = strings.TrimSpace(strings.TrimSuffix(line, "\n"))
-			ending := "\n"
-			if !strings.HasSuffix(line, "\n") {
-				ending = ""
-			}
+		if inDependencies && openString == "" && dependencyLineKey(body) == name {
+			previous = strings.TrimSpace(strings.TrimRight(line, "\r\n"))
+			// Preserve the original line ending: a CRLF manifest must not gain a
+			// lone LF in the middle of it.
+			ending := line[len(strings.TrimRight(line, "\r\n")):]
 			lines[i] = depLine + ending
 			return strings.Join(lines, ""), previous, true
 		}
 	}
 
 	if sectionHeader >= 0 {
+		header := lines[sectionHeader]
+		// A header that is the file's last line has no newline of its own, so an
+		// insert glues the key onto it: `[dependencies]"name" = "1.0"`, which no
+		// longer parses. Give it one.
+		if !strings.HasSuffix(header, "\n") {
+			lines[sectionHeader] = header + "\n"
+		}
 		insertAt := sectionHeader + 1
 		line := depLine + "\n"
 		lines = append(lines, "")
@@ -264,15 +294,22 @@ func upsertDependencyLine(content, name, depLine string) (updated, previous stri
 	return content + prefix + "[dependencies]\n" + depLine + "\n", "", false
 }
 
-// dependencyLineKey extracts a quoted or bare TOML key only when the line is
-// a simple key/value entry. The exact returned token prevents prefix matches.
+// dependencyLineKey extracts a quoted, literal-quoted or bare TOML key, only
+// when the line is a simple key/value entry. The exact returned token prevents
+// prefix matches ("a/b" must never match "a/b_extra").
 func dependencyLineKey(line string) string {
 	trimmed := strings.TrimSpace(line)
 	if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 		return ""
 	}
-	if strings.HasPrefix(trimmed, `"`) {
-		end := strings.Index(trimmed[1:], `"`)
+	// TOML admits both basic ("k") and literal ('k') quoted keys. Handling only
+	// the basic form silently fails to find a literal-quoted dependency, and the
+	// insert that follows duplicates it.
+	for _, q := range []byte{'"', '\''} {
+		if trimmed[0] != q {
+			continue
+		}
+		end := strings.IndexByte(trimmed[1:], q)
 		if end < 0 {
 			return ""
 		}
@@ -287,6 +324,65 @@ func dependencyLineKey(line string) string {
 		return ""
 	}
 	return strings.TrimSpace(key)
+}
+
+// stripLineComment removes a trailing `#` comment that lies outside any quoted
+// string. A section header may legally carry one — `[dependencies] # deps` — and
+// an exact-string comparison against the raw line does not recognise it as the
+// dependencies table at all, so the writer appends a SECOND [dependencies]
+// table and the manifest stops parsing.
+func stripLineComment(line string) string {
+	var quote byte
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+		switch {
+		case quote != 0:
+			if c == quote {
+				quote = 0
+			}
+		case c == '"' || c == '\'':
+			quote = c
+		case c == '#':
+			return line[:i]
+		}
+	}
+	return line
+}
+
+// openMultilineString reports the delimiter of a multi-line string this line
+// opens and does not close, or "" when the line leaves no string open.
+func openMultilineString(line string) string {
+	for _, d := range []string{`"""`, `'''`} {
+		if n := strings.Count(line, d); n%2 == 1 {
+			return d
+		}
+	}
+	return ""
+}
+
+// writeManifestChecked writes the rewritten manifest, then refuses to leave the
+// file less parseable than it found it. The upsert above is a line scanner over
+// TOML, so its blind spots are open-ended by construction; this bounds them.
+// A manifest that was ALREADY broken is not held against the write — only a
+// manifest this call broke is rolled back.
+func writeManifestChecked(dir, path string, original []byte, updated string) error {
+	parsedBefore := true
+	if _, err := pkg.LoadManifest(dir); err != nil {
+		parsedBefore = false
+	}
+	if err := os.WriteFile(path, []byte(updated), 0644); err != nil {
+		return err
+	}
+	if !parsedBefore {
+		return nil
+	}
+	if _, err := pkg.LoadManifest(dir); err != nil {
+		if restoreErr := os.WriteFile(path, original, 0644); restoreErr != nil {
+			return fmt.Errorf("%s became unparseable and could not be restored: %w (restore failed: %v)", path, err, restoreErr)
+		}
+		return fmt.Errorf("refusing to write %s: the edit would make it unparseable (%w); the file is unchanged — please add the dependency by hand", path, err)
+	}
+	return nil
 }
 
 func pkgLockCommand(args []string) error {

--- a/cmd/ailang/pkg_commands_test.go
+++ b/cmd/ailang/pkg_commands_test.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/pkg"
+)
+
+const testPackageManifest = `[package]
+name = "sunholo/upsert_test"
+version = "0.1.0"
+edition = "1"
+
+[dependencies]
+`
+
+func writeTestManifest(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, pkg.ManifestFile), []byte(content), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+}
+
+func readTestManifest(t *testing.T, dir string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, pkg.ManifestFile))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	return string(data)
+}
+
+func countDependencyKey(content, name string) int {
+	count := 0
+	inDependencies := false
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") {
+			inDependencies = trimmed == "[dependencies]"
+			continue
+		}
+		key := strings.TrimSpace(strings.SplitN(trimmed, "=", 2)[0])
+		key = strings.Trim(key, `"`)
+		if inDependencies && key == name {
+			count++
+		}
+	}
+	return count
+}
+
+func TestAppendDependencyToFile_IdempotentUpsert(t *testing.T) {
+	dir := t.TempDir()
+	writeTestManifest(t, dir, testPackageManifest)
+
+	if err := appendDependencyToFile(dir, "sunholo/gemini_files", "0.2.0", false); err != nil {
+		t.Fatalf("first append: %v", err)
+	}
+	if err := appendDependencyToFile(dir, "sunholo/gemini_files", "0.2.0", false); err != nil {
+		t.Fatalf("second append: %v", err)
+	}
+
+	content := readTestManifest(t, dir)
+	if got := countDependencyKey(content, "sunholo/gemini_files"); got != 1 {
+		t.Fatalf("dependency key count = %d, want exactly 1\n%s", got, content)
+	}
+	manifest, err := pkg.LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("updated manifest must parse: %v", err)
+	}
+	if got := manifest.Dependencies["sunholo/gemini_files"].Version; got != "0.2.0" {
+		t.Fatalf("dependency version = %q, want second value %q", got, "0.2.0")
+	}
+}
+
+func TestAppendDependencyToFile_UpgradePreservesPosition(t *testing.T) {
+	dir := t.TempDir()
+	writeTestManifest(t, dir, testPackageManifest+"\"sunholo/first\" = \"1.0.0\"\n   sunholo/gemini_files = \"0.1.0\"\n\"sunholo/last\" = \"1.0.0\"\n")
+
+	if err := appendDependencyToFile(dir, "sunholo/gemini_files", "0.2.0", false); err != nil {
+		t.Fatalf("upgrade: %v", err)
+	}
+
+	content := readTestManifest(t, dir)
+	if got := countDependencyKey(content, "sunholo/gemini_files"); got != 1 {
+		t.Fatalf("dependency key count = %d, want exactly 1\n%s", got, content)
+	}
+	first := strings.Index(content, `"sunholo/first"`)
+	updated := strings.Index(content, `"sunholo/gemini_files" = "0.2.0"`)
+	last := strings.Index(content, `"sunholo/last"`)
+	if !(first < updated && updated < last) {
+		t.Fatalf("upgraded dependency did not preserve position\n%s", content)
+	}
+}
+
+func TestAppendGitDependencyToFile_IdempotentUpsert(t *testing.T) {
+	dir := t.TempDir()
+	writeTestManifest(t, dir, testPackageManifest)
+	name := "sunholo/git_dep"
+
+	if err := appendGitDependencyToFile(dir, name, []string{`git = "https://example.test/repo"`, `tag = "v0.1.0"`}, "https://example.test/repo", "v0.1.0", ""); err != nil {
+		t.Fatalf("first git append: %v", err)
+	}
+	if err := appendGitDependencyToFile(dir, name, []string{`git = "https://example.test/repo"`, `tag = "v0.2.0"`}, "https://example.test/repo", "v0.2.0", ""); err != nil {
+		t.Fatalf("second git append: %v", err)
+	}
+
+	content := readTestManifest(t, dir)
+	if got := countDependencyKey(content, name); got != 1 {
+		t.Fatalf("git dependency key count = %d, want exactly 1\n%s", got, content)
+	}
+	manifest, err := pkg.LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("updated git manifest must parse: %v", err)
+	}
+	if got := manifest.Dependencies[name].Tag; got != "v0.2.0" {
+		t.Fatalf("git dependency tag = %q, want %q", got, "v0.2.0")
+	}
+}
+
+func TestAppendDependencyToFile_DoesNotMatchPrefix(t *testing.T) {
+	dir := t.TempDir()
+	writeTestManifest(t, dir, testPackageManifest+"\"sunholo/gemini_files_extra\" = \"9.9.9\"\n")
+
+	if err := appendDependencyToFile(dir, "sunholo/gemini_files", "0.2.0", false); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	manifest, err := pkg.LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("manifest must parse: %v", err)
+	}
+	if got := manifest.Dependencies["sunholo/gemini_files_extra"].Version; got != "9.9.9" {
+		t.Fatalf("prefix dependency changed to %q", got)
+	}
+	if got := manifest.Dependencies["sunholo/gemini_files"].Version; got != "0.2.0" {
+		t.Fatalf("new dependency = %q, want %q", got, "0.2.0")
+	}
+}
+
+func TestAppendDependencyToFile_OtherTableUntouched(t *testing.T) {
+	dir := t.TempDir()
+	writeTestManifest(t, dir, testPackageManifest+"\n[metadata]\n\"sunholo/gemini_files\" = \"metadata-value\"\n")
+
+	if err := appendDependencyToFile(dir, "sunholo/gemini_files", "0.2.0", false); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	content := readTestManifest(t, dir)
+	if !strings.Contains(content, `[metadata]
+"sunholo/gemini_files" = "metadata-value"`) {
+		t.Fatalf("same-named key in metadata table was modified\n%s", content)
+	}
+	manifest, err := pkg.LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("manifest must parse: %v", err)
+	}
+	if got := manifest.Dependencies["sunholo/gemini_files"].Version; got != "0.2.0" {
+		t.Fatalf("dependency = %q, want %q", got, "0.2.0")
+	}
+}
+
+// TestAppendDependencyToFile_NewSectionKeepsBlankLineSeparator pins the formatting
+// of a freshly-created [dependencies] section. Before the upsert rewrite every
+// generated manifest carried a blank line ahead of the new header; the first
+// rewrite dropped it, producing a header flush against the previous key. That is
+// valid TOML, so no parse-based assertion can see it — this arm reads the two
+// lines around the header directly.
+//
+// Killing mutation: in upsertDependencyLine's final return, set prefix to "" when
+// content already ends in a newline.
+func TestAppendDependencyToFile_NewSectionKeepsBlankLineSeparator(t *testing.T) {
+	dir := t.TempDir()
+	const noDepsManifest = `[package]
+name = "sunholo/upsert_test"
+version = "0.1.0"
+edition = "1"
+
+[stability]
+level = "experimental"
+`
+	writeTestManifest(t, dir, noDepsManifest)
+
+	if err := appendDependencyToFile(dir, "sunholo/gemini_files", "0.2.1", false); err != nil {
+		t.Fatalf("appendDependencyToFile: %v", err)
+	}
+
+	content := readTestManifest(t, dir)
+	lines := strings.Split(content, "\n")
+
+	header := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "[dependencies]" {
+			header = i
+			break
+		}
+	}
+	if header < 0 {
+		t.Fatalf("instrument failure: no [dependencies] header in:\n%s", content)
+	}
+	// Known-positive control: the pre-existing [stability] header keeps its own
+	// blank-line separator, so a failure below is about the new section, not
+	// about the fixture.
+	stability := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "[stability]" {
+			stability = i
+			break
+		}
+	}
+	if stability < 1 || strings.TrimSpace(lines[stability-1]) != "" {
+		t.Fatalf("instrument failure: fixture's [stability] header is not blank-line separated")
+	}
+
+	if header < 1 || strings.TrimSpace(lines[header-1]) != "" {
+		t.Errorf("new [dependencies] header is not preceded by a blank line; got:\n%s", content)
+	}
+	if got := countDependencyKey(content, "sunholo/gemini_files"); got != 1 {
+		t.Errorf("dependency key count = %d, want 1", got)
+	}
+	if _, err := pkg.LoadManifest(dir); err != nil {
+		t.Errorf("manifest does not parse after upsert: %v", err)
+	}
+}
+
+// TestAppendDependencyToFile_EarlierTableUntouched covers the direction
+// TestAppendDependencyToFile_OtherTableUntouched cannot reach. That arm places the
+// rival table AFTER [dependencies], where the scan's break-on-next-section already
+// stops it — so it passes even when the in-section guard is removed (measured: the
+// `inDependencies &&` mutant survives it). Every real ailang.toml puts [package],
+// [exports], [effects] and [stability] BEFORE [dependencies], so the untested
+// direction is the common one.
+//
+// Killing mutation: drop the `inDependencies &&` conjunct from the match in
+// upsertDependencyLine.
+func TestAppendDependencyToFile_EarlierTableUntouched(t *testing.T) {
+	dir := t.TempDir()
+	const earlierTableManifest = `[package]
+name = "sunholo/upsert_test"
+version = "0.1.0"
+edition = "1"
+
+[metadata]
+"sunholo/gemini_files" = "metadata-value"
+
+[dependencies]
+`
+	writeTestManifest(t, dir, earlierTableManifest)
+
+	if err := appendDependencyToFile(dir, "sunholo/gemini_files", "0.2.0", false); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	content := readTestManifest(t, dir)
+	if !strings.Contains(content, "[metadata]\n\"sunholo/gemini_files\" = \"metadata-value\"") {
+		t.Errorf("same-named key in an EARLIER table was modified\n%s", content)
+	}
+	if got := countDependencyKey(content, "sunholo/gemini_files"); got != 1 {
+		t.Errorf("dependency key count = %d, want 1\n%s", got, content)
+	}
+	manifest, err := pkg.LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("manifest must parse: %v", err)
+	}
+	if got := manifest.Dependencies["sunholo/gemini_files"].Version; got != "0.2.0" {
+		t.Errorf("dependency = %q, want %q", got, "0.2.0")
+	}
+}

--- a/cmd/ailang/pkg_commands_test.go
+++ b/cmd/ailang/pkg_commands_test.go
@@ -33,17 +33,31 @@ func readTestManifest(t *testing.T, dir string) string {
 	return string(data)
 }
 
+// countDependencyKey counts keys named `name` inside [dependencies].
+//
+// It deliberately does NOT call the production stripLineComment/dependencyLineKey:
+// an instrument that shares the code under test's blind spots cannot detect them.
+// It grew its own comment handling because the first version compared the raw
+// line against "[dependencies]" and so reported 0 for the perfectly-correct
+// output of a manifest whose header carried a trailing comment — the instrument
+// failing in exactly the shape the arm was added to catch.
+//
+// It is not multi-line-string aware; arms that need that assert through
+// pkg.LoadManifest instead.
 func countDependencyKey(content, name string) int {
 	count := 0
 	inDependencies := false
 	for _, line := range strings.Split(content, "\n") {
+		if i := strings.IndexByte(line, '#'); i >= 0 && strings.Count(line[:i], `"`)%2 == 0 {
+			line = line[:i]
+		}
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, "[") {
 			inDependencies = trimmed == "[dependencies]"
 			continue
 		}
 		key := strings.TrimSpace(strings.SplitN(trimmed, "=", 2)[0])
-		key = strings.Trim(key, `"`)
+		key = strings.Trim(key, `"'`)
 		if inDependencies && key == name {
 			count++
 		}
@@ -266,5 +280,169 @@ edition = "1"
 	}
 	if got := manifest.Dependencies["sunholo/gemini_files"].Version; got != "0.2.0" {
 		t.Errorf("dependency = %q, want %q", got, "0.2.0")
+	}
+}
+
+// The four arms below each pin a shape the first line-scanner could not see.
+// All four were found by the iteration-202 evaluator, reproduced first-party
+// against the real binary, and are TOML-legal — none needs adversarial intent.
+
+// B1: `[dependencies]` as the file's last line with no newline after it. The
+// insert glued the key onto the header (`[dependencies]"x" = "1"`), which does
+// not parse.
+// Killing mutation: drop the `if !strings.HasSuffix(header, "\n")` repair.
+func TestAppendDependencyToFile_HeaderIsLastLineWithoutNewline(t *testing.T) {
+	dir := t.TempDir()
+	writeTestManifest(t, dir, "[package]\nname = \"sunholo/upsert_test\"\nversion = \"0.1.0\"\nedition = \"1\"\n\n[dependencies]")
+
+	if err := appendDependencyToFile(dir, "sunholo/newdep", "0.5.0", false); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	content := readTestManifest(t, dir)
+	if strings.Contains(content, `[dependencies]"`) {
+		t.Errorf("key glued onto the section header:\n%s", content)
+	}
+	if _, err := pkg.LoadManifest(dir); err != nil {
+		t.Errorf("manifest does not parse after upsert: %v\n%s", err, content)
+	}
+}
+
+// B2: a header carrying a trailing comment. The exact-string compare did not
+// recognise it, so a SECOND [dependencies] table was appended — reproducing
+// #718's own failure ("Key 'dependencies' has already been defined"). This is a
+// regression the upsert rewrite introduced: the pre-rewrite substring match
+// handled it.
+// Killing mutation: compare against the raw line instead of stripLineComment's
+// output in upsertDependencyLine.
+func TestAppendDependencyToFile_HeaderWithTrailingComment(t *testing.T) {
+	dir := t.TempDir()
+	writeTestManifest(t, dir, "[package]\nname = \"sunholo/upsert_test\"\nversion = \"0.1.0\"\nedition = \"1\"\n\n[dependencies] # deps go here\n\"sunholo/existing\" = \"1.0.0\"\n")
+
+	if err := appendDependencyToFile(dir, "sunholo/existing", "2.0.0", false); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	content := readTestManifest(t, dir)
+	if got := strings.Count(content, "[dependencies]"); got != 1 {
+		t.Errorf("[dependencies] table count = %d, want 1\n%s", got, content)
+	}
+	if got := countDependencyKey(content, "sunholo/existing"); got != 1 {
+		t.Errorf("key count = %d, want 1\n%s", got, content)
+	}
+	manifest, err := pkg.LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("manifest does not parse: %v\n%s", err, content)
+	}
+	if got := manifest.Dependencies["sunholo/existing"].Version; got != "2.0.0" {
+		t.Errorf("version = %q, want 2.0.0", got)
+	}
+}
+
+// B3: a multi-line string whose content contains a line that looks like a
+// section header. The scanner broke out of [dependencies] at that line and
+// never saw the real key below it, then inserted a duplicate and printed
+// "Added" over a corrupted file.
+// Killing mutation: remove the openString tracking in upsertDependencyLine.
+func TestAppendDependencyToFile_MultilineStringIsNotStructure(t *testing.T) {
+	dir := t.TempDir()
+	writeTestManifest(t, dir, "[package]\nname = \"sunholo/upsert_test\"\nversion = \"0.1.0\"\nedition = \"1\"\n\n[dependencies]\nnotes = \"\"\"\n[dependencies.fake]\njust prose inside a string\n\"\"\"\n\"sunholo/existing\" = \"1.0.0\"\n")
+
+	if err := appendDependencyToFile(dir, "sunholo/existing", "2.0.0", false); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	content := readTestManifest(t, dir)
+	// countDependencyKey shares the scanner's old blind spot — it also treats the
+	// string's `[dependencies.fake]` line as a section header — so this arm counts
+	// the raw key occurrence and defers table membership to the real parser.
+	if got := strings.Count(content, `"sunholo/existing" =`); got != 1 {
+		t.Errorf("key occurrence count = %d, want 1\n%s", got, content)
+	}
+	if !strings.Contains(content, "[dependencies.fake]") {
+		t.Errorf("multi-line string content was rewritten\n%s", content)
+	}
+	manifest, err := pkg.LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("manifest does not parse after upsert: %v\n%s", err, content)
+	}
+	if got := manifest.Dependencies["sunholo/existing"].Version; got != "2.0.0" {
+		t.Errorf("version = %q, want 2.0.0\n%s", got, content)
+	}
+}
+
+// B4: a literal-quoted (single-quote) key. dependencyLineKey handled only the
+// basic form, so the existing entry was never found and a duplicate followed.
+// Killing mutation: drop '\” from dependencyLineKey's quote loop.
+func TestAppendDependencyToFile_LiteralQuotedKey(t *testing.T) {
+	dir := t.TempDir()
+	writeTestManifest(t, dir, "[package]\nname = \"sunholo/upsert_test\"\nversion = \"0.1.0\"\nedition = \"1\"\n\n[dependencies]\n'sunholo/existing' = \"1.0.0\"\n")
+
+	// Control: the fixture is valid TOML before we touch it, so a later parse
+	// failure is about the upsert and not about the fixture.
+	if _, err := pkg.LoadManifest(dir); err != nil {
+		t.Fatalf("instrument failure: fixture does not parse: %v", err)
+	}
+
+	if err := appendDependencyToFile(dir, "sunholo/existing", "2.0.0", false); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	content := readTestManifest(t, dir)
+	manifest, err := pkg.LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("manifest does not parse after upsert: %v\n%s", err, content)
+	}
+	if got := manifest.Dependencies["sunholo/existing"].Version; got != "2.0.0" {
+		t.Errorf("version = %q, want 2.0.0\n%s", got, content)
+	}
+}
+
+// A CRLF manifest must not gain a lone LF mid-file.
+// Killing mutation: hardcode ending to "\n" in the replacement branch.
+func TestAppendDependencyToFile_PreservesCRLF(t *testing.T) {
+	dir := t.TempDir()
+	writeTestManifest(t, dir, "[package]\r\nname = \"sunholo/upsert_test\"\r\nversion = \"0.1.0\"\r\nedition = \"1\"\r\n\r\n[dependencies]\r\n\"sunholo/existing\" = \"1.0.0\"\r\n")
+
+	if err := appendDependencyToFile(dir, "sunholo/existing", "2.0.0", false); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	content := readTestManifest(t, dir)
+	if strings.Count(content, "\n") != strings.Count(content, "\r\n") {
+		t.Errorf("mixed line endings after upsert: %d LF vs %d CRLF\n%q",
+			strings.Count(content, "\n"), strings.Count(content, "\r\n"), content)
+	}
+}
+
+// writeManifestChecked is the structural bound on every blind spot the scanner
+// still has: a write that would make a previously-parseable manifest
+// unparseable is rolled back and reported, never left on disk.
+// Killing mutation: drop the post-write LoadManifest re-check.
+func TestWriteManifestChecked_RollsBackACorruptingWrite(t *testing.T) {
+	dir := t.TempDir()
+	const good = "[package]\nname = \"sunholo/upsert_test\"\nversion = \"0.1.0\"\nedition = \"1\"\n"
+	writeTestManifest(t, dir, good)
+	path := filepath.Join(dir, pkg.ManifestFile)
+
+	// Control: the guard passes a write that keeps the file parseable.
+	okContent := good + "\n[dependencies]\n\"sunholo/existing\" = \"1.0.0\"\n"
+	if err := writeManifestChecked(dir, path, []byte(good), okContent); err != nil {
+		t.Fatalf("instrument failure: a valid write was rejected: %v", err)
+	}
+	if readTestManifest(t, dir) != okContent {
+		t.Fatalf("instrument failure: a valid write did not land")
+	}
+
+	before := readTestManifest(t, dir)
+	err := writeManifestChecked(dir, path, []byte(before), "[package]\nname = = = broken\n")
+	if err == nil {
+		t.Fatal("corrupting write was accepted")
+	}
+	if !strings.Contains(err.Error(), "unparseable") {
+		t.Errorf("error does not say what happened: %v", err)
+	}
+	if got := readTestManifest(t, dir); got != before {
+		t.Errorf("file was not restored\nwant:\n%s\ngot:\n%s", before, got)
 	}
 }

--- a/internal/pipeline/package_resolver.go
+++ b/internal/pipeline/package_resolver.go
@@ -1,8 +1,10 @@
 package pipeline
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/sunholo-data/ailang/internal/ast"
@@ -25,21 +27,25 @@ var currentModulePrefixMap map[string]string
 var currentRootPkgName string
 
 // tryLoadPackageResolver attempts to set up a package resolver from
-// ailang.toml + ailang.lock in the given directory. Returns nil if
-// no package manifest exists (backward compatible — bare projects work unchanged).
-func tryLoadPackageResolver(dir string) loader.PackageResolver {
+// ailang.toml + ailang.lock in the given directory. Returns (nil, nil) if no
+// package manifest exists (backward compatible — bare projects work unchanged).
+func tryLoadPackageResolver(dir string) (loader.PackageResolver, error) {
 	// Check if ailang.toml exists
 	manifestDir := pkg.FindManifest(dir)
 	if manifestDir == "" {
 		currentPackageManifest = nil
-		return nil // No package manifest — use legacy module resolution
+		currentModulePrefixMap = nil
+		currentRootPkgName = ""
+		return nil, nil // No package manifest — use legacy module resolution
 	}
 
 	// Load manifest for effect ceiling checks
 	manifest, err := pkg.LoadManifest(manifestDir)
 	if err != nil {
 		currentPackageManifest = nil
-		return nil
+		currentModulePrefixMap = nil
+		currentRootPkgName = ""
+		return nil, fmt.Errorf("cannot load package manifest %s: %w", filepath.Join(manifestDir, pkg.ManifestFile), err)
 	}
 	currentPackageManifest = manifest
 	currentRootPkgName = manifest.Package.Name
@@ -53,7 +59,10 @@ func tryLoadPackageResolver(dir string) loader.PackageResolver {
 	// Load lock file
 	lf, err := pkg.LoadLockFile(manifestDir)
 	if err != nil {
-		return nil // No lock file or invalid — skip package resolution
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil // Lock files are optional while authoring a package.
+		}
+		return nil, fmt.Errorf("cannot load package lock file %s: %w", filepath.Join(manifestDir, pkg.LockFileName), err)
 	}
 
 	// Validate content hashes — detect stale lock files
@@ -71,7 +80,7 @@ func tryLoadPackageResolver(dir string) loader.PackageResolver {
 		}
 	}
 
-	return pkgLoader
+	return pkgLoader, nil
 }
 
 // loadDepManifest loads a dependency's manifest via the package loader.

--- a/internal/pipeline/package_resolver_test.go
+++ b/internal/pipeline/package_resolver_test.go
@@ -52,3 +52,73 @@ func TestTryLoadPackageResolver_NoManifestUsesLegacyResolution(t *testing.T) {
 		t.Fatalf("legacy bare-project pipeline failed: %v", err)
 	}
 }
+
+// The lock-file load is the widest-blast-radius half of this change: it used to
+// degrade to nil for ANY error, and now only a MISSING lock does. Both directions
+// need an arm, because getting the split wrong breaks either every package
+// project without a lock (authoring) or every project with a corrupt one
+// (silently, which is the bug being fixed).
+
+const validPackageManifest = `[package]
+name = "sunholo/lockarms"
+version = "0.1.0"
+edition = "1"
+`
+
+// A missing ailang.lock stays OPTIONAL — a package being authored before its
+// first `ailang lock` must still compile.
+//
+// Killing mutation: drop the errors.Is(err, os.ErrNotExist) branch so any lock
+// error is fatal.
+func TestTryLoadPackageResolver_MissingLockIsOptional(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ailang.toml"), []byte(validPackageManifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	// Control: the manifest itself is loadable, so a failure below is about the
+	// absent lock and not about the fixture.
+	if _, err := os.Stat(filepath.Join(dir, "ailang.toml")); err != nil {
+		t.Fatalf("instrument failure: fixture manifest missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "ailang.lock")); !os.IsNotExist(err) {
+		t.Fatalf("instrument failure: fixture must have no lock file, got %v", err)
+	}
+
+	resolver, err := tryLoadPackageResolver(dir)
+	if err != nil {
+		t.Fatalf("a missing lock file must not be an error: %v", err)
+	}
+	if resolver != nil {
+		t.Errorf("resolver = %v, want nil so the self-only path takes over", resolver)
+	}
+}
+
+// An ailang.lock that EXISTS and is malformed is loud, naming its path and the
+// underlying parse error — the same Critical-Principle-2 correction the manifest
+// half makes. Asserting on the message text, not on err != nil: every failure
+// path in this function produces a non-nil error, so `err != nil` is satisfied
+// by the missing-lock case too and would pass for the wrong reason.
+//
+// Killing mutation: return (nil, nil) from the malformed-lock branch.
+func TestTryLoadPackageResolver_MalformedLockSurfacesParseError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ailang.toml"), []byte(validPackageManifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	lockPath := filepath.Join(dir, "ailang.lock")
+	if err := os.WriteFile(lockPath, []byte("{ this is not json"), 0o644); err != nil {
+		t.Fatalf("write lock: %v", err)
+	}
+
+	resolver, err := tryLoadPackageResolver(dir)
+	if err == nil {
+		t.Fatalf("malformed lock file was swallowed; resolver = %v", resolver)
+	}
+	message := err.Error()
+	if !strings.Contains(message, lockPath) {
+		t.Errorf("error does not name the lock path %q: %s", lockPath, message)
+	}
+	if !strings.Contains(message, "parse") {
+		t.Errorf("error does not carry the underlying parse detail: %s", message)
+	}
+}

--- a/internal/pipeline/package_resolver_test.go
+++ b/internal/pipeline/package_resolver_test.go
@@ -1,0 +1,54 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTryLoadPackageResolver_BrokenManifestSurfacesParseError(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "ailang.toml")
+	manifest := `[package]
+name = "sunholo/broken"
+version = "0.1.0"
+edition = "1"
+
+[dependencies]
+"sunholo/duplicate" = "0.1.0"
+"sunholo/duplicate" = "0.2.0"
+`
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	_, err := tryLoadPackageResolver(dir)
+	if err == nil {
+		t.Fatal("broken manifest unexpectedly loaded")
+	}
+	message := err.Error()
+	if !strings.Contains(message, manifestPath) {
+		t.Fatalf("error does not name manifest path %q: %s", manifestPath, message)
+	}
+	if !strings.Contains(message, "already been defined") || !strings.Contains(message, "sunholo/duplicate") {
+		t.Fatalf("error does not carry duplicate-key TOML detail: %s", message)
+	}
+}
+
+func TestTryLoadPackageResolver_NoManifestUsesLegacyResolution(t *testing.T) {
+	dir := t.TempDir()
+	resolver, err := tryLoadPackageResolver(dir)
+	if err != nil || resolver != nil {
+		t.Fatalf("no manifest: resolver = %T, error = %v; want nil, nil", resolver, err)
+	}
+
+	sourcePath := filepath.Join(dir, "main.ail")
+	source := "module main\n\npure func answer() -> int = 42\n"
+	if err := os.WriteFile(sourcePath, []byte(source), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if _, err := Run(Config{Mode: ModeCheck, PackageDir: dir}, Source{Filename: sourcePath}); err != nil {
+		t.Fatalf("legacy bare-project pipeline failed: %v", err)
+	}
+}

--- a/internal/pipeline/pipeline_module.go
+++ b/internal/pipeline/pipeline_module.go
@@ -100,7 +100,15 @@ func runModuleWithContext(ctx context.Context, cfg Config, src Source) (Result, 
 	// cfg.PackageDir overrides "." so callers (e.g. the named-test harness)
 	// can resolve package manifests relative to the source file rather than CWD.
 	pkgSearchDir := loaderBaseDir
-	pkgResolver := tryLoadPackageResolver(pkgSearchDir)
+	pkgResolver, err := tryLoadPackageResolver(pkgSearchDir)
+	if err != nil {
+		loadErr := fmt.Errorf("package resolution setup failed: %w", err)
+		loadSpan.RecordError(loadErr)
+		loadSpan.SetStatus(codes.Error, "package resolution setup failed")
+		loadSpan.End()
+		pipelineSpan.RecordError(loadErr)
+		return result, loadErr
+	}
 	if pkgResolver == nil {
 		pkgResolver = tryLoadSelfOnlyPackageResolver(pkgSearchDir)
 	}


### PR DESCRIPTION
Fixes #718.

Two halves, both reproduced first-party at `6f3e6bce7` before any code was written, each with a firing control.

## Half 1 — `ailang install` wrote a duplicate TOML key

`appendDependencyToFile` / `appendGitDependencyToFile` found `[dependencies]` with a bare `strings.Index` and inserted unconditionally. A second `ailang install <pkg>@<ver>` in a project that already declared the dependency produced two identical keys and an unparseable manifest.

    ailang install sunholo/gemini_files@0.2.1   # rc=0 "✓ Added"
    ailang install sunholo/gemini_files@0.2.1   # rc=0 "✓ Added"   <-- again
    ailang lock -> rc=1  Key 'dependencies."sunholo/gemini_files"' has already been defined
    CONTROL, one install: ailang lock rc=0, "✓ Generated ailang.lock (3 packages)"

Both helpers now share one `upsertDependencyLine`. The guard is in the **helpers**, not the call sites: of the five sites, `addPathDep`/`addVersionDep`/`addGitDep` pre-check and error, while `install` (`pkg_install.go:130`) and `init --deps` (`pkg_init.go:88`) did not — the guard-the-helper-miss-the-call-site shape. `add` keeps its explicit "already exists" error; `install` prints `Updated` on a version change.

**End-to-end acceptance, through the real registry path** (the arm the executor could not write offline, run by the controller):

    install 0.2.0 -> "✓ Added"
    install 0.2.0 -> "✓ Added"        (idempotent)
    install 0.2.1 -> "✓ Updated sunholo/gemini_files ("…" = "0.2.0" -> 0.2.1)"
    key count = 1 · ailang lock rc=0

## Half 2 — the symptom blamed a missing `ailang.toml` (Critical Principle 2)

`tryLoadPackageResolver` discarded `LoadManifest`'s error and returned nil, indistinguishable from "no manifest". Package imports then died at `loader.go:148` telling the user to run `ailang init package` — for a manifest that exists. It now returns `(resolver, error)`: absent manifest → `(nil, nil)`, unchanged for bare projects and separately armed; existing-but-broken → loud, naming the path and the TOML error. The lock-file load had the same shape and is split the same way (missing = optional, malformed = loud).

    SUBJECT (duplicate-key manifest): ailang check rc=1, the misleading message
    CONTROL (healthy manifest):       ailang check rc=0, "✓ No errors found!"

## Verification

Gates, **all outside the sandbox, on darwin/arm64** — windows and ubuntu legs unrun locally: `go test ./cmd/ailang/... ./internal/pipeline/...` rc=0 · `go vet` rc=0 · `make fmt-check` / `vet` / `check-file-sizes` / `check-boundaries` / `check-changelog` / `check-skills` all rc=0. Note `go build ./...` is rc=1 on pristine `dev` (`cmd/wasm`) and was not used as a gate.

Mutation drill, one per branch, each asserted LANDED (sha256) and BUILDS before the result was read:

| arm | mutant | result |
|---|---|---|
| upsert | unconditional insert | red |
| upgrade preserves position | unconditional insert | red |
| git helper | shared-replacement disabled | red |
| prefix non-match | exact key → `strings.Contains` | red |
| **section bounds** | drop `inDependencies &&` | **SURVIVED — see below** |
| broken manifest surfaces error | restore `return nil, nil` | red |
| no manifest → legacy | return an error | red |
| new-section formatting | drop the blank-line prefix | red |

**The finding worth carrying forward.** `TestAppendDependencyToFile_OtherTableUntouched` claims to pin "a same-named key in another table is untouched" and does not: its fixture puts `[metadata]` **after** `[dependencies]`, where the scan's break-on-next-section stops the mutant regardless of the guard. Every real `ailang.toml` puts `[package]`/`[exports]`/`[effects]`/`[stability]` **before** `[dependencies]`, so the untested direction was the common one. Added `TestAppendDependencyToFile_EarlierTableUntouched`; under the mutant it reds (the earlier table's key is rewritten to the new version and **no dependency is declared at all**), and the whole package with that one arm `-skip`ped is rc=0 — so it is the sole killer and the exposure had been entirely undetected.

Also fixed: the first rewrite dropped the blank line before a brand-new `[dependencies]` header (valid TOML, so no parse assertion can see it — measured fixed-vs-base on the same fresh project), now pinned by its own arm with a known-positive control.

## Routing

Executor codex `gpt-5.6-sol`; controller opus re-ran every gate outside the sandbox (the executor's full-package run was correctly labelled `UNINFORMATIVE UNDER SANDBOX` on a loopback-bind denial). One executor deviation, stated and correct: AC6's offline end-to-end `install` test is impossible without network, so none was faked — the controller ran it live instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
