### PR TITLE
test(pkg): pin ParseManifestFile in its own package — the #720 mechanism had zero coverage there

### DIFF
--- a/internal/pkg/manifest_test.go
+++ b/internal/pkg/manifest_test.go
@@ -142,6 +142,87 @@ level = "invalid"
 	}
 }
 
+func TestParseManifestFile(t *testing.T) {
+	cases := []struct {
+		name          string
+		content       string
+		missing       bool
+		wantParseErr  string
+		wantLoadError bool
+	}{
+		{
+			name: "valid TOML without required edition",
+			content: `[package]
+name = "test/pkg"
+version = "0.1.0"
+`,
+			wantLoadError: true,
+		},
+		{
+			name:         "missing file",
+			missing:      true,
+			wantParseErr: "failed to read",
+		},
+		{
+			name: "malformed TOML with duplicate dependency",
+			content: `[package]
+name = "test/pkg"
+version = "0.1.0"
+edition = "1"
+
+[dependencies]
+"sunholo/json" = "0.3.1"
+"sunholo/json" = "0.3.2"
+`,
+			wantParseErr: "failed to parse",
+		},
+		{
+			name: "fully valid manifest",
+			content: `[package]
+name = "test/pkg"
+version = "0.1.0"
+edition = "1"
+`,
+		},
+	}
+	if len(cases) < 4 {
+		t.Fatalf("expected at least 4 ParseManifestFile cases, got %d", len(cases))
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), ManifestFile)
+			if !tc.missing {
+				if err := os.WriteFile(path, []byte(tc.content), 0644); err != nil {
+					t.Fatalf("write manifest: %v", err)
+				}
+			}
+
+			err := ParseManifestFile(path)
+			if tc.wantParseErr != "" {
+				if err == nil {
+					t.Fatalf("ParseManifestFile() error = nil, want error containing %q", tc.wantParseErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantParseErr) {
+					t.Fatalf("ParseManifestFile() error = %q, want error containing %q", err, tc.wantParseErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseManifestFile() unexpected error: %v", err)
+			}
+
+			_, loadErr := LoadManifestFile(path)
+			if tc.wantLoadError && loadErr == nil {
+				t.Fatal("LoadManifestFile() error = nil, want validation error")
+			}
+			if !tc.wantLoadError && loadErr != nil {
+				t.Fatalf("LoadManifestFile() unexpected error: %v", loadErr)
+			}
+		})
+	}
+}
+
 func TestInitManifest(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## What

Adds `TestParseManifestFile` (4 arms) to `internal/pkg/manifest_test.go`. Test-only; no production
code changes.

## Why — measured, not assumed

`pkg.ParseManifestFile` shipped in #722 as the load-bearing half of #720's fix. It had **zero tests
in its own package**:

- `grep -c 'ParseManifestFile'` across all 14 `internal/pkg/*_test.go` files → **0**
  (same-scope control `LoadManifestFile` → **9** in `manifest_test.go`, so the zero is a
  measurement, not a broken pattern)
- `go tool cover -func` → `ParseManifestFile 0.0%`, beside `LoadManifest 100.0%`,
  `LoadManifestFile 88.9%`, `Validate 90.7%` in the same file
- Its only pins live in `cmd/ailang`, and `make test-coverage` runs without `-coverpkg`, so those
  attribute nothing to `internal/pkg`

**Consequence, measured before this PR:** reverting the #720 mechanism — making `ParseManifestFile`
call `Validate` again — left the **entire `internal/pkg` package green**.

This is also the single largest contributor to the currently-red SonarCloud new-code coverage gate
on `dev`: **7 of the 29** uncovered new lines (143 to cover, 79.72% vs an 80% bar), and the only
file in the window at 0.0%.

## The arms

| arm | pins |
|---|---|
| `valid TOML without required edition` | `ParseManifestFile` ACCEPTS what `LoadManifestFile` REJECTS — the parse-vs-validate distinction the whole fix rests on |
| `missing file` | read branch, asserted on `failed to read` |
| `malformed TOML with duplicate dependency` | parse branch, asserted on `failed to parse` |
| `fully valid manifest` | positive control |

Both refusal branches return non-nil, so `err != nil` cannot distinguish them — hence the message
assertions. And the discriminating arm asserts **both** halves: the accept-half alone would pass
identically for a function returning nil unconditionally.

## Mutation drill

Run by the executor and **independently re-run by the controller outside the sandbox**. Every
mutant asserted LANDED (sha256) and BUILDS (`go build` rc=0) before its result was read, and each
reds its OWN arm rather than the suite:

| mutation | landed | builds | failing arm |
|---|---|---|---|
| `ParseManifestFile` calls `Validate` | yes | rc=0 | `valid_TOML_without_required_edition` |
| read branch → `if false && err != nil` | yes | rc=0 | `missing_file` |
| parse branch → `if false && err != nil` | yes | rc=0 | `malformed_TOML_with_duplicate_dependency` |

Inverse arm for the load-bearing mutant: `go test ./internal/pkg/ -skip TestParseManifestFile`
is **rc=0**, so this test is the sole killer, not a bystander. `manifest.go` restored
byte-identical (sha256 `32fcbfa2…`) from a `cp` backup after each mutation.

## Gates

All run on **darwin/arm64** outside the sandbox; the windows and ubuntu matrix legs are unrun
locally and are CI's to report.

`go build ./internal/pkg/` · `go test ./internal/pkg/ -run ParseManifestFile -v` (4 arms) ·
`go test ./internal/pkg/` (whole package) · `go vet ./internal/pkg/` · `gofmt -l` ·
`make check-changelog check-file-sizes check-boundaries fmt-check vet check-skills` — all rc=0.

Coverage: `ParseManifestFile` 0.0% → **100.0%**; `Validate` 90.7% → 92.6%; package 68.7% → 69.4%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
