### PR TITLE
fix(#689): an empty list literal took its element sort from a default, not from context

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,54 @@
 
 ## [Unreleased]
 
+### Fixed — `ailang verify`: an empty list literal took its element sort from a hardcoded default, not from context
+
+Found triaging [ailang#689](https://github.com/sunholo-data/ailang/issues/689), a
+downstream report that `ailang verify` reported a hard ERROR — a raw Z3 exit
+status and a fragment of SMT-LIB — on a record constructor whose contract only
+talked about list lengths.
+
+**Root cause.** An empty list literal carries no element type of its own, and
+SMT-LIB is monomorphically sorted: `(as seq.empty (Seq X))` fixes `X` at the
+term and Z3 will not unify it with a differently-sorted sequence. The encoder
+emitted `(Seq Int)` for every empty literal, with a source comment asserting
+that "the SMT solver will unify sorts as needed". It does not. Wherever the
+expected element type was anything but `int`, the query was ill-sorted and Z3
+rejected it outright.
+
+**The report's characterisation was too narrow.** It attributes the failure to
+"a record containing an ADT-typed field"; neither the record nor the ADT is the
+trigger. Measured at `d22681e27`: a record with a single `list[string]` field
+fails identically with no ADT anywhere, a `list[int]` field verifies, and a
+plain `-> list[string] { [] }` with no record at all fails the same way. The
+element type is the whole variable. Seven contexts were affected — record
+construction, record update, direct return, cons tail, an `if` branch, an empty
+literal nested inside a non-empty one, and the reported composite.
+
+**ANF is why the obvious fix does not work.** Every literal is hoisted into a
+temporary before it reaches the site whose declared type would supply its sort,
+so the encoder sees `let $t = [] in (mk_S $t "x")` and the record's field sorts
+never meet the literal. Empty-list bindings are therefore inlined along the
+let-spine first — sound because an empty list is a pure, constant, argument-free
+value — which puts the literal back at the position whose sort is known.
+
+The declared sort is then threaded from the three places a type is actually
+committed to: a record field's sort, a record update's field sort, and the
+function's return sort, propagating through `if` branches and into nested list
+elements. `x :: []` is emitted as the singleton `(seq.unit x)`, which needs no
+element sort at all. Where no declared sort is available the behaviour is
+unchanged, so this can only replace an ill-sorted `(Seq Int)` with the sort the
+declaration had already committed to.
+
+**Contracts over these shapes are now checked, not merely accepted.** The
+reported function verifies, and the five negative arms — the same shapes with
+their contracts negated — still report violations. All 34 shipped contract
+examples are byte-identical before and after.
+
+New fixture `examples/runnable/contracts/empty_list_sort_verify.ail`: 7
+functions, **7 errors before / 7 verified after**, one per affected context.
+
+
 ### Fixed — `charAt` allocated the whole string on every call, and the compiled backend indexed it by byte
 
 Two defects in one primitive family, found triaging ailang#688 (a downstream

--- a/cmd/ailang/verify_empty_list_sort_e2e_test.go
+++ b/cmd/ailang/verify_empty_list_sort_e2e_test.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/smt"
+)
+
+// verifyJSON is the subset of `ailang verify --json` this file asserts on.
+type verifyJSON struct {
+	Results []struct {
+		Function string `json:"function"`
+		Status   string `json:"status"`
+	} `json:"results"`
+}
+
+// TestVerify_EmptyListTakesElementSortFromContext is the end-to-end acceptance
+// test for ailang#689.
+//
+// An empty list literal carries no element type of its own, and SMT-LIB is
+// monomorphically sorted, so encoding `[]` as `(Seq Int)` regardless of context
+// emitted an ill-sorted term wherever the expected element type was anything
+// but int. Z3 rejected the whole query with a raw sort error, which reads like
+// the contract FAILED rather than like the tool declining to try.
+//
+// Every function in the fixture is an ERROR before the fix and VERIFIED after,
+// so each is its own arm: the fixture reds if any single context regresses.
+func TestVerify_EmptyListTakesElementSortFromContext(t *testing.T) {
+	if !smt.Z3Available() {
+		t.Skip("Z3 not installed (e.g. Windows CI) — verify e2e needs the solver")
+	}
+	bin := buildAilang(t)
+	stdout, stderr, _ := runAilangBin(t, bin, "verify", "--json",
+		"examples/runnable/contracts/empty_list_sort_verify.ail")
+
+	// A sort mismatch surfaces as a raw Z3 error, never as a verdict.
+	combined := stdout + stderr
+	for _, bad := range []string{"unknown constant", "unknown sort", "sort mismatch", "are incompatible"} {
+		if strings.Contains(combined, bad) {
+			t.Fatalf("verify leaked a Z3 sort error %q; output:\n%s", bad, combined)
+		}
+	}
+
+	var payload verifyJSON
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("verify --json did not emit valid JSON: %v\nstdout:\n%s", err, stdout)
+	}
+
+	// Assert per-function, not on an aggregate: an aggregate over a SHORT result
+	// list is vacuously green, so the expected set is named and its size checked.
+	want := map[string]bool{
+		"emptyDoc":    false, // record construction, four distinct element sorts
+		"clearLines":  false, // record update
+		"noLines":     false, // direct return, list[string]
+		"noBlocks":    false, // direct return, list[ADT]
+		"single":      false, // cons onto an empty tail
+		"oneEmptyRow": false, // empty literal nested inside a non-empty one
+		"maybeLines":  false, // if-branch
+	}
+	for _, r := range payload.Results {
+		if _, expected := want[r.Function]; !expected {
+			continue
+		}
+		if r.Status != "verified" {
+			t.Errorf("%s: status = %q, want \"verified\"", r.Function, r.Status)
+		}
+		want[r.Function] = true
+	}
+	for fn, seen := range want {
+		if !seen {
+			t.Errorf("%s: absent from verify output — the fixture no longer covers this context", fn)
+		}
+	}
+}
+
+// TestVerify_EmptyListContractsStillFail is the discriminating half of the arm
+// above. Making a shape ENCODABLE is only correct if a false contract over that
+// same shape still fails: a status of "verified" must mean Z3 checked it, not
+// that the encoder waved it through. Each case below is the fixture's shape with
+// its contract negated, and each must report a violation.
+func TestVerify_EmptyListContractsStillFail(t *testing.T) {
+	if !smt.Z3Available() {
+		t.Skip("Z3 not installed (e.g. Windows CI) — verify e2e needs the solver")
+	}
+	bin := buildAilang(t)
+
+	cases := []struct {
+		name string
+		fn   string
+		src  string
+	}{
+		{
+			name: "direct return",
+			fn:   "f",
+			src: `export func f() -> list[string] ! {}
+ensures { listLength(result) == 1 } {
+  []
+}`,
+		},
+		{
+			name: "record construction",
+			fn:   "mk",
+			src: `export type S = { items: list[string], tag: string }
+export func mk() -> S ! {}
+ensures { listLength(result.items) > 0 } {
+  { items: [], tag: "x" }
+}`,
+		},
+		{
+			name: "record update",
+			fn:   "clear",
+			src: `export type S = { items: list[string], tag: string }
+export func clear(s: S) -> S ! {}
+ensures { listLength(result.items) > 0 } {
+  { s | items: [] }
+}`,
+		},
+		{
+			name: "cons onto empty",
+			fn:   "f",
+			src: `export func f(x: string) -> list[string] ! {}
+ensures { listLength(result) == 2 } {
+  x :: []
+}`,
+		},
+		{
+			name: "nested empty",
+			fn:   "f",
+			src: `export func f() -> list[list[string]] ! {}
+ensures { listLength(result) == 0 } {
+  [[]]
+}`,
+		},
+	}
+
+	projectRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("project root: %v", err)
+	}
+	// The file must live under the project root, not os.TempDir(): CWD-relative
+	// path resolution behaves differently from a temp-shaped directory, so a
+	// /tmp fixture fails for its LOCATION rather than for the code under test.
+	dir, err := os.MkdirTemp(projectRoot, "verify_neg_")
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	rel, err := filepath.Rel(projectRoot, dir)
+	if err != nil {
+		t.Fatalf("rel: %v", err)
+	}
+	modBase := filepath.ToSlash(rel)
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			name := "neg"
+			path := filepath.Join(dir, name+".ail")
+			src := "module " + modBase + "/" + name + "\n\n" +
+				"import std/list (length as listLength)\n\n" + tc.src +
+				"\n\nexport func main() -> int ! {} { 0 }\n"
+			if err := os.WriteFile(path, []byte(src), 0o600); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			relPath := filepath.ToSlash(filepath.Join(modBase, name+".ail"))
+			stdout, stderr, _ := runAilangBin(t, bin, "verify", "--json", relPath)
+
+			var payload verifyJSON
+			if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+				t.Fatalf("case %d: verify --json did not emit valid JSON: %v\nstdout:\n%s\nstderr:\n%s",
+					i, err, stdout, stderr)
+			}
+			var found bool
+			for _, r := range payload.Results {
+				if r.Function != tc.fn {
+					continue
+				}
+				found = true
+				// "violated" is the honest outcome. "verified" would mean the
+				// encoding made a false contract provable; "error" would mean
+				// the shape is still unencodable and the positive arm above is
+				// passing for the wrong reason.
+				if r.Status == "verified" || r.Status == "error" {
+					t.Fatalf("%s (%s): status = %q, want a violation; stdout:\n%s",
+						tc.fn, tc.name, r.Status, stdout)
+				}
+			}
+			if !found {
+				t.Fatalf("%s (%s): absent from verify output; stdout:\n%s", tc.fn, tc.name, stdout)
+			}
+		})
+	}
+}

--- a/examples/manifest.json
+++ b/examples/manifest.json
@@ -1638,6 +1638,21 @@
       "description": "A named record containing list[ADT] verifies with dependency-ordered SMT declarations"
     },
     {
+      "path": "runnable/contracts/empty_list_sort_verify.ail",
+      "status": "working",
+      "tags": [
+        "contracts",
+        "smt-verification",
+        "records",
+        "adt",
+        "lists"
+      ],
+      "description": "Empty list literals take their element sort from context (record field, return, cons, nesting, if-branch)",
+      "modules": [
+        "std/list"
+      ]
+    },
+    {
       "path": "runnable/contracts/record_verify.ail",
       "status": "working",
       "tags": [
@@ -2718,11 +2733,11 @@
     }
   ],
   "statistics": {
-    "total": 195,
-    "working": 187,
+    "total": 196,
+    "working": 188,
     "aspirational": 4,
     "broken": 4,
-    "coverage": 0.958974358974359,
+    "coverage": 0.9591836734693877,
     "experimental": 0
   },
   "milestones": {

--- a/examples/runnable/contracts/empty_list_sort_verify.ail
+++ b/examples/runnable/contracts/empty_list_sort_verify.ail
@@ -1,0 +1,80 @@
+-- An empty list literal carries no element type of its own, but SMT-LIB is
+-- monomorphically sorted. Encoding `[]` as `(Seq Int)` regardless of context
+-- produced an ill-sorted term wherever the expected element type was anything
+-- but int, and Z3 rejected the whole query with a raw sort error (ailang#689).
+--
+-- Every function below puts an empty list somewhere its element sort has to
+-- come from context. Each one is an ERROR before the fix and VERIFIED after.
+--
+-- Run: ailang verify examples/runnable/contracts/empty_list_sort_verify.ail
+-- Expect: 7 verified
+
+module examples/runnable/contracts/empty_list_sort_verify
+
+import std/list (length as listLength)
+
+export type Block = Para(string) | Head(int, string)
+
+export type Doc = {
+  blocks: list[Block],
+  lines: list[string],
+  rows: list[list[string]],
+  title: string
+}
+
+-- 1. Record construction: the field's declared sort supplies the element sort.
+--    This is ailang#689's reported shape — a record whose list fields are of
+--    four different element types, one of them a user ADT.
+export func emptyDoc() -> Doc ! {}
+ensures {
+  listLength(result.blocks) == 0 &&
+  listLength(result.lines) == 0 &&
+  listLength(result.rows) == 0
+} {
+  { blocks: [], lines: [], rows: [], title: "" }
+}
+
+-- 2. Record update: the same, through `{ base | field: val }`.
+export func clearLines(d: Doc) -> Doc ! {}
+ensures { listLength(result.lines) == 0 } {
+  { d | lines: [] }
+}
+
+-- 3. Direct return: the declared return sort supplies it.
+export func noLines() -> list[string] ! {}
+ensures { listLength(result) == 0 } {
+  []
+}
+
+-- 4. Return of an empty list whose element type is a user ADT.
+export func noBlocks() -> list[Block] ! {}
+ensures { listLength(result) == 0 } {
+  []
+}
+
+-- 5. Cons onto an empty tail: `x :: []` IS the singleton sequence, so the
+--    element sort follows from the head and never needs annotating.
+export func single(x: string) -> list[string] ! {}
+ensures { listLength(result) == 1 } {
+  x :: []
+}
+
+-- 6. Nested: the outer literal is non-empty, the INNER one is empty, and its
+--    element sort has to reach one level down.
+export func oneEmptyRow() -> list[list[string]] ! {}
+ensures { listLength(result) == 1 } {
+  [[]]
+}
+
+-- 7. If-branches: both arms produce the function's value, so both inherit it.
+--    The contract here is deliberately trivial: what this arm tests is that the
+--    BODY can be encoded at all. Before the fix it could not, and Z3 rejected
+--    the query whatever the contract said. (Asserting a seq-length property
+--    across an `ite` instead costs Z3 ~12s, which is a solver cost, not more
+--    coverage.)
+export func maybeLines(b: bool) -> list[string] ! {}
+ensures { b == b } {
+  if b then ["a"] else []
+}
+
+export func main() -> int ! {} { 0 }

--- a/internal/smt/codegen.go
+++ b/internal/smt/codegen.go
@@ -442,7 +442,10 @@ func EncodeFunction(
 		bodyExpr = fmt.Sprintf("(%s %s)", unrollTopName, strings.Join(paramNames, " "))
 	} else {
 		var err error
-		bodyExpr, err = EncodeExpr(body)
+		// The result sort is determined BEFORE the body is encoded so it can
+		// resolve empty list literals in the body, whose element sort is not
+		// recoverable from the literal itself (ailang#689).
+		bodyExpr, err = encodeExprWithSortHint(body, resultSortFor(params, body, ctx, adtTypes, returnSort))
 		if err != nil {
 			return nil, fmt.Errorf("cannot encode function body: %w", err)
 		}
@@ -450,10 +453,7 @@ func EncodeFunction(
 	result.BodyExpr = bodyExpr
 
 	// Determine result type
-	resultSort := returnSort
-	if resultSort == "" {
-		resultSort = inferResultSort(params, body, ctx, adtTypes)
-	}
+	resultSort := resultSortFor(params, body, ctx, adtTypes, returnSort)
 	resultDecl := fmt.Sprintf("(define-const result %s %s)", resultSort, bodyExpr)
 	result.Declarations = append(result.Declarations, resultDecl)
 

--- a/internal/smt/codegen_apps.go
+++ b/internal/smt/codegen_apps.go
@@ -268,6 +268,12 @@ func encodeListBuiltin(spec ListBuiltinSpec, args []core.CoreExpr) (string, erro
 		if err != nil {
 			return "", err
 		}
+		// `x :: []` IS the singleton sequence. Emitting it as such keeps Z3
+		// inferring the element sort from the head, instead of appending an
+		// empty literal whose sort has to be guessed (ailang#689).
+		if isEmptyListLiteral(args[1]) {
+			return fmt.Sprintf("(seq.unit %s)", head), nil
+		}
 		tail, err := EncodeExpr(args[1])
 		if err != nil {
 			return "", err

--- a/internal/smt/codegen_infer.go
+++ b/internal/smt/codegen_infer.go
@@ -82,3 +82,14 @@ func inferResultSortInner(body core.CoreExpr, ctx *SMTContext, ctorToType map[st
 	}
 	return "Int"
 }
+
+// resultSortFor returns the sort of a function's result: the declared return
+// sort when the signature supplies one, otherwise the inferred sort. It is
+// called both to pick the hint used while encoding the body and to declare
+// `result`, so the two can never disagree.
+func resultSortFor(params []FunctionParam, body core.CoreExpr, ctx *SMTContext, adtTypes map[string][]ADTVariant, returnSort string) string {
+	if returnSort != "" {
+		return returnSort
+	}
+	return inferResultSort(params, body, ctx, adtTypes)
+}

--- a/internal/smt/codegen_records.go
+++ b/internal/smt/codegen_records.go
@@ -270,7 +270,9 @@ func encodeRecord(rec *core.Record) (string, error) {
 		if !ok {
 			return "", fmt.Errorf("record construction: missing field %q", fieldName)
 		}
-		encoded, err := EncodeExpr(fieldExpr)
+		// The field's declared sort resolves an otherwise-ambiguous empty list
+		// literal (ailang#689); an unknown field sort leaves behaviour unchanged.
+		encoded, err := encodeExprWithSortHint(fieldExpr, info.FieldSorts[fieldName])
 		if err != nil {
 			return "", fmt.Errorf("record field %q: %w", fieldName, err)
 		}
@@ -311,7 +313,7 @@ func encodeRecordUpdate(ru *core.RecordUpdate) (string, error) {
 	var args []string
 	for _, fieldName := range info.FieldNames {
 		if updateExpr, ok := ru.Updates[fieldName]; ok {
-			encoded, err := EncodeExpr(updateExpr)
+			encoded, err := encodeExprWithSortHint(updateExpr, info.FieldSorts[fieldName])
 			if err != nil {
 				return "", fmt.Errorf("record update field %q: %w", fieldName, err)
 			}

--- a/internal/smt/codegen_seq_hint.go
+++ b/internal/smt/codegen_seq_hint.go
@@ -1,0 +1,144 @@
+package smt
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sunholo-data/ailang/internal/core"
+)
+
+// An empty list literal carries no element type of its own, but SMT-LIB is
+// monomorphically sorted: `(as seq.empty (Seq X))` fixes X at the term, and Z3
+// will NOT unify it with a differently-sorted sequence. Encoding every empty
+// list as `(Seq Int)` therefore produces an ill-sorted term wherever the
+// expected element type is anything but int, and Z3 rejects the whole query
+// with a raw sort error (ailang#689).
+//
+// The expected sort is available at the points where a *declared* type is
+// known — a record field's sort, a function's return sort — so it is threaded
+// down from there as a hint. Where no hint is available the behaviour is
+// unchanged, so this can only replace an ill-sorted `(Seq Int)` with the sort
+// the declaration already committed to.
+
+// seqElemSort returns the element sort of an SMT-LIB sequence sort:
+// "(Seq String)" → "String", "(Seq (Seq String))" → "(Seq String)".
+// The second result is false when sort is not a sequence sort.
+func seqElemSort(sort string) (string, bool) {
+	s := strings.TrimSpace(sort)
+	if !strings.HasPrefix(s, "(Seq ") || !strings.HasSuffix(s, ")") {
+		return "", false
+	}
+	elem := strings.TrimSpace(s[len("(Seq ") : len(s)-1])
+	if elem == "" {
+		return "", false
+	}
+	return elem, true
+}
+
+// encodeExprWithSortHint encodes expr exactly as EncodeExpr does, except that
+// empty list literals reachable from expr are given expectedSort's element sort
+// instead of the Int default. The hint propagates through the constructs that
+// pass a value through unchanged (if-branches, let bodies) and into list
+// elements; every other expression is delegated to EncodeExpr untouched.
+//
+// An empty hint, or a hint that is not a sequence sort, reproduces EncodeExpr's
+// behaviour exactly.
+func encodeExprWithSortHint(expr core.CoreExpr, expectedSort string) (string, error) {
+	if expr == nil {
+		return "", fmt.Errorf("nil expression")
+	}
+	if expectedSort == "" {
+		return EncodeExpr(expr)
+	}
+
+	// ANF hoists every literal into a temporary, so an empty list literal is
+	// never syntactically AT the site whose declared type would give it an
+	// element sort. Put it back there first.
+	expr = inlineEmptyListBindings(expr)
+
+	switch e := expr.(type) {
+	case *core.List:
+		return encodeListWithSortHint(e, expectedSort)
+
+	case *core.If:
+		// Both branches produce the function's value, so both inherit the hint.
+		cond, err := EncodeExpr(e.Cond)
+		if err != nil {
+			return "", fmt.Errorf("if condition: %w", err)
+		}
+		then, err := encodeExprWithSortHint(e.Then, expectedSort)
+		if err != nil {
+			return "", fmt.Errorf("if then: %w", err)
+		}
+		els, err := encodeExprWithSortHint(e.Else, expectedSort)
+		if err != nil {
+			return "", fmt.Errorf("if else: %w", err)
+		}
+		return fmt.Sprintf("(ite %s %s %s)", cond, then, els), nil
+
+	default:
+		return EncodeExpr(expr)
+	}
+}
+
+// encodeListWithSortHint encodes a list literal, using expectedSort to resolve
+// the element sort of an empty literal and to propagate into nested elements.
+func encodeListWithSortHint(list *core.List, expectedSort string) (string, error) {
+	elemSort, ok := seqElemSort(expectedSort)
+	if !ok {
+		// Not a sequence sort — no usable hint, so behave exactly as before.
+		return encodeList(list)
+	}
+
+	if len(list.Elements) == 0 {
+		return fmt.Sprintf("(as seq.empty (Seq %s))", elemSort), nil
+	}
+
+	// Non-empty: element sorts are inferable from the elements themselves, but
+	// an element may ITSELF be an empty list (e.g. [[]] at list[list[string]]),
+	// so the hint has to reach them too.
+	encoded := make([]string, len(list.Elements))
+	for i, elem := range list.Elements {
+		enc, err := encodeExprWithSortHint(elem, elemSort)
+		if err != nil {
+			return "", fmt.Errorf("list element %d: %w", i, err)
+		}
+		encoded[i] = fmt.Sprintf("(seq.unit %s)", enc)
+	}
+	if len(encoded) == 1 {
+		return encoded[0], nil
+	}
+	return fmt.Sprintf("(seq.++ %s)", strings.Join(encoded, " ")), nil
+}
+
+// isEmptyListLiteral reports whether expr is a literal `[]`.
+func isEmptyListLiteral(expr core.CoreExpr) bool {
+	l, ok := expr.(*core.List)
+	return ok && len(l.Elements) == 0
+}
+
+// inlineEmptyListBindings rewrites `let x = [] in body` to `body[x := []]`
+// along the ANF let-spine.
+//
+// The rewrite is semantically neutral: an empty list literal is a pure,
+// constant, argument-free value, so substituting it for its single binding
+// changes no evaluation order and duplicates no work. What it buys is
+// position — after inlining, the literal sits at the record field / cons /
+// element position whose declared sort can supply its element type.
+//
+// Shadowing is handled by SubstituteLambdaVar, which stops at any binder that
+// rebinds the name.
+func inlineEmptyListBindings(expr core.CoreExpr) core.CoreExpr {
+	let, ok := expr.(*core.Let)
+	if !ok {
+		return expr
+	}
+	body := inlineEmptyListBindings(let.Body)
+	if isEmptyListLiteral(let.Value) {
+		return SubstituteLambdaVar(body, let.Name, let.Value)
+	}
+	if body == let.Body {
+		return expr
+	}
+	return &core.Let{Name: let.Name, Value: let.Value, Body: body}
+}

--- a/internal/smt/codegen_seq_hint_test.go
+++ b/internal/smt/codegen_seq_hint_test.go
@@ -1,0 +1,133 @@
+package smt
+
+import (
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/core"
+)
+
+func TestSeqElemSort(t *testing.T) {
+	tests := []struct {
+		in       string
+		wantElem string
+		wantOK   bool
+	}{
+		{"(Seq String)", "String", true},
+		{"(Seq Int)", "Int", true},
+		{"(Seq Block)", "Block", true},
+		// Nested: the element is itself a sequence sort, so the whole inner
+		// term must come back, not just its head.
+		{"(Seq (Seq String))", "(Seq String)", true},
+		{"(Seq (Seq (Seq Int)))", "(Seq (Seq Int))", true},
+		// Not sequence sorts — these must NOT yield an element sort, otherwise
+		// a record sort would be mistaken for a sequence and the hint would
+		// annotate an empty list with nonsense.
+		{"Int", "", false},
+		{"String", "", false},
+		{"MdParseState", "", false},
+		{"", "", false},
+		{"(Seq )", "", false},
+		{"(Array Int Int)", "", false},
+	}
+	for _, tc := range tests {
+		gotElem, gotOK := seqElemSort(tc.in)
+		if gotOK != tc.wantOK || gotElem != tc.wantElem {
+			t.Errorf("seqElemSort(%q) = (%q, %v), want (%q, %v)",
+				tc.in, gotElem, gotOK, tc.wantElem, tc.wantOK)
+		}
+	}
+}
+
+func TestEncodeListWithSortHint(t *testing.T) {
+	empty := &core.List{}
+	tests := []struct {
+		name string
+		list *core.List
+		hint string
+		want string
+	}{
+		{"empty at string", empty, "(Seq String)", "(as seq.empty (Seq String))"},
+		{"empty at ADT", empty, "(Seq Block)", "(as seq.empty (Seq Block))"},
+		{"empty at nested", empty, "(Seq (Seq String))", "(as seq.empty (Seq (Seq String)))"},
+		// No usable hint ⇒ unchanged behaviour, so the fix can only ever
+		// REPLACE an ill-sorted default, never introduce a new guess.
+		{"empty, non-seq hint", empty, "MdParseState", "(as seq.empty (Seq Int))"},
+		{"empty, no hint", empty, "", "(as seq.empty (Seq Int))"},
+		// A non-empty literal whose single element is itself empty: the hint has
+		// to reach one level down or the inner literal defaults to Int again.
+		{
+			"nested empty inside non-empty",
+			&core.List{Elements: []core.CoreExpr{&core.List{}}},
+			"(Seq (Seq String))",
+			"(seq.unit (as seq.empty (Seq String)))",
+		},
+	}
+	for _, tc := range tests {
+		got, err := encodeListWithSortHint(tc.list, tc.hint)
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", tc.name, err)
+		}
+		if got != tc.want {
+			t.Errorf("%s: got %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestInlineEmptyListBindings(t *testing.T) {
+	emptyList := func() core.CoreExpr { return &core.List{} }
+
+	t.Run("inlines an empty-list binding into its use site", func(t *testing.T) {
+		// ANF: let $t = [] in { items: $t }
+		in := &core.Let{
+			Name:  "$t",
+			Value: emptyList(),
+			Body:  &core.Record{Fields: map[string]core.CoreExpr{"items": &core.Var{Name: "$t"}}},
+		}
+		out := inlineEmptyListBindings(in)
+		rec, ok := out.(*core.Record)
+		if !ok {
+			t.Fatalf("got %T, want the let to be gone and the record to surface", out)
+		}
+		if !isEmptyListLiteral(rec.Fields["items"]) {
+			t.Fatalf("field 'items' = %T, want the empty list literal substituted in", rec.Fields["items"])
+		}
+	})
+
+	t.Run("leaves a non-empty-list binding alone", func(t *testing.T) {
+		// The rewrite is only sound because an empty list is a pure constant.
+		// Anything else must keep its binding.
+		in := &core.Let{
+			Name:  "$t",
+			Value: &core.List{Elements: []core.CoreExpr{&core.Lit{Kind: core.IntLit, Value: int64(1)}}},
+			Body:  &core.Var{Name: "$t"},
+		}
+		if out := inlineEmptyListBindings(in); out != core.CoreExpr(in) {
+			t.Fatalf("got %T, want the original let unchanged", out)
+		}
+	})
+
+	t.Run("stops at a shadowing binder", func(t *testing.T) {
+		// let $t = [] in (let $t = <int> in $t) — the inner $t is a different
+		// variable, so substituting into it would change the program's meaning.
+		inner := &core.Let{
+			Name:  "$t",
+			Value: &core.Lit{Kind: core.IntLit, Value: int64(7)},
+			Body:  &core.Var{Name: "$t"},
+		}
+		out := inlineEmptyListBindings(&core.Let{Name: "$t", Value: emptyList(), Body: inner})
+		got, ok := out.(*core.Let)
+		if !ok {
+			t.Fatalf("got %T, want the shadowing let to survive", out)
+		}
+		if v, ok := got.Body.(*core.Var); !ok || v.Name != "$t" {
+			t.Fatalf("inner body = %#v, want the shadowed var untouched", got.Body)
+		}
+	})
+
+	t.Run("non-let expressions pass through", func(t *testing.T) {
+		e := &core.Var{Name: "x"}
+		if out := inlineEmptyListBindings(e); out != core.CoreExpr(e) {
+			t.Fatalf("got %T, want the expression returned as-is", out)
+		}
+	})
+}


### PR DESCRIPTION
## What

`ailang verify` reported a hard **ERROR** — a raw Z3 exit status plus a fragment of SMT-LIB — on a record constructor whose contract only talked about list lengths (`ailang#689`). Root-caused and fixed; the reported contract now **verifies**.

## Root cause

An empty list literal carries no element type of its own, and SMT-LIB is monomorphically sorted: `(as seq.empty (Seq X))` fixes `X` at the term and Z3 will not unify it with a differently-sorted sequence. `encodeList` emitted `(Seq Int)` for **every** empty literal, under a source comment asserting that *"the SMT solver will unify sorts as needed"*. It does not.

## The report's characterisation is too narrow — measured, not assumed

`#689` attributes the failure to *"a record containing an ADT-typed field"*. Neither the record nor the ADT is the trigger. Measured at `d22681e27`:

| case | shape | elem type | literal | result |
|---|---|---|---|---|
| a1 | record field | `list[string]` | `[]` | **ERROR** `(Seq Int)` vs `(Seq String)` |
| a2 | record field | `list[string]` | `["a"]` | ✓ verified |
| a3 | record field | `list[int]` | `[]` | ✓ verified |
| a4 | **no record at all**, direct return | `list[string]` | `[]` | **ERROR** |
| a5 | direct return | `list[int]` | `[]` | ✓ verified |

The element type is the whole variable. **Seven** contexts were affected: record construction, record update, direct return, cons tail, `if` branch, an empty literal nested inside a non-empty one, and the reported composite.

## ANF is why the obvious fix does not work

Every literal is hoisted into a temporary before it reaches the site whose declared type would supply its sort, so the encoder sees

```
(define-const result S (let (($tmp2 (as seq.empty (Seq Int)))) (mk_S $tmp2 "x")))
```

and the record's field sorts never meet the literal. Empty-list bindings are therefore inlined along the let-spine first — sound because an empty list is a pure, constant, argument-free value, and `SubstituteLambdaVar` already stops at any shadowing binder — which puts the literal back at the position whose sort is known.

The declared sort is then threaded from the three places a type is actually committed to (record field, record update, function return sort), propagating through `if` branches and into nested elements. `x :: []` is emitted as the singleton `(seq.unit x)`, which needs no element sort at all.

**Where no declared sort is available the behaviour is unchanged**, so this can only replace an ill-sorted `(Seq Int)` with the sort the declaration had already committed to.

## Why this is better than the reported ask

`#689` asks, in order, for (1) reclassify the sort mismatch as `skipped` with a hint, or (2) fix the encoding if it is a bug. It is a bug, so (2) makes the contract genuinely verifiable — strictly better than declining to try. **(1) is still owed for the residual surface** and is filed separately: `shapes_verify.ail` ships today with `1 errors` for an unencodable tuple pattern, i.e. the ERROR-vs-`skipped` inconsistency is reproducible on a shipped example independently of this defect.

## Verification

- **Before/after differential**, same tree, two binaries: 6 probe arms flip `errors` → `verified`; the three `int`-element / non-empty controls are unchanged.
- **Fixture is its own discriminator**: `empty_list_sort_verify.ail` is **7 errors before / 7 verified after**.
- **Soundness**: 5 negative arms — the same shapes with contracts negated — still report **violations**. A `verified` here means Z3 checked it, not that the encoder waved it through. The e2e negative test fails on `verified` *and* on `error`, so it also catches the positive arm passing for the wrong reason.
- **No regressions**: all **34** shipped contract examples byte-identical before and after (`diff` empty; instrument control-verified).
- **9 mutation drills**, each asserted **LANDED** by sha256 and **BUILDS** by `go build` rc=0 *before any test result was read*, each restored by `cp` (never `git checkout --`) and verified byte-identical. **8 are unique killers** with inverse `-skip` rc=0 — the empty-list hint, ANF inlining (e2e and unit), cons identity, record-field hint, record-update hint, return-sort hint, `seqElemSort` nesting. The 9th (shadow guard) reds alongside a pre-existing `TestSubstituteLambdaVar_ShadowedByLet` and is recorded as a **set**, not claimed as a kill.

## Gates

Derived from `ci.yml` rather than recalled, then filtered to what this diff can break: `vet`, `fmt-check`, `check-file-sizes`, `check-boundaries`, `check-changelog`, `test-check-changelog`, `check-golden-drift`, `verify-examples`, `lint` — all rc=0. `go test ./...` rc=0, 110 packages ok.

`lint`'s single `unused` finding (`geminiPassThreshold`) is pre-existing.

**One red was attributed by measurement, not assumed**: `tests/golden/codegen/string_charat` reds locally with `undefined: CharCode`. That harness shells out to whatever `ailang` is on `PATH`, and this rig's system binary predates #775. Two arms: fresh worktree binary on `PATH` → **rc=0**; **pristine tree** with my changes stashed and the stale binary → **rc=1, identical failure**. Not from this diff.

**Platform narrowing**: every local gate ran on darwin/arm64. The linux and windows legs are covered only by the required contexts here. The new e2e tests skip when Z3 is absent (as the existing verify e2e does), so Windows exercises the unit tests only.

Fixes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)
