### PR TITLE
feat(#644): std/zip can build an archive in memory, with no FS effect

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,59 @@
 
 ## [Unreleased]
 
+### Added — `std/zip` can build an archive in memory, with no `FS` effect
+
+[ailang#644](https://github.com/sunholo-data/ailang/issues/644), from a downstream
+consumer (`ailang-parse`) generating OOXML/ODF documents.
+
+**The problem.** Every archive constructor in `std/zip` took an output *path* and
+carried the `FS` effect:
+
+```
+createArchive(string, [{name, content}])       -> Result[(), string] ! {FS}
+createArchiveWithBytes(string, [{name, data}]) -> Result[(), string] ! {FS}
+```
+
+A WASM/browser host has no filesystem, so the DOCX/PPTX/XLSX/ODT generators could
+not be loaded into a browser bundle **at all** — even though they build a complete
+part list in memory and hand it to `createArchive` purely to serialise it. The
+file write was incidental to what they wanted. Extraction already had an escape
+hatch (the docs-site demo unzips in JS and passes entry content into AILANG); the
+write path had none.
+
+**Two new pure functions**, mirroring the existing pair:
+
+```
+buildArchive([{name, content}])       -> Result[string, string]
+buildArchiveWithBytes([{name, data}]) -> Result[string, string]
+```
+
+They serialise to memory and **return** the archive base64-encoded — matching the
+base64-at-the-boundary convention `readEntryBytes`, `std/gzip` and `std/deflate`
+already use. No path, no `FS`, no capability: a program using only these
+type-checks and runs under `--caps IO`. A caller who wants a file writes the
+result itself via `std/fs`, which also makes the effect requirement honest —
+building a ZIP is pure, writing one is not.
+
+**Purity is a claim about the output, not just the signature.** `archive/zip`
+stamps entries with the zero `time.Time` (the MS-DOS epoch, 1979-11-30) rather
+than the wall clock, so the same entry list serialises to the same bytes on every
+call; a test pins that across a 2.1 s gap, which is past the 2-second resolution
+of a DOS timestamp. Byte-for-byte, `buildArchive` and `createArchive` produce the
+*same* archive for the same entries — also pinned — because all four builders now
+share one serialisation path. That shared path is what keeps the 10,000-entry cap,
+the path-traversal rejection and the 100MB per-entry cap identical across them
+instead of drifting between four copies.
+
+**One limit is new, and only on the in-memory pair**: a 100MB cap on *total*
+content across all entries. The FS builders stream to disk and stay unbounded in
+aggregate, as they always have; these retain the whole archive in memory and then
+expand it by 4/3 in base64, so an unbounded builder is an OOM primitive in a
+browser tab.
+
+Unblocks browser-side DOCX/PPTX/XLSX/ODT **generation**; the curated WASM module
+subset on the docs site could previously only parse.
+
 ### Fixed — `std/xml` dropped whitespace-only text nodes, jamming DOCX words together
 
 [ailang#646](https://github.com/sunholo-data/ailang/issues/646), from a downstream

--- a/examples/manifest.json
+++ b/examples/manifest.json
@@ -272,7 +272,7 @@
         "cons",
         "expression"
       ],
-      "description": "Cons (::) in expression position — building lists by prepending",
+      "description": "Cons (::) in expression position \u2014 building lists by prepending",
       "modules": [
         "std/io"
       ]
@@ -448,7 +448,7 @@
         "filter",
         "lambda"
       ],
-      "description": "Higher-order function verification — Z3 proves properties about map/filter with known lambdas via monomorphic inlining and bounded unrolling",
+      "description": "Higher-order function verification \u2014 Z3 proves properties about map/filter with known lambdas via monomorphic inlining and bounded unrolling",
       "modules": [
         "std/list"
       ]
@@ -465,7 +465,7 @@
         "list-extract",
         "z3-sequence-theory"
       ],
-      "description": "Recursive list operation contracts — Z3 proves containment and extraction properties using seq.contains and seq.extract",
+      "description": "Recursive list operation contracts \u2014 Z3 proves containment and extraction properties using seq.contains and seq.extract",
       "modules": [
         "std/list"
       ]
@@ -481,7 +481,7 @@
         "verify-attribute",
         "per-function-depth"
       ],
-      "description": "Per-function recursion depth — @verify(depth: N) attribute overrides global --verify-recursive-depth for individual functions"
+      "description": "Per-function recursion depth \u2014 @verify(depth: N) attribute overrides global --verify-recursive-depth for individual functions"
     },
     {
       "path": "runnable/contracts/quantifier_verify.ail",
@@ -494,7 +494,7 @@
         "forall",
         "bounded-quantifiers"
       ],
-      "description": "Bounded quantifier verification — forall i: lo..hi => P(i) in ensures clauses, encoded to Z3 bounded quantifiers"
+      "description": "Bounded quantifier verification \u2014 forall i: lo..hi => P(i) in ensures clauses, encoded to Z3 bounded quantifiers"
     },
     {
       "path": "runnable/serve_api_webhook.ail",
@@ -506,7 +506,7 @@
         "json",
         "headers"
       ],
-      "description": "@raw @route webhook handler — reads signature headers from a raw HTTP request via std/json.getString; demo main() exercises the handler",
+      "description": "@raw @route webhook handler \u2014 reads signature headers from a raw HTTP request via std/json.getString; demo main() exercises the handler",
       "modules": [
         "std/json",
         "std/string"
@@ -521,7 +521,7 @@
         "introspection",
         "future"
       ],
-      "description": "⚠️ VISION ONLY: AI agent integration demo. Uses unsupported syntax.",
+      "description": "\u26a0\ufe0f VISION ONLY: AI agent integration demo. Uses unsupported syntax.",
       "requires": [
         "effects",
         "introspection",
@@ -538,7 +538,7 @@
         "concurrency",
         "future"
       ],
-      "description": "⚠️ VISION ONLY: CSP-based concurrent pipeline. DO NOT RUN - causes infinite loop",
+      "description": "\u26a0\ufe0f VISION ONLY: CSP-based concurrent pipeline. DO NOT RUN - causes infinite loop",
       "requires": [
         "channels",
         "spawn",
@@ -556,7 +556,7 @@
         "tests",
         "future"
       ],
-      "description": "⚠️ VISION ONLY: Factorial with inline tests/properties. DO NOT RUN - causes infinite loop",
+      "description": "\u26a0\ufe0f VISION ONLY: Factorial with inline tests/properties. DO NOT RUN - causes infinite loop",
       "requires": [
         "func",
         "tests",
@@ -588,7 +588,7 @@
         "effects",
         "future"
       ],
-      "description": "⚠️ VISION ONLY: Web API with SQL quasiquotes. DO NOT RUN - causes infinite loop",
+      "description": "\u26a0\ufe0f VISION ONLY: Web API with SQL quasiquotes. DO NOT RUN - causes infinite loop",
       "requires": [
         "quasiquotes",
         "http-effects",
@@ -1303,7 +1303,7 @@
         "cache",
         "tool-use"
       ],
-      "description": "Demonstrates std/ai.stepWithCache — opt-in prompt caching across providers (M-AI-PROMPT-CACHING v0.18.4)",
+      "description": "Demonstrates std/ai.stepWithCache \u2014 opt-in prompt caching across providers (M-AI-PROMPT-CACHING v0.18.4)",
       "modules": [
         "std/ai",
         "std/io",
@@ -1335,7 +1335,7 @@
         "typed-errors",
         "json"
       ],
-      "description": "Demonstrates std/ai.callJsonSimpleResult — Result-returning no-schema JSON call with retryable typed errors (M-DOCPARSE-RESILIENCE-FIXES v0.23.0)",
+      "description": "Demonstrates std/ai.callJsonSimpleResult \u2014 Result-returning no-schema JSON call with retryable typed errors (M-DOCPARSE-RESILIENCE-FIXES v0.23.0)",
       "modules": [
         "std/ai",
         "std/io",
@@ -1353,7 +1353,7 @@
         "config-driven",
         "accumulator"
       ],
-      "description": "AI token streaming via std/ai/streaming.callStream — synchronous accumulator returning Result[string, AIError]",
+      "description": "AI token streaming via std/ai/streaming.callStream \u2014 synchronous accumulator returning Result[string, AIError]",
       "modules": [
         "std/ai/streaming",
         "std/io",
@@ -1390,7 +1390,7 @@
         "cache",
         "typed"
       ],
-      "description": "Demonstrates std/ai.stepWithStream — typed-StepResult streaming with per-chunk callback (M-AI-STEP-STREAMING v0.18.7)",
+      "description": "Demonstrates std/ai.stepWithStream \u2014 typed-StepResult streaming with per-chunk callback (M-AI-STEP-STREAMING v0.18.7)",
       "modules": [
         "std/ai",
         "std/io",
@@ -1446,7 +1446,7 @@
         "cross-function-calls",
         "transitive"
       ],
-      "description": "Cross-function verification — Z3 inlines callee definitions to verify 3-level call chains"
+      "description": "Cross-function verification \u2014 Z3 inlines callee definitions to verify 3-level call chains"
     },
     {
       "path": "runnable/contracts/unencodable_callee_skip.ail",
@@ -1458,7 +1458,7 @@
         "cross-function-calls",
         "unencodable-type"
       ],
-      "description": "Cross-function contract with a callee returning Option[float] — ailang verify skips gracefully (UNENCODABLE_TYPE) instead of crashing Z3",
+      "description": "Cross-function contract with a callee returning Option[float] \u2014 ailang verify skips gracefully (UNENCODABLE_TYPE) instead of crashing Z3",
       "modules": [
         "std/option"
       ]
@@ -1535,7 +1535,7 @@
         "complex",
         "business-rules"
       ],
-      "description": "Complex insurance pricing with 768 code paths — Z3 catches subtle discount overflow"
+      "description": "Complex insurance pricing with 768 code paths \u2014 Z3 catches subtle discount overflow"
     },
     {
       "path": "runnable/contracts/invoice.ail",
@@ -1552,7 +1552,7 @@
         "business-logic",
         "billing"
       ],
-      "description": "Provably correct invoice processing — Z3 verifies billing invariants across 5 tiers x 5 tax regions x promo codes x line items. Catches volume pricing bug.",
+      "description": "Provably correct invoice processing \u2014 Z3 verifies billing invariants across 5 tiers x 5 tax regions x promo codes x line items. Catches volume pricing bug.",
       "modules": [
         "std/list",
         "std/string"
@@ -1568,7 +1568,7 @@
         "lists",
         "z3-sequence-theory"
       ],
-      "description": "List contract verification — Z3 proves properties about list length, head, nth, cons using sequence theory",
+      "description": "List contract verification \u2014 Z3 proves properties about list length, head, nth, cons using sequence theory",
       "modules": [
         "std/list"
       ]
@@ -1584,7 +1584,7 @@
         "nested-records",
         "field-access"
       ],
-      "description": "Nested record contract verification — Z3 proves properties about nested record field access (o.pos.x) with dependency-ordered type declarations"
+      "description": "Nested record contract verification \u2014 Z3 proves properties about nested record field access (o.pos.x) with dependency-ordered type declarations"
     },
     {
       "path": "runnable/contracts/park.ail",
@@ -1611,7 +1611,7 @@
         "pattern-matching",
         "record-patterns"
       ],
-      "description": "Record pattern matching in contracts — Z3 verifies match expressions that destructure records into field bindings"
+      "description": "Record pattern matching in contracts \u2014 Z3 verifies match expressions that destructure records into field bindings"
     },
     {
       "path": "runnable/contracts/record_adt_cycle_verify.ail",
@@ -1664,7 +1664,7 @@
         "cross-function-calls",
         "record-construction"
       ],
-      "description": "Record contract verification — Z3 proves properties about record field access, construction, cross-function calls with records, and counterexample generation"
+      "description": "Record contract verification \u2014 Z3 proves properties about record field access, construction, cross-function calls with records, and counterexample generation"
     },
     {
       "path": "runnable/contracts/scoring.ail",
@@ -1676,7 +1676,7 @@
         "complex",
         "scoring"
       ],
-      "description": "Multi-factor scoring system — Z3 finds score exceeds 100 in specific enum combination"
+      "description": "Multi-factor scoring system \u2014 Z3 finds score exceeds 100 in specific enum combination"
     },
     {
       "path": "runnable/contracts/shapes_verify.ail",
@@ -1689,7 +1689,7 @@
         "adt",
         "tuples"
       ],
-      "description": "Structural contract generators — record, ADT, tuple, and scalar ensures parameters all execute property cases"
+      "description": "Structural contract generators \u2014 record, ADT, tuple, and scalar ensures parameters all execute property cases"
     },
     {
       "path": "runnable/contracts/showcase.ail",
@@ -1705,7 +1705,7 @@
         "cross-function-calls",
         "showcase"
       ],
-      "description": "Comprehensive verification showcase — combines enums, records, strings, lists, and cross-function calls in one file",
+      "description": "Comprehensive verification showcase \u2014 combines enums, records, strings, lists, and cross-function calls in one file",
       "modules": [
         "std/list",
         "std/string"
@@ -1721,7 +1721,7 @@
         "strings",
         "z3-string-theory"
       ],
-      "description": "String contract verification — Z3 proves properties about string concatenation, equality, and prefix operations",
+      "description": "String contract verification \u2014 Z3 proves properties about string concatenation, equality, and prefix operations",
       "modules": [
         "std/string"
       ]
@@ -1924,7 +1924,7 @@
         "charCode",
         "benchmark"
       ],
-      "description": "FNV-1a hash function using bitwise XOR, charCode, and foldChars — demonstrates character-level string processing and deterministic hashing",
+      "description": "FNV-1a hash function using bitwise XOR, charCode, and foldChars \u2014 demonstrates character-level string processing and deterministic hashing",
       "modules": [
         "std/string"
       ]
@@ -1982,7 +1982,7 @@
         "tools",
         "effects"
       ],
-      "description": "MCP tool definitions and dispatch demo (quarantined: getString→Option[string] regression)",
+      "description": "MCP tool definitions and dispatch demo (quarantined: getString\u2192Option[string] regression)",
       "modules": [
         "std/json",
         "std/list",
@@ -2460,6 +2460,27 @@
       ]
     },
     {
+      "path": "runnable/zip_build_in_memory.ail",
+      "status": "working",
+      "tags": [
+        "stdlib",
+        "zip",
+        "archive",
+        "wasm",
+        "browser",
+        "ooxml",
+        "pure",
+        "std/zip"
+      ],
+      "description": "Building a ZIP in memory with std/zip.buildArchive \u2014 no FS effect, so DOCX/OOXML generation works in a WASM/browser host (ailang#644)",
+      "modules": [
+        "std/bytes",
+        "std/io",
+        "std/option",
+        "std/zip"
+      ]
+    },
+    {
       "path": "runnable/zip_reader.ail",
       "status": "working",
       "tags": [
@@ -2751,11 +2772,11 @@
     }
   ],
   "statistics": {
-    "total": 197,
-    "working": 189,
+    "total": 198,
+    "working": 190,
     "aspirational": 4,
     "broken": 4,
-    "coverage": 0.9593908629441624,
+    "coverage": 0.9595959595959596,
     "experimental": 0
   },
   "milestones": {

--- a/examples/runnable/zip_build_in_memory.ail
+++ b/examples/runnable/zip_build_in_memory.ail
@@ -1,0 +1,62 @@
+-- zip_build_in_memory.ail — building a ZIP is pure; writing one is not
+--
+-- ailang#644. Every archive constructor in std/zip used to take a path and
+-- carry the FS effect, so DOCX/PPTX/XLSX/ODT generation could not run in a
+-- WASM/browser host at all — there is no filesystem there, even though every
+-- byte the generator needs is already in memory.
+--
+-- buildArchive / buildArchiveWithBytes are the in-memory counterparts: they
+-- return the archive base64-encoded instead of writing it. Note the signature
+-- of main below — this whole example runs under IO alone, no FS capability,
+-- which is the property the browser case depends on.
+
+module examples/runnable/zip_build_in_memory
+
+import std/zip (buildArchive, buildArchiveWithBytes)
+import std/bytes (fromBase64, fromString, toBase64, length as byteLength)
+import std/io (println)
+import std/option (Some, None)
+
+-- A minimal OOXML part list, the shape a DOCX generator produces.
+func documentParts() -> [{name: string, content: string}] = [
+  {name: "[Content_Types].xml", content: "<Types/>"},
+  {name: "word/document.xml", content: "<w:document><w:body/></w:document>"}
+]
+
+func archiveSize(b64: string) -> string =
+  match fromBase64(b64) {
+    Some(raw) => show(byteLength(raw)),
+    None => "not base64"
+  }
+
+export func main() -> () ! {IO} {
+  -- Text parts: the common case for OOXML, which is XML all the way down.
+  match buildArchive(documentParts()) {
+    Ok(b64) => println("docx bytes: ${archiveSize(b64)}"),
+    Err(msg) => println("build failed: ${msg}")
+  };
+
+  -- Mixed text/binary: encode text parts with std/bytes, pass images through
+  -- as base64 already.
+  let mixed = [
+    {name: "word/document.xml", data: toBase64(fromString("<w:document/>"))},
+    {name: "word/media/image1.png", data: "iVBORw0KGgo="}
+  ];
+  match buildArchiveWithBytes(mixed) {
+    Ok(b64) => println("mixed bytes: ${archiveSize(b64)}"),
+    Err(msg) => println("build failed: ${msg}")
+  };
+
+  -- An empty part list is a valid (empty) archive, not an error.
+  match buildArchive([]) {
+    Ok(b64) => println("empty bytes: ${archiveSize(b64)}"),
+    Err(msg) => println("build failed: ${msg}")
+  };
+
+  -- The security limits travel with the in-memory path: entry names are still
+  -- rejected for path traversal even though nothing touches a filesystem.
+  match buildArchive([{name: "../escape.txt", content: "x"}]) {
+    Ok(_) => println("traversal: NOT rejected"),
+    Err(msg) => println("traversal: ${msg}")
+  }
+}

--- a/internal/builtins/zip.go
+++ b/internal/builtins/zip.go
@@ -360,40 +360,7 @@ func zipCreateArchiveImpl(ctx *effects.EffContext, args []eval.Value) (eval.Valu
 	}
 
 	w := zip.NewWriter(f)
-	var writeErr error
-
-	for i, entry := range entriesVal.Elements {
-		rec, ok := entry.(*eval.RecordValue)
-		if !ok {
-			writeErr = fmt.Errorf("entry %d: expected record, got %T", i, entry)
-			break
-		}
-		nameVal, ok := rec.Fields["name"].(*eval.StringValue)
-		if !ok {
-			writeErr = fmt.Errorf("entry %d: 'name' field must be string", i)
-			break
-		}
-		contentVal, ok := rec.Fields["content"].(*eval.StringValue)
-		if !ok {
-			writeErr = fmt.Errorf("entry %d: 'content' field must be string", i)
-			break
-		}
-
-		if strings.Contains(nameVal.Value, "..") {
-			writeErr = fmt.Errorf("entry %d: path traversal rejected: %s", i, nameVal.Value)
-			break
-		}
-
-		ew, err := w.Create(nameVal.Value)
-		if err != nil {
-			writeErr = fmt.Errorf("entry %d: cannot create: %v", i, err)
-			break
-		}
-		if _, err := io.WriteString(ew, contentVal.Value); err != nil {
-			writeErr = fmt.Errorf("entry %d: write error: %v", i, err)
-			break
-		}
-	}
+	writeErr := writeZipEntries(w, "_zip_createArchive", entriesVal.Elements, zipEntryText, 0)
 
 	// Always close the writer and file
 	if cerr := w.Close(); cerr != nil && writeErr == nil {
@@ -485,51 +452,7 @@ func zipCreateArchiveWithBytesImpl(ctx *effects.EffContext, args []eval.Value) (
 	}
 
 	w := zip.NewWriter(f)
-	var writeErr error
-
-	for i, entry := range entriesVal.Elements {
-		rec, ok := entry.(*eval.RecordValue)
-		if !ok {
-			writeErr = fmt.Errorf("entry %d: expected record, got %T", i, entry)
-			break
-		}
-		nameVal, ok := rec.Fields["name"].(*eval.StringValue)
-		if !ok {
-			writeErr = fmt.Errorf("entry %d: 'name' field must be string", i)
-			break
-		}
-		dataVal, ok := rec.Fields["data"].(*eval.StringValue)
-		if !ok {
-			writeErr = fmt.Errorf("entry %d: 'data' field must be string (base64-encoded)", i)
-			break
-		}
-
-		if strings.Contains(nameVal.Value, "..") {
-			writeErr = fmt.Errorf("entry %d: path traversal rejected: %s", i, nameVal.Value)
-			break
-		}
-
-		decoded, err := base64.StdEncoding.DecodeString(dataVal.Value)
-		if err != nil {
-			writeErr = fmt.Errorf("entry %d: invalid base64: %v", i, err)
-			break
-		}
-
-		if len(decoded) > zipMaxDecompressedSize {
-			writeErr = fmt.Errorf("entry %d: data too large: %d bytes (max %d)", i, len(decoded), zipMaxDecompressedSize)
-			break
-		}
-
-		ew, err := w.Create(nameVal.Value)
-		if err != nil {
-			writeErr = fmt.Errorf("entry %d: cannot create: %v", i, err)
-			break
-		}
-		if _, err := ew.Write(decoded); err != nil {
-			writeErr = fmt.Errorf("entry %d: write error: %v", i, err)
-			break
-		}
-	}
+	writeErr := writeZipEntries(w, "_zip_createArchiveWithBytes", entriesVal.Elements, zipEntryBase64, 0)
 
 	if cerr := w.Close(); cerr != nil && writeErr == nil {
 		writeErr = fmt.Errorf("close archive: %v", cerr)
@@ -549,6 +472,89 @@ func zipCreateArchiveWithBytesImpl(ctx *effects.EffContext, args []eval.Value) (
 // ============================================================================
 // Shared helpers
 // ============================================================================
+
+// zipEntryEncoding selects how an entry record's payload field is interpreted.
+type zipEntryEncoding int
+
+const (
+	// zipEntryText reads the "content" field and writes it verbatim.
+	zipEntryText zipEntryEncoding = iota
+	// zipEntryBase64 reads the "data" field and writes its base64 decoding.
+	zipEntryBase64
+)
+
+func (e zipEntryEncoding) field() string {
+	if e == zipEntryBase64 {
+		return "data"
+	}
+	return "content"
+}
+
+// writeZipEntries is the single serialisation path shared by every archive
+// builder — the FS-writing pair and the in-memory pair alike. Keeping one
+// implementation is what makes the entry cap, the path-traversal rejection and
+// the per-entry size cap identical across all four; a second copy is how those
+// drift apart.
+//
+// budget, when > 0, caps the total number of payload bytes written across all
+// entries. The FS builders pass 0 (unbounded, as they always have — the archive
+// lands on disk, not in the process); the in-memory builders pass a real budget
+// because their output is retained in memory and then base64-expanded.
+func writeZipEntries(w *zip.Writer, fn string, entries []eval.Value, enc zipEntryEncoding, budget int) error {
+	payloadField := enc.field()
+	total := 0
+
+	for i, entry := range entries {
+		rec, ok := entry.(*eval.RecordValue)
+		if !ok {
+			return fmt.Errorf("entry %d: expected record, got %T", i, entry)
+		}
+		nameVal, ok := rec.Fields["name"].(*eval.StringValue)
+		if !ok {
+			return fmt.Errorf("entry %d: 'name' field must be string", i)
+		}
+		payloadVal, ok := rec.Fields[payloadField].(*eval.StringValue)
+		if !ok {
+			if enc == zipEntryBase64 {
+				return fmt.Errorf("entry %d: 'data' field must be string (base64-encoded)", i)
+			}
+			return fmt.Errorf("entry %d: 'content' field must be string", i)
+		}
+
+		if strings.Contains(nameVal.Value, "..") {
+			return fmt.Errorf("entry %d: path traversal rejected: %s", i, nameVal.Value)
+		}
+
+		payload := []byte(payloadVal.Value)
+		if enc == zipEntryBase64 {
+			decoded, err := base64.StdEncoding.DecodeString(payloadVal.Value)
+			if err != nil {
+				return fmt.Errorf("entry %d: invalid base64: %v", i, err)
+			}
+			payload = decoded
+		}
+
+		if len(payload) > zipMaxDecompressedSize {
+			return fmt.Errorf("entry %d: data too large: %d bytes (max %d)", i, len(payload), zipMaxDecompressedSize)
+		}
+		if budget > 0 {
+			total += len(payload)
+			if total > budget {
+				return fmt.Errorf("%s: archive contents too large: %d bytes (max %d)", fn, total, budget)
+			}
+		}
+
+		ew, err := w.Create(nameVal.Value)
+		if err != nil {
+			return fmt.Errorf("entry %d: cannot create: %v", i, err)
+		}
+		if _, err := ew.Write(payload); err != nil {
+			return fmt.Errorf("entry %d: write error: %v", i, err)
+		}
+	}
+
+	return nil
+}
 
 // readZipEntry reads a zip file entry with size limits
 func readZipEntry(f *zip.File) ([]byte, error) {

--- a/internal/builtins/zip_memory.go
+++ b/internal/builtins/zip_memory.go
@@ -1,0 +1,178 @@
+package builtins
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/sunholo-data/ailang/internal/effects"
+	"github.com/sunholo-data/ailang/internal/eval"
+	"github.com/sunholo-data/ailang/internal/types"
+)
+
+// In-memory ZIP archive builders for AILANG.
+//
+// ailang#644: every archive constructor in std/zip wrote to a filesystem path
+// and carried the FS effect, which made document GENERATION impossible in the
+// browser — a WASM host has no filesystem, so the OOXML/ODF generators could
+// not be loaded into a browser bundle at all even though every byte they need
+// is already in memory. Extraction already had an escape hatch (the docs-site
+// demo unzips in JS and hands entry content to AILANG); the write path had none.
+//
+// These two builders are the counterpart: they serialise to memory and RETURN
+// the archive as base64 instead of writing it. That also makes the effect
+// requirement honest — building a ZIP is pure, writing one is not. A caller who
+// wants a file writes the result itself via std/fs.
+//
+// Purity is a real claim about this output, not a convenience: archive/zip
+// stamps entries with the zero time.Time (MS-DOS epoch 1979-11-30) rather than
+// the wall clock, so the same entry list serialises to the same bytes on every
+// call. TestZipBuildArchive_Deterministic pins that.
+
+// zipMaxArchiveContentSize caps the TOTAL payload bytes an in-memory builder
+// will accept across all entries. The FS builders are unbounded in aggregate
+// because their output streams to disk; these retain the whole archive in
+// memory and then base64-expand it by 4/3, so an unbounded builder is an OOM
+// primitive in a browser tab.
+//
+// A var rather than a const so the guard is reachable from a test at a sane
+// size. A limit whose only exercise would be allocating 100MB is a limit
+// nothing ever reds on, which is not a limit — it is a comment.
+var zipMaxArchiveContentSize = 100 * 1024 * 1024 // 100MB
+
+func init() {
+	registerZipBuildArchive()
+	registerZipBuildArchiveWithBytes()
+}
+
+// buildZipArchiveB64 serialises entries to an in-memory ZIP and returns the
+// archive as a base64 string, mirroring the base64-at-the-boundary convention
+// std/zip.readEntryBytes, std/gzip and std/deflate already use.
+func buildZipArchiveB64(fn string, args []eval.Value, enc zipEntryEncoding) (eval.Value, error) {
+	entriesVal, ok := args[0].(*eval.ListValue)
+	if !ok {
+		return nil, fmt.Errorf("%s: expected List for entries, got %T", fn, args[0])
+	}
+
+	if len(entriesVal.Elements) > zipMaxEntries {
+		return zipMakeErr(fmt.Sprintf("too many entries: %d (max %d)", len(entriesVal.Elements), zipMaxEntries)), nil
+	}
+
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+
+	writeErr := writeZipEntries(w, fn, entriesVal.Elements, enc, zipMaxArchiveContentSize)
+
+	// Always close the writer: it is what flushes the central directory, so an
+	// archive whose Close is skipped is silently truncated rather than absent.
+	if cerr := w.Close(); cerr != nil && writeErr == nil {
+		writeErr = fmt.Errorf("close archive: %v", cerr)
+	}
+
+	if writeErr != nil {
+		return zipMakeErr(writeErr.Error()), nil
+	}
+
+	return zipMakeOk(&eval.StringValue{Value: base64.StdEncoding.EncodeToString(buf.Bytes())}), nil
+}
+
+// ============================================================================
+// _zip_buildArchive: [{name: string, content: string}] -> Result[string, string]   (pure)
+// ============================================================================
+
+func registerZipBuildArchive() {
+	err := RegisterEffectBuiltin(BuiltinSpec{
+		Module:  "std/zip",
+		Name:    "_zip_buildArchive",
+		NumArgs: 1,
+		IsPure:  true,
+		Effect:  "",
+		Type:    makeZipBuildArchiveType,
+		Impl:    zipBuildArchiveImpl,
+		Metadata: &BuiltinMetadata{
+			Description: "Build a ZIP archive in memory from text entries (base64 out, no FS)",
+			LongDesc:    "Serialises a list of {name: string, content: string} records into a ZIP archive held in memory and returns it base64-encoded. The in-memory counterpart of _zip_createArchive: no filesystem, no FS effect, so it works in WASM/browser hosts where document GENERATION was previously impossible. Rejects path traversal and caps total content at 100MB. Output is deterministic — entries carry the MS-DOS epoch, not the wall clock.",
+			Params: []ParamDoc{
+				{Name: "entries", Description: "List of {name: string, content: string} records"},
+			},
+			Returns: "Result[string, string] - Ok(base64 of the ZIP archive) or Err(error message)",
+			Examples: []Example{
+				{Code: `_zip_buildArchive([{name: "hello.txt", content: "Hello!"}])`, Description: "Returns Ok(base64-encoded archive bytes)"},
+			},
+			SeeAlso:   []string{"_zip_buildArchiveWithBytes", "_zip_createArchive", "_zip_readEntry"},
+			Since:     "v0.34.0",
+			Stability: StabilityStable,
+			Tags:      []string{"zip", "archive", "build", "memory", "base64", "pure", "wasm"},
+			Category:  "zip",
+		},
+	})
+	if err != nil {
+		panic(fmt.Sprintf("failed to register _zip_buildArchive: %v", err))
+	}
+}
+
+func makeZipBuildArchiveType() types.Type {
+	T := types.NewBuilder()
+	entryType := T.Record(
+		types.Field("name", T.String()),
+		types.Field("content", T.String()),
+	)
+	return T.Func(T.List(entryType)).Returns(
+		T.App("Result", T.String(), T.String()),
+	).Build()
+}
+
+func zipBuildArchiveImpl(_ *effects.EffContext, args []eval.Value) (eval.Value, error) {
+	return buildZipArchiveB64("_zip_buildArchive", args, zipEntryText)
+}
+
+// ============================================================================
+// _zip_buildArchiveWithBytes: [{name: string, data: string}] -> Result[string, string]   (pure)
+// ============================================================================
+
+func registerZipBuildArchiveWithBytes() {
+	err := RegisterEffectBuiltin(BuiltinSpec{
+		Module:  "std/zip",
+		Name:    "_zip_buildArchiveWithBytes",
+		NumArgs: 1,
+		IsPure:  true,
+		Effect:  "",
+		Type:    makeZipBuildArchiveWithBytesType,
+		Impl:    zipBuildArchiveWithBytesImpl,
+		Metadata: &BuiltinMetadata{
+			Description: "Build a ZIP archive in memory from base64 entries (base64 out, no FS)",
+			LongDesc:    "Serialises a list of {name: string, data: string} records — where data is base64-encoded — into a ZIP archive held in memory and returns it base64-encoded. The in-memory counterpart of _zip_createArchiveWithBytes. Use for mixed text/binary documents (DOCX/PPTX/XLSX/ODT with embedded images or fonts) in WASM/browser hosts. Rejects path traversal and caps total decoded content at 100MB. Output is deterministic.",
+			Params: []ParamDoc{
+				{Name: "entries", Description: "List of {name: string, data: string} where data is base64-encoded"},
+			},
+			Returns: "Result[string, string] - Ok(base64 of the ZIP archive) or Err(error message)",
+			Examples: []Example{
+				{Code: `_zip_buildArchiveWithBytes([{name: "image.png", data: "iVBORw0KGgo..."}])`, Description: "Returns Ok(base64-encoded archive bytes)"},
+			},
+			SeeAlso:   []string{"_zip_buildArchive", "_zip_createArchiveWithBytes", "_zip_readEntryBytes"},
+			Since:     "v0.34.0",
+			Stability: StabilityStable,
+			Tags:      []string{"zip", "archive", "build", "memory", "binary", "base64", "pure", "wasm"},
+			Category:  "zip",
+		},
+	})
+	if err != nil {
+		panic(fmt.Sprintf("failed to register _zip_buildArchiveWithBytes: %v", err))
+	}
+}
+
+func makeZipBuildArchiveWithBytesType() types.Type {
+	T := types.NewBuilder()
+	entryType := T.Record(
+		types.Field("name", T.String()),
+		types.Field("data", T.String()),
+	)
+	return T.Func(T.List(entryType)).Returns(
+		T.App("Result", T.String(), T.String()),
+	).Build()
+}
+
+func zipBuildArchiveWithBytesImpl(_ *effects.EffContext, args []eval.Value) (eval.Value, error) {
+	return buildZipArchiveB64("_zip_buildArchiveWithBytes", args, zipEntryBase64)
+}

--- a/internal/builtins/zip_memory_test.go
+++ b/internal/builtins/zip_memory_test.go
@@ -1,0 +1,377 @@
+package builtins
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sunholo-data/ailang/internal/eval"
+)
+
+// Tests for the ailang#644 in-memory ZIP builders.
+//
+// The property under test throughout is that these produce a REAL archive with
+// no filesystem anywhere near them — so every assertion here reads the bytes
+// the builtin returned rather than re-deriving what it should have returned.
+
+// ============================================================================
+// helpers
+// ============================================================================
+
+func textEntries(pairs ...[2]string) []eval.Value {
+	out := make([]eval.Value, 0, len(pairs))
+	for _, p := range pairs {
+		out = append(out, &eval.RecordValue{Fields: map[string]eval.Value{
+			"name":    &eval.StringValue{Value: p[0]},
+			"content": &eval.StringValue{Value: p[1]},
+		}})
+	}
+	return out
+}
+
+func byteEntries(pairs ...[2]string) []eval.Value {
+	out := make([]eval.Value, 0, len(pairs))
+	for _, p := range pairs {
+		out = append(out, &eval.RecordValue{Fields: map[string]eval.Value{
+			"name": &eval.StringValue{Value: p[0]},
+			"data": &eval.StringValue{Value: base64.StdEncoding.EncodeToString([]byte(p[1]))},
+		}})
+	}
+	return out
+}
+
+// buildArchiveBytes runs the builtin and decodes the base64 archive it returned.
+// It deliberately goes through the Ok payload rather than calling the writer
+// directly: the base64 boundary is part of the contract callers depend on.
+func buildArchiveBytes(t *testing.T, impl func(entries []eval.Value) eval.Value, entries []eval.Value) []byte {
+	t.Helper()
+	inner := assertOk(t, impl(entries))
+	sv, ok := inner.(*eval.StringValue)
+	if !ok {
+		t.Fatalf("expected StringValue in Ok, got %T", inner)
+	}
+	raw, err := base64.StdEncoding.DecodeString(sv.Value)
+	if err != nil {
+		t.Fatalf("builtin returned a value that is not valid base64: %v", err)
+	}
+	return raw
+}
+
+func callBuildArchive(entries []eval.Value) eval.Value {
+	// nil EffContext on purpose: a PURE builtin must never reach for one.
+	v, err := zipBuildArchiveImpl(nil, []eval.Value{&eval.ListValue{Elements: entries}})
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+func callBuildArchiveWithBytes(entries []eval.Value) eval.Value {
+	v, err := zipBuildArchiveWithBytesImpl(nil, []eval.Value{&eval.ListValue{Elements: entries}})
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// readArchive parses archive bytes into name -> content.
+func readArchive(t *testing.T, raw []byte) map[string]string {
+	t.Helper()
+	zr, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
+	if err != nil {
+		t.Fatalf("builtin output is not a readable ZIP: %v", err)
+	}
+	out := map[string]string{}
+	for _, f := range zr.File {
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open entry %s: %v", f.Name, err)
+		}
+		var b bytes.Buffer
+		if _, err := b.ReadFrom(rc); err != nil {
+			t.Fatalf("read entry %s: %v", f.Name, err)
+		}
+		_ = rc.Close()
+		out[f.Name] = b.String()
+	}
+	return out
+}
+
+// ============================================================================
+// The headline property of ailang#644: these are PURE — no FS effect at all.
+// ============================================================================
+
+func TestZipBuildArchive_RegisteredPure(t *testing.T) {
+	for _, name := range []string{"_zip_buildArchive", "_zip_buildArchiveWithBytes"} {
+		spec, ok := GetSpec(name)
+		if !ok {
+			t.Fatalf("%s is not registered", name)
+		}
+		if !spec.IsPure {
+			t.Errorf("%s: IsPure = false, want true — the whole point of #644 is that "+
+				"building a ZIP needs no filesystem", name)
+		}
+		if spec.Effect != "" {
+			t.Errorf("%s: Effect = %q, want \"\" — an effect here makes the builder "+
+				"unusable in a WASM host, which is the case it exists for", name, spec.Effect)
+		}
+		if spec.NumArgs != 1 {
+			t.Errorf("%s: NumArgs = %d, want 1 (entries only — no path)", name, spec.NumArgs)
+		}
+	}
+
+	// Control: the FS-writing siblings must still be impure and FS-effecting,
+	// so a registry-wide mistake cannot make this test pass vacuously.
+	for _, name := range []string{"_zip_createArchive", "_zip_createArchiveWithBytes"} {
+		spec, ok := GetSpec(name)
+		if !ok {
+			t.Fatalf("control %s is not registered", name)
+		}
+		if spec.IsPure || spec.Effect != "FS" {
+			t.Errorf("control %s: IsPure=%v Effect=%q, want false/\"FS\"",
+				name, spec.IsPure, spec.Effect)
+		}
+	}
+}
+
+// ============================================================================
+// Round-trip: the returned bytes are a real archive with the right contents.
+// ============================================================================
+
+func TestZipBuildArchive_TextRoundTrip(t *testing.T) {
+	raw := buildArchiveBytes(t, callBuildArchive, textEntries(
+		[2]string{"[Content_Types].xml", "<Types/>"},
+		[2]string{"word/document.xml", "<w:document><w:body/></w:document>"},
+	))
+
+	got := readArchive(t, raw)
+	want := map[string]string{
+		"[Content_Types].xml": "<Types/>",
+		"word/document.xml":   "<w:document><w:body/></w:document>",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("entry count = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for name, content := range want {
+		if got[name] != content {
+			t.Errorf("entry %q = %q, want %q", name, got[name], content)
+		}
+	}
+}
+
+func TestZipBuildArchiveWithBytes_Base64RoundTrip(t *testing.T) {
+	// A payload that is NOT valid UTF-8, which is the case base64 exists for.
+	binary := string([]byte{0x89, 0x50, 0x4E, 0x47, 0x00, 0xFF, 0xFE})
+	raw := buildArchiveBytes(t, callBuildArchiveWithBytes, byteEntries(
+		[2]string{"word/media/image1.png", binary},
+	))
+
+	got := readArchive(t, raw)
+	if got["word/media/image1.png"] != binary {
+		t.Errorf("binary entry round-tripped as %q, want %q",
+			got["word/media/image1.png"], binary)
+	}
+}
+
+func TestZipBuildArchive_EmptyEntryListIsAValidArchive(t *testing.T) {
+	// An empty part list is a legitimate request, not an error — and the result
+	// must still be a parseable archive (i.e. the central directory was
+	// flushed), not an empty string.
+	raw := buildArchiveBytes(t, callBuildArchive, nil)
+	if len(raw) == 0 {
+		t.Fatal("empty entry list produced zero bytes; expected an empty but valid archive")
+	}
+	if got := readArchive(t, raw); len(got) != 0 {
+		t.Errorf("empty entry list produced %d entries: %v", len(got), got)
+	}
+}
+
+// ============================================================================
+// Purity is a claim about the OUTPUT, not just about the signature.
+// ============================================================================
+
+func TestZipBuildArchive_Deterministic(t *testing.T) {
+	entries := textEntries([2]string{"a.txt", "alpha"}, [2]string{"b/c.txt", "beta"})
+
+	first := buildArchiveBytes(t, callBuildArchive, entries)
+	// MS-DOS timestamps have 2-second resolution, so a wall-clock stamp would
+	// have to cross a 2s boundary to differ. Sleep past it: without this the
+	// test passes whether or not the builder is deterministic.
+	time.Sleep(2100 * time.Millisecond)
+	second := buildArchiveBytes(t, callBuildArchive, entries)
+
+	if !bytes.Equal(first, second) {
+		t.Errorf("two builds of identical entries differ (%d vs %d bytes) — the builtin "+
+			"is registered PURE, so a wall-clock timestamp in the output is a soundness bug",
+			len(first), len(second))
+	}
+}
+
+// TestZipBuildArchive_MatchesFSArchive pins that the in-memory and FS builders
+// share one serialisation path. If they ever diverge, a document that opens
+// from disk could fail to open from the browser (or vice versa) for reasons no
+// caller could see.
+func TestZipBuildArchive_MatchesFSArchive(t *testing.T) {
+	entries := textEntries(
+		[2]string{"[Content_Types].xml", "<Types/>"},
+		[2]string{"word/document.xml", "<w:document><w:body/></w:document>"},
+	)
+
+	inMemory := buildArchiveBytes(t, callBuildArchive, entries)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fs.zip")
+	ctx := makeTestCtx(t)
+	res, err := zipCreateArchiveImpl(ctx, []eval.Value{
+		&eval.StringValue{Value: path},
+		&eval.ListValue{Elements: entries},
+	})
+	if err != nil {
+		t.Fatalf("_zip_createArchive: %v", err)
+	}
+	assertOk(t, res)
+
+	onDisk, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fs archive: %v", err)
+	}
+
+	if !bytes.Equal(inMemory, onDisk) {
+		t.Errorf("in-memory archive (%d bytes) differs from the FS archive (%d bytes) "+
+			"for identical entries", len(inMemory), len(onDisk))
+	}
+}
+
+// ============================================================================
+// Refusals. One arm per refusal branch (skill rule 3j).
+// ============================================================================
+
+func TestZipBuildArchive_RejectsPathTraversal(t *testing.T) {
+	assertErr(t, callBuildArchive(textEntries([2]string{"../escape.txt", "x"})),
+		"path traversal rejected")
+	assertErr(t, callBuildArchiveWithBytes(byteEntries([2]string{"../escape.bin", "x"})),
+		"path traversal rejected")
+}
+
+func TestZipBuildArchiveWithBytes_RejectsInvalidBase64(t *testing.T) {
+	entries := []eval.Value{&eval.RecordValue{Fields: map[string]eval.Value{
+		"name": &eval.StringValue{Value: "bad.bin"},
+		"data": &eval.StringValue{Value: "!!! not base64 !!!"},
+	}}}
+	assertErr(t, callBuildArchiveWithBytes(entries), "invalid base64")
+}
+
+func TestZipBuildArchive_RejectsMalformedEntryRecord(t *testing.T) {
+	// Wrong payload field: a {name, data} record handed to the TEXT builder.
+	assertErr(t, callBuildArchive([]eval.Value{&eval.RecordValue{Fields: map[string]eval.Value{
+		"name": &eval.StringValue{Value: "a.txt"},
+		"data": &eval.StringValue{Value: "x"},
+	}}}), "'content' field must be string")
+
+	// And the mirror: a {name, content} record handed to the BYTES builder.
+	assertErr(t, callBuildArchiveWithBytes([]eval.Value{&eval.RecordValue{Fields: map[string]eval.Value{
+		"name":    &eval.StringValue{Value: "a.bin"},
+		"content": &eval.StringValue{Value: "x"},
+	}}}), "'data' field must be string")
+
+	// Non-string name.
+	assertErr(t, callBuildArchive([]eval.Value{&eval.RecordValue{Fields: map[string]eval.Value{
+		"name":    &eval.IntValue{Value: 1},
+		"content": &eval.StringValue{Value: "x"},
+	}}}), "'name' field must be string")
+
+	// Not a record at all.
+	assertErr(t, callBuildArchive([]eval.Value{&eval.StringValue{Value: "nope"}}),
+		"expected record")
+}
+
+func TestZipBuildArchive_RejectsTooManyEntries(t *testing.T) {
+	entries := make([]eval.Value, zipMaxEntries+1)
+	for i := range entries {
+		entries[i] = &eval.RecordValue{Fields: map[string]eval.Value{
+			"name":    &eval.StringValue{Value: fmt.Sprintf("f%d.txt", i)},
+			"content": &eval.StringValue{Value: "x"},
+		}}
+	}
+	assertErr(t, callBuildArchive(entries), "too many entries")
+}
+
+// TestZipBuildArchive_RejectsOversizeTotal exercises the budget that only the
+// in-memory builders carry. It is reachable because the cap is a var: at its
+// production value the only way to red this would be to allocate 100MB, i.e.
+// the guard would never be exercised at all.
+func TestZipBuildArchive_RejectsOversizeTotal(t *testing.T) {
+	saved := zipMaxArchiveContentSize
+	zipMaxArchiveContentSize = 16
+	defer func() { zipMaxArchiveContentSize = saved }()
+
+	// Each entry is under the cap; the TOTAL is not. A per-entry-only check
+	// passes this and is exactly the bug the budget exists to prevent.
+	entries := textEntries(
+		[2]string{"a.txt", "0123456789"},
+		[2]string{"b.txt", "0123456789"},
+	)
+	assertErr(t, callBuildArchive(entries), "archive contents too large")
+
+	// Same for the base64 arm, measured on DECODED length.
+	assertErr(t, callBuildArchiveWithBytes(byteEntries(
+		[2]string{"a.bin", "0123456789"},
+		[2]string{"b.bin", "0123456789"},
+	)), "archive contents too large")
+
+	// Control: comfortably under the cap still succeeds, so the arm above is
+	// not passing because the builder is broken outright.
+	assertOk(t, callBuildArchive(textEntries([2]string{"a.txt", "tiny"})))
+}
+
+// TestZipCreateArchive_StaysUnboundedInAggregate is the negative control for
+// the budget: the FS builders share the serialiser but pass budget=0, and must
+// not inherit a cap they never had.
+func TestZipCreateArchive_StaysUnboundedInAggregate(t *testing.T) {
+	saved := zipMaxArchiveContentSize
+	zipMaxArchiveContentSize = 16
+	defer func() { zipMaxArchiveContentSize = saved }()
+
+	dir := t.TempDir()
+	ctx := makeTestCtx(t)
+	res, err := zipCreateArchiveImpl(ctx, []eval.Value{
+		&eval.StringValue{Value: filepath.Join(dir, "big.zip")},
+		&eval.ListValue{Elements: textEntries(
+			[2]string{"a.txt", "0123456789"},
+			[2]string{"b.txt", "0123456789"},
+		)},
+	})
+	if err != nil {
+		t.Fatalf("_zip_createArchive: %v", err)
+	}
+	assertOk(t, res)
+}
+
+// ============================================================================
+// Type surface
+// ============================================================================
+
+func TestZipBuildArchive_TypeIsPureAndReturnsString(t *testing.T) {
+	for name, mk := range map[string]func() interface{ String() string }{
+		"_zip_buildArchive":          func() interface{ String() string } { return makeZipBuildArchiveType() },
+		"_zip_buildArchiveWithBytes": func() interface{ String() string } { return makeZipBuildArchiveWithBytesType() },
+	} {
+		got := mk().String()
+		if want := "Result[string, string]"; !contains(got, want) {
+			t.Errorf("%s type = %s, want it to return %s", name, got, want)
+		}
+		// The FS siblings carry `! {FS}`; these must not.
+		if contains(got, "FS") {
+			t.Errorf("%s type = %s, want no FS effect", name, got)
+		}
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return bytes.Contains([]byte(haystack), []byte(needle))
+}

--- a/internal/pipeline/testdata/builtin_types.golden
+++ b/internal/pipeline/testdata/builtin_types.golden
@@ -289,6 +289,8 @@ _xml_sanitize : string -> string
 _xml_serialize : XmlNode -> string
 _xml_serializeWithDecl : XmlNode -> string
 _yaml_to_json : string -> Result[string, string]
+_zip_buildArchive : list[{content: string, name: string}] -> Result[string, string]
+_zip_buildArchiveWithBytes : list[{data: string, name: string}] -> Result[string, string]
 _zip_createArchive : (string, list[{content: string, name: string}]) -> Result[(), string] ! {FS}
 _zip_createArchiveWithBytes : (string, list[{data: string, name: string}]) -> Result[(), string] ! {FS}
 _zip_listEntries : string -> Result[list[string], string] ! {FS}

--- a/std/zip.ail
+++ b/std/zip.ail
@@ -3,7 +3,8 @@
 -- Read and write entries in ZIP archives (including .docx, .xlsx, .pptx).
 -- Stream XML entries via fold for memory-efficient processing (v0.11.0).
 --
--- Requires: FS capability (--caps FS)
+-- Requires: FS capability (--caps FS) for the path-based functions.
+-- buildArchive / buildArchiveWithBytes are PURE (in-memory, no FS) -- ailang#644.
 --
 -- Security: Path traversal rejected, 10K entry limit, 100MB decompressed size limit.
 --
@@ -78,3 +79,25 @@ export func createArchive(path: string, entries: [{name: string, content: string
 -- @requires FS capability
 -- @sandbox Respects AILANG_FS_SANDBOX
 export func createArchiveWithBytes(path: string, entries: [{name: string, data: string}]) -> Result[(), string] ! {FS} = _zip_createArchiveWithBytes(path, entries)
+
+-- ailang#644: in-memory ZIP construction (no filesystem, no FS effect)
+
+-- Build a ZIP archive in memory and return it base64-encoded.
+-- Each entry is {name: string, content: string} (text, written verbatim).
+-- The in-memory counterpart of createArchive: nothing touches the filesystem,
+-- so this works in WASM/browser hosts where document GENERATION was previously
+-- impossible. Building a ZIP is pure; writing one is not -- a caller who wants
+-- a file writes the returned bytes itself via std/fs.
+-- Returns Ok(base64 of the archive) or Err(message).
+-- Output is deterministic: entries carry the MS-DOS epoch, not the wall clock.
+-- Security: path traversal rejected, 10K entry limit, 100MB total content limit.
+export pure func buildArchive(entries: [{name: string, content: string}]) -> Result[string, string] = _zip_buildArchive(entries)
+
+-- Build a ZIP archive in memory from binary entries and return it base64-encoded.
+-- Each entry is {name: string, data: string} where data is base64.
+-- The in-memory counterpart of createArchiveWithBytes. Use for mixed
+-- text/binary documents (DOCX/PPTX/XLSX/ODT with embedded images or fonts);
+-- encode text parts with std/bytes (toBase64 . fromString).
+-- Returns Ok(base64 of the archive) or Err(message).
+-- Security: path traversal rejected, 10K entry limit, 100MB total content limit.
+export pure func buildArchiveWithBytes(entries: [{name: string, data: string}]) -> Result[string, string] = _zip_buildArchiveWithBytes(entries)


### PR DESCRIPTION
Closes #644.

## The problem

Every archive constructor in `std/zip` took an output *path* and carried the `FS` effect:

```
createArchive(string, [{name, content}])       -> Result[(), string] ! {FS}
createArchiveWithBytes(string, [{name, data}]) -> Result[(), string] ! {FS}
```

A WASM/browser host has no filesystem, so the DOCX/PPTX/XLSX/ODT generators could not be loaded into a browser bundle **at all** — even though they build a complete part list in memory and hand it to `createArchive` purely to serialise it. The file write was incidental to what they wanted. Extraction already had an escape hatch (the docs-site demo unzips in JS and passes entry content into AILANG); the write path had none.

## The change

Two pure functions, mirroring the existing pair:

```
buildArchive([{name, content}])       -> Result[string, string]
buildArchiveWithBytes([{name, data}]) -> Result[string, string]
```

They serialise to memory and **return** the archive base64-encoded, matching the base64-at-the-boundary convention `readEntryBytes`, `std/gzip` and `std/deflate` already use. No path, no `FS`, no capability. A caller who wants a file writes the result itself via `std/fs`, which also makes the effect requirement honest — building a ZIP is pure, writing one is not.

All four builders now share **one** serialisation path. That is what keeps the 10,000-entry cap, the path-traversal rejection and the 100MB per-entry cap identical across them rather than drifting between four copies.

## Measured, not assumed

- **Purity is a claim about the OUTPUT, not the signature.** `archive/zip` stamps entries with the zero `time.Time` (MS-DOS epoch, 1979-11-30) rather than the wall clock, so the same entry list serialises to the same bytes every call. Pinned across a **2.1 s** gap — past the 2-second resolution of a DOS timestamp, without which the test passes whether or not the builder is deterministic.
- **`buildArchive` and `createArchive` produce byte-identical archives** for the same entries (`sha ede7a339…`, 323 bytes), also pinned.
- **The `FS` gate is real**, so the contrast is a measurement rather than an assertion: `createArchive` under `--caps IO` is denied (`effect 'FS' requires capability`); the new builders succeed under the same caps. The runnable example's `main` is `-> () ! {IO}`.
- **Both builtins ship in `bin/ailang.wasm`** — 8 and 4 occurrences, controls `_zip_createArchive` 14 and `_deflate_inflate` 11.
- **The builtin golden snapshot moved by exactly 2 lines with 338 signatures unchanged**, and neither new line carries an effect annotation — an independent confirmation from a gate this PR did not write.

## One new limit, only on the in-memory pair

A cap on **total** content across all entries. The FS builders stream to disk and stay unbounded in aggregate as they always have (a negative control pins that they did not inherit the cap); these retain the whole archive in memory and then expand it by 4/3 in base64, so an unbounded builder is an OOM primitive in a browser tab. The cap is a `var` rather than a `const` so the guard is reachable from a test at a sane size — a limit whose only exercise would be allocating 100MB is a limit nothing ever reds on.

## Mutation drill

10 mutants, each asserted **LANDED** by sha256 and **BUILDS** by `go build` rc=0 *before* any test result was read, each restored by `cp` and verified byte-identical.

| Mutant | Result |
|---|---|
| `IsPure: true` → `false` | sole killer `RegisteredPure`, inverse `-skip` rc=0 |
| `Effect: ""` → `"FS"` | sole killer `RegisteredPure` |
| neuter total-size budget | sole killer `RejectsOversizeTotal`, inverse rc=0 |
| wall-clock entry timestamps | sole killer `Deterministic`, inverse rc=0 |
| neuter entry cap | sole killer `RejectsTooManyEntries`, inverse rc=0 |
| neuter path-traversal check | red SET of **3** (1 new arm + 2 pre-existing FS arms) |
| accept invalid base64 | red SET of **2** |
| skip `w.Close()` | red SET of **4** |
| `buildArchive` reads the base64 field | red SET of **6** |
| return raw bytes not base64 | first attempt `BUILDS=NO` (unused import) — **discarded, not counted**; re-run with an import-preserving mutant reds a SET of **4** |

Broad-blast-radius mutants are recorded as **enumerated red sets** rather than an `rc=0` inverse criterion, which such a mutant cannot satisfy by construction.

## Gates

All on **darwin/arm64**; the linux and windows legs were unrun locally and are settled by CI.

`fmt-check` · `vet` · `lint` · `check-file-sizes` · `check-boundaries` · `check-changelog` · `test-check-changelog` · `check-skills` · `check-golden-drift` · `doctor` · `test-regression-guards` · `test-imports-success` · `test-import-errors` · `test-lowering` · `verify-no-shim` · `test-stdlib-ail` · `test-coverage-gate` · `build-wasm` — all rc=0.
`verify-examples` rc=0 at **192 modules, 0 drift**. `go test ./...` rc=0 across **110 packages, 0 FAIL**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
