### PR TITLE
feat(#662): make the WASM type-check budget host-configurable and observable

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,59 @@
 
 ## [Unreleased]
 
+### Added — WASM type-check budget is now host-configurable and reports what it consumed
+
+[ailang#662](https://github.com/sunholo-data/ailang/issues/662), from a downstream
+consumer whose deployed demo broke for a real user on Firefox.
+
+**The complaint.** The WASM type-checker's 2 s budget is WALL-CLOCK and was a
+hardcoded constant, so whether a module loads depends on the visitor's hardware:
+the same bytes pass on a fast desktop and fail on a slower machine, and CI on
+fast runners cannot see it. The reporter measured it with CPU throttling over a
+25-module, ~367 KB corpus — 0 failures at 1x, 4 at 2x (which took out the main
+demo), 10 at 4x. 2x is a mid-range laptop. Their modules are not pathological;
+`docx_parser` is ~1200 lines of real Office parsing, and flattening matches does
+not shrink a module that is simply big. Adding ~107 ms to one module tipped a
+user over, invisibly.
+
+**Three changes.**
+
+1. **The limit is a host setting.** `ailangSetTypeCheckBudget(ms)` sets it; `0`
+   disables the wall-clock guard entirely. A rejected value (negative, NaN,
+   above 24 h, not a number) leaves the previous budget in force, so a
+   fat-fingered call cannot silently remove the guard. The default is unchanged
+   at 2 s, so hosts that never call it see no difference.
+2. **Consumption is reported on every outcome.** `ailangLoadModule()` now returns
+   `typeCheckMs`, `typeCheckSteps` and `budgetMs` on success *and* on failure, so
+   an embedder can watch headroom rather than discover the limit in production.
+3. **The error message stops describing a fixed limit.** It now names the budget
+   actually in force, the step count reached, the fact that the limit is
+   wall-clock and therefore machine-dependent, and how to raise it.
+
+`typeCheckSteps` counts instrumented type-checker entries and is **deterministic**:
+identical source yields an identical count on every machine. Gating on a step
+ceiling instead of on the clock is the reporter's preferred fix and is *not* done
+here — the counter ships first so the ceiling can be chosen from measurements on
+real corpora rather than guessed. Queued as
+`m-wasm-deterministic-typecheck-budget`.
+
+**The guard had no test coverage, by construction.** The whole mechanism lived
+behind `//go:build js && wasm`: measured at `8a6fd5570`, `go list` reported **0**
+native Go files containing it (control: the `_native.go` stub, 1; under
+`GOOS=js GOARCH=wasm`, 1), so no `go test` could reach it and none did. The state
+machine now lives in an untagged `internal/types/typecheck_budget.go` with an
+injectable clock — the defect under test *is* a timing dependence, so a test that
+measured it by sleeping would inherit the flakiness it exists to pin. Only the
+decision to **arm** stays build-tagged, and native never arms, so CLI behaviour is
+unchanged.
+
+14 arms, 12 mutation drills, 8 of them killed by exactly one arm. One drill
+earned its keep: deleting `begin()`'s own sticky-flag reset left the entire
+package green, because the arm asserting it called `end()` first and `end()` also
+clears the flag — the assertion never exercised the line it named. Re-armed
+without the intervening `end()`, which is also the case that matters (a host
+whose previous load panicked out).
+
 ### Fixed — `ailang verify`: an empty list literal took its element sort from a hardcoded default, not from context
 
 Found triaging [ailang#689](https://github.com/sunholo-data/ailang/issues/689), a

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"syscall/js"
+	"time"
 
 	"github.com/sunholo-data/ailang/internal/eval"
 	"github.com/sunholo-data/ailang/internal/repl"
@@ -294,11 +295,22 @@ func loadModule(this js.Value, args []js.Value) interface{} {
 	types.BeginWasmTypeCheck(name)
 	exports, err := replInstance.LoadModule(name, code)
 	types.EndWasmTypeCheck()
+
+	// ailang#662 ask 3 — report consumption on EVERY outcome, so an embedder
+	// can watch headroom rather than discover the limit in production.
+	// typeCheckSteps is the hardware-independent half: identical source gives
+	// an identical count on every machine, unlike typeCheckMs.
+	steps, elapsed := types.LastWasmTypeCheckStats()
+	result := map[string]interface{}{
+		"typeCheckMs":    float64(elapsed.Nanoseconds()) / float64(time.Millisecond),
+		"typeCheckSteps": float64(steps),
+		"budgetMs":       float64(types.WasmTypeCheckBudget().Nanoseconds()) / float64(time.Millisecond),
+	}
+
 	if err != nil {
-		return map[string]interface{}{
-			"success": false,
-			"error":   err.Error(),
-		}
+		result["success"] = false
+		result["error"] = err.Error()
+		return result
 	}
 
 	// Convert exports to JavaScript array
@@ -307,10 +319,61 @@ func loadModule(this js.Value, args []js.Value) interface{} {
 		jsExports[i] = exp
 	}
 
-	return map[string]interface{}{
-		"success": true,
-		"exports": jsExports,
+	result["success"] = true
+	result["exports"] = jsExports
+	return result
+}
+
+// setTypeCheckBudget lets the host choose its own type-check wall-clock limit.
+// JavaScript: ailangSetTypeCheckBudget(ms) -> {success: bool, budgetMs: number, error?: string}
+//
+// ailang#662: the limit was a hardcoded 2s, which makes shipped correctness
+// hardware-dependent — the same bytes load on a fast desktop and fail on a
+// slower laptop or a slower browser engine, and CI on fast runners cannot see
+// it. Embedders know their own tolerance; a host that has already downloaded a
+// 40 MB WASM binary may well prefer a slow load to a refused one.
+//
+// 0 disables the wall-clock limit entirely (steps are still counted and
+// reported). Takes effect at the next ailangLoadModule.
+func setTypeCheckBudget(this js.Value, args []js.Value) interface{} {
+	if len(args) < 1 {
+		return map[string]interface{}{
+			"success":  false,
+			"budgetMs": budgetMillis(),
+			"error":    "ailangSetTypeCheckBudget requires 1 argument: the budget in milliseconds (0 disables the limit)",
+		}
 	}
+	if args[0].Type() != js.TypeNumber {
+		return map[string]interface{}{
+			"success":  false,
+			"budgetMs": budgetMillis(),
+			"error":    fmt.Sprintf("ailangSetTypeCheckBudget expects a number of milliseconds, got %s", args[0].Type()),
+		}
+	}
+
+	d, err := types.ParseBudgetMillis(args[0].Float())
+	if err == nil {
+		err = types.SetWasmTypeCheckBudget(d)
+	}
+	if err != nil {
+		// The previous budget is deliberately left in force — a fat-fingered
+		// value must not silently remove the guard.
+		return map[string]interface{}{
+			"success":  false,
+			"budgetMs": budgetMillis(),
+			"error":    err.Error(),
+		}
+	}
+	return map[string]interface{}{
+		"success":  true,
+		"budgetMs": budgetMillis(),
+	}
+}
+
+// budgetMillis reports the configured type-check budget in milliseconds; 0
+// means the wall-clock limit is disabled.
+func budgetMillis() float64 {
+	return float64(types.WasmTypeCheckBudget().Nanoseconds()) / float64(time.Millisecond)
 }
 
 // listModules returns the list of loaded modules
@@ -588,6 +651,10 @@ func main() {
 	js.Global().Set("ailangListModules", js.FuncOf(listModules))
 	js.Global().Set("ailangStdlibStatus", js.FuncOf(stdlibStatus))
 	js.Global().Set("ailangCall", js.FuncOf(callExport))
+
+	// Type-check budget control (ailang#662) — the wall-clock limit is a host
+	// setting, not a property of the source.
+	js.Global().Set("ailangSetTypeCheckBudget", js.FuncOf(setTypeCheckBudget))
 
 	// Register effect handler functions (M-WASM-EFFECTS)
 	js.Global().Set("ailangSetEffectHandler", js.FuncOf(setEffectHandler))

--- a/docs/docs/reference/limitations.md
+++ b/docs/docs/reference/limitations.md
@@ -55,27 +55,63 @@ Named `func` recursion is also supported by `ailang verify` via bounded unrollin
 
 ### WASM Type-Checker Depth Limit (By Design, WASM-only)
 
-**Status**: WASM-specific constraint with structured error
+**Status**: WASM-specific constraint with structured error; the limit is **host-configurable** (unreleased, lands after v0.33.1)
 **Since**: v0.22.x
-**Verified at**: v0.33.1 (2026-08-17 — guard present in `internal/types/typechecker_wasm_depth_wasm.go`; WASM-host-only, not reproducible from the CLI, which is unaffected)
+**Verified at**: v0.33.1+unreleased (2026-08-18 — guard in `internal/types/typecheck_budget.go`, armed only by `internal/types/typechecker_wasm_depth_wasm.go`; WASM-host-only, not reproducible from the CLI, which is unaffected)
 **Affects**: AILANG modules compiled to WebAssembly (browser demos using `wasm/ailang.wasm`). **CLI is unaffected.**
 
 The WASM-compiled type-checker is bound by the host JavaScript engine's call-stack limit (~10–15K frames in Node, Chromium, Firefox) and by single-threaded execution. Modules with deeply-recursive or pathologically-slow type structure freeze the browser. On native Go the CLI handles them fine because goroutine stacks grow dynamically up to 1 GiB; on WASM we hit the cliff.
 
-**Enforcement**: a **wall-clock budget (2 s)** on the type-check of each module — it catches
-both true stack-depth blowups *and* pathologically slow analysis with the same structured
-error (earlier builds used a frame-count budget; the current guard is time-based).
+**Enforcement**: a **wall-clock budget** on the type-check of each module, default 2 s — it
+catches both true stack-depth blowups *and* pathologically slow analysis with the same
+structured error (earlier builds used a frame-count budget; the current guard is time-based).
+
+**The budget is wall-clock, so it is hardware-dependent** ([ailang#662](https://github.com/sunholo-data/ailang/issues/662)):
+the same bytes that load on a fast desktop can fail on a slower laptop, or under a slower
+browser engine, and CI on fast runners cannot catch it. A module is not "big enough" or "too
+big" in the abstract — it is too big *for the machine in front of it*. Two things follow.
+
+*Raise the limit if your modules are large rather than pathological.* Hosts choose their own
+tolerance:
+
+```js
+// milliseconds; 0 disables the wall-clock limit entirely.
+const r = ailangSetTypeCheckBudget(8000);
+// -> {success: true, budgetMs: 8000}
+// A rejected value (negative, NaN, > 24h, non-number) leaves the previous
+// budget in force and returns {success: false, budgetMs: <unchanged>, error}.
+```
+
+*Watch your headroom instead of discovering the limit in production.*
+`ailangLoadModule()` reports consumption on **every** outcome:
+
+```js
+const r = ailangLoadModule(name, src);
+// r.typeCheckMs    — wall-clock spent (hardware-dependent)
+// r.typeCheckSteps — instrumented type-checker entries; DETERMINISTIC, so the
+//                    same source gives the same count on every machine
+// r.budgetMs       — the limit in force for that load
+```
+
+`typeCheckSteps` is the number worth tracking over time and worth quoting in a bug report:
+unlike `typeCheckMs` it does not move when the hardware does. Gating on a step ceiling rather
+than on the clock — which would make the outcome reproducible and CI-testable — is not done
+yet; the counter ships first so the ceiling can be chosen from real corpora.
 
 **Example failure**:
 
 ```
 loadModule cognitive_commons/services/citizen failed:
-WASM type-checker budget exceeded (2s) while checking module
-"cognitive_commons/services/citizen".
+WASM type-checker budget exceeded (2s, <N> type-checker steps) while
+checking module "cognitive_commons/services/citizen".
 
-This module's type structure recurses too deeply OR triggers pathologically
-slow analysis for the WASM runtime. The same source likely works on the
-AILANG CLI — this limit is specific to browser execution.
+This limit is WALL-CLOCK, so it depends on how fast this machine and browser
+are: the same source may load elsewhere and fail here. The step count above is
+hardware-independent — quote it if you report this.
+
+If the module is simply large (rather than pathological), raise the limit from
+the host and reload:
+    ailangSetTypeCheckBudget(8000);   // milliseconds; 0 disables the limit
 ```
 
 **Common triggers**:

--- a/internal/types/typecheck_budget.go
+++ b/internal/types/typecheck_budget.go
@@ -1,0 +1,262 @@
+package types
+
+import (
+	"fmt"
+	"time"
+)
+
+// M-WASM-TYPECHECK-LIMITS — the type-check budget state machine.
+//
+// This file carries NO build tag on purpose. The guard it implements only
+// ever ARMS on WASM (BeginWasmTypeCheck is a no-op on native — see
+// typechecker_wasm_depth_native.go), but the mechanism itself compiles and
+// runs identically on both targets so it can be exercised by ordinary
+// `go test ./internal/types`.
+//
+// Before ailang#662 the whole mechanism lived behind `//go:build js && wasm`,
+// which put it outside the native build by construction: `go list` reports
+// zero native Go files containing it, so no native test could reach it and
+// none existed. A guard nothing can red when you remove it is not a guard.
+//
+// ailang#662 — the budget was also a hardcoded wall-clock constant, which
+// makes shipped correctness hardware-dependent: the same bytes load on a fast
+// desktop and fail on a slower laptop or a slower browser engine, and CI on
+// fast runners cannot see it. Two things change here:
+//
+//  1. the limit is CONFIGURABLE by the embedder (SetWasmTypeCheckBudget), so a
+//     host that knows its own tolerance is not held to ours; and
+//  2. consumption is REPORTED — both the wall-clock elapsed and a deterministic
+//     STEP count — so an embedder can watch headroom instead of discovering the
+//     limit in production.
+//
+// The step count is deliberately NOT a gate yet. It is a reproducible measure
+// of type-checker work (identical source ⇒ identical count, on every machine),
+// and it exists so the step ceiling that would REPLACE the wall-clock limit can
+// be chosen from measurements on real module corpora rather than guessed. See
+// the queue row m-wasm-deterministic-typecheck-budget.
+
+// DefaultWasmTypeCheckBudget is the wall-clock limit applied when an embedder
+// has not chosen one. Kept at the pre-ailang#662 value so behaviour is
+// unchanged for hosts that never call SetWasmTypeCheckBudget.
+//
+// Chosen empirically in v0.22.x by probing citizen.ail: 100ms false-fires on a
+// legitimate 7.5 KB module, 500ms and 2000ms both pass it. 2000ms shipped for
+// the headroom. ailang#662 is the report that the headroom is illusory on
+// slower hardware.
+const DefaultWasmTypeCheckBudget = 2 * time.Second
+
+// typeCheckBudget is the guard's state. Package-level rather than plumbed
+// through every recursive type-checker call because WASM Go is single-threaded
+// (the same reason the pre-#662 implementation used package-level vars).
+//
+// The clock is injectable so tests can drive the deadline deterministically
+// instead of sleeping — the defect ailang#662 reports IS a timing dependence,
+// so a test that measures it by sleeping would inherit the flakiness it is
+// meant to pin.
+type typeCheckBudget struct {
+	now   func() time.Time
+	limit time.Duration // 0 == no wall-clock limit
+
+	active   bool
+	tripped  bool
+	deadline time.Time
+	started  time.Time
+	module   string
+	steps    uint64
+
+	// Retained after end() so the bridge can report consumption for the
+	// check that just finished, on success as well as on failure.
+	lastSteps   uint64
+	lastElapsed time.Duration
+}
+
+var wasmBudget = &typeCheckBudget{
+	now:   time.Now,
+	limit: DefaultWasmTypeCheckBudget,
+}
+
+// begin arms the guard for one type-check and resets per-check state.
+func (b *typeCheckBudget) begin(module string) {
+	b.active = true
+	b.tripped = false
+	b.module = module
+	b.steps = 0
+	b.started = b.now()
+	if b.limit > 0 {
+		b.deadline = b.started.Add(b.limit)
+	} else {
+		b.deadline = time.Time{}
+	}
+}
+
+// end disarms the guard, capturing consumption for later reporting.
+func (b *typeCheckBudget) end() {
+	if b.active {
+		b.lastSteps = b.steps
+		b.lastElapsed = b.now().Sub(b.started)
+	}
+	b.active = false
+	b.tripped = false
+	b.module = ""
+	b.deadline = time.Time{}
+}
+
+// check is called from the instrumented type-checker entry points (inferCore
+// and Unify). It counts one step and reports whether the wall-clock limit has
+// been passed.
+//
+// Sticky: once tripped, every later call returns the same error until end().
+// Without this the type-checker's own error-recovery loop keeps trying
+// alternate inference paths after Unify returns an error, and the enclosing
+// loadModule never returns.
+func (b *typeCheckBudget) check() error {
+	if !b.active {
+		return nil
+	}
+	b.steps++
+	if b.tripped {
+		return b.err()
+	}
+	// deadline is zero exactly when limit <= 0, i.e. the embedder disabled
+	// the wall-clock guard. Steps are still counted.
+	if b.deadline.IsZero() {
+		return nil
+	}
+	if b.now().After(b.deadline) {
+		b.tripped = true
+		return b.err()
+	}
+	return nil
+}
+
+func (b *typeCheckBudget) err() WasmTypeCheckerBudgetExceededError {
+	return WasmTypeCheckerBudgetExceededError{
+		Budget: b.limit,
+		Module: b.module,
+		Steps:  b.steps,
+	}
+}
+
+// SetWasmTypeCheckBudget sets the wall-clock limit for subsequent
+// type-checks. A duration of 0 disables the wall-clock guard entirely (steps
+// are still counted and reported). A negative duration is rejected and leaves
+// the current limit unchanged.
+//
+// ailang#662: embedders know their own tolerance — a host that has already
+// downloaded a 40 MB WASM binary may well prefer a slow load to a refused one,
+// and a host targeting slow hardware needs a bigger number than a CI runner
+// does. Takes effect at the next BeginWasmTypeCheck; an in-flight check keeps
+// the deadline it was armed with.
+func SetWasmTypeCheckBudget(d time.Duration) error {
+	if d < 0 {
+		return fmt.Errorf("type-check budget must be >= 0 (0 disables the wall-clock limit), got %s", d)
+	}
+	wasmBudget.limit = d
+	return nil
+}
+
+// WasmTypeCheckBudget reports the configured wall-clock limit; 0 means the
+// wall-clock guard is disabled.
+func WasmTypeCheckBudget() time.Duration {
+	return wasmBudget.limit
+}
+
+// LastWasmTypeCheckStats reports consumption for the most recently completed
+// type-check: the deterministic step count and the wall-clock elapsed.
+//
+// ailang#662 ask 3 — "expose the consumed budget on success, so embedders can
+// monitor headroom instead of discovering the limit in production". steps is
+// the reproducible half: identical source yields an identical count on every
+// machine, unlike elapsed.
+func LastWasmTypeCheckStats() (steps uint64, elapsed time.Duration) {
+	return wasmBudget.lastSteps, wasmBudget.lastElapsed
+}
+
+// ParseBudgetMillis converts an embedder-supplied millisecond value into a
+// duration, rejecting the shapes a JS host can hand us that a time.Duration
+// cannot represent meaningfully.
+//
+// Lives here rather than in the WASM bridge so it is reachable from an
+// ordinary native test: everything inside cmd/wasm is behind `js && wasm` and
+// therefore untestable by `go test`.
+func ParseBudgetMillis(ms float64) (time.Duration, error) {
+	if ms != ms { // NaN
+		return 0, fmt.Errorf("type-check budget must be a number, got NaN")
+	}
+	if ms < 0 {
+		return 0, fmt.Errorf("type-check budget must be >= 0 milliseconds (0 disables the wall-clock limit), got %v", ms)
+	}
+	const maxBudgetMillis = 24 * 60 * 60 * 1000 // one day; well inside int64 nanoseconds
+	if ms > maxBudgetMillis {
+		return 0, fmt.Errorf("type-check budget must be <= %d milliseconds, got %v", int64(maxBudgetMillis), ms)
+	}
+	return time.Duration(ms * float64(time.Millisecond)), nil
+}
+
+// WasmTypeCheckerBudgetExceededError is returned when type-checking exceeds
+// the wall-clock budget. The message lists common triggers and workarounds so
+// the user can act without reading AILANG internals, and — since ailang#662 —
+// names the budget that was actually in force plus how to change it, because
+// the previous message described a fixed limit that is in fact a host setting.
+type WasmTypeCheckerBudgetExceededError struct {
+	Budget time.Duration
+	Module string
+	// Steps is the deterministic work count reached when the budget blew.
+	// Reproducible across machines for identical source, so it is the number
+	// worth quoting in a bug report.
+	Steps uint64
+}
+
+func (e WasmTypeCheckerBudgetExceededError) Error() string {
+	mod := e.Module
+	if mod == "" {
+		mod = "(module name unavailable)"
+	}
+	return fmt.Sprintf(
+		"WASM type-checker budget exceeded (%s, %d type-checker steps) while checking module %q.\n\n"+
+			"This limit is WALL-CLOCK, so it depends on how fast this machine and browser\n"+
+			"are: the same source may load elsewhere and fail here. The step count above is\n"+
+			"hardware-independent — quote it if you report this.\n\n"+
+			"If the module is simply large (rather than pathological), raise the limit from\n"+
+			"the host and reload:\n"+
+			"    ailangSetTypeCheckBudget(8000);   // milliseconds; 0 disables the limit\n"+
+			"ailangLoadModule() reports typeCheckMs / typeCheckSteps on success, so you can\n"+
+			"watch headroom instead of discovering this in production.\n\n"+
+			"Common triggers for genuinely pathological checking:\n"+
+			"  - Triple-nested match patterns (match inside match inside match)\n"+
+			"  - Multiple back-to-back matches on the same tagged-union value\n"+
+			"      (e.g. Ok(s) => s.x, then Ok(s) => s.y, then Ok(s) => s.z)\n"+
+			"  - Long chains of intra-package imports with destructured constructors\n"+
+			"  - Deeply-extended record rows used inside match arms\n\n"+
+			"Workarounds (in order of simplicity):\n"+
+			"  1. Flatten nested matches into sequential let-bindings:\n"+
+			"       let x = match foo { Ok(s) => s.x, Err(_) => 0.0 };\n"+
+			"  2. Extract a helper function that does one match and returns a record:\n"+
+			"       pure func unpack(r: Result[T, E]) -> { ok: bool, x: T } = match r { ... }\n"+
+			"  3. Split the function into smaller top-level functions.\n\n"+
+			"See: https://ailang.sunholo.com/docs/reference/limitations#wasm-type-checker-depth-limit-by-design-wasm-only\n"+
+			"Headless smoke harness: demos/scripts/wasm-loadmodule-harness.js (exit code 4 = this error)",
+		e.Budget, e.Steps, mod,
+	)
+}
+
+// checkWasmBudget is the instrumented hook called from Unify. It is inert
+// until BeginWasmTypeCheck arms the guard, which only happens on WASM — so on
+// native builds this is one predictable branch on a package-level bool, and
+// tests can arm it explicitly to exercise the real code path rather than a
+// build-tag twin of it.
+func checkWasmBudget() error {
+	return wasmBudget.check()
+}
+
+// wasmDepthEnter is called at the top of inferCore. Same hook, same inertness.
+func (tc *CoreTypeChecker) wasmDepthEnter(_ *InferenceContext) error {
+	return wasmBudget.check()
+}
+
+// wasmDepthExit is intentionally empty: the budget is checked on entry against
+// package-level state, so there is no per-call bookkeeping to unwind. Retained
+// so inferCore can `defer tc.wasmDepthExit(ctx)` unconditionally.
+func (tc *CoreTypeChecker) wasmDepthExit(_ *InferenceContext) {
+	// no-op — see comment above
+}

--- a/internal/types/typecheck_budget.go
+++ b/internal/types/typecheck_budget.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"math"
 	"time"
 )
 
@@ -180,7 +181,7 @@ func LastWasmTypeCheckStats() (steps uint64, elapsed time.Duration) {
 // ordinary native test: everything inside cmd/wasm is behind `js && wasm` and
 // therefore untestable by `go test`.
 func ParseBudgetMillis(ms float64) (time.Duration, error) {
-	if ms != ms { // NaN
+	if math.IsNaN(ms) {
 		return 0, fmt.Errorf("type-check budget must be a number, got NaN")
 	}
 	if ms < 0 {

--- a/internal/types/typecheck_budget_test.go
+++ b/internal/types/typecheck_budget_test.go
@@ -380,3 +380,50 @@ func TestTypeCheckerHooksRouteToTheBudget(t *testing.T) {
 	}
 	tc.wasmDepthExit(nil) // retained for the unconditional defer in inferCore
 }
+
+// LastWasmTypeCheckStats is the exported accessor the WASM bridge calls to
+// build the typeCheckMs / typeCheckSteps fields on every loadModule result;
+// exercised here against the package-level guard the bridge actually uses.
+func TestLastWasmTypeCheckStatsReportsThePackageGuard(t *testing.T) {
+	origNow, origLimit := wasmBudget.now, wasmBudget.limit
+	origSteps, origElapsed := wasmBudget.lastSteps, wasmBudget.lastElapsed
+	t.Cleanup(func() {
+		wasmBudget.now, wasmBudget.limit = origNow, origLimit
+		wasmBudget.lastSteps, wasmBudget.lastElapsed = origSteps, origElapsed
+		wasmBudget.end()
+	})
+
+	clk := &fakeClock{t: time.Date(2026, 8, 19, 0, 0, 0, 0, time.UTC)}
+	wasmBudget.now, wasmBudget.limit = clk.now, 10*time.Second
+
+	wasmBudget.begin("docparse/services/docx_parser")
+	tc := &CoreTypeChecker{}
+	for i := 0; i < 3; i++ {
+		clk.advance(50 * time.Millisecond)
+		if err := tc.wasmDepthEnter(nil); err != nil {
+			t.Fatalf("unexpected budget failure: %v", err)
+		}
+		tc.wasmDepthExit(nil)
+	}
+	wasmBudget.end()
+
+	steps, elapsed := LastWasmTypeCheckStats()
+	if steps != 3 {
+		t.Fatalf("LastWasmTypeCheckStats steps = %d; want 3", steps)
+	}
+	if elapsed != 150*time.Millisecond {
+		t.Fatalf("LastWasmTypeCheckStats elapsed = %s; want 150ms", elapsed)
+	}
+}
+
+// The bridge names the module, but a guard that trips outside a named check
+// must still produce a readable message rather than an empty pair of quotes.
+func TestBudgetErrorWithoutAModuleName(t *testing.T) {
+	msg := WasmTypeCheckerBudgetExceededError{Budget: time.Second, Steps: 12}.Error()
+	if !strings.Contains(msg, "(module name unavailable)") {
+		t.Fatalf("unnamed module rendered without a placeholder:\n%s", msg)
+	}
+	if !strings.Contains(msg, "12 type-checker steps") {
+		t.Fatalf("step count missing from the unnamed-module message:\n%s", msg)
+	}
+}

--- a/internal/types/typecheck_budget_test.go
+++ b/internal/types/typecheck_budget_test.go
@@ -1,0 +1,382 @@
+package types
+
+import (
+	"errors"
+	"math"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ailang#662 — the WASM type-check budget was a hardcoded wall-clock constant
+// living entirely behind `//go:build js && wasm`, so no native test could
+// reach it and none existed (`go list` reported zero native Go files carrying
+// it). These arms exercise the real state machine: the guard now compiles into
+// both targets and is inert until armed, so arming it here runs the same code
+// the WASM bridge runs.
+//
+// The clock is injected rather than slept on. The defect under test IS a
+// timing dependence, so a test that measured it by sleeping would inherit the
+// flakiness it exists to pin.
+
+// fakeClock drives the budget deterministically.
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) now() time.Time          { return c.t }
+func (c *fakeClock) advance(d time.Duration) { c.t = c.t.Add(d) }
+
+// newTestBudget returns an isolated budget plus its clock, so arms never touch
+// the package-level guard the type-checker uses.
+func newTestBudget(limit time.Duration) (*typeCheckBudget, *fakeClock) {
+	clk := &fakeClock{t: time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)}
+	return &typeCheckBudget{now: clk.now, limit: limit}, clk
+}
+
+func asBudgetErr(t *testing.T, err error) WasmTypeCheckerBudgetExceededError {
+	t.Helper()
+	var e WasmTypeCheckerBudgetExceededError
+	if !errors.As(err, &e) {
+		t.Fatalf("expected WasmTypeCheckerBudgetExceededError, got %T: %v", err, err)
+	}
+	return e
+}
+
+// An unarmed guard must never fire. This is what keeps the native/CLI
+// type-checker unbudgeted now that the mechanism compiles into both targets.
+func TestBudgetUnarmedIsInert(t *testing.T) {
+	b, clk := newTestBudget(time.Second)
+	clk.advance(time.Hour)
+	for i := 0; i < 10_000; i++ {
+		if err := b.check(); err != nil {
+			t.Fatalf("unarmed budget fired on step %d: %v", i, err)
+		}
+	}
+	if b.steps != 0 {
+		t.Fatalf("unarmed budget counted %d steps; want 0", b.steps)
+	}
+}
+
+func TestBudgetDoesNotFireBeforeDeadline(t *testing.T) {
+	b, clk := newTestBudget(2 * time.Second)
+	b.begin("m")
+	clk.advance(1999 * time.Millisecond)
+	if err := b.check(); err != nil {
+		t.Fatalf("budget fired at 1999ms of a 2s limit: %v", err)
+	}
+}
+
+func TestBudgetFiresAfterDeadline(t *testing.T) {
+	b, clk := newTestBudget(2 * time.Second)
+	b.begin("docparse/services/docx_parser")
+	clk.advance(2001 * time.Millisecond)
+	err := b.check()
+	if err == nil {
+		t.Fatal("budget did not fire at 2001ms of a 2s limit")
+	}
+	e := asBudgetErr(t, err)
+	if e.Module != "docparse/services/docx_parser" {
+		t.Fatalf("error names module %q; want the module passed to begin()", e.Module)
+	}
+	if e.Budget != 2*time.Second {
+		t.Fatalf("error reports budget %s; want 2s", e.Budget)
+	}
+}
+
+// Once tripped the guard stays tripped, even if the clock goes backwards. The
+// type-checker's own error-recovery loop keeps trying alternate inference
+// paths after Unify returns an error; without stickiness loadModule never
+// returns.
+func TestBudgetIsSticky(t *testing.T) {
+	b, clk := newTestBudget(time.Second)
+	b.begin("m")
+	clk.advance(2 * time.Second)
+	if err := b.check(); err == nil {
+		t.Fatal("budget did not fire")
+	}
+	clk.t = clk.t.Add(-2 * time.Second) // rewind well inside the deadline
+	if err := b.check(); err == nil {
+		t.Fatal("budget un-tripped when the clock went backwards; stickiness lost")
+	}
+}
+
+// THE ailang#662 REGRESSION GUARD. Identical work and identical elapsed time,
+// two different configured budgets, two different outcomes — which is exactly
+// what "the limit is a host setting, not a property of the source" means. If
+// the budget ever stops reaching the guard, this arm reds while every other
+// arm here still passes.
+func TestConfiguredBudgetChangesTheOutcome(t *testing.T) {
+	const elapsed = 3 * time.Second
+
+	tight, clkT := newTestBudget(1 * time.Second)
+	tight.begin("output_formatter")
+	clkT.advance(elapsed)
+	tightErr := tight.check()
+
+	roomy, clkR := newTestBudget(10 * time.Second)
+	roomy.begin("output_formatter")
+	clkR.advance(elapsed)
+	roomyErr := roomy.check()
+
+	if tightErr == nil {
+		t.Fatal("3s of work passed a 1s budget")
+	}
+	if roomyErr != nil {
+		t.Fatalf("3s of work failed a 10s budget: %v", roomyErr)
+	}
+	if tight.steps != roomy.steps {
+		t.Fatalf("step counts diverged (%d vs %d) for identical work; the count must not depend on the budget",
+			tight.steps, roomy.steps)
+	}
+}
+
+// 0 disables the wall-clock guard entirely — the embedder's escape hatch for
+// "I have already downloaded 40 MB, I can wait."
+func TestZeroBudgetDisablesTheWallClockGuard(t *testing.T) {
+	b, clk := newTestBudget(0)
+	b.begin("m")
+	clk.advance(24 * time.Hour)
+	if err := b.check(); err != nil {
+		t.Fatalf("budget of 0 fired after 24h; 0 must disable the wall-clock limit: %v", err)
+	}
+	if b.steps != 1 {
+		t.Fatalf("steps not counted with the wall-clock guard disabled: got %d, want 1", b.steps)
+	}
+}
+
+// begin() must reset per-check state ITSELF, or a module that blew the budget
+// poisons every later load in the same session.
+//
+// Deliberately re-arms WITHOUT calling end() first. An earlier version of this
+// arm did call end(), and end() also clears the sticky flag — so deleting
+// begin()'s own `b.tripped = false` left the whole suite green (mutation drill
+// M11, iteration 225). The end()-then-begin() path is the happy path the bridge
+// takes; this arm exists for the one where end() never ran, which is precisely
+// when a leaked trip flag would be permanent.
+func TestBeginResetsPerCheckState(t *testing.T) {
+	b, clk := newTestBudget(time.Second)
+	b.begin("first")
+	clk.advance(2 * time.Second)
+	if err := b.check(); err == nil {
+		t.Fatal("setup: budget did not fire")
+	}
+	if !b.tripped {
+		t.Fatal("setup: budget fired without setting the sticky flag")
+	}
+
+	// Re-arm with no intervening end() — e.g. a host whose previous load
+	// panicked out before EndWasmTypeCheck.
+	b.begin("second")
+	if b.steps != 0 {
+		t.Fatalf("begin() left %d steps from the previous check", b.steps)
+	}
+	if b.tripped {
+		t.Fatal("begin() left the sticky trip flag set; every later module would fail unconditionally")
+	}
+	if err := b.check(); err != nil {
+		t.Fatalf("second check inherited the first check's failure: %v", err)
+	}
+	if b.module != "second" {
+		t.Fatalf("begin() left module %q; want %q", b.module, "second")
+	}
+}
+
+// end() must also clear the sticky flag — the bridge's normal path is
+// begin/…/end/begin, and a trip surviving end() would fail the next load.
+func TestEndClearsTheStickyFlag(t *testing.T) {
+	b, clk := newTestBudget(time.Second)
+	b.begin("first")
+	clk.advance(2 * time.Second)
+	if err := b.check(); err == nil {
+		t.Fatal("setup: budget did not fire")
+	}
+	b.end()
+	if b.tripped {
+		t.Fatal("end() left the sticky trip flag set")
+	}
+	if b.active {
+		t.Fatal("end() left the guard armed")
+	}
+}
+
+// ailang#662 ask 3: consumption must be readable AFTER the check finishes,
+// which is the only moment the bridge can report it.
+func TestStatsSurviveEnd(t *testing.T) {
+	b, clk := newTestBudget(10 * time.Second)
+	b.begin("m")
+	for i := 0; i < 7; i++ {
+		clk.advance(100 * time.Millisecond)
+		if err := b.check(); err != nil {
+			t.Fatalf("unexpected budget failure: %v", err)
+		}
+	}
+	b.end()
+	if b.lastSteps != 7 {
+		t.Fatalf("lastSteps = %d; want 7", b.lastSteps)
+	}
+	if b.lastElapsed != 700*time.Millisecond {
+		t.Fatalf("lastElapsed = %s; want 700ms", b.lastElapsed)
+	}
+}
+
+// The step count is the hardware-INDEPENDENT half of the report: it must be a
+// function of the work alone. Two runs doing the same number of checks under
+// wildly different clocks must agree.
+func TestStepCountIsIndependentOfTheClock(t *testing.T) {
+	run := func(perStep time.Duration) uint64 {
+		b, clk := newTestBudget(0) // 0: no wall-clock limit, so neither run trips
+		b.begin("m")
+		for i := 0; i < 250; i++ {
+			clk.advance(perStep)
+			if err := b.check(); err != nil {
+				t.Fatalf("unexpected failure with the wall-clock guard disabled: %v", err)
+			}
+		}
+		b.end()
+		return b.lastSteps
+	}
+	fast := run(time.Microsecond)
+	slow := run(time.Second)
+	if fast != slow {
+		t.Fatalf("step count depends on the clock: %d (fast) vs %d (slow)", fast, slow)
+	}
+	if fast != 250 {
+		t.Fatalf("step count = %d; want 250 (one per instrumented entry)", fast)
+	}
+}
+
+// The message must carry the values only this path can produce — the budget
+// actually in force and the step count reached — not merely "something went
+// wrong". A reader on different hardware can act on the step count; they
+// cannot act on ours.
+func TestBudgetErrorMessageCarriesBudgetAndSteps(t *testing.T) {
+	b, clk := newTestBudget(1500 * time.Millisecond)
+	b.begin("docparse/services/docx_parser")
+	for i := 0; i < 3; i++ {
+		_ = b.check()
+	}
+	clk.advance(2 * time.Second)
+	msg := asBudgetErr(t, b.check()).Error()
+
+	for _, want := range []string{
+		"1.5s",                          // the configured budget, not a hardcoded 2s
+		"4 type-checker steps",          // the deterministic count reached
+		"docparse/services/docx_parser", // the module
+		"ailangSetTypeCheckBudget",      // how to change it
+		"typeCheckMs / typeCheckSteps",  // how to watch headroom
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("budget error message missing %q\n---\n%s", want, msg)
+		}
+	}
+}
+
+func TestSetWasmTypeCheckBudget(t *testing.T) {
+	orig := WasmTypeCheckBudget()
+	t.Cleanup(func() { _ = SetWasmTypeCheckBudget(orig) })
+
+	if orig != DefaultWasmTypeCheckBudget {
+		t.Fatalf("default budget = %s; want %s", orig, DefaultWasmTypeCheckBudget)
+	}
+	if err := SetWasmTypeCheckBudget(8 * time.Second); err != nil {
+		t.Fatalf("setting a positive budget failed: %v", err)
+	}
+	if got := WasmTypeCheckBudget(); got != 8*time.Second {
+		t.Fatalf("budget = %s after setting 8s", got)
+	}
+	if err := SetWasmTypeCheckBudget(0); err != nil {
+		t.Fatalf("setting 0 (disable) failed: %v", err)
+	}
+	if got := WasmTypeCheckBudget(); got != 0 {
+		t.Fatalf("budget = %s after setting 0", got)
+	}
+}
+
+// A rejected budget must leave the previous one intact — a host that fat-fingers
+// a negative value should not silently lose its guard.
+func TestSetWasmTypeCheckBudgetRejectsNegativeAndKeepsPrevious(t *testing.T) {
+	orig := WasmTypeCheckBudget()
+	t.Cleanup(func() { _ = SetWasmTypeCheckBudget(orig) })
+
+	if err := SetWasmTypeCheckBudget(5 * time.Second); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	err := SetWasmTypeCheckBudget(-1 * time.Second)
+	if err == nil {
+		t.Fatal("a negative budget was accepted")
+	}
+	if got := WasmTypeCheckBudget(); got != 5*time.Second {
+		t.Fatalf("a rejected budget clobbered the previous one: now %s, want 5s", got)
+	}
+}
+
+func TestParseBudgetMillis(t *testing.T) {
+	tests := []struct {
+		name    string
+		ms      float64
+		want    time.Duration
+		wantErr string
+	}{
+		{name: "typical", ms: 8000, want: 8 * time.Second},
+		{name: "zero disables", ms: 0, want: 0},
+		{name: "fractional", ms: 1500.5, want: 1500500 * time.Microsecond},
+		{name: "negative", ms: -1, wantErr: ">= 0 milliseconds"},
+		{name: "NaN", ms: math.NaN(), wantErr: "NaN"},
+		{name: "absurd", ms: 1e18, wantErr: "<= 86400000 milliseconds"},
+		{name: "infinity", ms: math.Inf(1), wantErr: "<= 86400000 milliseconds"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseBudgetMillis(tt.ms)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ParseBudgetMillis(%v) = %s, want error containing %q", tt.ms, got, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q does not contain %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseBudgetMillis(%v) errored: %v", tt.ms, err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseBudgetMillis(%v) = %s; want %s", tt.ms, got, tt.want)
+			}
+		})
+	}
+}
+
+// The hooks the type-checker actually calls must route to the state machine.
+// Without this, the extraction could leave checkWasmBudget/wasmDepthEnter
+// wired to nothing and every arm above would still pass.
+func TestTypeCheckerHooksRouteToTheBudget(t *testing.T) {
+	origNow, origLimit := wasmBudget.now, wasmBudget.limit
+	t.Cleanup(func() {
+		wasmBudget.now, wasmBudget.limit = origNow, origLimit
+		wasmBudget.end()
+	})
+
+	clk := &fakeClock{t: time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)}
+	wasmBudget.now, wasmBudget.limit = clk.now, time.Second
+
+	// Unarmed — the native/CLI production state.
+	if err := checkWasmBudget(); err != nil {
+		t.Fatalf("checkWasmBudget fired while unarmed: %v", err)
+	}
+	tc := &CoreTypeChecker{}
+	if err := tc.wasmDepthEnter(nil); err != nil {
+		t.Fatalf("wasmDepthEnter fired while unarmed: %v", err)
+	}
+
+	wasmBudget.begin("m")
+	clk.advance(2 * time.Second)
+	if err := checkWasmBudget(); err == nil {
+		t.Fatal("checkWasmBudget did not reach the budget: no error past the deadline")
+	}
+	wasmBudget.begin("m")
+	clk.advance(2 * time.Second)
+	if err := tc.wasmDepthEnter(nil); err == nil {
+		t.Fatal("wasmDepthEnter did not reach the budget: no error past the deadline")
+	}
+	tc.wasmDepthExit(nil) // retained for the unconditional defer in inferCore
+}

--- a/internal/types/typechecker_wasm_depth_native.go
+++ b/internal/types/typechecker_wasm_depth_native.go
@@ -2,38 +2,31 @@
 
 package types
 
-// M-WASM-TYPECHECK-LIMITS (v0.22.x) — native-build stubs for the WASM-only
-// wall-clock budget guard. On CLI / native targets, type-checker recursion
-// is bound by Go goroutine stacks (which grow dynamically up to 1 GiB), so
-// we have no budget. These stubs compile away — callers can invoke them
-// unconditionally without build-tag conditionals.
+// M-WASM-TYPECHECK-LIMITS (v0.22.x) — native-build stubs for ARMING the
+// type-check budget guard.
 //
-// The WASM-targeted counterparts live in typechecker_wasm_depth_wasm.go,
-// gated by `//go:build js && wasm`. See design_docs/planned/v0_22_0/
-// m-wasm-typecheck-limits.md for the full rationale.
+// On CLI / native targets, type-checker recursion is bound by Go goroutine
+// stacks (which grow dynamically up to 1 GiB), so a long type-check is slow
+// rather than fatal and no budget is wanted: arming one here would start
+// refusing large modules that work today.
+//
+// The guard's mechanism is NOT build-tagged — it lives in typecheck_budget.go
+// and compiles into both targets, so `go test ./internal/types` can exercise
+// it. It is inert until armed, and these stubs never arm it, so native
+// behaviour is unchanged: checkWasmBudget() takes one predictable branch on a
+// package-level bool and returns nil. Tests arm the state machine directly.
+//
+// The WASM-targeted counterparts live in typechecker_wasm_depth_wasm.go, gated
+// by `//go:build js && wasm`. See design_docs/planned/v0_22_0/
+// m-wasm-typecheck-limits.md for the full rationale, and ailang#662 for why
+// the budget became configurable and observable.
 
-// BeginWasmTypeCheck — no-op on native. WASM bridge calls this before each
-// loadModule to start the wall-clock budget.
+// BeginWasmTypeCheck — no-op on native. The WASM bridge calls this before each
+// loadModule to arm the budget.
 func BeginWasmTypeCheck(_ string) {
 	// Native Go grows goroutine stacks dynamically — no budget needed.
 }
 
-// EndWasmTypeCheck — no-op on native.
+// EndWasmTypeCheck — no-op on native: nothing was armed, so nothing to clear.
 func EndWasmTypeCheck() {
-	// Native: nothing to clean up.
-}
-
-// checkWasmBudget — no-op on native. Always returns nil so the caller's
-// `if err != nil` branch is always taken on the negative side.
-func checkWasmBudget() error {
-	return nil
-}
-
-func (tc *CoreTypeChecker) wasmDepthEnter(_ *InferenceContext) error {
-	// Native: no budget. Caller's err check is always nil.
-	return nil
-}
-
-func (tc *CoreTypeChecker) wasmDepthExit(_ *InferenceContext) {
-	// Native: nothing to track or clean up.
 }

--- a/internal/types/typechecker_wasm_depth_wasm.go
+++ b/internal/types/typechecker_wasm_depth_wasm.go
@@ -2,183 +2,48 @@
 
 package types
 
-import (
-	"fmt"
-	"time"
-)
-
-// M-WASM-TYPECHECK-LIMITS (v0.22.x) — wall-clock budget guard for the
-// AILANG WASM type-checker.
+// M-WASM-TYPECHECK-LIMITS (v0.22.x) — WASM-only ARMING of the type-check
+// budget guard. The guard itself (state machine, configuration, step counting,
+// error type, and the checkWasmBudget / wasmDepthEnter hooks) lives in the
+// build-tag-free typecheck_budget.go so it is reachable from native tests;
+// only the decision to arm it is target-specific.
 //
-// Why this exists:
+// Why the guard exists:
 //
 // The browser-freeze symptom is silent unresponsiveness for 80–120 seconds
 // before the JS engine eventually throws "Maximum call stack size exceeded"
-// (or the user force-quits the tab). Whether the cause is true stack
-// overflow OR pathological type-checker slowness (e.g. quadratic isTaggedUnion
+// (or the user force-quits the tab). Whether the cause is true stack overflow
+// OR pathological type-checker slowness (e.g. quadratic isTaggedUnion
 // analysis, deeply-nested unify recursion), the user experience is the same:
-// browser is frozen. A wall-clock budget catches BOTH causes with the same
-// structured error.
+// browser is frozen. A budget catches BOTH causes with one structured error.
 //
 // First hit 2026-05-20: cognitive_commons/services/citizen.ail loaded in 18ms
 // on CLI but hung WASM for 80+ seconds. Full diagnostic trail:
 // demos/debug-notes/wasm-citizen-stack-overflow.md.
 //
-// On CLI the corresponding stubs in typechecker_wasm_depth_native.go are
-// no-ops. Native Go has dynamically-growable per-goroutine stacks AND no
-// host call-stack limit, so we don't need a budget there.
+// Why native does NOT arm it (see typechecker_wasm_depth_native.go): native Go
+// has dynamically-growable per-goroutine stacks and no host call-stack limit,
+// so a CLI type-check that takes a long time is slow, not fatal — and applying
+// a wall-clock limit there would refuse large modules that work fine today.
 //
-// Implementation strategy:
-//
-// WASM Go is single-threaded, so we use a package-level deadline variable
-// instead of plumbing context through every recursive function. The WASM
-// bridge (cmd/wasm/main.go::loadModule) sets the deadline before invoking
-// the type-checker via beginWasmTypeCheck(); helpers check it on every
-// recursive call (inferCore, Unify) and return a structured error when
-// exceeded. endWasmTypeCheck() clears the deadline.
+// Honest scope of this guard: it catches type-checker pathologies whose hot
+// loop goes through Unify or inferCore, the two instrumented entry points.
+// citizen.ail's specific shape does most of its 80+s in pattern resolution /
+// constraint substitution, which those call sites miss; the demos harness has
+// its own 15s per-module timeout as a fallback. Plumbing the check into
+// inferRecordAccess / checkPattern / ApplySubstitution would need signature
+// changes or panic-based unwinding, and remains deferred.
 
-// wasmTypeCheckBudget — chosen empirically by probing citizen.ail. The
-// guard fires when checkWasmBudget() is called from instrumented sites
-// (currently Unify + inferCore entry). Empirical results:
-//
-//	Budget   citizen.ail (pathological)        commons_browser (legit, 7.5KB)
-//	100ms    ✓ fires in 110ms                  ✗ false-fire at 102ms
-//	500ms    ✗ Unify-free phase hides it       ✓ passes (102ms)
-//	2000ms   ✗ same as 500ms                   ✓ passes
-//
-// **Honest scope of this guard**: catches type-checker pathologies whose
-// hot loop goes through Unify or inferCore. citizen.ail's specific shape
-// happens to do most of its 80+s in pattern resolution / constraint
-// substitution, which our current call sites miss. The harness in the
-// demos repo has its own 15s per-module timeout that catches citizen as
-// a fallback.
-//
-// 2000ms ships as the production budget — gives 10-20x headroom over the
-// slowest legitimate module (commons_browser at 102-225ms) and still
-// catches pathologies that DO go through Unify. If a future module hits
-// the limit, the user sees the same clear error pointing at the standard
-// workarounds (flatten matches, extract helpers).
-//
-// Future improvement (deferred): plumb checkWasmBudget into more entry
-// points (inferRecordAccess, checkPattern, ApplySubstitution) so the
-// guard catches citizen-shape recursions too. Currently this would
-// require signature changes (ApplySubstitution returns Type, not error)
-// or panic-based unwinding. Both are non-trivial and deferred.
-const wasmTypeCheckBudget = 2 * time.Second
-
-// wasmDeadline is the current type-check's wall-clock deadline. Zero means
-// no active check. Package-level (rather than ctx-plumbed) so it's
-// accessible from Unify without requiring an InferenceContext parameter.
-// Safe because WASM Go is single-threaded.
-var wasmDeadline time.Time
-
-// wasmActiveModule is the module name being checked, for inclusion in the
-// budget-exceeded error message. Set alongside wasmDeadline.
-var wasmActiveModule string
-
-// wasmBudgetTripped is "sticky" — once the budget is exceeded once, every
-// subsequent checkWasmBudget() call returns the same error until
-// EndWasmTypeCheck() resets the state. Without this, the type-checker's
-// own error-recovery loop kept trying alternate inference paths after we
-// returned an error from Unify, and the loadModule call never returned.
-// Sticky semantics: budget exceeded → abort everything in the current
-// loadModule, surface the error to the bridge, let the bridge re-arm.
-var wasmBudgetTripped bool
-
-// BeginWasmTypeCheck starts the wall-clock budget for the next type-check.
-// Called by the WASM bridge before invoking loadModule. The CLI build has
-// a no-op stub of this function.
+// BeginWasmTypeCheck arms the budget for the next type-check. Called by the
+// WASM bridge (cmd/wasm/main.go::loadModule) before invoking the type-checker.
+// The native build has a no-op stub.
 func BeginWasmTypeCheck(moduleName string) {
-	wasmDeadline = time.Now().Add(wasmTypeCheckBudget)
-	wasmActiveModule = moduleName
-	wasmBudgetTripped = false
+	wasmBudget.begin(moduleName)
 }
 
-// EndWasmTypeCheck clears the deadline. Called by the WASM bridge after
-// loadModule returns (success or failure). The CLI build has a no-op stub.
+// EndWasmTypeCheck disarms the budget and records consumption, which the
+// bridge then reports via LastWasmTypeCheckStats. Called after loadModule
+// returns, on success or failure. The native build has a no-op stub.
 func EndWasmTypeCheck() {
-	wasmDeadline = time.Time{}
-	wasmActiveModule = ""
-	wasmBudgetTripped = false
-}
-
-// checkWasmBudget returns a structured error if the budget has been
-// exceeded. Sticky: once tripped, every subsequent call returns the same
-// error until EndWasmTypeCheck() resets. Called at the top of every
-// recursive type-checker entry (inferCore, Unify). Fast-path zero-check
-// means uninstrumented calls (e.g. during REPL evaluation before
-// BeginWasmTypeCheck) skip the time.Now() syscall.
-func checkWasmBudget() error {
-	if wasmDeadline.IsZero() {
-		return nil
-	}
-	if wasmBudgetTripped {
-		return WasmTypeCheckerBudgetExceededError{
-			Budget: wasmTypeCheckBudget,
-			Module: wasmActiveModule,
-		}
-	}
-	if time.Now().After(wasmDeadline) {
-		wasmBudgetTripped = true
-		return WasmTypeCheckerBudgetExceededError{
-			Budget: wasmTypeCheckBudget,
-			Module: wasmActiveModule,
-		}
-	}
-	return nil
-}
-
-// wasmDepthEnter is called at the top of inferCore. Delegates to the
-// shared wall-clock check.
-func (tc *CoreTypeChecker) wasmDepthEnter(ctx *InferenceContext) error {
-	return checkWasmBudget()
-}
-
-// wasmDepthExit is intentionally empty for the wall-clock budget design.
-// The depth-counter design had bookkeeping here (decrement on exit) but
-// the wall-clock variant doesn't need to track per-call state — checks
-// happen on entry against a package-level deadline. The function is
-// retained so the native + WASM stub signatures stay aligned and the
-// inferCore caller can `defer tc.wasmDepthExit(ctx)` unconditionally.
-func (tc *CoreTypeChecker) wasmDepthExit(_ *InferenceContext) {
-	// no-op — see comment above
-}
-
-// WasmTypeCheckerBudgetExceededError is returned when type-checking exceeds
-// the wall-clock budget on WASM. The error message lists common triggers
-// and workarounds so the user can flatten their module without needing to
-// read AILANG internals.
-//
-// Defined here so it compiles into the WASM binary only.
-type WasmTypeCheckerBudgetExceededError struct {
-	Budget time.Duration
-	Module string
-}
-
-func (e WasmTypeCheckerBudgetExceededError) Error() string {
-	mod := e.Module
-	if mod == "" {
-		mod = "(module name unavailable)"
-	}
-	return fmt.Sprintf(
-		"WASM type-checker budget exceeded (%s) while checking module %q.\n\n"+
-			"This module's type structure recurses too deeply OR triggers pathologically\n"+
-			"slow analysis for the WASM runtime. The same source likely works on the\n"+
-			"AILANG CLI — this limit is specific to browser execution.\n\n"+
-			"Common triggers:\n"+
-			"  - Triple-nested match patterns (match inside match inside match)\n"+
-			"  - Multiple back-to-back matches on the same tagged-union value\n"+
-			"      (e.g. Ok(s) => s.x, then Ok(s) => s.y, then Ok(s) => s.z)\n"+
-			"  - Long chains of intra-package imports with destructured constructors\n"+
-			"  - Deeply-extended record rows used inside match arms\n\n"+
-			"Workarounds (in order of simplicity):\n"+
-			"  1. Flatten nested matches into sequential let-bindings:\n"+
-			"       let x = match foo { Ok(s) => s.x, Err(_) => 0.0 };\n"+
-			"  2. Extract a helper function that does one match and returns a record:\n"+
-			"       pure func unpack(r: Result[T, E]) -> { ok: bool, x: T } = match r { ... }\n"+
-			"  3. Split the function into smaller top-level functions.\n\n"+
-			"See: https://ailang.sunholo.com/docs/reference/limitations#wasm-type-checker-depth-limit-by-design-wasm-only\n"+
-			"Headless smoke harness: demos/scripts/wasm-loadmodule-harness.js (exit code 4 = this error)",
-		e.Budget, mod,
-	)
+	wasmBudget.end()
 }


### PR DESCRIPTION
## What

`ailang#662`, from a downstream consumer whose deployed demo broke for a real user on Firefox.

The WASM type-checker's 2 s budget is **wall-clock** and was a hardcoded constant, so whether a module loads depends on the visitor's hardware: the same bytes pass on a fast desktop and fail on a slower machine, and CI on fast runners cannot catch it. The reporter measured it with CPU throttling over a 25-module, ~367 KB corpus — **0 failures at 1x, 4 at 2x** (which took out the main demo), **10 at 4x**. 2x is a mid-range laptop. Their modules are not pathological; `docx_parser` is ~1200 lines of real Office parsing, and flattening matches does not shrink a module that is simply big.

## Three changes

1. **The limit is a host setting.** `ailangSetTypeCheckBudget(ms)`; `0` disables the wall-clock guard. A rejected value (negative, NaN, > 24 h, non-number) leaves the previous budget **in force**, so a fat-fingered call cannot silently remove the guard. Default unchanged at 2 s — hosts that never call it see no difference.
2. **Consumption is reported on every outcome.** `ailangLoadModule()` returns `typeCheckMs`, `typeCheckSteps` and `budgetMs` on success *and* on failure.
3. **The error message stops describing a fixed limit** — it names the budget actually in force, the step count reached, that the limit is wall-clock and therefore machine-dependent, and how to raise it.

`typeCheckSteps` counts instrumented type-checker entries and is **deterministic**: identical source gives an identical count on every machine. Gating on a step ceiling instead of on the clock is the reporter's preferred fix and is **not** done here — the counter ships first so the ceiling can be chosen from measurements on real corpora rather than guessed. Queued as `m-wasm-deterministic-typecheck-budget`.

## The guard had no test coverage, by construction

The whole mechanism sat behind `//go:build js && wasm`. Measured at `8a6fd5570`: `go list` reported **0** native Go files containing it (control: the `_native.go` stub → 1; under `GOOS=js GOARCH=wasm` → 1). No `go test` could reach it and none did.

The state machine moves to an untagged `internal/types/typecheck_budget.go` with an **injectable clock** — the defect under test *is* a timing dependence, so a test that measured it by sleeping would inherit the flakiness it exists to pin. Only the decision to **arm** stays build-tagged, and native never arms, so CLI behaviour is unchanged.

## Verification

14 arms; **12 mutation drills, 8 killed by exactly one arm**. Every mutant was asserted **LANDED** (sha256 changed) and **BUILDS** (`go build` rc=0) before its result was read, and the file restored byte-identical afterwards.

One drill earned its keep: deleting `begin()`'s own sticky-flag reset left the **entire package green**, because the arm asserting it called `end()` first and `end()` also clears the flag — the assertion never exercised the line it named. Re-armed without the intervening `end()`, which is also the case that matters (a host whose previous load panicked out). A second arm now covers the `end()` path separately.

Gates — **darwin/arm64; the linux and windows legs were not run locally**: `make test` rc=0 (**0 FAIL / 7401 PASS**), plus `lint`, `vet`, `fmt-check`, `check-file-sizes`, `check-boundaries`, `check-changelog`, `test-check-changelog`, `check-skills`, `test-coverage-gate`, `check-golden-drift`, `build-wasm` — all rc=0.

> Rig note, not a finding about this diff: `make test` first came back red on `tests/golden/codegen/string_charat` (`undefined: CharCode`). It reproduces **identically on an untouched `origin/dev` tree**, and a two-arm control isolates the cause — that test execs the **PATH** binary, which is 9 commits stale here (`v0.33.1-125-gc575cd44e-dirty`, predating `a1dad782a`/#775); with the freshly built binary on PATH the same test is rc=0. `make build` does not fix it, because it writes `bin/ailang` and this test does not look there.

Refs #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)
