### PR TITLE
fix(ci): the changelog gate certified a link to a file that did not exist

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,34 @@
 
 ## [Unreleased]
 
+### Fixed — the changelog index gate certified a link to a file that did not exist
+
+The gate's link check was guarded by `[ -n "$ACTIVE" ]`, so when `ls changelogs/ | grep current`
+came back empty the check was skipped entirely. Measured on `dev` at `a99083ae5`: `rm -rf
+changelogs/` gives `rc=0`, and so does a `changelogs/` holding only `v0.17-old.md` — both printing
+`✓ CHANGELOG.md is index-only and links changelogs/`, with a blank filename in the success message.
+
+That is the same silent drop this gate exists to prevent, arriving from the far end. The gate
+watches for release notes piling up in the index; nothing watched whether the archive they are
+supposed to move *into* still existed. `release-manager` builds the notes from the active file, so
+with no active file there are no notes — and the gate said green.
+
+`ls changelogs/` is an enumerator, and an enumerator that comes back empty must fail loudly rather
+than pass. There is now a second anti-vacuity floor beside the archive-heading one, and the
+now-provably-true `[ -n "$ACTIVE" ]` guard is gone rather than left as a branch that can never fire.
+
+The self-test grows from 9 arms to 13: two for the new floor (directory removed; directory present
+with no `*current*` file), and two pinning `## [Unreleased]` and `## [v0.32.0]` by name. The
+structural rule already refuses both bracketed shapes, but only arms 3–5 pinned it — so a future
+rewrite could regress the shapes the *old* lexical gate caught while every existing arm stayed
+green. All four arms come from motoko's `#758`, closed as superseded on 2026-08-17 under the
+repo-ownership rule; carrying them over is what stops a closed PR's work being lost.
+
+Drilled both ways: `if false && [ -z "$ACTIVE" ]` leaves all eleven other arms green and fails
+**only** the two new floor arms, so they are the branch's killers rather than bystanders; `if false
+&& [ -n "$OFFENDERS" ]` fails the two new bracketed arms alongside arms 2–5, which share that
+branch. Mutants asserted landed by sha256 and valid by `bash -n`; restore verified byte-identical.
+
 ### Fixed — the stdlib run-fixture harness never granted `--caps IO`, and hid the error that said so
 
 `9504393d0` closed a real hole: bare prelude `println` bypassed the capability system, so `--caps`

--- a/scripts/check_changelog.sh
+++ b/scripts/check_changelog.sh
@@ -35,6 +35,29 @@ fi
 
 ACTIVE=$(ls changelogs/ 2>/dev/null | grep current | head -1)
 
+# Second anti-vacuity floor, on the OTHER side of the index (added 2026-08-18,
+# iteration 218). The link check below is guarded by `[ -n "$ACTIVE" ]`, so an
+# absent or *current*-less changelogs/ directory skipped it entirely and the gate
+# exited 0 printing `links changelogs/` with an empty filename -- an index
+# certified as pointing at a file that does not exist. Measured on dev at
+# a99083ae5: `rm -rf changelogs/` gave rc=0, and so did a changelogs/ holding
+# only v0.17-old.md.
+#
+# That is the same silent-drop this whole gate exists to prevent, arriving from
+# the far end: release-manager builds notes from the active file, so if there is
+# no active file there are no release notes, and the gate said green.
+# A gate's coverage is a property of its enumerator; `ls changelogs/` is one, and
+# an enumerator that comes back empty must FAIL LOUDLY, never pass.
+if [ -z "$ACTIVE" ]; then
+	echo -e "${RED}✗ no changelogs/*current* file found -- the index points nowhere${RESET}"
+	echo ""
+	echo "$ROOT_CHANGELOG is an index into changelogs/, and release-manager builds"
+	echo "the release notes from the active changelogs/v*-current.md file. With no"
+	echo "such file there is nothing to build notes from, so this gate refuses"
+	echo "rather than passing on an empty enumeration."
+	exit 1
+fi
+
 # Anti-vacuity floor: the archive heading is the one heading an index is allowed
 # to have, and every check below is stated relative to it. Without it we cannot
 # tell an index from an empty file, and "no offenders found" would be vacuous.
@@ -69,7 +92,10 @@ if [ -n "$OFFENDERS" ]; then
 fi
 
 # The index is only useful if it actually points at the active changelog.
-if [ -n "$ACTIVE" ] && ! grep -qF "changelogs/$ACTIVE" "$ROOT_CHANGELOG"; then
+# No `[ -n "$ACTIVE" ]` guard: the floor above already refused the empty case, so
+# keeping one here would be a branch that can never fire -- and a permanently-true
+# guard is exactly what let the empty case slip past this check before.
+if ! grep -qF "changelogs/$ACTIVE" "$ROOT_CHANGELOG"; then
 	echo -e "${RED}✗ $ROOT_CHANGELOG does not link the active changelog (changelogs/$ACTIVE)${RESET}"
 	exit 1
 fi

--- a/scripts/test_check_changelog.sh
+++ b/scripts/test_check_changelog.sh
@@ -21,7 +21,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 GATE="$REPO_ROOT/scripts/check_changelog.sh"
 FAILED=0
 ARMS_RUN=0
-ARMS_EXPECTED=9
+ARMS_EXPECTED=13
 
 pass() { echo "  ok   — $1"; ARMS_RUN=$((ARMS_RUN + 1)); }
 fail() { echo "  FAIL — $1"; FAILED=1; ARMS_RUN=$((ARMS_RUN + 1)); }
@@ -146,6 +146,38 @@ D="$WORK/missing"; mkdir -p "$D/changelogs"
 printf '%s\n' '# Current' > "$D/changelogs/v0.18-current.md"
 run_gate "$D"
 expect "refuses a missing CHANGELOG.md" 1 "$RC" "not found (run from repo root)"
+
+# --- arms 10-11: NEW — bracketed headings, named explicitly ------------------------------------
+# The structural rule ("any heading but the archive table") already refuses these, and arms 3-5
+# above cover the shapes that used to be invisible. These two pin the shapes the OLD lexical gate
+# DID catch by name, so a future rewrite cannot regress them silently while arms 3-5 stay green.
+# Carried over from motoko's #758, which was closed as superseded on 2026-08-17 under the
+# repo-ownership rule; its self-test had these and the landed one did not.
+D="$WORK/bracketed-unreleased"; make_fixture "$D"
+printf '\n%s\n' '## [Unreleased]' >> "$D/CHANGELOG.md"
+run_gate "$D"
+expect "refuses '## [Unreleased]' (bracketed)" 1 "$RC" "contains release-note content"
+
+D="$WORK/bracketed-version"; make_fixture "$D"
+printf '\n%s\n' '## [v0.32.0]' >> "$D/CHANGELOG.md"
+run_gate "$D"
+expect "refuses '## [v0.32.0]' (bracketed version)" 1 "$RC" "contains release-note content"
+
+# --- arms 12-13: NEW — the index must point somewhere -------------------------------------------
+# These target the second anti-vacuity floor. Before it, BOTH of these fixtures exited 0 with
+# `✓ CHANGELOG.md is index-only and links changelogs/` — a blank filename in a success message,
+# certifying a link to a file that does not exist. Measured on dev at a99083ae5.
+# Two input shapes, one branch: the directory is gone, and the directory survives with no
+# *current* file in it (a rename or an archive rollover).
+D="$WORK/nochangelogsdir"; make_fixture "$D"
+rm -rf "$D/changelogs"
+run_gate "$D"
+expect "refuses a missing changelogs/ directory" 1 "$RC" "the index points nowhere"
+
+D="$WORK/nocurrentfile"; make_fixture "$D"
+rm -f "$D/changelogs/v0.18-current.md"; printf '%s\n' '# Old' > "$D/changelogs/v0.17-old.md"
+run_gate "$D"
+expect "refuses a changelogs/ with no *current* file" 1 "$RC" "the index points nowhere"
 
 # --- anti-vacuity: every arm must have run ------------------------------------------------------
 if [ "$ARMS_RUN" -ne "$ARMS_EXPECTED" ]; then


### PR DESCRIPTION
## What

`scripts/check_changelog.sh` guarded its link check with `[ -n "$ACTIVE" ]`, so an empty
`ls changelogs/ | grep current` skipped it entirely and the gate exited **0** printing
`✓ CHANGELOG.md is index-only and links changelogs/` — a blank filename in a success message,
certifying a link to a file that does not exist.

Measured on `dev` at `a99083ae5` (control: clean fixture rc=0):

| fixture | before | after |
|---|---|---|
| `rm -rf changelogs/` | **rc=0** ✓green | rc=1 |
| `changelogs/` with only `v0.17-old.md` | **rc=0** ✓green | rc=1 |
| `## [Unreleased]` in the index | rc=1 | rc=1 (now pinned) |
| `## [v0.32.0]` in the index | rc=1 | rc=1 (now pinned) |

This is the same silent drop the gate exists to prevent, arriving from the far end: it watched the
index filling up, and nothing watched whether the archive those entries move *into* still existed.
`release-manager` builds notes from the active file, so with no active file there are no release
notes — and the gate said green.

## Changes

- **New refusal branch** — a second anti-vacuity floor beside the archive-heading one. `ls
  changelogs/` is an enumerator, and an enumerator that returns empty must fail loudly. The
  now-provably-true `[ -n "$ACTIVE" ]` guard is deleted rather than left as a branch that can never
  fire.
- **Self-test 9 arms → 13.** Two pin the new floor; two pin `## [Unreleased]` / `## [v0.32.0]` by
  name. The structural rule already refuses both bracketed shapes, but only arms 3–5 pinned it, so
  a rewrite could regress the shapes the *old* lexical gate caught while every existing arm stayed
  green. All four arms are carried over from motoko's #758, closed as superseded on 2026-08-17
  under the repo-ownership rule — a follow-up that never gets written is how a closed PR's work is
  actually lost.

## Mutation drill

| mutant | result |
|---|---|
| `if false && [ -z "$ACTIVE" ]` | all **11** other arms green, **only** arms 12–13 fail → they are that branch's killers, not bystanders |
| `if false && [ -n "$OFFENDERS" ]` | arms 10–11 fail **alongside** arms 2–5, which share that branch → recorded honestly as shape pins, not branch killers |

Both mutants asserted LANDED by sha256 and valid by `bash -n`. Restored from a copy (never
`git checkout --`) and verified byte-identical to `9707d1185`.

## Gates

Baselined on pristine `origin/dev` first (9/9 arms, rc=0), so these measure the change and not the
repo. On **darwin/arm64**: `make check-changelog`, `make test-check-changelog` (13/13),
`make check-file-sizes`, `make check-boundaries` — all rc=0. Windows and ubuntu legs unrun locally.
No Go touched.

Queue item: `m-changelog-gate-deltas` (V1 mission iteration 218).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
