### PR TITLE
test(mission): guard that the controller model pin is EXPORTED, not just assigned (#696)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@
 # root-level stray build artifact (go build -o wasm ./cmd/wasm); the bare
 # pattern used to shadow the cmd/wasm SOURCE dir and forced -f adds
 /wasm
+# same class (go build ./tools/govulncheck-filter drops the binary at the root):
+# root-anchored so it cannot shadow the tracked tools/govulncheck-filter SOURCE
+# dir. Left untracked in the driver-pin worktree since 2026-08-15, and mission
+# iterations 213/214/215 each had to note and route around it at Gate 0.
+/govulncheck-filter
 
 # Test binary, built with `go test -c`
 *.test

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,31 @@
 
 ## [Unreleased]
 
+### Added — CI guard that the mission controller's model pin is exported, not merely assigned (`#696`)
+
+`#696` reported that `tools/launchd/mission-control.sh` never exported `MODEL`, so the skill's
+routing contract — which reads `$MODEL`/`$MODEL_WHY` inside the controller session and terminates
+every role's `#611` fallback chain there — was reading an always-empty variable. That defect is
+**fixed at HEAD**: `de0e41099` (2026-08-15) introduced `_mc_set_controller`, whose single
+`export CONTROLLER_PROVIDER CONTROLLER_ID MODEL MODEL_WHY MISSION_ANTHROPIC_AVAILABLE`
+(`:234`) runs on all four `select_model` paths — env pin, override file, probe-ok, and the
+Anthropic-unavailable Codex fallback. Confirmed live in a scheduled fire: `MODEL=claude-opus-5`,
+`MODEL_WHY=probe ok`.
+
+Nothing guarded it. `test_mission_routing.sh` already sourced the real selector into a lab, but
+read `MODEL_WHY` in the **same shell**, which passes whether or not `export` is present — so the
+existing coverage was hollow for exactly this defect. The new arm crosses a process boundary
+(`/usr/bin/env`), which is the only observable the `export` keyword actually moves, and pairs the
+check with an in-call known-positive control (`MC_EXPORT_CONTROL`) so a broken pipeline cannot read
+as a missing export.
+
+Two drills, both under `/bin/bash` 3.2.57 (the rig's shell, and the version CI asserts):
+reproducing `#696` by dropping `MODEL MODEL_WHY` from the export list left **all nine pre-existing
+arms green** and failed only the new one — so the new arm is the killer, not a bystander. Weakening
+the arm's own `unset` precondition then made it **pass under that same mutant**, because a suite run
+by the mission loop inherits the controller's real `MODEL`/`MODEL_WHY`; the guard would have been
+vacuous precisely where it matters, and the `unset` is what closes it.
+
 ### Fixed — the pin-root driver test inherited the scheduled driver's pin state
 
 `test_pin_root.sh` now clears the outer driver's exported pin variables before

--- a/tools/launchd/test_mission_routing.sh
+++ b/tools/launchd/test_mission_routing.sh
@@ -52,6 +52,34 @@ out=$(/bin/bash -c '
   printf "%s|%s|%s" "$CONTROLLER_ID" "$MISSION_ANTHROPIC_AVAILABLE" "$MODEL_WHY"
 ' _ "$lab/select.sh" "$lab")
 want "controller selector traverses Anthropic to Codex" "$out" "codex:gpt-5.6-sol|0|Anthropic unavailable; subscription fallback"
+
+# #696 regression guard. `_mc_set_controller` must EXPORT the controller pin, not
+# merely assign it: the skill's routing contract reads `$MODEL`/`$MODEL_WHY` from
+# inside the controller session — a CHILD of this driver — and every role's
+# end-of-chain fallback (#611) terminates at `$MODEL`. The assertion above reads
+# those variables in the SAME shell, so it passes whether or not `export` is
+# present; the observable has to cross a process boundary, and `/usr/bin/env` is
+# that boundary. The pre-`unset` matters: this suite is run by a controller
+# session that already has MODEL exported, so without it the child would inherit
+# the ambient value and the arm would pass for the wrong reason.
+# MC_EXPORT_CONTROL is the known-positive control, read from the SAME `env` call:
+# if it is missing the instrument is broken, not the driver.
+out=$(/bin/bash -c '
+  set -uo pipefail
+  unset MISSION_MODEL MODEL MODEL_WHY CONTROLLER_ID CONTROLLER_PROVIDER MISSION_ANTHROPIC_AVAILABLE
+  export MC_EXPORT_CONTROL=sentinel
+  . "$1"
+  _mc_probe() { [ "$1" = claude-opus-5 ]; }
+  _mc_probe_codex() { return 1; }
+  log() { :; }
+  PREFS="claude-opus-5,claude-fable-5"
+  CONTROLLER_FALLBACK="codex:gpt-5.6-sol"
+  OVERRIDE_FILE="$2/no-override"
+  select_model || exit 1
+  /usr/bin/env | grep -E "^(MC_EXPORT_CONTROL|MODEL|MODEL_WHY|CONTROLLER_ID)=" | LC_ALL=C sort | tr "\n" "|"
+' _ "$lab/select.sh" "$lab")
+want "controller pin is exported to child processes (#696)" "$out" \
+  "CONTROLLER_ID=claude:claude-opus-5|MC_EXPORT_CONTROL=sentinel|MODEL=claude-opus-5|MODEL_WHY=probe ok|"
 rm -rf "$lab"
 
 echo ""


### PR DESCRIPTION
## What

Adds a CI-gated regression guard proving the mission controller's model pin is **exported**, not merely assigned — and gitignores a stray root-level build artifact.

## Why — `#696`, ghost-disciplined at HEAD

`#696` reported that `tools/launchd/mission-control.sh` never exported `MODEL`, so the skill's routing contract (`$MODEL`/`$MODEL_WHY`, and the `#611` end-of-chain fallback every role terminates at) was reading an always-empty variable.

**The defect was REAL when filed (2026-08-13) and is FIXED at HEAD.** `de0e41099` (2026-08-15) introduced `_mc_set_controller`, whose single `export CONTROLLER_PROVIDER CONTROLLER_ID MODEL MODEL_WHY MISSION_ANTHROPIC_AVAILABLE` (`:234`) runs on **all four** `select_model` paths — env pin (`:239`), override file (`:249`), probe-ok (`:257`), Anthropic-unavailable Codex fallback (`:267`). Live-confirmed in a scheduled fire: `MODEL=claude-opus-5`, `MODEL_WHY=probe ok`.

`#696`'s own measurement was an over-anchored pattern (`^\s*export MODEL=|^\s*export MODEL$`) that cannot match a multi-variable bare `export`, which is why the fix arriving incidentally went unnoticed.

**Nothing guarded it**, so it could regress silently. `test_mission_routing.sh` already sourced the real selector into a lab, but read `MODEL_WHY` in the **same shell** — an assertion that passes whether or not `export` is present. Prior coverage was hollow for exactly this defect.

## The new arm

Reads the variables from a **child process** (`/usr/bin/env`) — the only observable the `export` keyword moves — with an in-call known-positive control (`MC_EXPORT_CONTROL`) so a broken pipeline cannot masquerade as a missing export.

## Mutation drills (both under `/bin/bash` 3.2.57 — the rig's shell; CI asserts 3.x)

| drill | result |
|---|---|
| Reproduce `#696`: drop `MODEL MODEL_WHY` from the export list. Mutant LANDED (sha256 changed) and valid (`bash -n` rc=0) | **all 9 pre-existing arms green, only the new arm failed**, control still firing → the new arm is the killer, not a bystander |
| Precondition-neutering: weaken the arm's own `unset`, keep the mutant | **arm PASSED vacuously** — a suite run by the mission loop inherits the controller's real `MODEL`/`MODEL_WHY`, which match the expected string exactly. The `unset` is what closes this. |

Driver restored from a copy (not `git checkout --`) and verified byte-identical by sha256 + `git diff --quiet`.

## Also

`/govulncheck-filter` added to `.gitignore`, root-anchored so it cannot shadow the tracked `tools/govulncheck-filter/` **source** dir — the same hazard the adjacent `/wasm` entry documents. Verified with four controls (root artifact ignored; tracked source not ignored; `/wasm` still ignored; a random new file not ignored). It has sat untracked in the driver-pin worktree since 2026-08-15, and mission iterations 213/214/215 each had to note and route around it at Gate 0.

## Gates

Baselined on **pristine `origin/dev`** first (rc=0, 9 passed / 0 failed), so these measure the change rather than the repo:

- `make test-launchd-drivers` → **rc=0, 10 passed / 0 failed**
- `make check-changelog` → rc=0
- `gofmt -l` → 0 files

Platform: green on **darwin/arm64**; the ubuntu and windows CI legs are unrun locally.

Fixes #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)
