### PR TITLE
fix(#687): the stale-binary warning was mtime-only, so it fired on a binary it could have proven correct

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,55 @@
 
 ## [Unreleased]
 
+### Fixed — `⚠ Binary may be stale` was an mtime heuristic, so it fired on a binary it could have proven correct
+
+`cmd/ailang/help.go` decided staleness by walking four CWD-relative source directories and
+warning if any `.go` file's `ModTime` was after the binary's. Creating a `git worktree`
+writes every tracked file with a *current* mtime, so the warning fired on a binary that was
+byte-identical to that worktree's own `HEAD` (ailang#687). Every mission sub-agent runs in a
+fresh worktree, so every one of them saw it; in mission iteration 190 a design-quorum
+reviewer rejected a design document because its premises "were measured with a PATH binary
+that explicitly warned it was stale", costing a full quorum round to refute.
+
+Measured at `c8b2ea0a2` with a differential whose only variable is the working directory:
+the same PATH binary, same arguments, warns when run from a worktree and is silent when run
+from `/tmp`.
+
+The mtime walk is now a cheap **pre-filter** rather than the verdict. When it fires, the
+binary's embedded commit is compared against the checkout before anything is printed:
+suppression requires that `Version` carries no `-dirty` marker, that `Commit` is a full
+40-character hex sha, that it equals `git rev-parse HEAD`, and that `git status --porcelain`
+is empty over **the same four directories the walk sampled**. Every undeterminable case —
+no git, no checkout, a probe timeout, an unreadable HEAD — falls through to the warning, so
+a failure here costs a spurious warning rather than a silenced real one. Ordinary users pay
+nothing: outside a checkout the pre-filter finds no source directories and no subprocess is
+ever spawned.
+
+The git probes resolve the binary once via `exec.LookPath` and refuse anything that is not an
+absolute path: this check runs on an ordinary `ailang` invocation, so it must not execute
+whatever a relative or writable `PATH` entry happens to call "git". An unresolvable git makes
+both probes undeterminable, which shows the warning.
+
+One arm redded the windows CI legs and is recorded because the class was *named in this same
+change before it bit*: the resolver's positive arm asserted `filepath.IsAbs("/usr/bin/git")`,
+which is **false on windows** (a volume name is required), so it failed for the platform rather
+than for the code. It now derives an absolute path at runtime. Local gates ran on darwin/arm64
+only; `test-windows` is what caught it.
+
+Pinned by 16 mutation drills covering every refusal branch, the enumerator's extension
+filter, the confirmation's *scope*, and both call-site conditions; each mutant asserted
+LANDED by sha256 and BUILDS by `go build` before any test result was read, and each inverse
+`-skip` run rc=0 so the new arms are the killers rather than bystanders.
+
+Two arms were **hollow on the first drill pass and are recorded because the drill is what
+found them**: an arm named for the `Commit` `-dirty` branch was in fact refused by the
+sha-shape check (no 40-character lowercase-hex string can contain `-dirty`, so that branch
+was unreachable — it has been removed rather than left as undeclared dead code), and an arm
+named for an unreadable `HEAD` supplied `("", false)`, which the *value mismatch* branch
+refused first; it now supplies the matching sha with `ok=false`, so only determinability can
+refuse it.
+
+
 ### Fixed — the prelude capability gate was a guard with no gate: neutering it left 100 packages green
 
 `9504393d0` closed a real capability bypass — the prelude `println` wrote to stdout via

--- a/cmd/ailang/help.go
+++ b/cmd/ailang/help.go
@@ -1,14 +1,58 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 )
 
-// checkStaleBinary warns if the binary is older than recent source changes
-// This prevents confusion when testing changes with an old binary
+// staleCheckDirs are the source directories the staleness heuristic samples.
+// They are CWD-relative on purpose: the check only means anything when the
+// binary is run from the checkout it was built from.
+var staleCheckDirs = []string{
+	"internal/parser",
+	"internal/elaborate",
+	"internal/eval",
+	"cmd/ailang",
+}
+
+// gitProbeTimeout bounds each git subprocess. A contended index.lock must
+// slow `ailang check` down by at most this, never wedge it.
+const gitProbeTimeout = 2 * time.Second
+
+// treeProbe reads the state of a git checkout. It exists as a struct so the
+// staleness decision can be tested without a git repository.
+type treeProbe struct {
+	// head returns the checkout's HEAD sha. ok is false when it cannot be read.
+	head func() (sha string, ok bool)
+	// dirty reports whether any of dirs holds uncommitted or untracked changes.
+	// ok is false when that cannot be determined.
+	dirty func(dirs []string) (dirty bool, ok bool)
+}
+
+// newGitProbe returns a treeProbe backed by git, rooted at dir.
+func newGitProbe(dir string) treeProbe {
+	git := gitBinary()
+	return treeProbe{
+		head:  func() (string, bool) { return gitHead(git, dir) },
+		dirty: func(dirs []string) (bool, bool) { return gitDirty(git, dir, dirs) },
+	}
+}
+
+// checkStaleBinary warns if the binary predates the source it is run against.
+//
+// The mtime walk below is a cheap PRE-FILTER only. It cannot stand on its own:
+// creating a git worktree stamps every tracked file with a current mtime, so
+// mtime alone reports a byte-identical binary as stale in every fresh worktree
+// (ailang#687). Before warning we therefore try to PROVE the binary matches the
+// tree by content, via the commit the binary embeds. Suppression requires that
+// proof — anything undeterminable falls through to the warning.
 func checkStaleBinary() {
 	// Get the binary's executable path
 	execPath, err := os.Executable()
@@ -21,19 +65,29 @@ func checkStaleBinary() {
 	if err != nil {
 		return // Can't stat binary, skip check
 	}
-	binaryTime := binaryInfo.ModTime()
 
-	// Check key source directories for recent changes
-	// We check parser and elaborator since those are most commonly modified
-	checkDirs := []string{
-		"internal/parser",
-		"internal/elaborate",
-		"internal/eval",
-		"cmd/ailang",
+	warnIfStale(os.Stderr, binaryInfo.ModTime(), staleCheckDirs, Version, Commit, newGitProbe("."))
+}
+
+// warnIfStale writes the staleness warning to w unless the binary is current.
+// It holds the whole decision so the suppression can be tested at the call site
+// rather than only in the helper it delegates to.
+func warnIfStale(w io.Writer, binaryTime time.Time, dirs []string, version, commit string, p treeProbe) {
+	if !sourcesNewerThan(binaryTime, dirs) {
+		return
 	}
+	if binaryMatchesTree(version, commit, dirs, p) {
+		return // content says the binary is current; the mtimes were misleading
+	}
+	fmt.Fprintf(w, "%s Binary may be stale (source files modified after build)\n", yellow("⚠"))
+	fmt.Fprintf(w, "  Run '%s' to rebuild\n", bold("make quick-install"))
+}
 
-	for _, dir := range checkDirs {
-		// Walk directory to find most recent .go file
+// sourcesNewerThan reports whether any .go file under dirs has an mtime after
+// binaryTime. Missing directories contribute nothing, so running outside a
+// checkout is silently false rather than an error.
+func sourcesNewerThan(binaryTime time.Time, dirs []string) bool {
+	for _, dir := range dirs {
 		newerFound := false
 		_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
@@ -47,14 +101,129 @@ func checkStaleBinary() {
 			}
 			return nil
 		})
-
 		if newerFound {
-			// Found source files newer than binary
-			fmt.Fprintf(os.Stderr, "%s Binary may be stale (source files modified after build)\n", yellow("⚠"))
-			fmt.Fprintf(os.Stderr, "  Run '%s' to rebuild\n", bold("make quick-install"))
-			return // Only warn once
+			return true
 		}
 	}
+	return false
+}
+
+// binaryMatchesTree reports whether the binary described by (version, commit)
+// was demonstrably built from the checkout p points at, with dirs unmodified
+// since. It returns true ONLY on proof; every undeterminable case is false, so
+// a failure here costs a spurious warning rather than a silenced real one.
+func binaryMatchesTree(version, commit string, dirs []string, p treeProbe) bool {
+	// A binary built from a dirty tree is not addressed by any sha, so its
+	// commit cannot prove anything. -ldflags stamps `git describe --dirty`
+	// into Version, which nothing else inspects, so it needs its own check.
+	if strings.Contains(version, "-dirty") {
+		return false
+	}
+	// "dev", "unknown" and abbreviations carry no comparable identity. This
+	// also subsumes the OTHER dirty marker: the debug.ReadBuildInfo fallback
+	// appends "-dirty" to Commit, and no 40-character lowercase-hex string can
+	// contain that substring, so a separate check for it would be unreachable.
+	if !isFullSHA(commit) {
+		return false
+	}
+	head, ok := p.head()
+	if !ok {
+		return false
+	}
+	if head != commit {
+		return false
+	}
+	dirty, ok := p.dirty(dirs)
+	if !ok {
+		return false
+	}
+	if dirty {
+		return false
+	}
+	return true
+}
+
+// isFullSHA reports whether s is a full 40-character lowercase hex object name.
+func isFullSHA(s string) bool {
+	if len(s) != 40 {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9', r >= 'a' && r <= 'f':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+var (
+	gitPathOnce sync.Once
+	gitPath     string
+)
+
+// resolveGit returns an ABSOLUTE path to git, or "" if look cannot produce one.
+//
+// Requiring an absolute result is deliberate: this check runs on an ordinary
+// `ailang` invocation, so it must not execute whatever a relative or writable
+// PATH entry happens to call "git". An empty result makes both probes report
+// undeterminable, which SHOWS the warning rather than suppressing it — a
+// failure here costs a spurious warning, never a silenced real one.
+func resolveGit(look func() (string, error)) string {
+	p, err := look()
+	if err != nil {
+		return ""
+	}
+	if !filepath.IsAbs(p) {
+		return ""
+	}
+	return p
+}
+
+// gitBinary resolves git once per process.
+func gitBinary() string {
+	gitPathOnce.Do(func() { gitPath = resolveGit(func() (string, error) { return exec.LookPath("git") }) })
+	return gitPath
+}
+
+// gitHead returns the HEAD sha of the checkout at dir, running the git at the
+// absolute path git.
+//
+// The empty-git guard below is a DECLARED-UNPINNABLE fast path: exec refuses an
+// empty command name with the same error, so removing the guard changes no
+// observable behaviour and no test can kill a mutation of it. It is kept
+// because handing an empty command name to exec is not something this code
+// should rely on being refused for it.
+func gitHead(git, dir string) (string, bool) {
+	if git == "" {
+		return "", false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), gitProbeTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, git, "-C", dir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(out)), true
+}
+
+// gitDirty reports whether any of dirs holds uncommitted or untracked changes.
+// It is scoped to the SAME directories sourcesNewerThan samples, so the
+// confirmation can never be narrower than the signal it confirms. Its empty-git
+// guard is declared-unpinnable for the same reason as gitHead's.
+func gitDirty(git, dir string, dirs []string) (bool, bool) {
+	if git == "" {
+		return false, false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), gitProbeTimeout)
+	defer cancel()
+	args := append([]string{"-C", dir, "status", "--porcelain", "--"}, dirs...)
+	out, err := exec.CommandContext(ctx, git, args...).Output()
+	if err != nil {
+		return false, false
+	}
+	return strings.TrimSpace(string(out)) != "", true
 }
 
 func printVersion() {

--- a/cmd/ailang/help_stale_test.go
+++ b/cmd/ailang/help_stale_test.go
@@ -1,0 +1,430 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// validSHA is a well-formed 40-character object name used as the baseline
+// commit in the tests below. It is not a real commit in this repository.
+const validSHA = "0123456789abcdef0123456789abcdef01234567"
+
+// okProbe returns a treeProbe that reports head and a clean tree — i.e. the
+// state in which binaryMatchesTree must return true. Every refusal arm below
+// perturbs exactly ONE input away from this baseline, so a mutation that
+// neuters one refusal branch reds exactly one arm rather than a set.
+func okProbe(head string) treeProbe {
+	return treeProbe{
+		head:  func() (string, bool) { return head, true },
+		dirty: func([]string) (bool, bool) { return false, true },
+	}
+}
+
+// TestBinaryMatchesTree_ProvesCurrentBinary is the positive control for the
+// whole suppression path: with every precondition satisfied the function must
+// return true. Without this arm the refusal arms below are all satisfiable by a
+// function that returns false unconditionally.
+func TestBinaryMatchesTree_ProvesCurrentBinary(t *testing.T) {
+	if !binaryMatchesTree("v0.33.1-103-g0002c9b0b", validSHA, staleCheckDirs, okProbe(validSHA)) {
+		t.Fatal("clean tree at the binary's own commit must prove the binary current")
+	}
+}
+
+// TestBinaryMatchesTree_Refusals drives every refusal branch. The observable is
+// a bool, which is over-subscribed by construction, so each case is built from
+// the passing baseline and perturbs one field only; `why` names the branch the
+// case is meant to reach so a failure identifies which one stopped refusing.
+func TestBinaryMatchesTree_Refusals(t *testing.T) {
+	cases := []struct {
+		why     string
+		version string
+		commit  string
+		probe   treeProbe
+	}{
+		{
+			why:     "ldflags Version carries -dirty: the built tree is not addressed by any sha",
+			version: "v0.33.1-103-g0002c9b0b-dirty",
+			commit:  validSHA,
+			probe:   okProbe(validSHA),
+		},
+		{
+			// The refuser here is the sha-shape check, not a dedicated -dirty
+			// branch: "-dirty" cannot occur inside 40 lowercase hex characters.
+			why:     "ReadBuildInfo Commit carries -dirty, so it is not a bare sha",
+			version: "v0.33.1-103-g0002c9b0b",
+			commit:  validSHA + "-dirty",
+			probe:   okProbe(validSHA + "-dirty"),
+		},
+		{
+			why:     "commit is the ldflag-less default 'dev'",
+			version: "dev",
+			commit:  "dev",
+			probe:   okProbe("dev"),
+		},
+		{
+			why:     "commit is 'unknown' (git unavailable at build time)",
+			version: "v0.33.1",
+			commit:  "unknown",
+			probe:   okProbe("unknown"),
+		},
+		{
+			why:     "commit is abbreviated, so identity is not comparable",
+			version: "v0.33.1",
+			commit:  validSHA[:7],
+			probe:   okProbe(validSHA[:7]),
+		},
+		{
+			why:     "commit is 40 chars but not hex",
+			version: "v0.33.1",
+			commit:  strings.Repeat("z", 40),
+			probe:   okProbe(strings.Repeat("z", 40)),
+		},
+		{
+			// The value is deliberately the MATCHING sha, so the only thing
+			// that can refuse here is the ok flag. A probe returning ("", false)
+			// would be refused by the head != commit branch instead, and the arm
+			// would pass without ever exercising determinability.
+			why:     "HEAD is undeterminable even though the value would match",
+			version: "v0.33.1",
+			commit:  validSHA,
+			probe: treeProbe{
+				head:  func() (string, bool) { return validSHA, false },
+				dirty: func([]string) (bool, bool) { return false, true },
+			},
+		},
+		{
+			why:     "HEAD is a different commit from the one the binary was built at",
+			version: "v0.33.1",
+			commit:  validSHA,
+			probe:   okProbe(strings.Repeat("a", 40)),
+		},
+		{
+			why:     "dirty state is undeterminable",
+			version: "v0.33.1",
+			commit:  validSHA,
+			probe: treeProbe{
+				head:  func() (string, bool) { return validSHA, true },
+				dirty: func([]string) (bool, bool) { return false, false },
+			},
+		},
+		{
+			why:     "the sampled directories hold uncommitted changes",
+			version: "v0.33.1",
+			commit:  validSHA,
+			probe: treeProbe{
+				head:  func() (string, bool) { return validSHA, true },
+				dirty: func([]string) (bool, bool) { return true, true },
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.why, func(t *testing.T) {
+			if binaryMatchesTree(tc.version, tc.commit, staleCheckDirs, tc.probe) {
+				t.Fatalf("must refuse to prove the binary current: %s", tc.why)
+			}
+		})
+	}
+}
+
+// TestBinaryMatchesTree_DirtyProbeScopedToSampledDirs pins the invariant that
+// makes the confirmation sound: the dirty probe must be asked about exactly the
+// directories the mtime pre-filter sampled. A narrower scope would suppress a
+// warning the pre-filter raised from a directory nobody checked for edits.
+func TestBinaryMatchesTree_DirtyProbeScopedToSampledDirs(t *testing.T) {
+	var got []string
+	p := treeProbe{
+		head:  func() (string, bool) { return validSHA, true },
+		dirty: func(dirs []string) (bool, bool) { got = append([]string(nil), dirs...); return false, true },
+	}
+	if !binaryMatchesTree("v0.33.1", validSHA, staleCheckDirs, p) {
+		t.Fatal("baseline must prove current")
+	}
+	if len(got) != len(staleCheckDirs) {
+		t.Fatalf("dirty probe saw %d dirs, mtime walk samples %d: %v vs %v",
+			len(got), len(staleCheckDirs), got, staleCheckDirs)
+	}
+	for i, d := range staleCheckDirs {
+		if got[i] != d {
+			t.Fatalf("dirty probe dir %d = %q, want %q", i, got[i], d)
+		}
+	}
+}
+
+// TestSourcesNewerThan covers the mtime pre-filter, including the two shapes
+// that must NOT trip it: a directory that does not exist, and a newer file that
+// is not Go source.
+func TestSourcesNewerThan(t *testing.T) {
+	base := time.Now()
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "pkg")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeAt := func(name string, mod time.Time) string {
+		p := filepath.Join(sub, name)
+		if err := os.WriteFile(p, []byte("package pkg\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(p, mod, mod); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	old := writeAt("old.go", base.Add(-time.Hour))
+	if sourcesNewerThan(base, []string{sub}) {
+		t.Fatalf("a .go file older than the binary must not report stale (%s)", old)
+	}
+
+	if sourcesNewerThan(base, []string{filepath.Join(dir, "does-not-exist")}) {
+		t.Fatal("a missing directory must contribute nothing")
+	}
+
+	writeAt("notes.txt", base.Add(time.Hour))
+	if sourcesNewerThan(base, []string{sub}) {
+		t.Fatal("a newer non-Go file must not report stale")
+	}
+
+	writeAt("new.go", base.Add(time.Hour))
+	if !sourcesNewerThan(base, []string{sub}) {
+		t.Fatal("a newer .go file must report stale")
+	}
+}
+
+func TestIsFullSHA(t *testing.T) {
+	if !isFullSHA(validSHA) {
+		t.Fatalf("%q is a full sha", validSHA)
+	}
+	// The ReadBuildInfo dirty marker must be unrepresentable as a bare sha.
+	// This is what lets binaryMatchesTree drop a dedicated -dirty branch for
+	// Commit; if it ever became true, that branch would have to come back.
+	if isFullSHA(validSHA + "-dirty") {
+		t.Fatal("a -dirty commit must never read as a bare sha")
+	}
+	for _, bad := range []string{"", "dev", "unknown", validSHA[:39], validSHA + "0",
+		strings.ToUpper(validSHA), strings.Repeat("g", 40)} {
+		if isFullSHA(bad) {
+			t.Fatalf("%q must not read as a full sha", bad)
+		}
+	}
+}
+
+// TestGitProbesAgainstRealCheckout exercises the real subprocess probes rather
+// than the stubs above, in both directions. It asserts determinability, never a
+// particular dirty state: the package directory is a live checkout and may hold
+// a sprint's uncommitted edits.
+func TestGitProbesAgainstRealCheckout(t *testing.T) {
+	head, ok := gitHead(gitBinary(), ".")
+	if !ok {
+		t.Fatal("instrument failure: the package directory is a git checkout, so HEAD must be readable")
+	}
+	if !isFullSHA(head) {
+		t.Fatalf("gitHead returned %q, want a full sha", head)
+	}
+	if _, ok := gitDirty(gitBinary(), ".", staleCheckDirs); !ok {
+		t.Fatal("instrument failure: dirty state must be determinable in a checkout")
+	}
+
+	// Negative arm. It points at a path that does NOT EXIST rather than at a
+	// plain temp directory: `git -C` walks UP the tree looking for a checkout,
+	// so a temp dir that happened to sit inside one would make both probes
+	// succeed and the arm would red for the runner's TMPDIR layout rather than
+	// for the code. A missing path fails identically on every platform.
+	outside := filepath.Join(t.TempDir(), "no-such-directory")
+	if _, ok := gitHead(gitBinary(), outside); ok {
+		t.Fatal("gitHead must not report a HEAD outside a checkout")
+	}
+	if _, ok := gitDirty(gitBinary(), outside, staleCheckDirs); ok {
+		t.Fatal("gitDirty must not report a state outside a checkout")
+	}
+}
+
+// TestStaleWarningNamesARealTarget pins the emitted advice, not a reconstruction
+// of it: the warning tells the user to run `make quick-install`, so that target
+// must exist. Reading it out of the make files is what makes this a check on the
+// product's own output rather than on the test author's arithmetic.
+func TestStaleWarningNamesARealTarget(t *testing.T) {
+	found := false
+	entries, err := os.ReadDir("../../make")
+	if err != nil {
+		t.Fatalf("instrument failure: make/ must be readable from the package dir: %v", err)
+	}
+	seen := 0
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".mk") {
+			continue
+		}
+		seen++
+		b, err := os.ReadFile(filepath.Join("../../make", e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, line := range strings.Split(string(b), "\n") {
+			if strings.HasPrefix(line, "quick-install:") {
+				found = true
+			}
+		}
+	}
+	if seen == 0 {
+		t.Fatal("instrument failure: no .mk files found")
+	}
+	if !found {
+		t.Fatal("the stale warning tells the user to run `make quick-install`, but no such target exists")
+	}
+}
+
+// staleFixture builds a temp source dir whose .go file is NEWER than the
+// binary time it returns, i.e. the state in which the mtime pre-filter fires.
+// This is the shape a freshly created git worktree is always in.
+func staleFixture(t *testing.T) (binaryTime time.Time, dirs []string) {
+	t.Helper()
+	binaryTime = time.Now().Add(-time.Hour)
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.go")
+	if err := os.WriteFile(src, []byte("package p\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(src, time.Now(), time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	return binaryTime, []string{dir}
+}
+
+// TestWarnIfStale_EmitsWhenTreeCannotProveCurrency is the positive control for
+// the emitting path, and it asserts the MESSAGE TEXT rather than "some output":
+// every silent arm below is a claim about absence, which many failures satisfy
+// equally, so the suite needs one arm that pins what is actually written.
+func TestWarnIfStale_EmitsWhenTreeCannotProveCurrency(t *testing.T) {
+	binaryTime, dirs := staleFixture(t)
+	var buf strings.Builder
+	// Perturbed one field from the suppressing baseline: the tree is dirty.
+	p := treeProbe{
+		head:  func() (string, bool) { return validSHA, true },
+		dirty: func([]string) (bool, bool) { return true, true },
+	}
+	warnIfStale(&buf, binaryTime, dirs, "v0.33.1", validSHA, p)
+
+	got := buf.String()
+	if !strings.Contains(got, "Binary may be stale (source files modified after build)") {
+		t.Fatalf("missing the staleness sentence; got %q", got)
+	}
+	if !strings.Contains(got, "make quick-install") {
+		t.Fatalf("missing the remedy command; got %q", got)
+	}
+}
+
+// TestWarnIfStale_SilentWhenBinaryProvenCurrent is ailang#687 itself: a fresh
+// worktree stamps every file with a current mtime, so the pre-filter fires on a
+// binary that is byte-identical to the tree. With the commit matching and the
+// tree clean, nothing may be written.
+func TestWarnIfStale_SilentWhenBinaryProvenCurrent(t *testing.T) {
+	binaryTime, dirs := staleFixture(t)
+	if !sourcesNewerThan(binaryTime, dirs) {
+		t.Fatal("instrument failure: the fixture must trip the mtime pre-filter")
+	}
+	var buf strings.Builder
+	warnIfStale(&buf, binaryTime, dirs, "v0.33.1", validSHA, okProbe(validSHA))
+	if got := buf.String(); got != "" {
+		t.Fatalf("a binary proven current must warn about nothing; got %q", got)
+	}
+}
+
+// TestWarnIfStale_SilentWhenSourcesOlder pins the pre-filter's own short
+// circuit: with no source newer than the binary there is nothing to confirm, and
+// in particular no git subprocess is run. The probe panics to prove that.
+func TestWarnIfStale_SilentWhenSourcesOlder(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.go")
+	if err := os.WriteFile(src, []byte("package p\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	past := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(src, past, past); err != nil {
+		t.Fatal(err)
+	}
+	neverProbe := treeProbe{
+		head:  func() (string, bool) { panic("git must not be consulted when no source is newer") },
+		dirty: func([]string) (bool, bool) { panic("git must not be consulted when no source is newer") },
+	}
+	var buf strings.Builder
+	warnIfStale(&buf, time.Now(), []string{dir}, "v0.33.1", validSHA, neverProbe)
+	if got := buf.String(); got != "" {
+		t.Fatalf("an up-to-date binary must warn about nothing; got %q", got)
+	}
+}
+
+// TestGitBinaryIsAbsolute pins the resolution contract: whatever git we run, we
+// run it by absolute path. A relative or unresolvable result must degrade to
+// "no git", which makes both probes undeterminable and therefore shows the
+// warning rather than suppressing it.
+func TestGitBinaryIsAbsolute(t *testing.T) {
+	got := gitBinary()
+	if got == "" {
+		t.Skip("no git on PATH in this environment")
+	}
+	if !filepath.IsAbs(got) {
+		t.Fatalf("git resolved to %q, which is not an absolute path", got)
+	}
+}
+
+// TestResolveGitRefusesAnythingNotAbsolute drives the real resolver, not a
+// re-implementation of its predicate, across every way it can fail. The
+// positive arm is what stops the refusals passing vacuously.
+func TestResolveGitRefusesAnythingNotAbsolute(t *testing.T) {
+	// Derive the absolute path at runtime rather than writing a POSIX literal:
+	// filepath.IsAbs("/usr/bin/git") is FALSE on windows, which needs a volume
+	// name, so a hardcoded path would red for the platform and not for the code.
+	absGit := filepath.Join(t.TempDir(), "git")
+	if !filepath.IsAbs(absGit) {
+		t.Fatalf("instrument failure: %q must be absolute on this platform", absGit)
+	}
+	if got := resolveGit(func() (string, error) { return absGit, nil }); got != absGit {
+		t.Fatalf("an absolute path must be accepted; got %q", got)
+	}
+	for _, tc := range []struct {
+		why  string
+		path string
+		err  error
+	}{
+		{"git is not on PATH at all", "", exec.ErrNotFound},
+		{"lookup errored but still returned a usable-looking path", "ERRPATH", exec.ErrNotFound},
+		{"git resolved to a RELATIVE path", "bin/git", nil},
+		{"git resolved to a bare name", "git", nil},
+		{"git resolved to a CWD-relative path", "./git", nil},
+	} {
+		t.Run(tc.why, func(t *testing.T) {
+			path := tc.path
+			if path == "ERRPATH" {
+				path = absGit // absolute AND erroring: only the error may refuse it
+			}
+			if got := resolveGit(func() (string, error) { return path, tc.err }); got != "" {
+				t.Fatalf("must refuse %q (%s); got %q", tc.path, tc.why, got)
+			}
+		})
+	}
+}
+
+// TestGitProbesRefuseWithoutResolvableGit pins the CONTRACT for an unresolvable
+// git: undeterminable, never a confident answer. Note honestly what it does not
+// do — neutering the empty-git guard leaves this green, because exec refuses an
+// empty command name with the same error. The guard is a declared fast path,
+// not a pinned branch, and this arm pins the outcome rather than the mechanism.
+func TestGitProbesRefuseWithoutResolvableGit(t *testing.T) {
+	if _, ok := gitHead("", "."); ok {
+		t.Fatal("with no resolvable git, HEAD must be undeterminable")
+	}
+	if _, ok := gitDirty("", ".", staleCheckDirs); ok {
+		t.Fatal("with no resolvable git, dirty state must be undeterminable")
+	}
+	// Control: the same call in the same directory IS determinable with a real
+	// git, so the refusals above are about the empty binary and not the path.
+	if _, ok := gitHead(gitBinary(), "."); !ok {
+		t.Fatal("instrument failure: HEAD must be readable here with a real git")
+	}
+}


### PR DESCRIPTION
Closes #687.

## The defect

`checkStaleBinary` decided staleness by walking four **CWD-relative** source directories and
warning if any `.go` file's `ModTime` was after the binary's. Creating a `git worktree` writes
every tracked file with a *current* mtime, so the warning fired on a binary that was
byte-identical to that worktree's own `HEAD`.

Every mission sub-agent runs in a fresh worktree, so every one of them saw it. In mission
iteration 190 a design-quorum reviewer rejected a design document because its premises "were
measured with a PATH binary that explicitly warned it was stale" — a full quorum round spent
refuting a false alarm.

Reproduced at `c8b2ea0a2` with a differential whose only variable is the working directory:
the same PATH binary, same arguments, **warns from a worktree and is silent from `/tmp`**.

## The fix

The mtime walk becomes a cheap **pre-filter** instead of the verdict. When it fires,
`binaryMatchesTree` tries to prove the binary current from the commit it already embeds,
before anything is printed. Suppression requires all of:

- `Version` carries no `-dirty` marker (a binary built from a dirty tree is addressed by no sha);
- `Commit` is a full 40-character lowercase-hex sha (so `dev`, `unknown` and abbreviations refuse);
- it equals `git rev-parse HEAD`;
- `git status --porcelain` is empty over **the same four directories the walk sampled** — the
  confirmation can never be narrower than the signal it confirms.

Every undeterminable case — no git, no checkout, a 2s probe timeout, an unreadable HEAD —
falls through to the warning, so a failure costs a spurious warning rather than a silenced
real one. Ordinary users pay nothing: outside a checkout the pre-filter finds no source
directories and no subprocess is ever spawned.

## Evidence

**End-to-end differential**, one binary per arm, sources genuinely newer than both binaries:

| arm | binary | worktree | result |
|---|---|---|---|
| A | new @`fc8ef61ce` | clean @`fc8ef61ce` | **SILENT** — the fix |
| A′ | **old** (mechanism removed) | same worktree | **WARNS** — the #687 defect |
| B | new @`fc8ef61ce` | same worktree, one file edited | **WARNS** — genuine staleness still reported |
| C | new @`fc8ef61ce` | clean @`c8b2ea0a2` | **WARNS** — commit mismatch |

A vs A′ isolates the code change; A vs B and A vs C show the suppression is not blanket.

**13 mutation drills, zero survivors** — every refusal branch, the enumerator's extension
filter, the confirmation's *scope*, `isFullSHA`'s length and hex checks separately, both
call-site conditions, and the `gitHead` error branch. Each mutant asserted **LANDED** by
sha256 and **BUILDS** by `go build` rc=0 *before* any test result was read; each inverse
`-skip` run rc=0, so the new arms are the killers rather than bystanders. `help.go` restored
from a copy (never `git checkout --`), byte-identity re-verified by sha256 each time.

**The drill found two hollow arms, and both are repaired rather than reported:**

- an arm named for a `Commit` `-dirty` branch was in fact refused by the sha-shape check —
  no 40-character lowercase-hex string can contain `-dirty`, so that branch was **unreachable**.
  It is removed rather than left as undeclared dead code, and `TestIsFullSHA` now pins the
  subsumption so the branch would have to come back if it ever stopped holding.
- an arm named for an unreadable `HEAD` supplied `("", false)`, which the *value mismatch*
  branch refused first. It now supplies the **matching** sha with `ok=false`, so only
  determinability can refuse it.

Two drills red a set rather than a single arm and are recorded as sets: neutering `!isFullSHA`
reds all five sha-shape arms (they route through one check), and `isFullSHA`'s length and hex
sub-conditions are what discriminate two of those five.

## Gates

Baselined on pristine `origin/dev` first (`go build ./cmd/ailang` rc=0, `go test ./cmd/ailang/...`
rc=0), so the gates measure the change and not the repo. Gate list **derived from `ci.yml`**
rather than recalled, then filtered to what this diff can break: `go vet`, `gofmt`,
`check-file-sizes`, `check-boundaries`, `check-changelog`, `test-check-changelog`,
`check-golden-drift`, `test-coverage-gate`, `lint`, and `go test ./cmd/ailang/...` — **all rc=0**
(`lint`'s single `unused` finding, `geminiPassThreshold`, is pre-existing).

**Platform:** all local gates ran on **darwin/arm64**; the ubuntu and windows legs are covered
only by the green `test`/`test-windows`/`build` contexts. One arm was hardened for this
explicitly — the "not a checkout" negative arm points at a path that cannot exist rather than at
a bare `t.TempDir()`, because `git -C` walks *up* the tree and would otherwise red for the
runner's TMPDIR layout rather than for the code.

Changelog filed into `changelogs/v0.18-current.md`, never the root index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
