### PR TITLE
test(ci): pin the two untested decide() refusal branches in govulncheck-filter

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,30 @@
 
 ## [Unreleased]
 
+### Fixed — govulncheck-filter: two `decide()` refusal branches had no test at any level
+
+`decide()` has exactly four `return 2` refusal branches. Two were pinned by
+`TestDecideExitCodes` (malformed expiry on a reaching entry, and on a module-only entry);
+the other two were reachable from tests only after `#726` extracted the exit-code decision
+out of `main()`, and nobody had gone back for them:
+
+- a repeated `id:` in `.govulncheck-allow.yml`, which exits 2 rather than silently masking
+  one of the entries;
+- govulncheck JSON that will not decode, which exits 2 rather than being read as an empty
+  finding set.
+
+Neither is a correctness bug today; the risk is that a regression in either path ships
+silently. Exit code 2 is over-subscribed — all four branches reach it — so both new arms
+assert a branch-unique message (`duplicate allowlist entry for GO-REACH`, `parse stdin:`)
+rather than the code alone, following the pattern the malformed-expiry arms already set.
+
+Drilled per arm, each mutant asserted LANDED by sha256 and BUILDS by `go build` rc=0:
+`if _, dup := byID[e.ID]; false && dup` reds **only** `duplicate allowlist id exits 2`, and
+`if false && err != nil` on the `readFindings` result reds **only** `unparseable stdin exits
+2`. In both drills the other six arms stay green and the rest of the package is rc=0, so each
+new arm is its branch's killer rather than a bystander. `main.go` was restored from a copy
+(never `git checkout --`) and verified byte-identical by sha256. Closes `#727`.
+
 ### Fixed — the changelog index gate certified a link to a file that did not exist
 
 The gate's link check was guarded by `[ -n "$ACTIVE" ]`, so when `ls changelogs/ | grep current`

--- a/tools/govulncheck-filter/main_test.go
+++ b/tools/govulncheck-filter/main_test.go
@@ -143,6 +143,32 @@ func TestDecideExitCodes(t *testing.T) {
 			wantCode: 2,
 			wantOut:  `bad expires date "not-a-date" for GO-REACH`,
 		},
+		{
+			// #727 branch 1 of 2: a repeated `id:` in .govulncheck-allow.yml
+			// exits 2 rather than silently masking one of the entries. This
+			// branch runs BEFORE readFindings, so the findings here are valid
+			// and non-gating — the only thing that can produce a non-zero is
+			// the duplicate. Exit code 2 is over-subscribed (four distinct
+			// causes reach it), so the assertion is on the branch-unique
+			// message, never on the code alone.
+			name:     "duplicate allowlist id exits 2",
+			findings: reachingListed,
+			allow:    []allowEntry{freshReaching, {ID: "GO-REACH", Reason: "duplicate row", Expires: "2031-01-01"}},
+			wantCode: 2,
+			wantOut:  "duplicate allowlist entry for GO-REACH",
+		},
+		{
+			// #727 branch 2 of 2: govulncheck JSON that will not decode is an
+			// input error, not an empty finding set. Without this arm the
+			// readFindings error path is indistinguishable from a clean run
+			// with no findings — both would leave decide() returning 0.
+			// `allow` is nil so the duplicate branch above cannot fire first.
+			name:     "unparseable stdin exits 2",
+			findings: "this is not govulncheck json",
+			allow:    nil,
+			wantCode: 2,
+			wantOut:  "parse stdin:",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Closes #727.

## What

`decide()` in `tools/govulncheck-filter/main.go` has **exactly four** `return 2` refusal
branches (enumeration anchored to the code, not to the issue text):

| branch | pinned before this PR |
|---|---|
| duplicate `id:` in `.govulncheck-allow.yml` | **no** |
| `readFindings` fails on malformed govulncheck JSON | **no** |
| `classifyReaching` malformed expiry | yes (`malformed reaching expiry exits 2`) |
| `validateModuleOnly` malformed expiry | yes (`malformed module-only expiry exits 2`) |

This adds one `TestDecideExitCodes` arm per unpinned branch (5 arms → 7).

## Why the assertion is on the message, not the code

Exit code 2 is over-subscribed — all four branches above reach it — so an arm asserting only
`wantCode: 2` would pass for any of the other three. Both new arms assert a branch-unique
substring (`duplicate allowlist entry for GO-REACH`, `parse stdin:`), following the pattern
the malformed-expiry arms already set. Each arm is also constructed so no *earlier* branch can
fire first: the duplicate arm supplies valid, non-gating findings, and the unparseable-stdin
arm supplies `allow: nil`.

## Verification

Baselined on pristine `origin/dev` (`0524a0fc5`) before any edit: package `rc=0`.

Mutation drill, per arm. Each mutant asserted **LANDED** (sha256 before ≠ after) and **BUILDS**
(`go build ./tools/govulncheck-filter/` rc=0) before its test result was read:

| mutation | arms redded | rest of package |
|---|---|---|
| `if _, dup := byID[e.ID]; false && dup` | **only** `duplicate allowlist id exits 2` (other 6 green) | `-skip TestDecideExitCodes` rc=0 |
| `if false && err != nil` on the `readFindings` result | **only** `unparseable stdin exits 2` (other 6 green) | `-skip TestDecideExitCodes` rc=0 |

The `-skip` arm is what proves each new test is its branch's **killer** rather than a bystander
riding someone else's red. `main.go` was restored from a copy (never `git checkout --`, which
would have deleted uncommitted work) and verified byte-identical by sha256 in both drills.

Gates run: `gofmt -l` (clean), `go vet`, `go build`, `go test`, `make check-changelog`,
`make test-check-changelog` (13 arms), `make check-file-sizes`, `make check-boundaries` — all
rc=0. All on **darwin/arm64**; the ubuntu and windows legs are unrun locally and are CI's to
report.

Changelog entry filed into `changelogs/v0.18-current.md`, never the root index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
