### PR TITLE
fix(eval): RT_REC_003 advertised "enable tail recursion", an option that has never existed

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,39 @@
 
 ## [Unreleased]
 
+### Fixed — `RT_REC_003` no longer advertises an option that does not exist
+
+[ailang#676](https://github.com/sunholo-data/ailang/issues/676) (first-party finding,
+mission iteration 228).
+
+When the tree-walking evaluator hit its recursion ceiling it told the user to
+"enable tail recursion":
+
+```
+RT_REC_003: max recursion depth 10000 exceeded. Try smaller input, enable tail
+recursion, or increase with --max-recursion-depth
+```
+
+There is no such option. The evaluator has **no** tail-call elimination — that
+machinery lives in `internal/vm` and `internal/bytecode`, which `ailang run` does
+not use — and no CLI flag, env var or pragma enables it. Measured: the only two
+mentions of tail recursion anywhere in `internal/eval` are a test comment and this
+message itself, so the sole reference to the feature was the advertisement for it.
+A user following the advice has nowhere to go.
+
+The message now names remedies that exist — a smaller input, an iterative
+`std/list` helper such as `foldl` or `map` (both delegate to iterative builtins and
+never recurse), or `--max-recursion-depth`.
+
+Pinned by two arms in `internal/eval/rt_rec_003_message_test.go` that take the
+remedy **out of the evaluator's own output** rather than reconstructing it: every
+`--flag` the message names must map to a knob the evaluator actually has, and the
+test then *applies* that knob and requires the previously-failing program to
+succeed. An anti-vacuity floor fails loudly if the message names no flag at all.
+Restoring the old message reds one arm; advertising a plausible-but-fake
+`--enable-tail-recursion` reds the other; each is the sole killer of its arm.
+
+
 ### Added — `std/zip` can build an archive in memory, with no `FS` effect
 
 [ailang#644](https://github.com/sunholo-data/ailang/issues/644), from a downstream

--- a/internal/eval/eval_operations.go
+++ b/internal/eval/eval_operations.go
@@ -55,7 +55,7 @@ func (e *CoreEvaluator) evalCoreApp(app *core.App) (retVal Value, err error) {
 		e.recursionDepth++
 		if e.recursionDepth > e.maxRecursionDepth {
 			e.recursionDepth--
-			return nil, fmt.Errorf("RT_REC_003: max recursion depth %d exceeded. Try smaller input, enable tail recursion, or increase with --max-recursion-depth", e.maxRecursionDepth)
+			return nil, fmt.Errorf("RT_REC_003: max recursion depth %d exceeded. Try a smaller input, an iterative std/list helper such as foldl or map instead of hand-rolled recursion, or raise the ceiling with --max-recursion-depth", e.maxRecursionDepth)
 		}
 		defer func() { e.recursionDepth-- }()
 

--- a/internal/eval/rt_rec_003_message_test.go
+++ b/internal/eval/rt_rec_003_message_test.go
@@ -1,0 +1,135 @@
+package eval
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/core"
+)
+
+// RT_REC_003 is a string the product hands a human to act on, so it is tested the
+// way rule 3k requires: the remedy is taken OUT of the evaluator's own output and
+// EXECUTED, rather than reconstructed from what the message ought to say. A test
+// that rebuilt the advice independently would pass on advice that cannot be
+// followed — which is exactly how the message spent its life telling users to
+// "enable tail recursion", an option that has never existed in this evaluator
+// (tail-call machinery lives in internal/vm and internal/bytecode, which
+// `ailang run` does not use).
+
+// recursionRemedies maps a CLI flag the RT_REC_003 message may advertise onto the
+// evaluator knob that flag drives. A flag with no entry here is advice the runtime
+// cannot honour, and the test fails loudly rather than accepting it.
+var recursionRemedies = map[string]func(*CoreEvaluator, int){
+	"--max-recursion-depth": (*CoreEvaluator).SetMaxRecursionDepth,
+}
+
+// sumProgram builds `letrec sum = λn. if n <= 0 then 0 else n + sum(n-1) in sum(n)`,
+// whose depth is proportional to n, so it overflows at a low ceiling and succeeds at
+// a raised one. That difference is what makes the remedy checkable.
+func sumProgram(n int) *core.LetRec {
+	body := &core.If{
+		Cond: &core.BinOp{
+			Op:    "<=",
+			Left:  &core.Var{Name: "n"},
+			Right: &core.Lit{Kind: core.IntLit, Value: 0},
+		},
+		Then: &core.Lit{Kind: core.IntLit, Value: 0},
+		Else: &core.BinOp{
+			Op:   "+",
+			Left: &core.Var{Name: "n"},
+			Right: &core.App{
+				Func: &core.Var{Name: "sum"},
+				Args: []core.CoreExpr{
+					&core.BinOp{
+						Op:    "-",
+						Left:  &core.Var{Name: "n"},
+						Right: &core.Lit{Kind: core.IntLit, Value: 1},
+					},
+				},
+			},
+		},
+	}
+	return &core.LetRec{
+		Bindings: []core.RecBinding{
+			{Name: "sum", Value: &core.Lambda{Params: []string{"n"}, Body: body}},
+		},
+		Body: &core.App{
+			Func: &core.Var{Name: "sum"},
+			Args: []core.CoreExpr{&core.Lit{Kind: core.IntLit, Value: n}},
+		},
+	}
+}
+
+func newSumEvaluator(depth int) *CoreEvaluator {
+	ev := NewCoreEvaluator()
+	ev.SetExperimentalBinopShim(true)
+	ev.SetMaxRecursionDepth(depth)
+	return ev
+}
+
+// TestRTREC003AdvertisesOnlyRemediesThatExist reads every flag RT_REC_003 names out of
+// the emitted error and requires each one to be a knob this evaluator actually has —
+// then applies it and requires the previously-failing program to succeed.
+func TestRTREC003AdvertisesOnlyRemediesThatExist(t *testing.T) {
+	const n = 300
+
+	_, err := newSumEvaluator(100).evalCore(sumProgram(n))
+	if err == nil {
+		t.Fatal("instrument failure: sum(300) at depth 100 did not exceed the recursion guard, so no message was produced")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "RT_REC_003") {
+		t.Fatalf("instrument failure: expected an RT_REC_003 error, got: %v", err)
+	}
+
+	flags := regexp.MustCompile(`--[a-z][a-z0-9-]*`).FindAllString(msg, -1)
+	// Anti-vacuity floor: a message naming no flag at all would satisfy every
+	// assertion below by having nothing to check.
+	if len(flags) == 0 {
+		t.Fatalf("instrument failure: RT_REC_003 names no actionable flag at all: %q", msg)
+	}
+
+	for _, f := range flags {
+		apply, ok := recursionRemedies[f]
+		if !ok {
+			t.Fatalf("RT_REC_003 advertises %q, which this evaluator has no knob for; message: %q", f, msg)
+		}
+
+		ev := NewCoreEvaluator()
+		ev.SetExperimentalBinopShim(true)
+		apply(ev, 10000)
+
+		result, rerr := ev.evalCore(sumProgram(n))
+		if rerr != nil {
+			t.Fatalf("following the advertised remedy %q did not resolve the failure: %v", f, rerr)
+		}
+		intVal, ok := result.(*IntValue)
+		if !ok {
+			t.Fatalf("after remedy %q: expected IntValue, got %T", f, result)
+		}
+		if want := n * (n + 1) / 2; intVal.Value != want {
+			t.Errorf("after remedy %q: expected sum(%d) = %d, got %d", f, n, want, intVal.Value)
+		}
+	}
+}
+
+// TestRTREC003DoesNotAdvertiseTailRecursion pins the specific defect: the evaluator has
+// no tail-call elimination, so naming it sends the reader hunting for a flag that was
+// never built. Kept separate from the flag check above because "enable tail recursion"
+// is prose, not a flag, and so is invisible to a flag-shaped matcher.
+func TestRTREC003DoesNotAdvertiseTailRecursion(t *testing.T) {
+	_, err := newSumEvaluator(100).evalCore(sumProgram(300))
+	if err == nil {
+		t.Fatal("instrument failure: expected the recursion guard to fire")
+	}
+	lower := strings.ToLower(err.Error())
+	if !strings.Contains(lower, "rt_rec_003") {
+		t.Fatalf("instrument failure: expected an RT_REC_003 error, got: %v", err)
+	}
+	for _, banned := range []string{"tail recursion", "tail call", "tail-call"} {
+		if strings.Contains(lower, banned) {
+			t.Errorf("RT_REC_003 advertises %q, but this evaluator has no tail-call elimination: %q", banned, err.Error())
+		}
+	}
+}


### PR DESCRIPTION
## The defect

`RT_REC_003` told users to "enable tail recursion":

    RT_REC_003: max recursion depth 10000 exceeded. Try smaller input, enable tail
    recursion, or increase with --max-recursion-depth

There is no such option — no CLI flag, no env var, no pragma. The tree-walking
evaluator has **no** tail-call elimination; that machinery lives in `internal/vm`
and `internal/bytecode`, which `ailang run` does not use.

Measured at HEAD: the only two mentions of tail recursion anywhere in
`internal/eval` are a test comment and **this message itself**, so the sole
reference to the feature was the advertisement for it. `ailang run --help` offers
only `-max-recursion-depth` (control: that grep does see the flag). A user
following the advice has nowhere to go.

This is the emitted-string class: the product hands a human an instruction and
nothing tests that it is actionable.

## The fix

The message now names remedies that exist — a smaller input, an iterative
`std/list` helper such as `foldl` or `map` (`std/list.ail:56,60`; both delegate to
iterative builtins and never recurse), or `--max-recursion-depth`.

## How it is pinned

Two arms in `internal/eval/rt_rec_003_message_test.go` take the remedy **out of the
evaluator's own output** rather than reconstructing it. A test that rebuilt the
advice independently would pass on advice that cannot be followed — which is how
this message survived since v0.3.0.

- Every `--flag` the emitted message names must map to a knob the evaluator
  actually has; the test then **applies** that knob and requires the
  previously-failing program to succeed.
- An anti-vacuity floor fails loudly if the message names no flag at all.
- A second arm pins the specific regression, kept separate because "enable tail
  recursion" is prose and therefore invisible to a flag-shaped matcher.

## Mutation drill

Both mutants asserted **LANDED** (sha256) and **BUILDS** (`go build` rc=0) before
any test result was read; source restored and verified byte-identical.

| Mutant | Reds | Blast radius | Inverse `-skip` both arms |
|---|---|---|---|
| M1 — restore the original message | `TestRTREC003DoesNotAdvertiseTailRecursion` only | 1 test | rc=0 |
| M2 — advertise `--enable-tail-recursion` | `TestRTREC003AdvertisesOnlyRemediesThatExist` only | 1 test | rc=0 |

Both are single-test mutants, so the `rc=0` inverse criterion applies and holds:
each arm is the **sole killer** of its own mutant.

## Gates

`check-changelog` · `fmt-check` · `vet` · `check-file-sizes` · `check-boundaries`
all rc=0. `go test` rc=0 on `internal/eval`, `internal/builtins`, `cmd/ailang`.
All local gates ran on **darwin/arm64**; the linux and windows legs are unrun
locally and settled by CI.

`go build ./...` fails at base on `cmd/wasm` (no native `main`) — a pre-existing
condition of untouched `dev`, not this diff; `go build ./internal/...` is rc=0.

## Provenance

Found first-party at mission iteration 228 while diagnosing
[#676](https://github.com/sunholo-data/ailang/issues/676); fixed at iteration 230.
Satisfies **AC-8** of the superseded `m-list-cons-quadratic` design doc. Does not
touch the list representation and is independent of `D-19`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
