### PR TITLE
fix(#646): std/xml dropped whitespace-only text, jamming DOCX words together

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,49 @@
 
 ## [Unreleased]
 
+### Fixed — `std/xml` dropped whitespace-only text nodes, jamming DOCX words together
+
+[ailang#646](https://github.com/sunholo-data/ailang/issues/646), from a downstream
+consumer doing OOXML text extraction.
+
+**The complaint.** `getText` returned `""` for a whitespace-only text node, so
+`parseLenient("<r><t xml:space=\"preserve\"> </t></r>")` lost the space while
+`">a </t>"` kept its trailing one. Word splits runs at every formatting boundary
+and the separating space very commonly lands in a run of its own, so a document
+with mixed inline formatting extracted as `plain bolditalic` instead of
+`plain bold italic` — corrupting downstream text, markdown, search and chunking.
+
+**Two changes, because the reported fix was unreachable without the second.**
+
+1. **`xml:space` is honoured.** All four parse entry points (`parse`,
+   `parseLenient`, `parseWithLimit`) and all three streaming scanners
+   (`parseElements`, `parseFold`, `parseFoldStep`) now keep whitespace-only text
+   inside an `xml:space="preserve"` scope. Per XML 1.0 §2.10 the attribute is
+   **inherited** by descendants until overridden, so `preserve` on an ancestor
+   covers its subtree and `xml:space="default"` re-enables the drop below it. A
+   value the spec does not define is not an override — it inherits.
+   **The default is unchanged**: with no `xml:space` in scope, formatting
+   whitespace is still discarded, which is what element-content XML wants and
+   what every existing `getChildren` caller depends on.
+
+2. **The `xml:` prefix survives parsing.** Attribute and tag names were resolved
+   through the in-scope `xmlns` declarations, and the `xml` prefix is bound *by
+   definition* (XML Namespaces §3) and must never be declared — so it could never
+   be in that map, and `resolveTagName` fell through to the bare local name.
+   `xml:space` arrived as `space`, indistinguishable from an ordinary attribute
+   of that name; `getAttr(node, "xml:space")` returned `None` on a document that
+   plainly had one; and `serialize` round-tripped `<t xml:space="preserve"/>` out
+   as `<t space="preserve"/>`, silently changing what the document meant.
+   `xml:space`, `xml:lang`, `xml:id` and `xml:base` now keep their prefix.
+   Declared prefixes (`w:`, `r:`, …) resolve exactly as before.
+
+**Not closed by this:** a prefix that is *neither* declared nor `xml:` is still
+dropped (`<t w:val="x"/>` with no `xmlns:w` in scope yields `val`), and the three
+streaming scanners resolve the match name against a `nil` prefix map, so
+`parseElements(doc, "w:t")` finds nothing where `parseElements(doc, "t")` works.
+Both are pre-existing and queued separately.
+
+
 ### Added — WASM type-check budget is now host-configurable and reports what it consumed
 
 [ailang#662](https://github.com/sunholo-data/ailang/issues/662), from a downstream

--- a/examples/manifest.json
+++ b/examples/manifest.json
@@ -2420,6 +2420,24 @@
       ]
     },
     {
+      "path": "runnable/xml_space_preserve.ail",
+      "status": "working",
+      "tags": [
+        "stdlib",
+        "xml",
+        "whitespace",
+        "namespaces",
+        "ooxml",
+        "std/xml"
+      ],
+      "description": "xml:space=\"preserve\" keeps significant whitespace (OOXML separator runs); the default still drops formatting whitespace",
+      "modules": [
+        "std/io",
+        "std/list",
+        "std/xml"
+      ]
+    },
+    {
       "path": "runnable/xml_walk_perf.ail",
       "status": "working",
       "tags": [
@@ -2733,11 +2751,11 @@
     }
   ],
   "statistics": {
-    "total": 196,
-    "working": 188,
+    "total": 197,
+    "working": 189,
     "aspirational": 4,
     "broken": 4,
-    "coverage": 0.9591836734693877,
+    "coverage": 0.9593908629441624,
     "experimental": 0
   },
   "milestones": {

--- a/examples/runnable/xml_space_preserve.ail
+++ b/examples/runnable/xml_space_preserve.ail
@@ -1,0 +1,50 @@
+-- xml_space_preserve.ail — xml:space="preserve" keeps significant whitespace
+--
+-- A text node made up entirely of whitespace is dropped by default, because
+-- element-content XML is normally pretty-printed and that whitespace is layout
+-- rather than data. Mixed content is the opposite case: Word splits runs at
+-- every formatting boundary, so the separating space very commonly lands in a
+-- run of its own and dropping it jams words together.
+--
+-- xml:space="preserve" is exactly the signal that the whitespace is significant.
+-- Per XML 1.0 §2.10 it is INHERITED by descendants until an xml:space="default"
+-- overrides it.
+
+module examples/runnable/xml_space_preserve
+
+import std/xml (parseLenient, getText, findFirst, getAttr, getChildren, serialize)
+import std/list (length)
+import std/io (println)
+
+func textOf(doc: string) -> string =
+  match parseLenient(doc) {
+    Ok(node) => getText(node),
+    Err(msg) => concat_String("parse error: ", msg)
+  }
+
+export func main() -> () ! {IO} {
+  -- The DOCX shape: the separator run is its own <w:t>.
+  let runs = "<w:r><w:t xml:space=\"preserve\">plain </w:t></w:r><w:r><w:t>bold</w:t></w:r>";
+  let docx = "<w:p xmlns:w=\"urn:w\">${runs}<w:r><w:t xml:space=\"preserve\"> </w:t></w:r><w:r><w:t>italic</w:t></w:r></w:p>";
+  println("docx: ${textOf(docx)}");
+
+  -- Default is unchanged: pretty-printing whitespace is still discarded.
+  println("pretty: ${show(textOf("<r>\n  <a>x</a>\n  <b>y</b>\n</r>"))}");
+  println("bare:   ${show(textOf("<r><t> </t></r>"))}");
+
+  -- preserve on an ancestor covers the subtree; default opts back out.
+  println("inherited: ${show(textOf("<r xml:space=\"preserve\"><t> </t></r>"))}");
+  println("overridden: ${show(textOf("<r xml:space=\"preserve\"><t xml:space=\"default\"> </t></r>"))}");
+
+  -- The attribute keeps its prefix, so it is readable and round-trips.
+  match parseLenient("<r><t xml:space=\"preserve\"> </t></r>") {
+    Ok(node) => {
+      match findFirst(node, "t") {
+        Some(t) => println("getAttr: ${show(getAttr(t, "xml:space"))} children=${show(length(getChildren(t)))}"),
+        None => println("getAttr: <t> not found")
+      };
+      println("serialize: ${serialize(node)}")
+    },
+    Err(msg) => println("parse error: ${msg}")
+  }
+}

--- a/internal/builtins/xml.go
+++ b/internal/builtins/xml.go
@@ -18,6 +18,12 @@ import (
 const (
 	xmlMaxDepth     = 256
 	xmlMaxInputSize = 50 * 1024 * 1024 // 50MB
+
+	// xmlNamespaceURI is the namespace the "xml" prefix is bound to by
+	// definition (XML Namespaces §3). It is never declared with an xmlns
+	// attribute — the spec forbids binding it to any other prefix — so it
+	// can never appear in a prefixMap and must be recognised structurally.
+	xmlNamespaceURI = "http://www.w3.org/XML/1998/namespace"
 )
 
 func init() {
@@ -131,7 +137,7 @@ func registerXmlParse() {
 		Impl:    xmlParseImpl,
 		Metadata: &BuiltinMetadata{
 			Description: "Parse an XML string into an XmlNode tree",
-			LongDesc:    "Parses well-formed XML into an XmlNode algebraic data type tree. Supports elements, text, CDATA, and comments. Namespace prefixes are preserved in tag names (e.g., w:p). Rejects input >50MB and depth >256.",
+			LongDesc:    "Parses well-formed XML into an XmlNode algebraic data type tree. Supports elements, text, CDATA, and comments. Namespace prefixes are preserved on tags and attributes (e.g., w:p, w:val); the implicitly-bound xml prefix is recognised structurally, so xml:space/xml:lang/xml:id keep it. Whitespace-only text nodes are dropped unless xml:space=\"preserve\" is in scope, which is inherited by descendants until an xml:space=\"default\" overrides it. Rejects input >50MB and depth >256.",
 			Params: []ParamDoc{
 				{Name: "xml", Description: "XML string to parse"},
 			},
@@ -172,7 +178,7 @@ func xmlParseImpl(_ *effects.EffContext, args []eval.Value) (eval.Value, error) 
 	}
 
 	decoder := xml.NewDecoder(strings.NewReader(input))
-	children, err := parseXmlChildren(decoder, 0, nil)
+	children, err := parseXmlChildren(decoder, 0, nil, false)
 	if err != nil {
 		return xmlMakeErr(fmt.Sprintf("XML parse error: %v", err)), nil
 	}
@@ -280,7 +286,7 @@ func scanForElements(decoder *xml.Decoder, tagName string, limit int, results *[
 				// Build subtree for this matched element
 				localPM := extractPrefixMap(t, nil)
 				attrs := buildAttrs(t, localPM)
-				childNodes, err := parseXmlChildren(decoder, 1, localPM)
+				childNodes, err := parseXmlChildren(decoder, 1, localPM, spaceMode(t, false))
 				if err != nil {
 					return false
 				}
@@ -391,7 +397,7 @@ func xmlParseWithLimitImpl(_ *effects.EffContext, args []eval.Value) (eval.Value
 	nodeCount := 0
 
 	decoder := xml.NewDecoder(strings.NewReader(input))
-	children, err := parseXmlChildrenLimited(decoder, 0, nil, &nodeCount, maxNodes)
+	children, err := parseXmlChildrenLimited(decoder, 0, nil, &nodeCount, maxNodes, false)
 	if err != nil {
 		return xmlMakeErr(fmt.Sprintf("XML parse error: %v", err)), nil
 	}
@@ -405,7 +411,7 @@ func xmlParseWithLimitImpl(_ *effects.EffContext, args []eval.Value) (eval.Value
 	return xmlMakeOk(makeXmlElement("", nil, children)), nil
 }
 
-func parseXmlChildrenLimited(decoder *xml.Decoder, depth int, pm *prefixMap, nodeCount *int, maxNodes int) ([]eval.Value, error) {
+func parseXmlChildrenLimited(decoder *xml.Decoder, depth int, pm *prefixMap, nodeCount *int, maxNodes int, preserve bool) ([]eval.Value, error) {
 	if depth > xmlMaxDepth {
 		return nil, fmt.Errorf("maximum depth exceeded (%d)", xmlMaxDepth)
 	}
@@ -428,7 +434,7 @@ func parseXmlChildrenLimited(decoder *xml.Decoder, depth int, pm *prefixMap, nod
 			}
 			localPM := extractPrefixMap(t, pm)
 			attrs := buildAttrs(t, localPM)
-			childNodes, err := parseXmlChildrenLimited(decoder, depth+1, localPM, nodeCount, maxNodes)
+			childNodes, err := parseXmlChildrenLimited(decoder, depth+1, localPM, nodeCount, maxNodes, spaceMode(t, preserve))
 			if err != nil {
 				return nil, err
 			}
@@ -439,7 +445,7 @@ func parseXmlChildrenLimited(decoder *xml.Decoder, depth int, pm *prefixMap, nod
 			return children, nil
 
 		case xml.CharData:
-			if !isAllWhitespace(t) {
+			if preserve || !isAllWhitespace(t) {
 				*nodeCount++
 				if *nodeCount > maxNodes {
 					return nil, fmt.Errorf("node limit exceeded: %d nodes (max %d)", *nodeCount, maxNodes)
@@ -487,6 +493,13 @@ func resolveTagName(name xml.Name, pm *prefixMap) string {
 	if name.Space == "" {
 		return name.Local
 	}
+	// The "xml" prefix is bound by definition and must not be declared, so no
+	// prefixMap can ever resolve it. Without this, xml:space / xml:lang / xml:id
+	// all arrive as bare "space" / "lang" / "id" — indistinguishable from an
+	// unprefixed attribute of the same name, and unreachable via getAttr.
+	if name.Space == xmlNamespaceURI {
+		return "xml:" + name.Local
+	}
 	if pm != nil {
 		if prefix := pm.lookupPrefix(name.Space); prefix != "" {
 			return prefix + ":" + name.Local
@@ -495,7 +508,29 @@ func resolveTagName(name xml.Name, pm *prefixMap) string {
 	return name.Local
 }
 
-func parseXmlChildren(decoder *xml.Decoder, depth int, pm *prefixMap) ([]eval.Value, error) {
+// spaceMode reports whether whitespace inside start's content is significant.
+//
+// xml:space (XML 1.0 §2.10) takes exactly "preserve" or "default" and is
+// INHERITED by descendants until overridden, so the answer for an element is a
+// function of its own attribute and its ancestors'. A value the spec does not
+// define is not an override — it inherits, which is the lenient reading and
+// matches parseLenient's contract for real-world documents.
+func spaceMode(start xml.StartElement, inherited bool) bool {
+	for _, a := range start.Attr {
+		if a.Name.Local != "space" || a.Name.Space != xmlNamespaceURI {
+			continue
+		}
+		switch a.Value {
+		case "preserve":
+			return true
+		case "default":
+			return false
+		}
+	}
+	return inherited
+}
+
+func parseXmlChildren(decoder *xml.Decoder, depth int, pm *prefixMap, preserve bool) ([]eval.Value, error) {
 	if depth > xmlMaxDepth {
 		return nil, fmt.Errorf("maximum depth exceeded (%d)", xmlMaxDepth)
 	}
@@ -514,7 +549,7 @@ func parseXmlChildren(decoder *xml.Decoder, depth int, pm *prefixMap) ([]eval.Va
 		case xml.StartElement:
 			localPM := extractPrefixMap(t, pm)
 			attrs := buildAttrs(t, localPM)
-			childNodes, err := parseXmlChildren(decoder, depth+1, localPM)
+			childNodes, err := parseXmlChildren(decoder, depth+1, localPM, spaceMode(t, preserve))
 			if err != nil {
 				return nil, err
 			}
@@ -525,7 +560,7 @@ func parseXmlChildren(decoder *xml.Decoder, depth int, pm *prefixMap) ([]eval.Va
 			return children, nil
 
 		case xml.CharData:
-			if !isAllWhitespace(t) {
+			if preserve || !isAllWhitespace(t) {
 				children = append(children, makeXmlText(string(t)))
 			}
 

--- a/internal/builtins/xml_fold.go
+++ b/internal/builtins/xml_fold.go
@@ -204,7 +204,7 @@ func scanForElementsFoldStepInner(decoder *xml.Decoder, tagName string, acc eval
 			if resolvedName == tagName {
 				localPM := extractPrefixMap(t, nil)
 				attrs := buildAttrs(t, localPM)
-				childNodes, parseErr := parseXmlChildren(decoder, 1, localPM)
+				childNodes, parseErr := parseXmlChildren(decoder, 1, localPM, spaceMode(t, false))
 				if parseErr != nil {
 					return acc, false, parseErr
 				}
@@ -275,7 +275,7 @@ func scanForElementsFoldInner(decoder *xml.Decoder, tagName string, acc eval.Val
 				// Build subtree for this matched element
 				localPM := extractPrefixMap(t, nil)
 				attrs := buildAttrs(t, localPM)
-				childNodes, parseErr := parseXmlChildren(decoder, 1, localPM)
+				childNodes, parseErr := parseXmlChildren(decoder, 1, localPM, spaceMode(t, false))
 				if parseErr != nil {
 					return acc, parseErr
 				}

--- a/internal/builtins/xml_implicit_prefix_test.go
+++ b/internal/builtins/xml_implicit_prefix_test.go
@@ -1,0 +1,127 @@
+package builtins
+
+import (
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/eval"
+)
+
+// Coverage for the second half of ailang#646: the prefix map is built from the
+// xmlns declarations in scope, and the "xml" prefix is bound BY DEFINITION and
+// must not be declared (XML Namespaces §3). So no document can put it in the
+// map, resolveTagName found nothing, and it fell through to the bare local name.
+//
+// The consequence is not cosmetic: xml:space arrived as "space", indistinguishable
+// from an ordinary unprefixed attribute of that name, getAttr(node, "xml:space")
+// returned None on a document that plainly has one, and serialize round-tripped
+// <t xml:space="preserve"/> out as <t space="preserve"/> — silently changing what
+// the document means.
+
+func xmlAttrNames(t *testing.T, elem *eval.TaggedValue) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for _, a := range xmlGetAttrs(t, elem) {
+		rv, ok := a.(*eval.RecordValue)
+		if !ok {
+			t.Fatalf("attr is %T, want RecordValue", a)
+		}
+		name, ok := rv.Fields["name"].(*eval.StringValue)
+		if !ok {
+			t.Fatalf("attr name is %T, want StringValue", rv.Fields["name"])
+		}
+		val, ok := rv.Fields["value"].(*eval.StringValue)
+		if !ok {
+			t.Fatalf("attr value is %T, want StringValue", rv.Fields["value"])
+		}
+		out[name.Value] = val.Value
+	}
+	return out
+}
+
+// TestXmlImplicitPrefix_XmlNamespaceKeepsItsPrefix pins the mapping itself, on
+// three of the four reserved attributes, so that a fix special-casing only
+// xml:space (the one #646 needed) still reds here.
+func TestXmlImplicitPrefix_XmlNamespaceKeepsItsPrefix(t *testing.T) {
+	root := xmlParseOne(t, `<r><t xml:space="preserve" xml:lang="en-GB" xml:id="a1" plain="p">x</t></r>`, "r")
+	attrs := xmlAttrNames(t, xmlFirstChildElem(t, root, "t"))
+
+	for name, want := range map[string]string{
+		"xml:space": "preserve",
+		"xml:lang":  "en-GB",
+		"xml:id":    "a1",
+		"plain":     "p", // control: an attribute in no namespace is untouched
+	} {
+		if got, ok := attrs[name]; !ok || got != want {
+			t.Fatalf("attr %q = %q (present=%v), want %q; full attr set: %v", name, got, ok, want, attrs)
+		}
+	}
+	// The stripped spelling must be gone, not merely accompanied — otherwise a
+	// caller written against the old behaviour keeps working and the two names
+	// diverge silently.
+	if _, ok := attrs["space"]; ok {
+		t.Fatalf("bare %q still present alongside %q: %v", "space", "xml:space", attrs)
+	}
+}
+
+// TestXmlImplicitPrefix_DeclaredPrefixesUnaffected is the negative control for
+// the mapping: ordinary declared prefixes must resolve exactly as before, and an
+// attribute in a declared namespace must not be rewritten to xml:.
+func TestXmlImplicitPrefix_DeclaredPrefixesUnaffected(t *testing.T) {
+	root := xmlParseOne(t,
+		`<w:p xmlns:w="urn:w"><w:t w:val="1" xml:space="preserve"> </w:t></w:p>`, "w:p")
+	wt := xmlFirstChildElem(t, root, "w:t")
+	attrs := xmlAttrNames(t, wt)
+	if got, ok := attrs["w:val"]; !ok || got != "1" {
+		t.Fatalf("declared-prefix attr w:val = %q (present=%v), want \"1\"; full attr set: %v", got, ok, attrs)
+	}
+	if got, ok := attrs["xml:space"]; !ok || got != "preserve" {
+		t.Fatalf("xml:space alongside a declared prefix = %q (present=%v), want \"preserve\"", got, ok)
+	}
+}
+
+// TestXmlImplicitPrefix_GetAttrFindsXmlSpace pins the accessor a caller actually
+// reaches for. Without it a user cannot observe the condition the parser is now
+// acting on, which is the seam that makes the #646 fix legible.
+func TestXmlImplicitPrefix_GetAttrFindsXmlSpace(t *testing.T) {
+	wt := xmlFirstChildElem(t, xmlParseOne(t, `<r><t xml:space="preserve"> </t></r>`, "r"), "t")
+
+	got, err := xmlGetAttrImpl(xmlTestCtx(t), []eval.Value{wt, &eval.StringValue{Value: "xml:space"}})
+	if err != nil {
+		t.Fatalf("xmlGetAttrImpl: %v", err)
+	}
+	sv, ok := xmlAssertSome(t, got).(*eval.StringValue)
+	if !ok {
+		t.Fatalf("getAttr payload is %T, want StringValue", got)
+	}
+	if sv.Value != "preserve" {
+		t.Fatalf(`getAttr(t, "xml:space") = %q, want "preserve"`, sv.Value)
+	}
+
+	// The old spelling must no longer answer.
+	none, err := xmlGetAttrImpl(xmlTestCtx(t), []eval.Value{wt, &eval.StringValue{Value: "space"}})
+	if err != nil {
+		t.Fatalf("xmlGetAttrImpl (bare name): %v", err)
+	}
+	xmlAssertNone(t, none)
+}
+
+// TestXmlImplicitPrefix_SerializeRoundTrip is the artifact-level arm: the two
+// halves of this fix are only worth anything together, since a preserved space
+// serialized back out under a rewritten attribute name no longer says to the
+// next reader what the source said.
+func TestXmlImplicitPrefix_SerializeRoundTrip(t *testing.T) {
+	const src = `<r><t xml:space="preserve"> </t></r>`
+	root := xmlParseOne(t, src, "r")
+
+	out, err := xmlSerializeImpl(xmlTestCtx(t), []eval.Value{root})
+	if err != nil {
+		t.Fatalf("xmlSerializeImpl: %v", err)
+	}
+	sv, ok := out.(*eval.StringValue)
+	if !ok {
+		t.Fatalf("serialize returned %T, want StringValue", out)
+	}
+	if sv.Value != src {
+		t.Fatalf("serialize round-trip = %q, want %q", sv.Value, src)
+	}
+}

--- a/internal/builtins/xml_space_test.go
+++ b/internal/builtins/xml_space_test.go
@@ -1,0 +1,317 @@
+package builtins
+
+import (
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/eval"
+)
+
+// Regression coverage for ailang#646: a whitespace-only text node was dropped
+// unconditionally, so OOXML separator runs (`<w:t xml:space="preserve"> </w:t>`)
+// vanished and "plain bold italic" extracted as "plain bolditalic".
+//
+// The arms below are split by BRANCH rather than by scenario: each names the one
+// line it exists to red, because `xml:space` handling is four decisions (match the
+// attribute, honour "preserve", honour "default", inherit otherwise) plus one
+// thread through each of the two recursive parsers, and a single end-to-end arm
+// would pass with most of them broken.
+
+// xmlTextsOf returns the Text-node contents directly under elem, in order.
+func xmlTextsOf(t *testing.T, elem *eval.TaggedValue) []string {
+	t.Helper()
+	var out []string
+	for _, c := range xmlGetChildren(t, elem) {
+		tv, ok := c.(*eval.TaggedValue)
+		if !ok || tv.CtorName != "Text" {
+			continue
+		}
+		sv, ok := tv.Fields[0].(*eval.StringValue)
+		if !ok {
+			t.Fatalf("Text node field 0 is %T, want StringValue", tv.Fields[0])
+		}
+		out = append(out, sv.Value)
+	}
+	return out
+}
+
+// xmlParseOne parses doc with impl and returns the single root element.
+func xmlParseOne(t *testing.T, doc string, tag string) *eval.TaggedValue {
+	t.Helper()
+	result, err := xmlParseImpl(xmlTestCtx(t), []eval.Value{&eval.StringValue{Value: doc}})
+	if err != nil {
+		t.Fatalf("xmlParseImpl(%q): %v", doc, err)
+	}
+	return xmlAssertElement(t, xmlAssertOk(t, result), tag)
+}
+
+// xmlFirstChildElem returns the first Element child of elem.
+func xmlFirstChildElem(t *testing.T, elem *eval.TaggedValue, tag string) *eval.TaggedValue {
+	t.Helper()
+	for _, c := range xmlGetChildren(t, elem) {
+		if tv, ok := c.(*eval.TaggedValue); ok && tv.CtorName == "Element" {
+			return xmlAssertElement(t, tv, tag)
+		}
+	}
+	t.Fatalf("no Element child <%s> under the given element", tag)
+	return nil
+}
+
+// TestXmlSpace_PreserveKeepsWhitespaceOnlyText is the reported defect itself.
+// It asserts the CONTENT (" "), not merely that a child exists, because a Text
+// node carrying "" would satisfy a count-based assertion while still losing the
+// separator that #646 is about.
+func TestXmlSpace_PreserveKeepsWhitespaceOnlyText(t *testing.T) {
+	root := xmlParseOne(t, `<r><t xml:space="preserve"> </t></r>`, "r")
+	got := xmlTextsOf(t, xmlFirstChildElem(t, root, "t"))
+	if len(got) != 1 || got[0] != " " {
+		t.Fatalf("texts under <t xml:space=\"preserve\"> = %q, want [\" \"]", got)
+	}
+}
+
+// TestXmlSpace_AbsentAttributeStillDropsWhitespace pins the DEFAULT, which the
+// fix must not move: element-content XML is normally pretty-printed, and every
+// existing caller of getChildren depends on formatting whitespace staying out of
+// the tree.
+func TestXmlSpace_AbsentAttributeStillDropsWhitespace(t *testing.T) {
+	root := xmlParseOne(t, `<r><t> </t></r>`, "r")
+	if got := xmlTextsOf(t, xmlFirstChildElem(t, root, "t")); len(got) != 0 {
+		t.Fatalf("texts under <t> with no xml:space = %q, want none", got)
+	}
+
+	// The pretty-printed shape, which is the one that would regress loudly.
+	pretty := xmlParseOne(t, "<r>\n  <a>x</a>\n  <b>y</b>\n</r>", "r")
+	if got := xmlTextsOf(t, pretty); len(got) != 0 {
+		t.Fatalf("texts directly under pretty-printed <r> = %q, want none", got)
+	}
+	if n := len(xmlGetChildren(t, pretty)); n != 2 {
+		t.Fatalf("children of pretty-printed <r> = %d, want 2 (the elements only)", n)
+	}
+}
+
+// TestXmlSpace_InheritedByDescendants pins the recursive thread: xml:space is
+// declared once on an ancestor (XML 1.0 §2.10) and governs descendant content.
+// Seeding preserve only from the element that carries the attribute would leave
+// this arm red while the arm above stays green.
+func TestXmlSpace_InheritedByDescendants(t *testing.T) {
+	root := xmlParseOne(t, `<r xml:space="preserve"><t> </t></r>`, "r")
+	got := xmlTextsOf(t, xmlFirstChildElem(t, root, "t"))
+	if len(got) != 1 || got[0] != " " {
+		t.Fatalf("texts under an inherited preserve scope = %q, want [\" \"]", got)
+	}
+}
+
+// TestXmlSpace_DefaultOverridesInheritedPreserve pins the "default" branch,
+// which is the only way back out of a preserve scope. Dropping it would leave
+// every arm above green.
+func TestXmlSpace_DefaultOverridesInheritedPreserve(t *testing.T) {
+	root := xmlParseOne(t, `<r xml:space="preserve"><t xml:space="default"> </t></r>`, "r")
+	if got := xmlTextsOf(t, xmlFirstChildElem(t, root, "t")); len(got) != 0 {
+		t.Fatalf(`texts under xml:space="default" inside a preserve scope = %q, want none`, got)
+	}
+
+	// ...and re-entering preserve below that default works, so the value is
+	// read per element rather than latched once.
+	root2 := xmlParseOne(t, `<r xml:space="preserve"><t xml:space="default"><u xml:space="preserve"> </u></t></r>`, "r")
+	u := xmlFirstChildElem(t, xmlFirstChildElem(t, root2, "t"), "u")
+	if got := xmlTextsOf(t, u); len(got) != 1 || got[0] != " " {
+		t.Fatalf("texts under a re-entered preserve scope = %q, want [\" \"]", got)
+	}
+}
+
+// TestXmlSpace_UndefinedValueInherits pins the fallthrough. The spec defines
+// exactly two values; a third is not an override, and the two directions are
+// asserted together so that hardcoding either answer reds.
+func TestXmlSpace_UndefinedValueInherits(t *testing.T) {
+	outside := xmlParseOne(t, `<r><t xml:space="bogus"> </t></r>`, "r")
+	if got := xmlTextsOf(t, xmlFirstChildElem(t, outside, "t")); len(got) != 0 {
+		t.Fatalf("undefined xml:space value outside a preserve scope kept %q, want none", got)
+	}
+
+	inside := xmlParseOne(t, `<r xml:space="preserve"><t xml:space="bogus"> </t></r>`, "r")
+	got := xmlTextsOf(t, xmlFirstChildElem(t, inside, "t"))
+	if len(got) != 1 || got[0] != " " {
+		t.Fatalf("undefined xml:space value inside a preserve scope = %q, want [\" \"]", got)
+	}
+}
+
+// TestXmlSpace_UnprefixedSpaceAttributeIsNotXmlSpace pins the namespace half of
+// the attribute match. A bare `space="preserve"` is an ordinary attribute in no
+// namespace and must NOT arm preservation — matching on Local alone would pass
+// every other arm in this file.
+func TestXmlSpace_UnprefixedSpaceAttributeIsNotXmlSpace(t *testing.T) {
+	root := xmlParseOne(t, `<r><t space="preserve"> </t></r>`, "r")
+	if got := xmlTextsOf(t, xmlFirstChildElem(t, root, "t")); len(got) != 0 {
+		t.Fatalf(`bare space="preserve" armed preservation (kept %q); it is not xml:space`, got)
+	}
+}
+
+// TestXmlSpace_ParseWithLimitHonoursPreserve covers the second recursive parser.
+// parseXmlChildrenLimited is a near-copy of parseXmlChildren, so a fix applied to
+// one and not the other is the likeliest way this regresses; the arms above all
+// run through the unlimited path only.
+func TestXmlSpace_ParseWithLimitHonoursPreserve(t *testing.T) {
+	result, err := xmlParseWithLimitImpl(xmlTestCtx(t), []eval.Value{
+		&eval.StringValue{Value: `<r><t xml:space="preserve"> </t></r>`},
+		&eval.IntValue{Value: 100},
+	})
+	if err != nil {
+		t.Fatalf("xmlParseWithLimitImpl: %v", err)
+	}
+	root := xmlAssertElement(t, xmlAssertOk(t, result), "r")
+	got := xmlTextsOf(t, xmlFirstChildElem(t, root, "t"))
+	if len(got) != 1 || got[0] != " " {
+		t.Fatalf("parseWithLimit texts under preserve = %q, want [\" \"]", got)
+	}
+}
+
+// TestXmlSpace_PreservedTextCountsAgainstNodeLimit pins the interaction between
+// the two: a preserved whitespace node is a node, so it must be counted and
+// limit-checked like any other. Emitting it outside the counter would let a
+// document defeat maxNodes with whitespace.
+func TestXmlSpace_PreservedTextCountsAgainstNodeLimit(t *testing.T) {
+	doc := `<r xml:space="preserve"><a> </a><b> </b><c> </c></r>`
+	// r,a,text,b,text,c,text = 7 nodes; a limit of 6 must refuse.
+	result, err := xmlParseWithLimitImpl(xmlTestCtx(t), []eval.Value{
+		&eval.StringValue{Value: doc},
+		&eval.IntValue{Value: 6},
+	})
+	if err != nil {
+		t.Fatalf("xmlParseWithLimitImpl: %v", err)
+	}
+	xmlAssertErr(t, result, "node limit exceeded")
+
+	// Control: the same document parses under a limit that accommodates them,
+	// so the arm above fails for the count and not for the parse.
+	ok, err := xmlParseWithLimitImpl(xmlTestCtx(t), []eval.Value{
+		&eval.StringValue{Value: doc},
+		&eval.IntValue{Value: 7},
+	})
+	if err != nil {
+		t.Fatalf("xmlParseWithLimitImpl (control): %v", err)
+	}
+	xmlAssertOk(t, ok)
+}
+
+// TestXmlSpace_DocxSeparatorRunSurvives is the reporter's own scenario, end to
+// end: Word splits runs at every formatting boundary and the separating space
+// very commonly lands in a run of its own.
+func TestXmlSpace_DocxSeparatorRunSurvives(t *testing.T) {
+	doc := `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+		`<w:r><w:t xml:space="preserve">plain </w:t></w:r>` +
+		`<w:r><w:t>bold</w:t></w:r>` +
+		`<w:r><w:t xml:space="preserve"> </w:t></w:r>` +
+		`<w:r><w:t>italic</w:t></w:r>` +
+		`</w:p>`
+	result, err := xmlGetTextImpl(xmlTestCtx(t), []eval.Value{
+		func() eval.Value {
+			r, err := xmlParseImpl(xmlTestCtx(t), []eval.Value{&eval.StringValue{Value: doc}})
+			if err != nil {
+				t.Fatalf("xmlParseImpl: %v", err)
+			}
+			return xmlAssertOk(t, r)
+		}(),
+	})
+	if err != nil {
+		t.Fatalf("xmlGetTextImpl: %v", err)
+	}
+	sv, ok := result.(*eval.StringValue)
+	if !ok {
+		t.Fatalf("getText returned %T, want StringValue", result)
+	}
+	if sv.Value != "plain bold italic" {
+		t.Fatalf("DOCX run extraction = %q, want %q", sv.Value, "plain bold italic")
+	}
+}
+
+// TestXmlSpace_StreamingPathsHonourPreserve covers the three scanners that build
+// a matched subtree without a full tree — parseElements, parseFold, parseFoldStep.
+// They seed preservation from the MATCHED element itself, because a streaming scan
+// has no ancestor context by construction (it passes a nil prefixMap for the same
+// reason), so their seed is a third code path that the two recursive parsers'
+// arms do not reach: the drill that added this arm found the parseElements seed
+// surviving every other assertion in this file.
+func TestXmlSpace_StreamingPathsHonourPreserve(t *testing.T) {
+	const doc = `<r><t xml:space="preserve"> </t></r>`
+
+	t.Run("parseElements", func(t *testing.T) {
+		result, err := xmlParseElementsImpl(xmlTestCtx(t), []eval.Value{
+			&eval.StringValue{Value: doc},
+			&eval.StringValue{Value: "t"},
+			&eval.IntValue{Value: 10},
+		})
+		if err != nil {
+			t.Fatalf("xmlParseElementsImpl: %v", err)
+		}
+		list, ok := xmlAssertOk(t, result).(*eval.ListValue)
+		if !ok {
+			t.Fatalf("parseElements payload is not a list")
+		}
+		if len(list.Elements) != 1 {
+			t.Fatalf("parseElements matched %d elements, want 1", len(list.Elements))
+		}
+		el := xmlAssertElement(t, list.Elements[0], "t")
+		if got := xmlTextsOf(t, el); len(got) != 1 || got[0] != " " {
+			t.Fatalf("parseElements texts under preserve = %q, want [\" \"]", got)
+		}
+	})
+
+	t.Run("parseFold", func(t *testing.T) {
+		result, err := xmlParseFoldImpl(xmlFoldTestCtx(), []eval.Value{
+			&eval.StringValue{Value: doc},
+			&eval.StringValue{Value: "t"},
+			&eval.ListValue{Elements: nil},
+			xmlFoldHandler(),
+		})
+		if err != nil {
+			t.Fatalf("xmlParseFoldImpl: %v", err)
+		}
+		list, ok := xmlAssertOk(t, result).(*eval.ListValue)
+		if !ok || len(list.Elements) != 1 {
+			t.Fatalf("parseFold accumulated %v, want one entry", xmlAssertOk(t, result))
+		}
+		sv, ok := list.Elements[0].(*eval.StringValue)
+		if !ok || sv.Value != " " {
+			t.Fatalf("parseFold text under preserve = %#v, want \" \"", list.Elements[0])
+		}
+	})
+
+	t.Run("parseFoldStep", func(t *testing.T) {
+		result, err := xmlParseFoldStepImpl(xmlFoldTestCtx(), []eval.Value{
+			&eval.StringValue{Value: doc},
+			&eval.StringValue{Value: "t"},
+			&eval.ListValue{Elements: nil},
+			xmlFoldStepContinueHandler(),
+		})
+		if err != nil {
+			t.Fatalf("xmlParseFoldStepImpl: %v", err)
+		}
+		list, ok := xmlAssertOk(t, result).(*eval.ListValue)
+		if !ok || len(list.Elements) != 1 {
+			t.Fatalf("parseFoldStep accumulated %v, want one entry", xmlAssertOk(t, result))
+		}
+		sv, ok := list.Elements[0].(*eval.StringValue)
+		if !ok || sv.Value != " " {
+			t.Fatalf("parseFoldStep text under preserve = %#v, want \" \"", list.Elements[0])
+		}
+	})
+}
+
+// xmlFoldStepContinueHandler is xmlFoldHandler wrapped in Continue, so the
+// parseFoldStep arm observes the same accumulated text as the parseFold arm.
+func xmlFoldStepContinueHandler() eval.Value {
+	inner := xmlFoldHandler().(*eval.BuiltinFunction)
+	return &eval.BuiltinFunction{
+		Name: "test_foldstep_continue_handler",
+		Fn: func(args []eval.Value) (eval.Value, error) {
+			acc, err := inner.Fn(args)
+			if err != nil {
+				return nil, err
+			}
+			return &eval.TaggedValue{
+				TypeName: "FoldStep",
+				CtorName: "Continue",
+				Fields:   []eval.Value{acc},
+			}, nil
+		},
+	}
+}

--- a/std/xml.ail
+++ b/std/xml.ail
@@ -44,6 +44,20 @@ export type NodeKind =
 
 -- Parse XML string into XmlNode tree
 -- Returns Ok(XmlNode) or Err(message) for malformed XML
+--
+-- Whitespace: a text node made up ENTIRELY of whitespace is dropped, because
+-- element-content XML is normally pretty-printed and that whitespace is
+-- formatting rather than data. Inside an `xml:space="preserve"` scope it is
+-- KEPT. Per XML 1.0 s2.10 the attribute is inherited by descendants until an
+-- `xml:space="default"` overrides it, so declaring it once on an ancestor
+-- covers the subtree. This is what makes OOXML separator runs
+-- (`<w:t xml:space="preserve"> </w:t>`) survive text extraction.
+--
+-- Namespaces: prefixes declared with xmlns are preserved on both tags and
+-- attributes (`w:p`, `w:val`). The `xml` prefix is bound by definition and is
+-- never declared, so it is recognised structurally: `xml:space`, `xml:lang`,
+-- `xml:id` and `xml:base` keep their prefix. A prefix that is neither declared
+-- nor `xml` is dropped to its local name.
 export pure func parse(xml: string) -> Result[XmlNode, string] = _xml_parse(xml)
 
 -- M-STDLIB-XML-LENIENT: lenient parsing for real-world (malformed) XML.
@@ -68,7 +82,10 @@ export pure func findAll(node: XmlNode, tag: string) -> List[XmlNode] = _xml_fin
 export pure func findFirst(node: XmlNode, tag: string) -> Option[XmlNode] = _xml_findFirst(node, tag)
 
 -- Extract text content from a node
--- For Element nodes, concatenates all descendant text
+-- For Element nodes, concatenates all descendant text.
+-- Whitespace-only text survives only where `xml:space="preserve"` was in scope
+-- at parse time (see `parse`) -- getText concatenates what the tree holds, so a
+-- node the parser dropped cannot be recovered here.
 export pure func getText(node: XmlNode) -> string = _xml_getText(node)
 
 -- Get attribute value by name


### PR DESCRIPTION
## `#646`: `std/xml` dropped whitespace-only text, jamming DOCX words together

Reproduced first-party at `6a4348ce3` before any change. The reporter's minimal case is exact, and the DOCX shape reproduces: `plain bolditalic` instead of `plain bold italic`. `findAllTexts` locates it — `[plain , bold, , italic]`, so the `<t>` element survives and its text child never existed.

### Two halves, because the reported fix was unobservable without the second

**1. `xml:space` is honoured.** Both recursive parsers and all three streaming scanners thread a preserve flag. Per XML 1.0 §2.10 the attribute is **inherited** until an `xml:space="default"` overrides it; a value the spec does not define is not an override, it inherits. **The default is unchanged** — with no `xml:space` in scope, formatting whitespace is still discarded, which is what element-content XML wants and what every existing `getChildren` caller depends on. A preserved node is counted against `maxNodes` like any other, so it cannot be used to defeat the node limit.

**2. The `xml:` prefix survives parsing.** Names were resolved through the in-scope `xmlns` declarations, and the `xml` prefix is bound *by definition* (XML Namespaces §3) and must never be declared — so it could never be in that map, and `resolveTagName` fell through to the bare local name. `getAttr(node, "xml:space")` returned `None` on a document that plainly had one, and `serialize` round-tripped `<t xml:space="preserve"/>` out as `<t space="preserve"/>`, silently changing what the document meant. Control in the same document: a **declared** `xmlns:w` resolved `w:p`/`w:t`/`w:val` correctly throughout, so only the never-declarable prefix was affected. Go's decoder already maps `xml:` to the canonical URI, so recognising that URI is the whole fix.

### Verified in both directions

One tree, two binaries (`sha256` distinct). Preserve-scoped cases flip 0 → 1 preserved node; every negative arm is unchanged:

| arm | before | after |
|---|---|---|
| N1 pretty-printed element content | 2 children, 0 text | **unchanged** |
| N2 whitespace-only, no `xml:space` | dropped | **unchanged** |
| P3 `xml:space="default"` inside a preserve scope | dropped | **unchanged** |
| P4 undefined value outside a preserve scope | dropped | **unchanged** |
| R1 serialize round-trip of pretty XML | `<r><a>x</a></r>` | **unchanged** |
| P1 `preserve` on the element | 0 | **1** |
| P2 inherited from an ancestor | 0 | **1** |
| P5 undefined value inside a preserve scope | 0 | **1** |
| P6 re-entered preserve below a default | 0 | **1** |

### Mutation drill

**14 mutants**, each asserted **LANDED** by `sha256` and **BUILDS** by `go build` rc=0 *before any test result was read*, each restored by `cp` (never `git checkout --`) and verified byte-identical. Every inverse `-skip <all drill arms>` run is **rc=0**, so these arms are the killers rather than bystanders. Sole killers: M2 (namespace half of the attribute match) → `UnprefixedSpaceAttributeIsNotXmlSpace`; M4 (`"default"` branch) → `DefaultOverridesInheritedPreserve`; M11/M12/M13 (the three streaming seeds) → `StreamingPathsHonourPreserve`.

**The drill earned its keep.** M11 initially **survived with zero killers**: the `parseElements` / `parseFold` / `parseFoldStep` seed is a third code path that neither recursive parser's arms reach, so nine arms and a green suite said nothing about it. `TestXmlSpace_StreamingPathsHonourPreserve` was added, after which M11/M12/M13 each die to it alone.

### Gates

Gate list **derived** from `ci.yml` rather than recalled: `fmt-check` · `vet` · `lint` · `check-file-sizes` · `check-boundaries` · `check-changelog` · `test-check-changelog` · `check-skills` · `check-golden-drift` · `test-stdlib-ail` · `test-regression-guards` · `test-imports` · `test-lowering` · `test-parser` · `verify-no-shim` — **all rc=0**. `make verify-examples` rc=0 (191 modules, **0 drift**; the new example is executed by the gate, and its first `modules` list was caught as drift and corrected). `go test ./...` **rc=0, 0 FAIL**.

**All of the above ran on darwin/arm64; the linux and windows legs are unrun locally and are settled by CI.** `go build ./...` fails at `cmd/wasm` both here and on untouched `origin/dev` (baselined from a pristine tree), so it is pre-existing.

### Not closed by this — queued separately

1. A prefix that is *neither* declared nor `xml:` is still dropped to its local name (`<t w:val="x"/>` with no `xmlns:w` in scope yields `val`) — bites anyone parsing extracted fragments.
2. The three streaming scanners resolve the *match name* against a `nil` prefix map, so `parseElements(doc, "w:t")` finds nothing where `parseElements(doc, "t")` works, even in a document declaring `xmlns:w` on its root.

Fixes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)
