### PR TITLE
fix(ci): govulncheck-filter expiry-checks module-level allowlist entries (#717)

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,36 @@
 
 ## [Unreleased]
 
+### Fixed — `govulncheck-filter` never expiry-checked module-level allowlist entries, so a stale suppression read clean forever
+
+`#716` gave module-level (not function-reaching) findings a third, non-gating report bucket
+annotated with allowlist status. `printModuleOnly` computed that annotation from **presence in the
+allowlist alone** — it never read the entry's `expires` date, and the expiry computation in `main`
+ran only over the *reaching* findings. So the allowlist's whole `expires` discipline (force a
+manual re-review once a date passes) was silently inert for the entire module-level class.
+
+Reproduced first-party on two fixtures differing only in whether the trace frame carries a
+`function` field, both with `expires: "2020-01-01"`: the module-only arm printed `[allowlisted]`
+at rc=0, while the reaching arm printed `(expired 2020-01-01)` at rc=1. The live entry
+`GO-2026-5750` (Ollama path-traversal, expiry 2026-10-29) is in that class, so on that date it
+would have kept reading `[allowlisted]` with no prompt to re-review.
+
+A second gap with the same root cause, not named in `#717`: a **malformed** `expires` date on a
+module-only entry was never validated either — `time.Parse` + `exit 2` also lived only in the
+reaching loop, so `expires: "not-a-date"` rode out as `[allowlisted]` at rc=0.
+
+Module-level findings now report as `[NOT allowlisted]`, `[allowlisted]`, or
+`[allowlisted, EXPIRED <date>]`, sharing one `classifyEntry` helper and one clock with the reaching
+path so the two cannot drift on the boundary. A malformed module-only expiry is reported and exits
+2 before any success output. Per `#703`'s ratified decision these findings remain **non-gating**:
+an expired module-only entry is surfaced and the process still exits 0.
+
+The exit-code decision moved out of `main` into a testable `decide`, because the non-gating
+invariant cannot be pinned through the per-class helpers — they are never handed module-only IDs.
+An earlier version of the test asserted `classifyReaching(nil, …)` returned empty, which passes for
+any implementation; measured, it stayed green under a mutant that added **every** finding to the
+blocking set. The replacement arms red on that mutant.
+
 ### Fixed — the `ailang.toml` rollback net gated on validity, so it never engaged for a parseable-but-invalid manifest
 
 `ailang install` writes its dependency line by scanning `ailang.toml` as text, and

--- a/tools/govulncheck-filter/main.go
+++ b/tools/govulncheck-filter/main.go
@@ -59,50 +59,47 @@ func main() {
 		os.Exit(2)
 	}
 
+	os.Exit(decide(os.Stdout, os.Stderr, allow, os.Stdin, time.Now().UTC()))
+}
+
+// decide runs the whole filter decision and returns the process exit code.
+// It is split out of main so the exit-code contract is testable without a
+// subprocess — in particular the #703 invariant that module-level findings
+// are reported but never gate, which cannot be pinned by calling the
+// per-class helpers directly (they are never handed module-only IDs).
+func decide(stdout, stderr io.Writer, allow *allowlist, in io.Reader, now time.Time) int {
 	// Index allowlist by ID for O(1) lookup. Surface duplicate IDs
 	// rather than silently masking them.
 	byID := map[string]allowEntry{}
 	for _, e := range allow.Allow {
 		if _, dup := byID[e.ID]; dup {
-			fmt.Fprintf(os.Stderr, "govulncheck-filter: duplicate allowlist entry for %s\n", e.ID)
-			os.Exit(2)
+			fmt.Fprintf(stderr, "govulncheck-filter: duplicate allowlist entry for %s\n", e.ID)
+			return 2
 		}
 		byID[e.ID] = e
 	}
 
-	reaching, moduleOnly, err := readFindings(os.Stdin)
+	reaching, moduleOnly, err := readFindings(in)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "govulncheck-filter: parse stdin: %v\n", err)
-		os.Exit(2)
+		fmt.Fprintf(stderr, "govulncheck-filter: parse stdin: %v\n", err)
+		return 2
 	}
 
-	now := time.Now().UTC()
-	var (
-		blocking []string // findings without allowlist entries
-		expired  []string // allowlist entries whose expiry has passed
-		seen     = map[string]bool{}
-	)
-
+	seen := map[string]bool{}
 	for _, id := range reaching {
 		seen[id] = true
-
-		entry, ok := byID[id]
-		if !ok {
-			blocking = append(blocking, id)
-			continue
-		}
-		t, err := time.Parse("2006-01-02", entry.Expires)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "govulncheck-filter: bad expires date %q for %s: %v\n",
-				entry.Expires, id, err)
-			os.Exit(2)
-		}
-		if !t.After(now) {
-			expired = append(expired, fmt.Sprintf("%s (expired %s)", id, entry.Expires))
-		}
 	}
 	for _, id := range moduleOnly {
 		seen[id] = true
+	}
+	blocking, expired, err := classifyReaching(reaching, byID, now)
+	if err != nil {
+		fmt.Fprintf(stderr, "govulncheck-filter: %v\n", err)
+		return 2
+	}
+	if err := validateModuleOnly(moduleOnly, byID, now); err != nil {
+		fmt.Fprintf(stderr, "govulncheck-filter: %v\n", err)
+		return 2
 	}
 
 	// Surface allowlist entries that no longer match any finding —
@@ -119,47 +116,89 @@ func main() {
 	sort.Strings(stale)
 
 	if len(blocking) == 0 && len(expired) == 0 {
-		fmt.Printf("govulncheck-filter: %d reachable finding(s), all allowlisted and unexpired.\n",
+		fmt.Fprintf(stdout, "govulncheck-filter: %d reachable finding(s), all allowlisted and unexpired.\n",
 			len(reaching))
-		printModuleOnly(os.Stdout, moduleOnly, byID)
+		printModuleOnly(stdout, moduleOnly, byID, now)
 		if len(stale) > 0 {
-			fmt.Printf("Note: %d stale allowlist entr(ies) — consider removing: %v\n",
+			fmt.Fprintf(stdout, "Note: %d stale allowlist entr(ies) — consider removing: %v\n",
 				len(stale), stale)
 		}
-		os.Exit(0)
+		return 0
 	}
 
 	if len(blocking) > 0 {
-		fmt.Fprintf(os.Stderr, "govulncheck-filter: %d unallowlisted finding(s):\n",
+		fmt.Fprintf(stderr, "govulncheck-filter: %d unallowlisted finding(s):\n",
 			len(blocking))
 		for _, id := range blocking {
-			fmt.Fprintf(os.Stderr, "  - %s\n", id)
+			fmt.Fprintf(stderr, "  - %s\n", id)
 		}
-		fmt.Fprintln(os.Stderr,
+		fmt.Fprintln(stderr,
 			"Either fix the underlying issue or add an entry to .govulncheck-allow.yml with a reason and expires date.")
 	}
 	if len(expired) > 0 {
-		fmt.Fprintf(os.Stderr, "govulncheck-filter: %d expired allowlist entr(ies):\n",
+		fmt.Fprintf(stderr, "govulncheck-filter: %d expired allowlist entr(ies):\n",
 			len(expired))
 		for _, e := range expired {
-			fmt.Fprintf(os.Stderr, "  - %s\n", e)
+			fmt.Fprintf(stderr, "  - %s\n", e)
 		}
-		fmt.Fprintln(os.Stderr,
+		fmt.Fprintln(stderr,
 			"Re-evaluate: bump expires forward, fix the underlying issue, or remove the dependency.")
 	}
-	printModuleOnly(os.Stderr, moduleOnly, byID)
-	os.Exit(1)
+	printModuleOnly(stderr, moduleOnly, byID, now)
+	return 1
 }
 
-func printModuleOnly(w io.Writer, ids []string, byID map[string]allowEntry) {
+func classifyEntry(entry allowEntry, now time.Time) (bool, error) {
+	t, err := time.Parse("2006-01-02", entry.Expires)
+	if err != nil {
+		return false, err
+	}
+	return !t.After(now), nil
+}
+
+func classifyReaching(ids []string, byID map[string]allowEntry, now time.Time) (blocking, expired []string, err error) {
+	for _, id := range ids {
+		entry, ok := byID[id]
+		if !ok {
+			blocking = append(blocking, id)
+			continue
+		}
+		isExpired, parseErr := classifyEntry(entry, now)
+		if parseErr != nil {
+			return nil, nil, fmt.Errorf("bad expires date %q for %s: %v", entry.Expires, id, parseErr)
+		}
+		if isExpired {
+			expired = append(expired, fmt.Sprintf("%s (expired %s)", id, entry.Expires))
+		}
+	}
+	return blocking, expired, nil
+}
+
+func validateModuleOnly(ids []string, byID map[string]allowEntry, now time.Time) error {
+	for _, id := range ids {
+		if entry, ok := byID[id]; ok {
+			if _, err := classifyEntry(entry, now); err != nil {
+				return fmt.Errorf("bad expires date %q for %s: %v", entry.Expires, id, err)
+			}
+		}
+	}
+	return nil
+}
+
+func printModuleOnly(w io.Writer, ids []string, byID map[string]allowEntry, now time.Time) {
 	if len(ids) == 0 {
 		return
 	}
 	fmt.Fprintf(w, "govulncheck-filter: %d module-level finding(s) (not function-reaching, not gating):\n", len(ids))
 	for _, id := range ids {
 		status := "NOT allowlisted"
-		if _, ok := byID[id]; ok {
-			status = "allowlisted"
+		if entry, ok := byID[id]; ok {
+			isExpired, _ := classifyEntry(entry, now) // validated before any output
+			if isExpired {
+				status = fmt.Sprintf("allowlisted, EXPIRED %s", entry.Expires)
+			} else {
+				status = "allowlisted"
+			}
 		}
 		fmt.Fprintf(w, "  - %s [%s]\n", id, status)
 	}

--- a/tools/govulncheck-filter/main_test.go
+++ b/tools/govulncheck-filter/main_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestReadFindingsClassifiesModuleOnlyAndReaching(t *testing.T) {
@@ -23,6 +25,139 @@ func TestReadFindingsClassifiesModuleOnlyAndReaching(t *testing.T) {
 
 	// Mutation killed: reverting readFindings to skip non-function traces
 	// (the pre-#703 `Function == ""` continue) empties moduleOnly and reds this test.
+}
+
+func TestPrintModuleOnlyAnnotations(t *testing.T) {
+	now := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name    string
+		entries map[string]allowEntry
+		want    string
+		notWant string
+	}{
+		{"expired", map[string]allowEntry{"GO-PAST": {ID: "GO-PAST", Expires: "2020-01-01"}}, "[allowlisted, EXPIRED 2020-01-01]", ""},
+		{"future", map[string]allowEntry{"GO-FUTURE": {ID: "GO-FUTURE", Expires: "2030-01-01"}}, "[allowlisted]", "EXPIRED"},
+		{"not allowlisted", map[string]allowEntry{}, "[NOT allowlisted]", "EXPIRED"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			id := "GO-UNLISTED"
+			for key := range tc.entries {
+				id = key
+			}
+			printModuleOnly(&out, []string{id}, tc.entries, now)
+			if !strings.Contains(out.String(), tc.want) {
+				t.Errorf("output %q does not contain %q", out.String(), tc.want)
+			}
+			if tc.notWant != "" && strings.Contains(out.String(), tc.notWant) {
+				t.Errorf("output %q unexpectedly contains %q", out.String(), tc.notWant)
+			}
+		})
+	}
+}
+
+func TestReachingExpiryBehaviorUnchanged(t *testing.T) {
+	now := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
+	_, expired, err := classifyReaching([]string{"GO-PAST"}, map[string]allowEntry{
+		"GO-PAST": {ID: "GO-PAST", Expires: "2020-01-01"},
+	}, now)
+	if err != nil {
+		t.Fatalf("classifyReaching() error = %v", err)
+	}
+	assertStringsEqual(t, "expired", expired, []string{"GO-PAST (expired 2020-01-01)"})
+}
+
+// TestDecideExitCodes pins the exit-code contract end to end, through the same
+// decision path the binary runs.
+//
+// The #703 invariant — module-level findings are reported but never gate — can
+// only be pinned here. An earlier version of this test called
+// classifyReaching(nil, ...) and asserted the result was empty; that passes for
+// ANY implementation, because the loop body never runs on a nil slice. Measured:
+// mutating classifyReaching to append every id to `blocking` left that test
+// green. These arms red on that mutant.
+func TestDecideExitCodes(t *testing.T) {
+	now := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
+
+	const modOnly = `{"finding":{"osv":"GO-MODULE","trace":[{"module":"example.com/m"}]}}`
+	const reachingListed = `{"finding":{"osv":"GO-REACH","trace":[{"module":"example.com/m","function":"Boom"}]}}`
+	const reachingUnlisted = `{"finding":{"osv":"GO-UNLISTED","trace":[{"module":"example.com/m","function":"Boom"}]}}`
+
+	expiredModule := allowEntry{ID: "GO-MODULE", Reason: "unreachable", Expires: "2020-01-01"}
+	freshReaching := allowEntry{ID: "GO-REACH", Reason: "pending fix", Expires: "2030-01-01"}
+	badModule := allowEntry{ID: "GO-MODULE", Reason: "typo", Expires: "not-a-date"}
+
+	tests := []struct {
+		name     string
+		findings string
+		allow    []allowEntry
+		wantCode int
+		wantOut  string // substring required in stdout+stderr
+	}{
+		{
+			// The load-bearing arm: an EXPIRED module-only entry is surfaced
+			// and the process still exits 0.
+			name:     "expired module-only does not gate",
+			findings: modOnly,
+			allow:    []allowEntry{expiredModule},
+			wantCode: 0,
+			wantOut:  "GO-MODULE [allowlisted, EXPIRED 2020-01-01]",
+		},
+		{
+			// Same, alongside a healthy reaching finding — the module-only
+			// class must not drag an otherwise-passing run to non-zero.
+			name:     "expired module-only alongside allowlisted reaching",
+			findings: modOnly + "\n" + reachingListed,
+			allow:    []allowEntry{expiredModule, freshReaching},
+			wantCode: 0,
+			wantOut:  "GO-MODULE [allowlisted, EXPIRED 2020-01-01]",
+		},
+		{
+			// A genuinely blocking REACHING finding still exits 1, so arm 1's
+			// zero is a decision and not a filter that never gates anything.
+			name:     "unallowlisted reaching finding gates",
+			findings: reachingUnlisted,
+			allow:    nil,
+			wantCode: 1,
+			wantOut:  "GO-UNLISTED",
+		},
+		{
+			// Malformed expiry on a module-only entry is an input error (2),
+			// not a silent pass.
+			name:     "malformed module-only expiry exits 2",
+			findings: modOnly,
+			allow:    []allowEntry{badModule},
+			wantCode: 2,
+			wantOut:  `bad expires date "not-a-date" for GO-MODULE`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			got := decide(&stdout, &stderr, &allowlist{Allow: tc.allow},
+				strings.NewReader(tc.findings), now)
+			if got != tc.wantCode {
+				t.Errorf("decide() = %d, want %d\nstdout: %s\nstderr: %s",
+					got, tc.wantCode, stdout.String(), stderr.String())
+			}
+			combined := stdout.String() + stderr.String()
+			if !strings.Contains(combined, tc.wantOut) {
+				t.Errorf("output %q does not contain %q", combined, tc.wantOut)
+			}
+		})
+	}
+}
+
+func TestValidateModuleOnlyRejectsMalformedExpiry(t *testing.T) {
+	now := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
+	err := validateModuleOnly([]string{"GO-BAD"}, map[string]allowEntry{
+		"GO-BAD": {ID: "GO-BAD", Expires: "not-a-date"},
+	}, now)
+	if err == nil || !strings.Contains(err.Error(), `bad expires date "not-a-date" for GO-BAD:`) {
+		t.Fatalf("validateModuleOnly() error = %v, want bad expires date for GO-BAD", err)
+	}
 }
 
 func assertStringsEqual(t *testing.T, name string, got, want []string) {

--- a/tools/govulncheck-filter/main_test.go
+++ b/tools/govulncheck-filter/main_test.go
@@ -131,6 +131,18 @@ func TestDecideExitCodes(t *testing.T) {
 			wantCode: 2,
 			wantOut:  `bad expires date "not-a-date" for GO-MODULE`,
 		},
+		{
+			// The reaching sibling of the arm above. This branch predates the
+			// module-only fix and was unpinned at 38641e216 too — measured:
+			// neutering `if parseErr != nil` in classifyReaching redded nothing.
+			// It is the direct counterpart of the #717 deliverable, so it is
+			// pinned here rather than left as debt.
+			name:     "malformed reaching expiry exits 2",
+			findings: reachingListed,
+			allow:    []allowEntry{{ID: "GO-REACH", Reason: "typo", Expires: "not-a-date"}},
+			wantCode: 2,
+			wantOut:  `bad expires date "not-a-date" for GO-REACH`,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## The defect (#717)

`printModuleOnly` annotated module-level findings from allowlist **presence only** — it never read
the entry's `expires`. The expiry computation in `main()` ran solely over the *reaching* findings,
so the allowlist's whole `expires` discipline was inert for the module-level class.

Reproduced first-party at `38641e216`, two fixtures differing **only** in whether the trace frame
carries a `function` field, `expires: "2020-01-01"` in both:

| arm | output | rc |
|---|---|---|
| module-only | `- GO-2026-9999 [allowlisted]` | 0 |
| reaching (control) | `GO-2026-8888 (expired 2020-01-01)` | 1 |

`GO-2026-5750` (Ollama path-traversal, expiry 2026-10-29) is in that class, so on that date it
would have kept reading `[allowlisted]` with no re-review prompt.

**Second gap, same root cause, not named in the issue**: a *malformed* module-only expiry was never
validated either — `time.Parse` + `exit 2` also lived only in the reaching loop, so
`expires: "not-a-date"` rode out as `[allowlisted]` at rc=0.

## The fix

- Module-level status is now `[NOT allowlisted]` / `[allowlisted]` / `[allowlisted, EXPIRED <date>]`,
  via one shared `classifyEntry` helper and one clock, so the two paths cannot drift on the
  `!t.After(now)` boundary.
- A malformed module-only expiry is reported and exits 2 **before** any success output.
- **Still non-gating** per #703: an expired module-only entry is surfaced and the process exits 0.
- The exit-code decision moved out of `main` into a testable `decide`.

## Why `decide` was extracted, and the vacuous test it replaced

The non-gating invariant **cannot** be pinned through the per-class helpers — they are never handed
module-only IDs. The executor's first version asserted `classifyReaching(nil, …)` returned empty.
That passes for any implementation, and measured: it stayed **GREEN** under a mutant that appended
*every* id to `blocking`. The replacement arms red on that mutant.

## Mutation drill

Each mutant asserted **LANDED** (sha256 changed) and **BUILDS** (`go build` rc=0) before its test
result was read, and neutered with `if false && …` so no import goes unused.

| mutant | reds |
|---|---|
| `printModuleOnly` expiry branch | `PrintModuleOnlyAnnotations/expired` + both `DecideExitCodes` expired arms |
| `validateModuleOnly` error return | `ValidateModuleOnlyRejectsMalformedExpiry` + `DecideExitCodes/malformed_module-only_expiry_exits_2` |
| `classifyReaching` gates everything | `DecideExitCodes/expired_module-only_alongside_allowlisted_reaching` — the arm the vacuous test could not |
| **precondition** expired fixture → future date | both expired arms |
| **precondition** module-only fixture → reaching | both expired arms |

Inverse arm: with the first mutant applied and the new tests `-skip`ped, the package is rc=0 — so
the new tests are the killers, not bystanders. Files restored byte-identical by `cp` from a backup
(never `git checkout --`, which would have destroyed uncommitted work).

## Gates

Run outside any sandbox on **darwin/arm64** (windows/ubuntu legs unrun locally, left to CI):
`go build` · `go test -v` · `go vet` · `gofmt -l` on the package · `go test ./tools/...` ·
`make check-changelog check-file-sizes check-boundaries fmt-check vet check-skills` — all rc=0.

End-to-end against the built binary: module-only+expired → `[allowlisted, EXPIRED 2020-01-01]` rc=0;
module-only+future → `[allowlisted]` rc=0 (no `EXPIRED`); module-only+malformed → exit 2;
reaching+expired → unchanged rc=1.

Fixes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)
