### PR TITLE
fix(#708): design-quorum discarded the token counts it had just read

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,53 @@
 
 ## [Unreleased]
 
+### Fixed — `design-quorum` discarded the token counts it had just read, so a quorum stage could only ever post zeros
+
+The mission-control Gate-3 chain ledger requires every metered stage to post
+`tokens_in`/`tokens_out`. A quorum stage could not: `RunReviewer` read the provider's
+counts, spent them on `estimateCost`, and dropped them — a reviewer object carried
+`cost_usd,landed,model,present,result` and nothing else. That is exactly the
+iteration-190 signature the mandate exists to prevent (`$0.0570`/`$0.0507` recorded at
+**zero** tokens), and it was a tool gap rather than a controller lapse (#708).
+
+The same counts were being discarded on **both** tiers, so the fix is one sweep rather
+than one patch:
+
+- `ReviewerOutcome` gains `tokens_in`/`tokens_out`, recorded alongside `cost_usd`.
+- The agentic (Tier-2) tier carries the executor's own counts through `AgenticRun` and
+  the `agenticCaller` adapter. Cost there stays **observed**, never re-derived from the
+  now-available tokens — the counts are for accounting, not pricing.
+- Tokens are recorded on a **failed** agentic run too, matching what cost already did: a
+  billed-but-failed reviewer is the least explicable spend in the artifact.
+- `Synthesis` gains `total_tokens_in`/`total_tokens_out` at the same Tier-1-only scope
+  `total_cost_usd` has always had, so the two totals stay comparable.
+- `QuorumResult.TokenAccountingGaps()` names any reviewer billed with zero reported
+  tokens — a zero there is indistinguishable from a free call, so it is surfaced by name
+  (stderr, loud) rather than defaulted away. It reports; it never blocks a quorum.
+
+A mutation drill found a second, larger hole while pinning the first: zeroing the token
+mapping in the production `coordinator.ExecuteResult` → `AgenticRun` adapter left the
+**entire package green**. That mapping sat behind `NewExecutorProvider`, so no test could
+reach it — i.e. the one place the executor's real counts enter the quorum had no coverage
+at all. It is now the extracted `agenticRunFromExecuteResult` and is pinned, nil guard
+included.
+
+**Ten** new arms, eight mutation drills. Every mutant was asserted LANDED by sha256 and
+BUILDS by `go build` rc=0 before any test result was read, and each drill's inverse
+`-skip` run is rc=0 — which is what proves the named arms are the killers rather than
+bystanders riding someone else's red. Six drills red exactly one arm each (text-tier
+recording, provider token mapping, provider nil guard, Tier-2 enumerator, synthesis
+totals, and the `json` tag). Two red a pair, recorded as such rather than claimed as
+unique kills: neutering the agentic recording reds both agentic arms, since one
+assignment serves its success and failure branches; widening the gap condition reds both
+gap-flagging arms, since each carries a healthy-reviewer control. The tenth arm
+(`SilentOnUnbilledReviewer`) is that widening drill's negative control and was not
+drilled on its own.
+
+The artifact arm is the one that matters most: every struct-level arm stays green under a
+`json:"-"` tag while the written artifact remains exactly as tokenless as before, so the
+assertion is on the emitted JSON keys the controller's `jq` actually reads.
+
 ### Fixed — govulncheck-filter: two `decide()` refusal branches had no test at any level
 
 `decide()` has exactly four `return 2` refusal branches. Two were pinned by

--- a/cmd/ailang/design_quorum.go
+++ b/cmd/ailang/design_quorum.go
@@ -66,6 +66,15 @@ func runDesignQuorum() {
 	}
 	fmt.Fprintf(os.Stderr, "quorum artifact: %s\n", artPath)
 
+	// LOUD, non-blocking: a reviewer billed with zero reported tokens leaves the
+	// Gate-3 chain ledger unreconcilable, and a zero there reads exactly like a
+	// free call. Name it rather than let it pass silently (#708). This never
+	// changes the exit code — an unreconcilable reviewer must not wedge a
+	// quorum the loop depends on.
+	for _, gap := range result.TokenAccountingGaps() {
+		fmt.Fprintf(os.Stderr, "design-quorum: TOKEN ACCOUNTING GAP — %s\n", gap)
+	}
+
 	// Optionally append the human markdown block to the mission log.
 	if *logPath != "" {
 		if _, lerr := quorum.AppendMarkdownToLog(*logPath, result); lerr != nil {

--- a/internal/mission/quorum/agentic_caller.go
+++ b/internal/mission/quorum/agentic_caller.go
@@ -30,6 +30,14 @@ type AgenticRun struct {
 	// CostUSD is the observed post-hoc cost (= coordinator ExecuteResult.Cost =
 	// executor CostUSD). The per-review cap is enforced against THIS value.
 	CostUSD float64
+	// InputTokens/OutputTokens are the executor's OWN reported token counts
+	// (= coordinator ExecuteResult.InputTokens/OutputTokens). They do NOT feed
+	// the cap — the agentic tier's cost stays OBSERVED, not derived — they are
+	// recorded so the artifact can satisfy the chain ledger's token mandate
+	// (#708). An executor that reports cost but no tokens leaves these zero,
+	// which TokenAccountingGaps surfaces rather than hides.
+	InputTokens  int
+	OutputTokens int
 }
 
 // AgenticRunner runs a single bounded, read-only agentic review and returns its
@@ -66,6 +74,11 @@ type agenticCaller struct {
 	// lastErr records an executor-level failure (Success=false) so the outcome
 	// is recorded as unreachable, not a silent pass.
 	lastErr string
+	// lastInputTokens/lastOutputTokens mirror lastCostUSD: the executor's own
+	// counts, captured on EVERY run (including a failed one) so the audit
+	// record is not silently narrower than the cost record.
+	lastInputTokens  int
+	lastOutputTokens int
 }
 
 // DefaultAgenticTimeout is the bounded wall-clock cap for a single agentic
@@ -74,9 +87,10 @@ type agenticCaller struct {
 const DefaultAgenticTimeout = 5 * time.Minute
 
 // CallJSON satisfies JSONCaller. It runs the bounded agentic review and returns
-// the raw verdict JSON. The *ai.Response it returns carries zero token counts:
-// the agentic tier's cost is OBSERVED (lastCostUSD), not derived from tokens,
-// so RunAgenticReviewer uses the observed cost rather than estimateCost.
+// the raw verdict JSON plus the executor's reported token counts. Cost is still
+// OBSERVED (lastCostUSD) rather than derived from those tokens, so
+// RunAgenticReviewer uses the observed cost rather than estimateCost — the
+// tokens are carried for ACCOUNTING (#708), not for pricing.
 func (c *agenticCaller) CallJSON(sysPrompt, userPrompt, _ string) (string, *ai.Response, error) {
 	timeout := c.timeout
 	if timeout <= 0 {
@@ -95,6 +109,7 @@ func (c *agenticCaller) CallJSON(sysPrompt, userPrompt, _ string) (string, *ai.R
 		return "", nil, fmt.Errorf("agentic runner returned nil run")
 	}
 	c.lastCostUSD = run.CostUSD
+	c.lastInputTokens, c.lastOutputTokens = run.InputTokens, run.OutputTokens
 	if !run.Success {
 		c.lastErr = run.Err
 		if c.lastErr == "" {
@@ -102,7 +117,11 @@ func (c *agenticCaller) CallJSON(sysPrompt, userPrompt, _ string) (string, *ai.R
 		}
 		return "", nil, fmt.Errorf("agentic run failed: %s", c.lastErr)
 	}
-	return strings.TrimSpace(run.Output), &ai.Response{}, nil
+	return strings.TrimSpace(run.Output), &ai.Response{
+		InputTokens:  run.InputTokens,
+		OutputTokens: run.OutputTokens,
+		TotalTokens:  run.InputTokens + run.OutputTokens,
+	}, nil
 }
 
 // agenticSystemPrompt is the SHIPPED reviewer systemPrompt PLUS the agentic-only
@@ -155,8 +174,11 @@ func RunAgenticReviewer(modelLabel, docPath, docBody, contestedPremise string, m
 
 	raw, _, cerr := caller.CallJSON(agenticSystemPrompt, BuildAgenticPrompt(docPath, docBody, contestedPremise), reviewSchema)
 
-	// Record the observed cost regardless of outcome (audit).
+	// Record the observed cost AND the executor's token counts regardless of
+	// outcome (audit). Recording cost without tokens is exactly the gap #708
+	// closes: a billed reviewer that reports zero tokens is unreconcilable.
 	out.CostUSD = caller.lastCostUSD
+	out.TokensIn, out.TokensOut = caller.lastInputTokens, caller.lastOutputTokens
 
 	if cerr != nil {
 		out.AbsentReason = ReasonUnreachable

--- a/internal/mission/quorum/agentic_provider.go
+++ b/internal/mission/quorum/agentic_provider.go
@@ -16,6 +16,7 @@ import (
 //   - bounded turn/time cap via opts.Timeout + opts.IdleTimeout,
 //   - cancellation via Execute(ctx, ...),
 //   - observed cost via result.Cost (= execResult.CostUSD),
+//   - observed token counts via result.InputTokens/OutputTokens (#708),
 //   - read-only worktree via opts.Workspace.
 //
 // executorName is the executor registered in the global factory ("codex" =
@@ -62,14 +63,30 @@ func NewCoordinatorAgenticRunner(executorName, workspace, model string, idleTime
 		if execErr != nil {
 			return &AgenticRun{Success: false, Err: execErr.Error()}, nil
 		}
-		if res == nil {
-			return &AgenticRun{Success: false, Err: "executor returned nil result"}, nil
-		}
-		return &AgenticRun{
-			Output:  res.Output,
-			Success: res.Success,
-			Err:     res.Error,
-			CostUSD: res.Cost,
-		}, nil
+		return agenticRunFromExecuteResult(res), nil
 	}, nil
+}
+
+// agenticRunFromExecuteResult maps the coordinator's ExecuteResult onto the
+// quorum's minimal AgenticRun surface.
+//
+// It is a named function rather than an inline literal because it is the ONLY
+// place the executor's real token counts enter the quorum, and it sits behind
+// NewExecutorProvider — which needs a registered executor, so no test reached
+// it. A mutation drill confirmed that: zeroing the token mapping here left the
+// entire package green (#708). Extracted so the mapping is pinnable on its own.
+//
+// A nil result is an executor-level failure, never a silent pass.
+func agenticRunFromExecuteResult(res *coordinator.ExecuteResult) *AgenticRun {
+	if res == nil {
+		return &AgenticRun{Success: false, Err: "executor returned nil result"}
+	}
+	return &AgenticRun{
+		Output:       res.Output,
+		Success:      res.Success,
+		Err:          res.Error,
+		CostUSD:      res.Cost,
+		InputTokens:  res.InputTokens,
+		OutputTokens: res.OutputTokens,
+	}
 }

--- a/internal/mission/quorum/artifact.go
+++ b/internal/mission/quorum/artifact.go
@@ -82,10 +82,12 @@ func WriteJSONArtifact(dir string, q *QuorumResult) (string, error) {
 func MarkdownBlock(q *QuorumResult) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "#### Design-quorum review — `%s` (%s)\n\n", q.Doc, q.ISOTimestamp)
-	fmt.Fprintf(&b, "- **Synthesis: %s** (total $%.4f)\n", strings.ToUpper(string(q.Synthesis.Verdict)), q.Synthesis.TotalCostUSD)
+	fmt.Fprintf(&b, "- **Synthesis: %s** (total $%.4f, %d in / %d out tok)\n",
+		strings.ToUpper(string(q.Synthesis.Verdict)), q.Synthesis.TotalCostUSD,
+		q.Synthesis.TotalTokensIn, q.Synthesis.TotalTokensOut)
 	for _, o := range q.Reviewers {
 		if o.Present {
-			fmt.Fprintf(&b, "- `%s` → **%s** ($%.4f) — %s\n", o.Model, o.Result.Verdict, o.CostUSD, o.Result.StrongestObjection)
+			fmt.Fprintf(&b, "- `%s` → **%s** ($%.4f, %d/%d tok) — %s\n", o.Model, o.Result.Verdict, o.CostUSD, o.TokensIn, o.TokensOut, o.Result.StrongestObjection)
 		} else {
 			fmt.Fprintf(&b, "- `%s` → **ABSENT** (%s) — degraded to N-1, not a silent pass\n", o.Model, o.AbsentReason)
 		}
@@ -100,7 +102,7 @@ func MarkdownBlock(q *QuorumResult) string {
 				continue
 			}
 			if o.Present {
-				fmt.Fprintf(&b, "  - `%s` (tier2) → **%s** ($%.4f) — %s\n", o.Model, o.Result.Verdict, o.CostUSD, o.Result.StrongestObjection)
+				fmt.Fprintf(&b, "  - `%s` (tier2) → **%s** ($%.4f, %d/%d tok) — %s\n", o.Model, o.Result.Verdict, o.CostUSD, o.TokensIn, o.TokensOut, o.Result.StrongestObjection)
 			} else {
 				fmt.Fprintf(&b, "  - `%s` (tier2) → **ABSENT** (%s) — degraded to N-1, not a silent pass\n", o.Model, o.AbsentReason)
 			}

--- a/internal/mission/quorum/quorum.go
+++ b/internal/mission/quorum/quorum.go
@@ -50,6 +50,12 @@ type Synthesis struct {
 	// with its reason. Empty when all reviewers were present.
 	AbsentReviewers []AbsentNote `json:"absent_reviewers"`
 	TotalCostUSD    float64      `json:"total_cost_usd"`
+	// TotalTokensIn/TotalTokensOut sum the TIER-1 reviewers only — exactly the
+	// scope TotalCostUSD has always had. A Tier-2 escalation's tokens live on
+	// its own outcomes under `tier2`, and are NOT folded in here, so the two
+	// totals stay comparable with the shipped cost total (#708).
+	TotalTokensIn  int `json:"total_tokens_in"`
+	TotalTokensOut int `json:"total_tokens_out"`
 }
 
 // AbsentNote records one missing reviewer for the synthesis.
@@ -141,6 +147,8 @@ func synthesize(outcomes []*ReviewerOutcome, controller *ControllerReview) Synth
 
 	for _, o := range outcomes {
 		s.TotalCostUSD += o.CostUSD
+		s.TotalTokensIn += o.TokensIn
+		s.TotalTokensOut += o.TokensOut
 		if !o.Present {
 			s.AbsentReviewers = append(s.AbsentReviewers, AbsentNote{Model: o.Model, Reason: o.AbsentReason})
 			continue

--- a/internal/mission/quorum/run.go
+++ b/internal/mission/quorum/run.go
@@ -44,6 +44,16 @@ type ReviewerOutcome struct {
 	Model   string  `json:"model"`
 	CostUSD float64 `json:"cost_usd"`
 
+	// TokensIn/TokensOut are the provider's OWN reported token counts for this
+	// reviewer call. They are recorded alongside CostUSD because the
+	// mission-control Gate-3 chain ledger requires every metered stage to post
+	// tokens_in/tokens_out, and a quorum stage could previously only supply
+	// zeros: the counts were read (to derive cost) and then discarded (#708).
+	// A zero here is indistinguishable from a free call, so it is a REPORTABLE
+	// gap rather than a default — see TokenAccountingGaps.
+	TokensIn  int `json:"tokens_in"`
+	TokensOut int `json:"tokens_out"`
+
 	// Present is true iff the reviewer ran and returned a valid verdict.
 	Present bool `json:"present"`
 	// AbsentReason is populated iff Present is false: one of "unreachable",
@@ -134,7 +144,10 @@ func runReviewerWith(caller JSONCaller, mc *eval_harness.ModelConfig, out *Revie
 		return out
 	}
 
-	// POST-flight actual cost from token counts × models.yml pricing.
+	// POST-flight actual cost from token counts × models.yml pricing. The same
+	// counts are RECORDED, not just consumed: cost alone cannot be reconciled
+	// against a provider bill, and the chain ledger mandates both (#708).
+	out.TokensIn, out.TokensOut = resp.InputTokens, resp.OutputTokens
 	out.CostUSD = estimateCost(mc, resp.InputTokens, resp.OutputTokens)
 
 	result, perr := ParseReviewResult(raw)

--- a/internal/mission/quorum/tokens.go
+++ b/internal/mission/quorum/tokens.go
@@ -1,0 +1,46 @@
+package quorum
+
+import "fmt"
+
+// TokenAccountingGaps names every reviewer outcome that recorded a NON-ZERO
+// cost while reporting ZERO tokens.
+//
+// Why this exists (#708): the mission-control Gate-3 chain ledger requires each
+// metered stage to post tokens_in/tokens_out, and a quorum stage could only
+// ever supply zeros — the provider's counts were read to derive cost and then
+// discarded. With the counts recorded, the remaining failure mode is a provider
+// or executor that bills without reporting usage. A zero there is
+// INDISTINGUISHABLE from a free call, so it must be surfaced by name rather
+// than defaulted away (Critical Principle 2 — no silent fallback on anything
+// that feeds a spend record).
+//
+// This is a REPORT, not a refusal: an unreconcilable reviewer must never wedge
+// a quorum the loop depends on. Callers print it loudly; tests assert on it.
+//
+// The enumeration deliberately covers BOTH tiers. A checker that walked only
+// q.Reviewers would be blind by construction to every escalated agentic
+// reviewer — precisely the tier whose cost is OBSERVED rather than derived, and
+// therefore the one most likely to bill without usage.
+func (q *QuorumResult) TokenAccountingGaps() []string {
+	if q == nil {
+		return nil
+	}
+	var gaps []string
+	collect := func(tier string, outcomes []*ReviewerOutcome) {
+		for _, o := range outcomes {
+			if o == nil {
+				continue
+			}
+			if o.CostUSD > 0 && o.TokensIn == 0 && o.TokensOut == 0 {
+				gaps = append(gaps, fmt.Sprintf(
+					"%s%s: $%.4f billed with ZERO reported tokens — spend cannot be reconciled",
+					o.Model, tier, o.CostUSD))
+			}
+		}
+	}
+	collect("", q.Reviewers)
+	if q.Tier2 != nil {
+		collect(" (tier2)", q.Tier2.Reviewers)
+	}
+	return gaps
+}

--- a/internal/mission/quorum/tokens_test.go
+++ b/internal/mission/quorum/tokens_test.go
@@ -1,0 +1,290 @@
+package quorum
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sunholo-data/ailang/internal/ai"
+	"github.com/sunholo-data/ailang/internal/coordinator"
+)
+
+// The token values below are deliberately ARBITRARY and DISTINCT per arm. An
+// assertion against a status enum, a boolean, or a zero passes for any number
+// of unrelated reasons; a specific pair of counts can only have come from the
+// stub these arms inject.
+const (
+	textTierIn   = 1234
+	textTierOut  = 567
+	agenticIn    = 4321
+	agenticOut   = 765
+	failedRunIn  = 999
+	failedRunOut = 111
+)
+
+const passVerdictJSON = `{"verdict":"pass","strongest_objection":"none — premises check out","catch":"ran the cited command"}`
+
+// TestTextTierRecordsProviderTokens is the branch killer for the text tier's
+// recording step. Before #708 the provider's counts were consumed by
+// estimateCost and then discarded, so this arm reds if that assignment is
+// removed — while the cost assertion beside it stays green, which is exactly
+// why cost alone was never evidence that usage had been captured.
+func TestTextTierRecordsProviderTokens(t *testing.T) {
+	stub := &stubCaller{
+		raw:  passVerdictJSON,
+		resp: &ai.Response{InputTokens: textTierIn, OutputTokens: textTierOut},
+	}
+	out := runReviewerWith(stub, cheapModel(), &ReviewerOutcome{Model: "test-model"}, "doc.md", "body", DefaultMaxCostUSD)
+
+	if !out.Present {
+		t.Fatalf("expected Present, got absent: %s", out.Err)
+	}
+	if out.TokensIn != textTierIn || out.TokensOut != textTierOut {
+		t.Errorf("tokens = %d/%d, want %d/%d — the provider's counts were read for cost and discarded (#708)",
+			out.TokensIn, out.TokensOut, textTierIn, textTierOut)
+	}
+	// The cost arithmetic must be UNCHANGED by the recording step. Compared
+	// with a tolerance, not for bit equality: measured on darwin/arm64 the two
+	// call sites differ by 1 ULP (0x…aab vs 0x…aac) because the compiler is
+	// free to contract `a*b + c*d` into an FMA in one inlining context and not
+	// the other. A bit-exact assertion here would red for the FPU, not for the
+	// change under test.
+	want := estimateCost(cheapModel(), textTierIn, textTierOut)
+	if math.Abs(out.CostUSD-want) > 1e-12 {
+		t.Errorf("cost = %v, want %v — recording tokens must not alter pricing", out.CostUSD, want)
+	}
+}
+
+// TestAgenticTierRecordsExecutorTokens is the branch killer for the agentic
+// tier. It is a SEPARATE arm on purpose: the two tiers reach ReviewerOutcome by
+// different code paths, and the agentic one additionally has to carry the
+// counts through AgenticRun and the agenticCaller adapter — three places a
+// count can be dropped, none of which the text-tier arm touches.
+func TestAgenticTierRecordsExecutorTokens(t *testing.T) {
+	stub := &stubAgenticRunner{
+		run: &AgenticRun{
+			Success:      true,
+			CostUSD:      0.05,
+			Output:       passVerdictJSON,
+			InputTokens:  agenticIn,
+			OutputTokens: agenticOut,
+		},
+	}
+	out := RunAgenticReviewer("gpt5-6-sol@codex", "doc.md", "body", "", DefaultMaxCostUSD, time.Minute, stub.Run)
+
+	if !out.Present {
+		t.Fatalf("expected Present, got absent: %s", out.Err)
+	}
+	if out.TokensIn != agenticIn || out.TokensOut != agenticOut {
+		t.Errorf("tier2 tokens = %d/%d, want %d/%d", out.TokensIn, out.TokensOut, agenticIn, agenticOut)
+	}
+	// Cost stays OBSERVED, never re-derived from the counts now available.
+	if out.CostUSD != 0.05 {
+		t.Errorf("observed cost = %f, want 0.05 — the agentic tier must not price from tokens", out.CostUSD)
+	}
+}
+
+// TestAgenticTierRecordsTokensOnFailedRun pins the audit PARITY between cost and
+// tokens. RunAgenticReviewer already records cost "regardless of outcome"; a
+// failed-but-billed run that recorded cost and dropped tokens would reproduce
+// #708 on the one path where the spend is least explicable.
+func TestAgenticTierRecordsTokensOnFailedRun(t *testing.T) {
+	stub := &stubAgenticRunner{
+		run: &AgenticRun{
+			Success:      false,
+			Err:          "agent hit an internal error",
+			CostUSD:      0.02,
+			InputTokens:  failedRunIn,
+			OutputTokens: failedRunOut,
+		},
+	}
+	out := RunAgenticReviewer("gpt5-6-sol@codex", "doc.md", "body", "", DefaultMaxCostUSD, time.Minute, stub.Run)
+
+	if out.Present {
+		t.Fatal("a failed executor run must be an absence, not a pass")
+	}
+	if out.CostUSD != 0.02 {
+		t.Errorf("cost = %f, want 0.02 (audit record on a failed run)", out.CostUSD)
+	}
+	if out.TokensIn != failedRunIn || out.TokensOut != failedRunOut {
+		t.Errorf("tokens on a failed run = %d/%d, want %d/%d — the audit record must not be narrower than the cost record",
+			out.TokensIn, out.TokensOut, failedRunIn, failedRunOut)
+	}
+}
+
+// TestTokenAccountingGaps_FlagsBilledReviewerWithZeroTokens is the loud-failure
+// arm the issue asks for. The healthy reviewer in the SAME result is the
+// control: it proves the checker is discriminating rather than flagging every
+// reviewer it is handed.
+func TestTokenAccountingGaps_FlagsBilledReviewerWithZeroTokens(t *testing.T) {
+	q := &QuorumResult{Reviewers: []*ReviewerOutcome{
+		{Model: "healthy", CostUSD: 0.03, TokensIn: 100, TokensOut: 20},
+		{Model: "billed-blind", CostUSD: 0.07},
+	}}
+	gaps := q.TokenAccountingGaps()
+
+	if len(gaps) != 1 {
+		t.Fatalf("gaps = %d (%v), want exactly 1 — the healthy reviewer is the control", len(gaps), gaps)
+	}
+	if !strings.Contains(gaps[0], "billed-blind") {
+		t.Errorf("gap must NAME the offending reviewer, got %q", gaps[0])
+	}
+	if !strings.Contains(gaps[0], "0.0700") {
+		t.Errorf("gap must quote the unreconcilable spend, got %q", gaps[0])
+	}
+}
+
+// TestTokenAccountingGaps_CoversTier2Reviewers pins the checker's ENUMERATOR,
+// one level below its condition. A checker that walked only q.Reviewers would
+// pass every arm above and still be blind by construction to the agentic tier —
+// the tier whose cost is OBSERVED rather than derived, and therefore the one
+// most likely to bill without reporting usage.
+func TestTokenAccountingGaps_CoversTier2Reviewers(t *testing.T) {
+	q := &QuorumResult{
+		Reviewers: []*ReviewerOutcome{
+			{Model: "healthy-tier1", CostUSD: 0.03, TokensIn: 100, TokensOut: 20},
+		},
+		Tier2: &Tier2Result{Reviewers: []*ReviewerOutcome{
+			nil, // a nil outcome must be skipped, not panic
+			{Model: "escalated-blind", CostUSD: 0.42, Tier: TierAgentic},
+		}},
+	}
+	gaps := q.TokenAccountingGaps()
+
+	if len(gaps) != 1 {
+		t.Fatalf("gaps = %d (%v), want exactly 1 from the tier-2 reviewer", len(gaps), gaps)
+	}
+	if !strings.Contains(gaps[0], "escalated-blind") || !strings.Contains(gaps[0], "tier2") {
+		t.Errorf("gap must name the tier-2 reviewer AND its tier, got %q", gaps[0])
+	}
+}
+
+// TestTokenAccountingGaps_SilentOnUnbilledReviewer: an absent or free reviewer
+// records zero cost AND zero tokens. That is not a gap — flagging it would make
+// the notice fire on every degraded quorum and train the reader to ignore it.
+func TestTokenAccountingGaps_SilentOnUnbilledReviewer(t *testing.T) {
+	q := &QuorumResult{Reviewers: []*ReviewerOutcome{
+		{Model: "absent", AbsentReason: ReasonUnreachable},
+		{Model: "free-local", CostUSD: 0},
+	}}
+	if gaps := q.TokenAccountingGaps(); len(gaps) != 0 {
+		t.Errorf("gaps = %v, want none — zero cost with zero tokens is a free call, not a gap", gaps)
+	}
+}
+
+// TestSynthesisTotalsTokens pins the totals at the SAME scope TotalCostUSD has
+// always had: tier-1 reviewers only. Quoting a tier-1 cost beside a
+// tier-1+tier-2 token total would make the two incomparable.
+func TestSynthesisTotalsTokens(t *testing.T) {
+	outcomes := []*ReviewerOutcome{
+		{Model: "a", CostUSD: 0.01, TokensIn: 100, TokensOut: 10, Present: true, Result: &ReviewResult{Verdict: VerdictPass}},
+		{Model: "b", CostUSD: 0.02, TokensIn: 250, TokensOut: 35, Present: true, Result: &ReviewResult{Verdict: VerdictPass}},
+	}
+	s := synthesize(outcomes, nil)
+
+	if s.TotalTokensIn != 350 || s.TotalTokensOut != 45 {
+		t.Errorf("totals = %d/%d, want 350/45", s.TotalTokensIn, s.TotalTokensOut)
+	}
+	if s.TotalCostUSD == 0 {
+		t.Fatal("control: TotalCostUSD is 0 — the synthesis loop did not run, so the token totals prove nothing")
+	}
+}
+
+// TestAgenticRunFromExecuteResult_CarriesExecutorTokens pins the PRODUCTION
+// mapping, which every other arm in this file bypasses: they stub AgenticRunner
+// directly, so the adapter from coordinator.ExecuteResult — the only place the
+// executor's real counts enter the quorum — was reachable by no test at all. A
+// mutation zeroing the token mapping there left the whole package green, which
+// is what this arm exists to stop.
+func TestAgenticRunFromExecuteResult_CarriesExecutorTokens(t *testing.T) {
+	run := agenticRunFromExecuteResult(&coordinator.ExecuteResult{
+		Output:       "verdict",
+		Success:      true,
+		Cost:         0.31,
+		InputTokens:  8642,
+		OutputTokens: 1357,
+	})
+
+	if run.InputTokens != 8642 || run.OutputTokens != 1357 {
+		t.Errorf("mapped tokens = %d/%d, want 8642/1357 — the executor's counts are dropped on the production path",
+			run.InputTokens, run.OutputTokens)
+	}
+	// Controls: the fields that already worked must still map, so a failure
+	// above is about tokens rather than about the mapping never running.
+	if run.CostUSD != 0.31 || run.Output != "verdict" || !run.Success {
+		t.Fatalf("control: cost/output/success mis-mapped (%v, %q, %v) — the mapping itself is broken",
+			run.CostUSD, run.Output, run.Success)
+	}
+}
+
+// TestAgenticRunFromExecuteResult_NilIsFailureNotSilentPass keeps the nil guard
+// pinned through the extraction: a nil executor result must be a named failure,
+// never a zero-value run that reads as a successful empty review.
+func TestAgenticRunFromExecuteResult_NilIsFailureNotSilentPass(t *testing.T) {
+	run := agenticRunFromExecuteResult(nil)
+	if run == nil {
+		t.Fatal("mapping must never return nil")
+	}
+	if run.Success {
+		t.Error("a nil executor result must not be Success")
+	}
+	if !strings.Contains(run.Err, "nil result") {
+		t.Errorf("failure must name the cause, got %q", run.Err)
+	}
+}
+
+// TestWrittenArtifactCarriesTokenKeys asserts on the ARTIFACT, not on the
+// struct. The consumer of this work is a controller running `jq` over the
+// written JSON to fill the Gate-3 chain ledger, so the load-bearing claim is
+// about the emitted keys. Every other arm here would stay green under a field
+// rename or a `json:"-"` tag while the artifact remained exactly as tokenless
+// as it was before (#708).
+func TestWrittenArtifactCarriesTokenKeys(t *testing.T) {
+	dir := t.TempDir()
+	q := &QuorumResult{
+		Doc:          "doc.md",
+		ISOTimestamp: "2026-08-18T00:00:00Z",
+		Reviewers: []*ReviewerOutcome{
+			{Model: "m", CostUSD: 0.04, TokensIn: 3141, TokensOut: 592, Present: true,
+				Result: &ReviewResult{Verdict: VerdictPass}},
+		},
+	}
+	q.Synthesis = synthesize(q.Reviewers, nil)
+
+	path, err := WriteJSONArtifact(dir, q)
+	if err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read artifact: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("artifact is not valid JSON: %v", err)
+	}
+	rev := got["reviewers"].([]any)[0].(map[string]any)
+	for key, want := range map[string]float64{"tokens_in": 3141, "tokens_out": 592} {
+		v, ok := rev[key]
+		if !ok {
+			t.Errorf("artifact reviewer has no %q key — the Gate-3 ledger cannot be filled from it", key)
+			continue
+		}
+		if v.(float64) != want {
+			t.Errorf("artifact %s = %v, want %v", key, v, want)
+		}
+	}
+	// Control: the key that has always been written must still be there, so a
+	// missing token key above is about tokens rather than a broken writer.
+	if _, ok := rev["cost_usd"]; !ok {
+		t.Fatal("control: cost_usd missing too — the artifact writer itself is broken")
+	}
+	syn := got["synthesis"].(map[string]any)
+	if syn["total_tokens_in"].(float64) != 3141 || syn["total_tokens_out"].(float64) != 592 {
+		t.Errorf("synthesis totals not in the artifact: %v / %v", syn["total_tokens_in"], syn["total_tokens_out"])
+	}
+}


### PR DESCRIPTION
Closes #708.

## The gap

The mission-control Gate-3 chain ledger requires every metered stage to post `tokens_in`/`tokens_out`. A quorum stage could only ever post zeros — `RunReviewer` read the provider's counts, spent them on `estimateCost`, and dropped them:

```
$ jq -r '[.reviewers[0]|keys[]]|join(",")' .ailang/state/mission-quorum/<newest>.json
cost_usd,landed,model,present,result
# control, same artifact: cost IS recorded, so the instrument reads the right object
$ jq -r '[paths|join(".")]|map(select(test("cost")))|join(" ")' <same artifact>
reviewers.0.cost_usd reviewers.1.cost_usd synthesis.total_cost_usd
```

That is exactly the iteration-190 signature the mandate exists to prevent (`$0.0570`/`$0.0507` recorded at **zero** tokens). Confirmed first-party at HEAD `9607d7c99` before any work.

## The fix — one sweep, because both tiers dropped the same counts

| | before | after |
|---|---|---|
| text tier (`run.go`) | counts consumed by `estimateCost`, discarded | recorded as `tokens_in`/`tokens_out` |
| agentic tier (`agentic_caller.go`) | `&ai.Response{}` — literally empty | executor's counts carried through `AgenticRun` |
| production adapter (`agentic_provider.go`) | `ExecuteResult.InputTokens` never read | mapped, and now **reachable by test** |
| `Synthesis` | `total_cost_usd` only | `+ total_tokens_in/out`, same Tier-1-only scope |
| unreconcilable spend | invisible | `TokenAccountingGaps()` names it, loudly, on stderr |

Cost on the agentic tier stays **observed**, never re-derived from the now-available tokens — they are for accounting, not pricing. Tokens are recorded on a *failed* agentic run too, matching what cost already did.

`TokenAccountingGaps` **reports, never refuses**: an executor that bills without reporting usage must not wedge a quorum the loop depends on.

## What the drill found that the issue did not

Zeroing the token mapping in the production `coordinator.ExecuteResult` → `AgenticRun` adapter left the **entire package green**. That mapping sat behind `NewExecutorProvider`, which needs a registered executor, so every test stubbed `AgenticRunner` directly and none reached it — i.e. the one place the executor's real counts enter the quorum had no coverage at all. Extracted as `agenticRunFromExecuteResult`, now pinned (nil guard included).

## Evidence

10 new arms, 8 mutation drills. Every mutant asserted **LANDED** by sha256 and **BUILDS** by `go build` rc=0 before any test result was read; every inverse `-skip` run rc=0, which is what proves the named arms are killers rather than bystanders. Restores from a `cp` backup (never `git checkout --`), byte-identity verified each time.

| drill | mutation | reds |
|---|---|---|
| M1 | text-tier recording → `_, _ =` | `TextTierRecordsProviderTokens` only |
| M2 | agentic recording → `_, _ =` | both agentic arms (one assignment, two outcome branches) |
| M3b | `InputTokens: res.InputTokens` → `0` | `AgenticRunFromExecuteResult_CarriesExecutorTokens` only |
| M3c | `if false && res == nil` | `..._NilIsFailureNotSilentPass` only |
| M4 | `if false && q.Tier2 != nil` | `TokenAccountingGaps_CoversTier2Reviewers` only |
| M5 | drop the zero-token requirement | both gap-flagging arms (each carries a healthy-reviewer control) |
| M6 | `s.TotalTokensIn +=` → `_ =` | `SynthesisTotalsTokens` only |
| M7 | `json:"tokens_in"` → `json:"-"` | `WrittenArtifactCarriesTokenKeys` only |

M2 and M5 are recorded as **pairs**, not claimed as unique kills. The tenth arm (`SilentOnUnbilledReviewer`) is M5's negative control and was not drilled on its own.

M7 is why the artifact arm exists: every struct-level arm stays green under a `json:"-"` tag while the written artifact remains exactly as tokenless as before. The consumer is a controller running `jq` over the file, so the assertion is on the emitted keys.

## Gates

Green on **darwin/arm64 only**; the ubuntu and windows legs are unrun locally. `internal/mission/quorum` rc=0 · `cmd/ailang` rc=0 · `vet` rc=0 · `fmt-check`, `check-changelog`, `test-check-changelog`, `check-file-sizes`, `check-boundaries`, `check-skills` all rc=0 (list derived from `ci.yml`, not from memory).

Baselined on pristine `origin/dev` first (quorum pkg rc=0). `go build ./...` fails identically at `cmd/wasm` on **untouched** `dev` (`function main is undeclared`), so the scoped build is the informative gate.

One assertion needed a tolerance rather than bit equality: on darwin/arm64 `estimateCost` differs by **1 ULP** between two call sites (`0x…aab` vs `0x…aac`) because the compiler may contract `a*b + c*d` into an FMA in one inlining context and not the other. A bit-exact check there would red for the FPU, not for the change.

Changelog filed into `changelogs/v0.18-current.md`, never the root index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
