### PR TITLE
test(launchd): isolate pin-root lab from driver state

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,13 @@
 
 ## [Unreleased]
 
+### Fixed — the pin-root driver test inherited the scheduled driver's pin state
+
+`test_pin_root.sh` now clears the outer driver's exported pin variables before
+running its synthetic drivers. Previously every case short-circuited as already
+pinned on the production rig, producing 25 failures there while remaining green
+in CI, where those variables are absent.
+
 ### Fixed — `govulncheck-filter` never expiry-checked module-level allowlist entries, so a stale suppression read clean forever
 
 `#716` gave module-level (not function-reaching) findings a third, non-gating report bucket

--- a/tools/launchd/test_pin_root.sh
+++ b/tools/launchd/test_pin_root.sh
@@ -20,6 +20,13 @@ export GIT_AUTHOR_NAME=pinlab GIT_AUTHOR_EMAIL=pinlab@invalid
 export GIT_COMMITTER_NAME=pinlab GIT_COMMITTER_EMAIL=pinlab@invalid
 export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
 
+# A scheduled driver re-execs with these variables exported. They describe the
+# real driver's outer pin and must not leak into the synthetic drivers below:
+# inherited AILANG_DRIVER_PINNED makes every case short-circuit as "already
+# pinned", which turns CI green while the test fails on the rig it protects.
+unset AILANG_DRIVER_PINNED AILANG_DRIVER_DRIFT AILANG_DRIVER_SRC AILANG_DRIVER_REF
+unset MISSION_WORKDIR
+
 PASS=0; FAIL=0
 ok()   { PASS=$((PASS+1)); echo "  PASS: $1"; }
 bad()  { FAIL=$((FAIL+1)); echo "  FAIL: $1"; echo "        got: $2"; }


### PR DESCRIPTION
## Summary

- clear scheduled-driver pin state before the hermetic pin-root lab runs
- make the rig exercise the same synthetic paths as CI
- document the rig-only false red in the current changelog

## Verification

- `bash -n tools/launchd/test_pin_root.sh`
- poisoned ambient arm: 35 passed, 0 failed
- mutation without the isolation: 3 passed, 32 failed
- `make test-launchd-drivers`
- `make check-changelog`

Motoko mission iteration 6, queue item 5b.
