### PR TITLE
fix(pkg): the ailang.toml rollback net never engaged for a parseable-but-invalid manifest, plus the #720 scanner gaps

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,47 @@
 
 ## [Unreleased]
 
+### Fixed — the `ailang.toml` rollback net gated on validity, so it never engaged for a parseable-but-invalid manifest
+
+`ailang install` writes its dependency line by scanning `ailang.toml` as text, and
+`writeManifestChecked` is the net that bounds that scanner's open-ended blind spots: it re-parses
+after every write and rolls back anything that would leave the manifest less parseable than it
+found it.
+
+Its "was this parseable before?" probe was `pkg.LoadManifest` — TOML parse **plus full semantic
+`Validate`**. So a manifest that is perfectly good TOML but fails validation (missing `edition`, a
+one-level `name`, missing `version`) counted as *already broken*, the post-write re-check was
+skipped, and the call returned nil. Measured on two fixtures differing by exactly one line
+(`edition = "1"`): without it, a duplicate dependency key was **written to disk** and the command
+printed `✓ Added`; with it, the write was refused and rolled back. A hand-written manifest missing
+`edition` is exactly the sort of project where someone runs `ailang install`, so `#720`'s framing —
+that none of the known scanner gaps ships corruption — did not hold for that whole class.
+
+Fixed by adding `pkg.ParseManifestFile` (read + `toml.Unmarshal`, no `Validate`) and pointing both
+probes at it. The net now engages for every manifest that **parses**.
+
+Three scanner gaps closed alongside, all reproduced first-party against controls that replaced
+cleanly:
+
+- `openMultilineString` counted `"""` occurrences, so `notes = 'contains """ triple double
+  quotes'` read as an open multi-line string and the scanner skipped the real `[dependencies]`
+  section, appending a second table. It now walks the line tracking single-line basic/literal
+  string state and only recognises a delimiter outside one.
+- A quoted table header `["dependencies"]` — semantically identical to `[dependencies]` — was
+  unrecognised. `tableHeaderName` now accepts bare, basic-quoted and literal-quoted single-segment
+  headers, and deliberately refuses `[[dependencies]]` and dotted headers.
+- `stripLineComment` had no escape awareness, so `"a\"#b" = "1.0"` truncated at the `#`.
+
+Appending to a manifest that did **not** parse beforehand no longer prints an unqualified
+`✓ Added`; it warns, names the file and the parse error, and leaves the exit status unchanged. The
+test helper `countDependencyKey` — which exists to be an independent control — had grown the same
+blind spots as the code under test and was repaired without calling the production helpers.
+
+Guarded by a twelve-shape corpus test that runs the real install path twice per shape and asserts
+the manifest still parses with exactly one dependency key and one `[dependencies]` table, with an
+anti-vacuity floor so the enumeration cannot silently shrink.
+
+
 ### Fixed — the SessionStart hook held its own stdout open, refusing 1 in 4 mission fires
 
 `scripts/hooks/session_start.sh` ended with `ailang docs embed-warmup --quiet --timeout 3m &`,

--- a/cmd/ailang/pkg_commands.go
+++ b/cmd/ailang/pkg_commands.go
@@ -363,11 +363,13 @@ func openMultilineString(line string) string {
 // writeManifestChecked writes the rewritten manifest, then refuses to leave the
 // file less parseable than it found it. The upsert above is a line scanner over
 // TOML, so its blind spots are open-ended by construction; this bounds them.
-// A manifest that was ALREADY broken is not held against the write — only a
-// manifest this call broke is rolled back.
+// A manifest that did not parse as TOML before the write is not held against
+// the write. The net engages for every parseable manifest, whether or not it
+// passes semantic validation.
 func writeManifestChecked(dir, path string, original []byte, updated string) error {
+	_ = dir
 	parsedBefore := true
-	if _, err := pkg.LoadManifest(dir); err != nil {
+	if err := pkg.ParseManifestFile(path); err != nil {
 		parsedBefore = false
 	}
 	if err := os.WriteFile(path, []byte(updated), 0644); err != nil {
@@ -376,7 +378,7 @@ func writeManifestChecked(dir, path string, original []byte, updated string) err
 	if !parsedBefore {
 		return nil
 	}
-	if _, err := pkg.LoadManifest(dir); err != nil {
+	if err := pkg.ParseManifestFile(path); err != nil {
 		if restoreErr := os.WriteFile(path, original, 0644); restoreErr != nil {
 			return fmt.Errorf("%s became unparseable and could not be restored: %w (restore failed: %v)", path, err, restoreErr)
 		}

--- a/cmd/ailang/pkg_commands.go
+++ b/cmd/ailang/pkg_commands.go
@@ -159,8 +159,13 @@ func appendGitDependencyToFile(dir, name string, parts []string, gitURL, tag, re
 	depLine := fmt.Sprintf("\"%s\" = { %s }", name, strings.Join(parts, ", "))
 	content, previous, replaced := upsertDependencyLine(string(data), name, depLine)
 
-	if err := writeManifestChecked(dir, path, data, content); err != nil {
+	parseErr, err := writeManifestChecked(path, data, content)
+	if err != nil {
 		return err
+	}
+	if parseErr != nil {
+		fmt.Printf("%s Wrote dependency %s to %s, but the manifest still does not parse: %v\n", yellow("⚠"), name, path, parseErr)
+		return nil
 	}
 
 	label := gitURL
@@ -196,8 +201,13 @@ func appendDependencyToFile(dir, name, value string, isPath bool) error {
 
 	content, previous, replaced := upsertDependencyLine(content, name, depLine)
 
-	if err := writeManifestChecked(dir, path, data, content); err != nil {
+	parseErr, err := writeManifestChecked(path, data, content)
+	if err != nil {
 		return err
+	}
+	if parseErr != nil {
+		fmt.Printf("%s Wrote dependency %s to %s, but the manifest still does not parse: %v\n", yellow("⚠"), name, path, parseErr)
+		return nil
 	}
 
 	label := value
@@ -362,6 +372,10 @@ func stripLineComment(line string) string {
 		c := line[i]
 		switch {
 		case quote != 0:
+			if quote == '"' && c == '\\' {
+				i++
+				continue
+			}
 			if c == quote {
 				quote = 0
 			}
@@ -422,27 +436,24 @@ func openMultilineString(line string) string {
 // file less parseable than it found it. The upsert above is a line scanner over
 // TOML, so its blind spots are open-ended by construction; this bounds them.
 // A manifest that did not parse as TOML before the write is not held against
-// the write. The net engages for every parseable manifest, whether or not it
-// passes semantic validation.
-func writeManifestChecked(dir, path string, original []byte, updated string) error {
-	_ = dir
-	parsedBefore := true
-	if err := pkg.ParseManifestFile(path); err != nil {
-		parsedBefore = false
-	}
+// the write. Its post-write parse error is returned separately so callers can
+// warn without changing command exit status. The net engages for every
+// parseable manifest, whether or not it passes semantic validation.
+func writeManifestChecked(path string, original []byte, updated string) (parseErr, writeErr error) {
+	beforeErr := pkg.ParseManifestFile(path)
 	if err := os.WriteFile(path, []byte(updated), 0644); err != nil {
-		return err
+		return nil, err
 	}
-	if !parsedBefore {
-		return nil
+	if beforeErr != nil {
+		return pkg.ParseManifestFile(path), nil
 	}
 	if err := pkg.ParseManifestFile(path); err != nil {
 		if restoreErr := os.WriteFile(path, original, 0644); restoreErr != nil {
-			return fmt.Errorf("%s became unparseable and could not be restored: %w (restore failed: %v)", path, err, restoreErr)
+			return nil, fmt.Errorf("%s became unparseable and could not be restored: %w (restore failed: %v)", path, err, restoreErr)
 		}
-		return fmt.Errorf("refusing to write %s: the edit would make it unparseable (%w); the file is unchanged — please add the dependency by hand", path, err)
+		return nil, fmt.Errorf("refusing to write %s: the edit would make it unparseable (%w); the file is unchanged — please add the dependency by hand", path, err)
 	}
-	return nil
+	return nil, nil
 }
 
 func pkgLockCommand(args []string) error {

--- a/cmd/ailang/pkg_commands.go
+++ b/cmd/ailang/pkg_commands.go
@@ -248,7 +248,8 @@ func upsertDependencyLine(content, name, depLine string) (updated, previous stri
 			if inDependencies {
 				break
 			}
-			inDependencies = trimmed == "[dependencies]"
+			header, ok := tableHeaderName(trimmed)
+			inDependencies = ok && header == "dependencies"
 			if inDependencies {
 				sectionHeader = i
 			}
@@ -292,6 +293,30 @@ func upsertDependencyLine(content, name, depLine string) (updated, previous stri
 		prefix = ""
 	}
 	return content + prefix + "[dependencies]\n" + depLine + "\n", "", false
+}
+
+// tableHeaderName returns the name of a simple, single-segment TOML table header.
+func tableHeaderName(trimmed string) (string, bool) {
+	if len(trimmed) < 2 || trimmed[0] != '[' || trimmed[1] == '[' || trimmed[len(trimmed)-1] != ']' {
+		return "", false
+	}
+	body := strings.TrimSpace(trimmed[1 : len(trimmed)-1])
+	if body == "" || strings.Contains(body, ".") {
+		return "", false
+	}
+	if body[0] == '"' || body[0] == '\'' {
+		quote := body[0]
+		if len(body) < 2 || body[len(body)-1] != quote {
+			return "", false
+		}
+		body = body[1 : len(body)-1]
+		if body == "" || strings.ContainsAny(body, "\"'") {
+			return "", false
+		}
+	} else if strings.ContainsAny(body, " \t\"'") {
+		return "", false
+	}
+	return body, true
 }
 
 // dependencyLineKey extracts a quoted, literal-quoted or bare TOML key, only
@@ -352,12 +377,45 @@ func stripLineComment(line string) string {
 // openMultilineString reports the delimiter of a multi-line string this line
 // opens and does not close, or "" when the line leaves no string open.
 func openMultilineString(line string) string {
-	for _, d := range []string{`"""`, `'''`} {
-		if n := strings.Count(line, d); n%2 == 1 {
-			return d
+	var singleQuote byte
+	open := ""
+	for i := 0; i < len(line); {
+		if open != "" {
+			if strings.HasPrefix(line[i:], open) {
+				open = ""
+				i += 3
+				continue
+			}
+			i++
+			continue
 		}
+		if singleQuote != 0 {
+			if singleQuote == '"' && line[i] == '\\' {
+				i += 2
+				continue
+			}
+			if line[i] == singleQuote {
+				singleQuote = 0
+			}
+			i++
+			continue
+		}
+		if strings.HasPrefix(line[i:], `"""`) {
+			open = `"""`
+			i += 3
+			continue
+		}
+		if strings.HasPrefix(line[i:], `'''`) {
+			open = `'''`
+			i += 3
+			continue
+		}
+		if line[i] == '"' || line[i] == '\'' {
+			singleQuote = line[i]
+		}
+		i++
 	}
-	return ""
+	return open
 }
 
 // writeManifestChecked writes the rewritten manifest, then refuses to leave the

--- a/cmd/ailang/pkg_commands_test.go
+++ b/cmd/ailang/pkg_commands_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,10 +38,9 @@ func readTestManifest(t *testing.T, dir string) string {
 //
 // It deliberately does NOT call the production stripLineComment/dependencyLineKey:
 // an instrument that shares the code under test's blind spots cannot detect them.
-// It grew its own comment handling because the first version compared the raw
-// line against "[dependencies]" and so reported 0 for the perfectly-correct
-// output of a manifest whose header carried a trailing comment — the instrument
-// failing in exactly the shape the arm was added to catch.
+// It has its own escape-aware basic/literal string comment handling and its own
+// quoted-header recognition. Keeping those independent prevents a shared blind
+// spot from making production code and its control agree on a wrong answer.
 //
 // It is not multi-line-string aware; arms that need that assert through
 // pkg.LoadManifest instead.
@@ -48,12 +48,23 @@ func countDependencyKey(content, name string) int {
 	count := 0
 	inDependencies := false
 	for _, line := range strings.Split(content, "\n") {
-		if i := strings.IndexByte(line, '#'); i >= 0 && strings.Count(line[:i], `"`)%2 == 0 {
-			line = line[:i]
+		var quote byte
+		for i := 0; i < len(line); i++ {
+			switch {
+			case quote == '"' && line[i] == '\\':
+				i++
+			case quote != 0 && line[i] == quote:
+				quote = 0
+			case quote == 0 && (line[i] == '"' || line[i] == '\''):
+				quote = line[i]
+			case quote == 0 && line[i] == '#':
+				line = line[:i]
+				i = len(line)
+			}
 		}
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, "[") {
-			inDependencies = trimmed == "[dependencies]"
+			inDependencies = trimmed == "[dependencies]" || trimmed == `["dependencies"]` || trimmed == "['dependencies']"
 			continue
 		}
 		key := strings.TrimSpace(strings.SplitN(trimmed, "=", 2)[0])
@@ -449,7 +460,7 @@ func TestWriteManifestChecked_RollsBackACorruptingWrite(t *testing.T) {
 
 	// Control: the guard passes a write that keeps the file parseable.
 	okContent := good + "\n[dependencies]\n\"sunholo/existing\" = \"1.0.0\"\n"
-	if err := writeManifestChecked(dir, path, []byte(good), okContent); err != nil {
+	if _, err := writeManifestChecked(path, []byte(good), okContent); err != nil {
 		t.Fatalf("instrument failure: a valid write was rejected: %v", err)
 	}
 	if readTestManifest(t, dir) != okContent {
@@ -457,7 +468,7 @@ func TestWriteManifestChecked_RollsBackACorruptingWrite(t *testing.T) {
 	}
 
 	before := readTestManifest(t, dir)
-	err := writeManifestChecked(dir, path, []byte(before), "[package]\nname = = = broken\n")
+	_, err := writeManifestChecked(path, []byte(before), "[package]\nname = = = broken\n")
 	if err == nil {
 		t.Fatal("corrupting write was accepted")
 	}
@@ -487,7 +498,7 @@ func TestWriteManifestChecked_ParseabilityNotValidity(t *testing.T) {
 			path := filepath.Join(dir, pkg.ManifestFile)
 			corrupt := tc.original + "\n[dependencies]\n\"sunholo/existing\" = \"2.0.0\"\n"
 
-			err := writeManifestChecked(dir, path, []byte(tc.original), corrupt)
+			_, err := writeManifestChecked(path, []byte(tc.original), corrupt)
 			if err == nil {
 				t.Fatal("corrupting write was accepted")
 			}
@@ -509,8 +520,12 @@ func TestWriteManifestChecked_AllowsWriteOverUnparseableInput(t *testing.T) {
 	writeTestManifest(t, dir, broken)
 	path := filepath.Join(dir, pkg.ManifestFile)
 
-	if err := writeManifestChecked(dir, path, []byte(broken), replacement); err != nil {
+	parseErr, err := writeManifestChecked(path, []byte(broken), replacement)
+	if err != nil {
 		t.Fatalf("already-unparseable manifest should not hold the write: %v", err)
+	}
+	if parseErr == nil {
+		t.Fatal("already-unparseable result was not reported")
 	}
 	if got := readTestManifest(t, dir); got != replacement {
 		t.Errorf("write did not land\nwant:\n%s\ngot:\n%s", replacement, got)
@@ -625,5 +640,63 @@ func TestAppendDependencyToFile_ManifestShapeCorpus(t *testing.T) {
 	}
 	if run != len(rows) {
 		t.Fatalf("ran %d corpus rows, want %d", run, len(rows))
+	}
+}
+
+// Killing mutation: delete stripLineComment's backslash-skip branch.
+func TestStripLineComment_EscapedQuoteDoesNotExposeHash(t *testing.T) {
+	subject := `"a\"#b" = "1.0"`
+	if got := stripLineComment(subject); got != subject {
+		t.Errorf("escaped quote exposed hash: got %q, want %q", got, subject)
+	}
+	control := `"a/b" = "1.0" # note`
+	if got, want := stripLineComment(control), `"a/b" = "1.0" `; got != want {
+		t.Errorf("genuine comment was not stripped: got %q, want %q", got, want)
+	}
+}
+
+// Killing mutation: restore countDependencyKey's double-quote-parity comment scan or literal header compare.
+func TestCountDependencyKey_IndependentQuotedControls(t *testing.T) {
+	content := `["dependencies"]
+'sunholo/#inside' = "1.0"
+`
+	if got := countDependencyKey(content, "sunholo/#inside"); got != 1 {
+		t.Fatalf("quoted-header/hash-in-literal key count = %d, want 1", got)
+	}
+}
+
+// Killing mutation: remove the parse-warning branch and restore the unconditional success print.
+func TestAppendDependencyToFile_AlreadyBrokenReportsWarning(t *testing.T) {
+	dir := t.TempDir()
+	const broken = "[package]\nname = = = broken\n"
+	writeTestManifest(t, dir, broken)
+
+	readEnd, writeEnd, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("capture stdout: %v", err)
+	}
+	originalStdout := os.Stdout
+	os.Stdout = writeEnd
+	callErr := appendDependencyToFile(dir, "sunholo/newdep", "1.0.0", false)
+	os.Stdout = originalStdout
+	if err := writeEnd.Close(); err != nil {
+		t.Fatalf("close captured stdout: %v", err)
+	}
+	output, err := io.ReadAll(readEnd)
+	if err != nil {
+		t.Fatalf("read captured stdout: %v", err)
+	}
+	if err := readEnd.Close(); err != nil {
+		t.Fatalf("close capture reader: %v", err)
+	}
+	if callErr != nil {
+		t.Fatalf("already-broken path changed exit status: %v", callErr)
+	}
+	text := string(output)
+	if !strings.Contains(text, "Wrote dependency sunholo/newdep") || !strings.Contains(text, pkg.ManifestFile) || !strings.Contains(text, "still does not parse") {
+		t.Errorf("missing actionable parse warning: %q", text)
+	}
+	if strings.Contains(text, "✓ Added") {
+		t.Errorf("already-broken manifest was announced as success: %q", text)
 	}
 }

--- a/cmd/ailang/pkg_commands_test.go
+++ b/cmd/ailang/pkg_commands_test.go
@@ -446,3 +446,51 @@ func TestWriteManifestChecked_RollsBackACorruptingWrite(t *testing.T) {
 		t.Errorf("file was not restored\nwant:\n%s\ngot:\n%s", before, got)
 	}
 }
+
+// Killing mutation: replace pkg.ParseManifestFile with pkg.LoadManifest in writeManifestChecked.
+func TestWriteManifestChecked_ParseabilityNotValidity(t *testing.T) {
+	const withoutEdition = "[package]\nname = \"sunholo/upsert_test\"\nversion = \"0.1.0\"\nnotes = 'contains \"\"\" triple double quotes'\n\n[dependencies]\n\"sunholo/existing\" = \"1.0.0\"\n"
+	const withEdition = "[package]\nname = \"sunholo/upsert_test\"\nversion = \"0.1.0\"\nedition = \"1\"\nnotes = 'contains \"\"\" triple double quotes'\n\n[dependencies]\n\"sunholo/existing\" = \"1.0.0\"\n"
+
+	for _, tc := range []struct {
+		name     string
+		original string
+	}{
+		{name: "validation-invalid missing edition", original: withoutEdition},
+		{name: "validation-valid control", original: withEdition},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeTestManifest(t, dir, tc.original)
+			path := filepath.Join(dir, pkg.ManifestFile)
+			corrupt := tc.original + "\n[dependencies]\n\"sunholo/existing\" = \"2.0.0\"\n"
+
+			err := writeManifestChecked(dir, path, []byte(tc.original), corrupt)
+			if err == nil {
+				t.Fatal("corrupting write was accepted")
+			}
+			if !strings.Contains(err.Error(), "unparseable") {
+				t.Errorf("error does not identify unparseable result: %v", err)
+			}
+			if got := readTestManifest(t, dir); got != tc.original {
+				t.Errorf("file changed despite rollback\nwant:\n%s\ngot:\n%s", tc.original, got)
+			}
+		})
+	}
+}
+
+// Killing mutation: force parsedBefore=true in writeManifestChecked.
+func TestWriteManifestChecked_AllowsWriteOverUnparseableInput(t *testing.T) {
+	dir := t.TempDir()
+	const broken = "[package]\nname = = = broken\n"
+	const replacement = "[package]\nname = = = still-broken\n"
+	writeTestManifest(t, dir, broken)
+	path := filepath.Join(dir, pkg.ManifestFile)
+
+	if err := writeManifestChecked(dir, path, []byte(broken), replacement); err != nil {
+		t.Fatalf("already-unparseable manifest should not hold the write: %v", err)
+	}
+	if got := readTestManifest(t, dir); got != replacement {
+		t.Errorf("write did not land\nwant:\n%s\ngot:\n%s", replacement, got)
+	}
+}

--- a/cmd/ailang/pkg_commands_test.go
+++ b/cmd/ailang/pkg_commands_test.go
@@ -65,6 +65,28 @@ func countDependencyKey(content, name string) int {
 	return count
 }
 
+func countDependenciesTables(content string) int {
+	count := 0
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(strings.SplitN(line, "#", 2)[0])
+		if line == "[dependencies]" || line == `["dependencies"]` || line == "['dependencies']" {
+			count++
+		}
+	}
+	return count
+}
+
+func countNamedKeyOccurrences(content, name string) int {
+	count := 0
+	for _, line := range strings.Split(content, "\n") {
+		key, _, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if ok && strings.Trim(strings.TrimSpace(key), `"'`) == name {
+			count++
+		}
+	}
+	return count
+}
+
 func TestAppendDependencyToFile_IdempotentUpsert(t *testing.T) {
 	dir := t.TempDir()
 	writeTestManifest(t, dir, testPackageManifest)
@@ -492,5 +514,116 @@ func TestWriteManifestChecked_AllowsWriteOverUnparseableInput(t *testing.T) {
 	}
 	if got := readTestManifest(t, dir); got != replacement {
 		t.Errorf("write did not land\nwant:\n%s\ngot:\n%s", replacement, got)
+	}
+}
+
+// Killing mutation: restore openMultilineString's strings.Count(delimiter)%2 scanner.
+func TestUpsertDependencyLine_TripleQuoteInsideSingleLineString(t *testing.T) {
+	const original = "[package]\nname = \"sunholo/upsert_test\"\nversion = \"0.1.0\"\nedition = \"1\"\nnotes = 'contains \"\"\" triple double quotes'\n\n[dependencies]\n\"sunholo/existing\" = \"1.0.0\"\n"
+	updated, _, replaced := upsertDependencyLine(original, "sunholo/existing", `"sunholo/existing" = "2.0.0"`)
+	if !replaced {
+		t.Fatal("existing dependency was not replaced")
+	}
+	dir := t.TempDir()
+	writeTestManifest(t, dir, updated)
+	if err := pkg.ParseManifestFile(filepath.Join(dir, pkg.ManifestFile)); err != nil {
+		t.Fatalf("updated manifest does not parse: %v\n%s", err, updated)
+	}
+	if got := countDependenciesTables(updated); got != 1 {
+		t.Fatalf("dependencies table count = %d, want 1\n%s", got, updated)
+	}
+}
+
+// Killing mutation: restore the dependencies-header check to trimmed == "[dependencies]".
+func TestUpsertDependencyLine_QuotedDependenciesHeader(t *testing.T) {
+	const original = "[package]\nname = \"sunholo/upsert_test\"\nversion = \"0.1.0\"\nedition = \"1\"\n\n[\"dependencies\"]\n\"sunholo/existing\" = \"1.0.0\"\n"
+	updated, _, replaced := upsertDependencyLine(original, "sunholo/existing", `"sunholo/existing" = "2.0.0"`)
+	if !replaced {
+		t.Fatal("existing dependency was not replaced")
+	}
+	dir := t.TempDir()
+	writeTestManifest(t, dir, updated)
+	if err := pkg.ParseManifestFile(filepath.Join(dir, pkg.ManifestFile)); err != nil {
+		t.Fatalf("updated manifest does not parse: %v\n%s", err, updated)
+	}
+	if got := countDependenciesTables(updated); got != 1 {
+		t.Fatalf("dependencies table count = %d, want 1\n%s", got, updated)
+	}
+}
+
+// Killing mutation: make tableHeaderName accept a [[-prefixed array-of-tables header.
+func TestTableHeaderName_RejectsArrayOfTables(t *testing.T) {
+	if name, ok := tableHeaderName("[[dependencies]]"); ok || name != "" {
+		t.Fatalf("array-of-tables accepted as simple header: name=%q ok=%v", name, ok)
+	}
+}
+
+// Killing mutation: restore openMultilineString's strings.Count(delimiter)%2 scanner.
+func TestOpenMultilineString_QuotedDelimiterCorpus(t *testing.T) {
+	tests := []struct {
+		line string
+		want string
+	}{
+		{line: `notes = """`, want: `"""`},
+		{line: `text = """abc`, want: `"""`},
+		{line: `notes = 'contains """ triple double quotes'`, want: ""},
+		{line: `notes = "he said \"\"\" once"`, want: ""},
+	}
+	for _, tc := range tests {
+		if got := openMultilineString(tc.line); got != tc.want {
+			t.Errorf("openMultilineString(%q) = %q, want %q", tc.line, got, tc.want)
+		}
+	}
+}
+
+// Killing mutation: restore either the delimiter-count scanner or literal header comparison.
+func TestAppendDependencyToFile_ManifestShapeCorpus(t *testing.T) {
+	const base = "[package]\nname = \"sunholo/upsert_test\"\nversion = \"0.1.0\"\nedition = \"1\"\n"
+	const dep = "sunholo/gemini_files"
+	rows := []struct {
+		name     string
+		manifest string
+	}{
+		{name: "no dependencies", manifest: base},
+		{name: "different dependency", manifest: base + "\n[dependencies]\n\"sunholo/other\" = \"1.0.0\"\n"},
+		{name: "same dependency older", manifest: base + "\n[dependencies]\n\"" + dep + "\" = \"0.1.0\"\n"},
+		{name: "header trailing comment", manifest: base + "\n[dependencies] # managed\n"},
+		{name: "header final line", manifest: base + "\n[dependencies]"},
+		{name: "multiline string with header-shaped line", manifest: base + "description = \"\"\"prose\n[not-a-table]\nmore prose\"\"\"\n\n[dependencies]\n"},
+		{name: "literal triple double quote", manifest: base + "notes = 'contains \"\"\" triple double quotes'\n\n[dependencies]\n"},
+		{name: "quoted dependencies header", manifest: base + "\n[\"dependencies\"]\n"},
+		{name: "literal quoted key", manifest: base + "\n[dependencies]\n'" + dep + "' = \"0.1.0\"\n"},
+		{name: "CRLF", manifest: strings.ReplaceAll(base+"\n[dependencies]\n", "\n", "\r\n")},
+		{name: "followed by another table", manifest: base + "\n[dependencies]\n\n[metadata]\nowner = \"test\"\n"},
+		{name: "missing edition", manifest: "[package]\nname = \"sunholo/upsert_test\"\nversion = \"0.1.0\"\n\n[dependencies]\n"},
+	}
+	if len(rows) < 12 {
+		t.Fatalf("corpus shrank to %d rows; want at least 12", len(rows))
+	}
+	run := 0
+	for _, tc := range rows {
+		t.Run(tc.name, func(t *testing.T) {
+			run++
+			dir := t.TempDir()
+			writeTestManifest(t, dir, tc.manifest)
+			for i := 0; i < 2; i++ {
+				if err := appendDependencyToFile(dir, dep, "0.2.0", false); err != nil {
+					t.Fatalf("install %d: %v", i+1, err)
+				}
+			}
+			content := readTestManifest(t, dir)
+			if err := pkg.ParseManifestFile(filepath.Join(dir, pkg.ManifestFile)); err != nil {
+				t.Errorf("manifest does not parse: %v\n%s", err, content)
+			}
+			if got := countNamedKeyOccurrences(content, dep); got != 1 {
+				t.Errorf("dependency key count = %d, want 1\n%s", got, content)
+			}
+			if got := countDependenciesTables(content); got != 1 {
+				t.Errorf("dependencies table count = %d, want 1\n%s", got, content)
+			}
+		})
+	}
+	if run != len(rows) {
+		t.Fatalf("ran %d corpus rows, want %d", run, len(rows))
 	}
 }

--- a/cmd/ailang/pkg_commands_test.go
+++ b/cmd/ailang/pkg_commands_test.go
@@ -566,10 +566,54 @@ func TestUpsertDependencyLine_QuotedDependenciesHeader(t *testing.T) {
 	}
 }
 
-// Killing mutation: make tableHeaderName accept a [[-prefixed array-of-tables header.
-func TestTableHeaderName_RejectsArrayOfTables(t *testing.T) {
-	if name, ok := tableHeaderName("[[dependencies]]"); ok || name != "" {
-		t.Fatalf("array-of-tables accepted as simple header: name=%q ok=%v", name, ok)
+// One arm per refusal branch in tableHeaderName. A helper whose contract is
+// "refuse anything that is not a simple single-segment header" has several
+// distinct ways to refuse, and a branch nothing reds for is not a guard — the
+// caller's `header == "dependencies"` compare happens to make some of these
+// harmless today, which is exactly why the CLAIM needs pinning rather than the
+// consequence.
+//
+// Killing mutations, one per row: neuter that row's guard with
+// `if false && <cond>` in tableHeaderName.
+func TestTableHeaderName_RefusalBranches(t *testing.T) {
+	refused := []struct {
+		label string
+		line  string
+	}{
+		{"array-of-tables", "[[dependencies]]"},
+		{"dotted header", "[dependencies.sub]"},
+		{"dotted header, quoted", `["dependencies.sub"]`},
+		{"quote mismatch", `["dependencies']`},
+		{"unterminated quote", `["dependencies]`},
+		{"empty body", "[]"},
+		{"interior quote", `["deps"x"]`},
+		{"bare header with a space", "[two words]"},
+		{"not a header", "dependencies"},
+	}
+	for _, tc := range refused {
+		if name, ok := tableHeaderName(tc.line); ok || name != "" {
+			t.Errorf("%s: tableHeaderName(%q) = (%q, %v), want (\"\", false)", tc.label, tc.line, name, ok)
+		}
+	}
+
+	// Control: the accepted forms must still be accepted, or every row above
+	// passes for the trivial reason that the helper refuses everything.
+	accepted := []struct {
+		line string
+		want string
+	}{
+		{"[dependencies]", "dependencies"},
+		{`["dependencies"]`, "dependencies"},
+		{"['dependencies']", "dependencies"},
+		{"[ dependencies ]", "dependencies"},
+		{"[\tdependencies\t]", "dependencies"},
+		{"[package]", "package"},
+	}
+	for _, tc := range accepted {
+		name, ok := tableHeaderName(tc.line)
+		if !ok || name != tc.want {
+			t.Errorf("instrument failure: tableHeaderName(%q) = (%q, %v), want (%q, true)", tc.line, name, ok, tc.want)
+		}
 	}
 }
 
@@ -666,6 +710,48 @@ func TestCountDependencyKey_IndependentQuotedControls(t *testing.T) {
 }
 
 // Killing mutation: remove the parse-warning branch and restore the unconditional success print.
+// The SECOND call site of the same warn branch. appendGitDependencyToFile has
+// its own copy, and neutering it left the entire package green — a branch whose
+// twin is tested reads as covered.
+//
+// Killing mutation: `if false && parseErr != nil` in appendGitDependencyToFile.
+func TestAppendGitDependencyToFile_AlreadyBrokenReportsWarning(t *testing.T) {
+	dir := t.TempDir()
+	const broken = "[package]\nname = = = broken\n"
+	writeTestManifest(t, dir, broken)
+
+	readEnd, writeEnd, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("capture stdout: %v", err)
+	}
+	originalStdout := os.Stdout
+	os.Stdout = writeEnd
+	callErr := appendGitDependencyToFile(dir, "sunholo/newdep",
+		[]string{`git = "https://example.invalid/r.git"`, `tag = "v1"`},
+		"https://example.invalid/r.git", "v1", "")
+	os.Stdout = originalStdout
+	if err := writeEnd.Close(); err != nil {
+		t.Fatalf("close captured stdout: %v", err)
+	}
+	output, err := io.ReadAll(readEnd)
+	if err != nil {
+		t.Fatalf("read captured stdout: %v", err)
+	}
+	if err := readEnd.Close(); err != nil {
+		t.Fatalf("close capture reader: %v", err)
+	}
+	if callErr != nil {
+		t.Fatalf("already-broken path changed exit status: %v", callErr)
+	}
+	text := string(output)
+	if !strings.Contains(text, "Wrote dependency sunholo/newdep") || !strings.Contains(text, pkg.ManifestFile) || !strings.Contains(text, "still does not parse") {
+		t.Errorf("missing actionable parse warning: %q", text)
+	}
+	if strings.Contains(text, "✓ Added") {
+		t.Errorf("already-broken manifest was announced as success: %q", text)
+	}
+}
+
 func TestAppendDependencyToFile_AlreadyBrokenReportsWarning(t *testing.T) {
 	dir := t.TempDir()
 	const broken = "[package]\nname = = = broken\n"

--- a/internal/pkg/manifest.go
+++ b/internal/pkg/manifest.go
@@ -234,6 +234,20 @@ func LoadManifestFile(path string) (*PackageManifest, error) {
 	return &m, nil
 }
 
+// ParseManifestFile checks TOML parseability without validation so rollback nets also protect incomplete manifests.
+func ParseManifestFile(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", path, err)
+	}
+
+	var m PackageManifest
+	if err := toml.Unmarshal(data, &m); err != nil {
+		return fmt.Errorf("failed to parse %s: %w", path, err)
+	}
+	return nil
+}
+
 // Validate checks the manifest for required fields and consistency.
 func (m *PackageManifest) Validate() error {
 	if m.Package.Name == "" {


### PR DESCRIPTION
Closes #720.

`#720` catalogued four blind spots in the `ailang.toml` dependency upsert and framed all of them as
non-corrupting, on the grounds that `writeManifestChecked` rolls back any write that leaves a
previously-parseable manifest unparseable. **That framing does not hold**, and finding out why was
the substance of this iteration.

### The wider defect (not in `#720`)

`writeManifestChecked` decided *"was this parseable before?"* with `pkg.LoadManifest` — TOML parse
**plus full semantic `Validate`**. So a manifest that is perfectly good TOML but fails validation
(missing `edition`, a one-level `name`, missing `version`) counted as *already broken*, the
post-write re-check was skipped, and the call returned `nil`.

Measured on two fixtures differing by exactly one line (`edition = "1"`):

| arm | result |
|---|---|
| no `edition` | duplicate dependency key **written to disk**, `err=nil`, caller prints `✓ Added` |
| `edition` present, otherwise identical | write **refused and rolled back**, one key on disk |

That is `#718`'s own failure mode, un-netted, on a manifest shape a user plausibly hand-writes.
Fixed by adding `pkg.ParseManifestFile` (read + `toml.Unmarshal`, no `Validate`) and pointing both
probes at it. The net now engages for every manifest that **parses**.

### The four `#720` gaps

All reproduced first-party at `83149133b`, each against a control that replaced cleanly:

- **`openMultilineString` false-positives on a literal `"""`.** `notes = 'contains """ triple double quotes'`
  read as an open multi-line string, so the scanner skipped the real `[dependencies]` section and
  appended a second table. Rewritten to walk the line tracking single-line basic/literal string
  state and recognise a delimiter only outside one.
- **Quoted table header.** `["dependencies"]` is semantically identical to `[dependencies]`.
  `tableHeaderName` now accepts bare, basic-quoted and literal-quoted single-segment headers, and
  deliberately refuses `[[dependencies]]` and dotted headers.
- **`stripLineComment` escape awareness.** `"a\"#b" = "1.0"` truncated at the `#`. Latent (no real
  `vendor/name` contains both a quote and a `#`) but one branch to close.
- **`countDependencyKey`.** It exists to be an independent control and had grown the same blind
  spots as the code under test. Repaired *without* calling any production helper, so it stays a
  control rather than a mirror.

Plus: appending to a manifest that did not parse beforehand no longer prints an unqualified
`✓ Added` — it warns and names the file and the parse error. Exit status deliberately unchanged.

### The instrument iteration 202 was missing

A twelve-shape corpus table runs the **real** `appendDependencyToFile` path twice per shape
(install-then-install-again) and asserts, for each, that the file parses, has exactly one key for
the dependency, and exactly one `[dependencies]` table — with an anti-vacuity floor so the
enumeration cannot silently shrink. Iteration 202's round-1 regression (a precise mechanism
withdrawing a permissive one's accidental coverage) is exactly what a differential corpus catches
and no test written for the new code can.

### Design call, made rather than drifted into

`#720` asks whether this path should hand-edit TOML text at all, or parse → mutate → re-serialize.
**Decision: keep hand-editing.** Comment and formatting preservation in a file users read and edit
by hand is a real product property, and with the M1 predicate fixed the rollback net bounds the
scanner's open-ended blind spots by construction. Recorded so a future iteration does not re-litigate it.

### Verification

Executor **codex `gpt-5.6-sol`**; every gate re-run by the controller **outside the sandbox**
(the executor's `go test` verdicts were loopback-bind denials, `UNINFORMATIVE UNDER SANDBOX`):

```
go build ./cmd/ailang/... ./internal/...   rc=0
go test ./cmd/ailang/                      rc=0
go test ./internal/pkg/                    rc=0
go vet ./cmd/... ./internal/pkg/...        rc=0
make check-changelog check-file-sizes check-boundaries fmt-check vet check-skills   all rc=0
```

`go build ./...` is **not** a gate here: it is red on pristine `origin/dev` (`cmd/wasm`: *function
main is undeclared*), measured at base, so it would measure the repo rather than the change.

Eight mutations run by the executor, each asserted **LANDED** (sha256) and **BUILDS** before its
result was read, each the sole killer (inverse `-skip` rc=0). The load-bearing one — reverting the
predicate to `LoadManifest` — was re-run independently by the controller against its own
pre-registered arm: mutant builds, lands, and the `edition`-absent arm reports
*"the net did NOT engage"* with `keys-on-disk=2`; restored byte-identical by `cp`.

Three commits, one per milestone, each boundary green for `go build` + both test packages.
Reconstruction verified byte-identical to the executor's final tree by `shasum -c`.

**Platform: darwin/arm64.** The Windows and Linux legs are unrun locally; this diff is
platform-neutral Go string handling, but the claim travels with its narrowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
