### PR TITLE
test(eval): pin the prelude capability gate — neutering it left 100 packages green

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,55 @@
 
 ## [Unreleased]
 
+### Fixed — the prelude capability gate was a guard with no gate: neutering it left 100 packages green
+
+`9504393d0` closed a real capability bypass — the prelude `println` wrote to stdout via
+`fmt` directly while `import std/io (println)` routed through `RequireCap`, so both forms
+declared `! {IO}`, both passed effect checking, and only the imported one was enforced.
+`--caps` was evadable by *not* importing `std/io`, and a program with no capabilities at
+all could still perform IO.
+
+The fix was correct. Nothing tested it. Measured at `5a3a59126` by neutering the call
+site (`if err := requireCap(e, "IO"); false && err != nil`): the mutant built and **every
+package under `./internal/...` and `./cmd/ailang/...` stayed green — 100 ok, rc=0**. The
+security hole could be re-opened in full without redding a single test. `requireCap` and
+`registerBuiltins` appeared in zero `_test.go` files (control: `func Test` matched 11
+files in the same directory, and `--caps` matched 5 test files elsewhere, so the zeros are
+measurements).
+
+Surfaced by the standing SonarCloud quality-gate red — `78.3%` coverage on new code
+against an `80%` threshold — which four prior iterations had named and none had opened.
+The gate's 44 uncovered new lines were not a rounding error: nine of them are the
+capability gate itself.
+
+Pinned, and swept across the construction sites rather than the one that was found
+(Principle 3). `internal/eval` has four production `registerBuiltins` call sites —
+`NewCoreEvaluator`, `NewCoreEvaluatorWithRegistry`, `Fork`, and `NewTypedEvaluator`
+(which passes nil, an ungated path by design) — and the new arms drive all four:
+
+- IO denied → `println` returns the refusal, returns a nil value, and **writes nothing to
+  stdout**. The stdout assertion is the one that separates "refused" from "errored after
+  printing"; a returned error alone is satisfied by any failure.
+- IO granted → the payload reaches stdout, and the capability requested is asserted to be
+  exactly `IO`, so demanding the wrong capability is a distinct, catchable regression.
+- The three `return nil` paths `requireCap` documents (nil evaluator, effect context that
+  is not a `capRequirer`, no effect context) are pinned as ungated — not because they
+  enforce anything, but because a future "fail closed everywhere" change would silently
+  break the REPL and `TypedEvaluator`, which never granted capabilities in the first place.
+- `Fork` re-registers builtins against the fork, so a request goroutine whose context
+  denies IO refuses even when the parent granted it — with the parent asserted unaffected
+  in the same test, so the arm measures isolation rather than a global flip.
+
+**Nine arms, six mutation drills.** Every mutant was asserted LANDED by sha256 and BUILDS
+by `go build` rc=0 before any test result was read, and every drill's inverse `-skip` run
+is rc=0 — which is what proves the new arms are the killers rather than bystanders riding
+someone else's red. Two drills red a set rather than a single arm (neutering the gate reds
+both constructor arms plus `Fork`; swapping `IO` for `FS` reds every name assertion) and
+are recorded as sets rather than claimed as unique kills.
+
+No production code changed.
+
+
 ### Fixed — `design-quorum` discarded the token counts it had just read, so a quorum stage could only ever post zeros
 
 The mission-control Gate-3 chain ledger requires every metered stage to post

--- a/internal/eval/prelude_cap_gate_test.go
+++ b/internal/eval/prelude_cap_gate_test.go
@@ -1,0 +1,262 @@
+package eval
+
+import (
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/types"
+)
+
+// Pins for the prelude capability gate added by 9504393d0 ("prelude println
+// bypassed the capability system").
+//
+// Why these exist: the fix shipped `requireCap` and gated the prelude `println`
+// builtin on IO, and NOTHING in the repo exercised either. Measured at
+// 5a3a59126 by neutering the call site (`if err := requireCap(e, "IO"); false &&
+// err != nil`): the mutant built and every package under ./internal/... and
+// ./cmd/ailang/... stayed green (100 ok, rc=0). A capability refusal that no
+// test can red is not a gate.
+//
+// The observable is deliberately narrow (rule 3i): each arm asserts the
+// capability NAME requested and whether the effect actually reached stdout,
+// not merely that some error came back. "An error was returned" is satisfied by
+// any failure; "IO was requested and nothing was written" is satisfied only by
+// this gate.
+
+// errCapDenied is a sentinel so an arm can assert THIS refusal rather than any
+// error (errors.Is, not a substring match).
+var errCapDenied = errors.New("prelude_cap_gate_test: capability denied")
+
+// fakeCapCtx is a minimal effect context implementing the locally-declared
+// capRequirer interface. internal/eval cannot import internal/effects (import
+// cycle) — which is exactly why capRequirer is declared locally, so the fake
+// stands in for *effects.EffContext here.
+type fakeCapCtx struct {
+	grant     bool
+	requested []string
+}
+
+func (f *fakeCapCtx) RequireCap(name string) error {
+	f.requested = append(f.requested, name)
+	if f.grant {
+		return nil
+	}
+	return errCapDenied
+}
+
+// nonRequirerCtx is an effect context that does NOT implement capRequirer.
+// requireCap documents this as "no capability system wired" — ungated.
+type nonRequirerCtx struct{}
+
+// captureStdout runs fn with os.Stdout redirected and returns what was written.
+// The prelude println writes with fmt.Print directly, so stdout is the only
+// place the effect is observable — and observing it is what discriminates
+// "refused before the effect" from "errored after printing".
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	saved := os.Stdout
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+	fn()
+	os.Stdout = saved
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	out := <-done
+	if err := r.Close(); err != nil {
+		t.Fatalf("close pipe reader: %v", err)
+	}
+	return out
+}
+
+// preludePrintln pulls the prelude println builtin out of an environment.
+// It is registered by registerBuiltins, so its ABSENCE is itself a failure
+// worth naming rather than a nil-deref later.
+func preludePrintln(t *testing.T, env *Environment) *BuiltinFunction {
+	t.Helper()
+	v, ok := env.Get("println")
+	if !ok {
+		t.Fatal("prelude println is not registered — registerBuiltins did not run")
+	}
+	fn, ok := v.(*BuiltinFunction)
+	if !ok {
+		t.Fatalf("prelude println is %T, want *BuiltinFunction", v)
+	}
+	return fn
+}
+
+// gatedConstructors is every production site that builds a CoreEvaluator and
+// registers prelude builtins against it. Both must gate; pinning only one
+// leaves the other free to regress (Principle 3 — sweep the sites, do not patch
+// the one you happened to find). Fork is the third site and has its own test;
+// NewTypedEvaluator is the fourth and passes nil, which is an ungated path.
+var gatedConstructors = []struct {
+	name string
+	ctor func() *CoreEvaluator
+}{
+	{"NewCoreEvaluator", NewCoreEvaluator},
+	{"NewCoreEvaluatorWithRegistry", func() *CoreEvaluator {
+		return NewCoreEvaluatorWithRegistry(types.NewDictionaryRegistry())
+	}},
+}
+
+func TestPreludePrintlnRequiresIOCapability(t *testing.T) {
+	for _, tc := range gatedConstructors {
+		t.Run(tc.name, func(t *testing.T) {
+			deny := &fakeCapCtx{grant: false}
+			e := tc.ctor()
+			e.SetEffContext(deny)
+
+			var got Value
+			var err error
+			out := captureStdout(t, func() {
+				got, err = preludePrintln(t, e.Env()).Fn([]Value{&StringValue{Value: "leaked"}})
+			})
+
+			if !errors.Is(err, errCapDenied) {
+				t.Fatalf("println with IO denied: err = %v, want errCapDenied", err)
+			}
+			if got != nil {
+				t.Errorf("println with IO denied returned %v, want nil value", got)
+			}
+			// The refusal must precede the effect: a gate that returns the error
+			// AFTER writing has not stopped anything.
+			if out != "" {
+				t.Errorf("println wrote %q to stdout despite refusing IO — the effect escaped the gate", out)
+			}
+			// Assert WHICH capability was demanded. Under a `"FS"` mutant the
+			// assertions above still pass (the fake denies everything); this is
+			// the assertion that pins IO.
+			if len(deny.requested) != 1 || deny.requested[0] != "IO" {
+				t.Errorf("capabilities requested = %v, want exactly [IO]", deny.requested)
+			}
+		})
+	}
+}
+
+func TestPreludePrintlnAllowedWithIOCapability(t *testing.T) {
+	for _, tc := range gatedConstructors {
+		t.Run(tc.name, func(t *testing.T) {
+			grant := &fakeCapCtx{grant: true}
+			e := tc.ctor()
+			e.SetEffContext(grant)
+
+			var got Value
+			var err error
+			out := captureStdout(t, func() {
+				got, err = preludePrintln(t, e.Env()).Fn([]Value{&StringValue{Value: "allowed"}})
+			})
+
+			if err != nil {
+				t.Fatalf("println with IO granted: unexpected error %v", err)
+			}
+			if _, ok := got.(*UnitValue); !ok {
+				t.Errorf("println returned %T, want *UnitValue", got)
+			}
+			if !strings.Contains(out, "allowed") {
+				t.Errorf("println wrote %q, want it to contain %q", out, "allowed")
+			}
+			if len(grant.requested) != 1 || grant.requested[0] != "IO" {
+				t.Errorf("capabilities requested = %v, want exactly [IO]", grant.requested)
+			}
+		})
+	}
+}
+
+// The three ungated paths requireCap documents. They are pinned not because
+// they enforce anything but because each is a `return nil` branch that a
+// future "fail closed everywhere" change would silently flip — breaking the
+// REPL / TypedEvaluator / SimpleEvaluator, which never granted caps at all.
+func TestPreludePrintlnUngatedPaths(t *testing.T) {
+	t.Run("no effect context", func(t *testing.T) {
+		e := NewCoreEvaluator() // effContext stays nil
+		out := captureStdout(t, func() {
+			if _, err := preludePrintln(t, e.Env()).Fn([]Value{&StringValue{Value: "repl"}}); err != nil {
+				t.Fatalf("unexpected error with no effect context: %v", err)
+			}
+		})
+		if !strings.Contains(out, "repl") {
+			t.Errorf("stdout = %q, want it to contain %q", out, "repl")
+		}
+	})
+
+	t.Run("effect context is not a capRequirer", func(t *testing.T) {
+		e := NewCoreEvaluator()
+		e.SetEffContext(&nonRequirerCtx{})
+		out := captureStdout(t, func() {
+			if _, err := preludePrintln(t, e.Env()).Fn([]Value{&StringValue{Value: "noncap"}}); err != nil {
+				t.Fatalf("unexpected error for a non-capRequirer context: %v", err)
+			}
+		})
+		if !strings.Contains(out, "noncap") {
+			t.Errorf("stdout = %q, want it to contain %q", out, "noncap")
+		}
+	})
+
+	t.Run("nil evaluator (TypedEvaluator path)", func(t *testing.T) {
+		// The real production site: NewTypedEvaluator calls
+		// registerBuiltins(env, nil). Driving the constructor rather than
+		// re-creating its binding is what makes this arm notice if that call
+		// site ever starts passing a real evaluator.
+		te := NewTypedEvaluator(false, 0, false)
+		out := captureStdout(t, func() {
+			if _, err := preludePrintln(t, te.env).Fn([]Value{&StringValue{Value: "typed"}}); err != nil {
+				t.Fatalf("unexpected error for a nil evaluator: %v", err)
+			}
+		})
+		if !strings.Contains(out, "typed") {
+			t.Errorf("stdout = %q, want it to contain %q", out, "typed")
+		}
+	})
+}
+
+// Fork re-registers builtins so they close over the FORK, not the parent —
+// the comment at eval_evaluator.go's registerBuiltins(env, forked) call. Each
+// request goroutine gets its own Fork, so a fork whose context denies IO must
+// refuse even though the parent granted it. Under `registerBuiltins(env, e)`
+// the fork's println consults the parent and this arm reds.
+func TestPreludePrintlnForkGatesOnForkContext(t *testing.T) {
+	grant := &fakeCapCtx{grant: true}
+	parent := NewCoreEvaluator()
+	parent.SetEffContext(grant)
+
+	forked := parent.Fork()
+	deny := &fakeCapCtx{grant: false}
+	forked.SetEffContext(deny)
+
+	var forkErr error
+	forkOut := captureStdout(t, func() {
+		_, forkErr = preludePrintln(t, forked.Env()).Fn([]Value{&StringValue{Value: "fork"}})
+	})
+	if !errors.Is(forkErr, errCapDenied) {
+		t.Fatalf("forked println: err = %v, want errCapDenied (the fork's own context must gate it)", forkErr)
+	}
+	if forkOut != "" {
+		t.Errorf("forked println wrote %q despite refusing IO", forkOut)
+	}
+	if len(deny.requested) != 1 || deny.requested[0] != "IO" {
+		t.Errorf("fork requested %v, want exactly [IO]", deny.requested)
+	}
+
+	// Control: the parent is unaffected, so the arm above measures the fork's
+	// isolation rather than a global flip.
+	parentOut := captureStdout(t, func() {
+		if _, err := preludePrintln(t, parent.Env()).Fn([]Value{&StringValue{Value: "parent"}}); err != nil {
+			t.Fatalf("parent println after fork: unexpected error %v", err)
+		}
+	})
+	if !strings.Contains(parentOut, "parent") {
+		t.Errorf("parent stdout = %q, want it to contain %q", parentOut, "parent")
+	}
+}


### PR DESCRIPTION
## The standing SonarCloud red, opened

`SonarCloud Code Analysis` has been `failure` on `dev` for six consecutive analysed
commits. Iterations 217–220 each named it and moved on, because it is non-required and
the required set was green. Opening it turned out to be worth an iteration.

One failed condition: **78.3% coverage on new code, threshold 80%**. Everything else on
the gate is OK (reliability/security/maintainability A, duplication 0.2%, hotspots 100%
reviewed). The new-code window is `previous_version` = `v0.33.0` (2026-08-13).

The gate is decided over `new_lines_to_cover = 203` — of `new_lines = 5408`, because
`sonar.coverage.exclusions` deliberately excludes `cmd/ailang/**`,
`internal/storage/firestore/**` and others. So 44 uncovered lines set it. Enumerating
those 44 by file reproduced the project aggregate **exactly** (44 = 9+8+6+5+3+3+2+2+2+1+1+1+1),
which is what makes the enumeration complete rather than a sample.

**Nine of the 44 are the prelude capability gate.**

## The defect

`9504393d0` ("prelude println bypassed the capability system") closed a real bypass: the
prelude `println` wrote to stdout via `fmt` directly, while `import std/io (println)`
routed through `RequireCap`. Both declare `! {IO}`, both pass effect checking, only the
imported one was enforced — so `--caps` was evadable by *not* importing `std/io`, and a
program with no capabilities at all could still perform IO.

The fix is correct. Nothing tested it.

Measured at `5a3a59126`, neutering the call site with the skill's `if false &&` form so
every symbol stays used:

```
if err := requireCap(e, "IO"); false && err != nil {
```

- mutant **LANDED** (sha256 differs), **BUILDS** (`go build ./internal/... ./cmd/ailang` rc=0)
- `go test ./internal/... ./cmd/ailang/...` → **rc=0, 100 packages ok, zero FAIL**

The security hole re-opened in full without redding a single test. Supporting measurement,
with a firing same-path control: `requireCap` and `registerBuiltins` matched **0**
`_test.go` files under `internal/eval/`, while `func Test` matched **11** files in the
same directory and `--caps` matched **5** test files elsewhere — so the zeros are
measurements, not a broken grep.

## What landed

No production code changed. One test file, and a changelog entry.

The sweep is over construction sites, not over the one that was found (Principle 3).
`internal/eval` has exactly four production `registerBuiltins` call sites — and the arms
drive all four:

| site | gated? | arm |
|---|---|---|
| `NewCoreEvaluator` | yes | denied / granted |
| `NewCoreEvaluatorWithRegistry` | yes | denied / granted |
| `Fork` | yes, on the **fork's own** context | fork-isolation arm |
| `NewTypedEvaluator` (passes nil) | no, by design | ungated arm |

The observable is deliberately narrow. "An error was returned" is satisfied by any
failure, so the denied arms assert that **nothing reached stdout** (`os.Stdout` swapped for
a pipe) and that the capability requested was **exactly `IO`**. The granted arms assert the
payload did reach stdout. The fork arm asserts the parent is unaffected in the same test,
so it measures isolation rather than a global flip.

The three `return nil` paths `requireCap` documents are pinned as *ungated* — not because
they enforce anything, but because a future "fail closed everywhere" change would silently
break the REPL and `TypedEvaluator`, which never granted capabilities in the first place.

## Mutation drills — 9 arms, 6 drills

Every mutant asserted **LANDED** by sha256 and **BUILDS** by `go build` rc=0 *before* any
test result was read. Every drill's inverse `-skip TestPreludePrintln` run is **rc=0**,
which is what proves the new arms are their branch's killer rather than bystanders riding
someone else's red.

| # | mutation | arms redded | inverse `-skip` |
|---|---|---|---|
| M1 | gate neutered at the call site | `Requires*` (both ctors) + `Fork` | rc=0 |
| M2 | gate demands `"FS"` not `"IO"` | every name assertion (5 arms) | rc=0 |
| M3 | `requireCap`'s `e == nil` branch dead | `nil evaluator (TypedEvaluator path)` | rc=0 |
| M4 | `requireCap`'s `!ok` branch dead | `no effect context` | rc=0 |
| M5 | `Fork` registers the **parent**'s builtins | `Fork` only | rc=0 |
| M6 | `NewCoreEvaluatorWithRegistry` passes nil | `*WithRegistry` sub-arms only | rc=0 |

Two are recorded as **sets, not unique kills**: M1 and M2 red several arms by construction.

M4 is stated precisely rather than as its aggregate output: a panic in the first ungated
subtest short-circuits the rest, so run alone, M4 reds `no effect context` **and**
`effect context is not a capRequirer` (both panic on the nil interface) and leaves
`nil evaluator` green — correctly, since that arm exits at the earlier `e == nil` branch.

M6 is the drill that justifies extending the table: it reds *only* the
`NewCoreEvaluatorWithRegistry` sub-arms, which did not exist before the site enumeration.

## Gates

Baselined on pristine `origin/dev` first, so the gates measure the change and not the repo
(`go build` scoped rc=0; `./internal/eval/... ./internal/effects/... ./internal/pipeline/...` rc=0).

Gate list **derived from `ci.yml`** rather than recalled, then filtered to what this diff
can plausibly break:

`make vet` · `make fmt-check` · `make check-file-sizes` · `make check-boundaries` ·
`make check-changelog` · `make test-check-changelog` · `make lint` ·
`make test-coverage-gate` — **all rc=0**
(`lint`'s single `unused` finding is pre-existing: `geminiPassThreshold` in
`internal/eval_harness/gemini_evaluator_bridge.go`.)
`go test -count=1 ./internal/... ./cmd/ailang/...` → **rc=0, 100 ok**.
`make test-coverage-gate` → `Coverage 45.6% meets threshold 29%`.

**Platform narrowing, stated:** every local gate ran on **darwin/arm64**; the ubuntu and
windows legs are covered only by the green `test`/`build` contexts. The diff contains no
per-GOOS construct (no `HOME`/`USERPROFILE`, no path separators, no case-sensitivity
assumptions) — `os.Pipe` and the `os.Stdout` swap are portable.

Source files restored from a `cp` backup after every drill, never `git checkout --`
(the file under test is uncommitted by construction in a sprint worktree), and byte-identity
verified by sha256 each time.

## Effect on the Sonar gate

Local coverage before/after on `internal/eval` shows all 20 previously-uncovered new lines
in `eval_typed_helpers.go` (9), `eval_evaluator.go` (8) and `eval_typed.go` (3) are now
covered; package coverage 26.0% → 27.4%.

Predicted, not claimed: `new_uncovered_lines` 44 → 24 of 203 ⇒ **~88.2%**, over the 80%
threshold. It is arithmetic on Sonar's current numbers — the window and the denominator
move on the merge, so the gate's actual verdict is whatever it reports on `dev`.

Closing the red is a **side effect**. The deliverable is the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
