### PR TITLE
docs(mission): enumerate iteration 206 open decisions

### DIFF
--- a/design_docs/mission-dashboard.md
+++ b/design_docs/mission-dashboard.md
@@ -28,4 +28,5 @@
 - `metered=$0.00`; running skill matches origin; billing CLEAN; inbox and human directives empty.
 
 ## Parked on Mark (issue #635)
-`D-1`, `D-2`, `D-8`–`D-14`, and `D-COV-1` are OPEN in the authoritative decision ledger.
+`D-1`, `D-2`, `D-8`, `D-9`, `D-10`, `D-11`, `D-12`, `D-13`, `D-14`, and `D-COV-1` are OPEN in
+the authoritative decision ledger.


### PR DESCRIPTION
Fix the iteration-206 dashboard's open-decision list to enumerate IDs explicitly. The decision-ledger contract forbids ranges because decisions resolve out of order.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
