### PR TITLE
fix(loader): resolve package manifests from the source file's dir, not the CWD (#671)

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,46 @@
 
 ## [Unreleased]
 
+### Fixed — package imports now resolve from the source file's directory, not the process CWD
+
+[ailang#671](https://github.com/sunholo-data/ailang/issues/671) (downstream-consumer
+report, mission iteration 231).
+
+An AILANG program that lives inside a package could not resolve its own imports
+unless `ailang` happened to be invoked from that package's directory tree:
+
+```
+Error: module loading error: failed to load pkg/sunholo/duckdb/types:
+  package import "pkg/sunholo/duckdb/types" requires ailang.toml and ailang.lock;
+  run 'ailang init package' and 'ailang lock'
+```
+
+The manifest search was anchored at `"."` — the process working directory —
+while `FindManifest` walks *upward* from wherever it starts. Run from inside the
+project it found `ailang.toml` and everything worked; run from anywhere else it
+found nothing, wired no package resolver, and every `pkg/...` and `./sibling`
+import failed. That is the normal case for an installed CLI, which the user
+invokes from wherever their data is.
+
+Two things made it hard to diagnose. The advice was impossible to act on — both
+files already existed, next to the source file. And the *same* string was emitted
+whether the manifest was somewhere else or genuinely absent, so it could not
+distinguish "you are standing in the wrong directory" from "you have no package".
+
+The manifest search is now anchored at the entry source file's directory, which
+is a superset of the old behaviour for any file inside its own project (the
+search still walks upward, so running from a subdirectory is unaffected). The
+named-test harness already passed `PackageDir` for exactly this reason; every
+other entry point — `run`, `check`, `serve-api`, the MCP server, `embed` — did
+not. When no resolver can be wired the error now names the directory actually
+searched, and distinguishes a missing manifest from one that exists but could
+not be loaded.
+
+Code compiled from a string, a REPL buffer or a synthetic `<stdin>` name keeps
+the previous behaviour: a name that never named a file does not get a directory
+invented for it.
+
+
 ### Fixed — `RT_REC_003` no longer advertises an option that does not exist
 
 [ailang#676](https://github.com/sunholo-data/ailang/issues/676) (first-party finding,

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -28,6 +28,13 @@ type ModuleLoader struct {
 	pkgLoader          PackageResolver     // Optional package loader for pkg/ imports
 	modulePrefixMap    map[string][]string // module_prefix → package names (e.g., "docparse" → ["sunholo/ailang_parse", "sunholo/docparse"])
 	currentPackageName string              // <vendor>/<name> of the package being compiled, when known. Enables bare-canonical self-imports (e.g., "import sunholo/linkedin/types" from within sunholo/linkedin).
+
+	// pkgResolverAbsentReason explains why pkgLoader is nil, as diagnosed by
+	// whoever wired (or failed to wire) the resolver. The loader cannot know:
+	// a nil resolver has several causes, and the message must not assert one.
+	// See ailang#671 — users were told to create an ailang.toml/ailang.lock
+	// that were sitting next to the source file the whole time.
+	pkgResolverAbsentReason string
 }
 
 // PackageResolver resolves package imports to source file paths.
@@ -66,6 +73,13 @@ func (ml *ModuleLoader) SetStrictSyntaxMode(strict bool) {
 // SetPackageResolver sets the resolver for pkg/ imports.
 func (ml *ModuleLoader) SetPackageResolver(resolver PackageResolver) {
 	ml.pkgLoader = resolver
+}
+
+// SetPackageResolverAbsentReason records WHY no package resolver could be
+// wired, so a failing pkg/ import can report the actual cause instead of
+// guessing one. Callers that wire a resolver need not call this.
+func (ml *ModuleLoader) SetPackageResolverAbsentReason(reason string) {
+	ml.pkgResolverAbsentReason = reason
 }
 
 // SetModulePrefixMap sets the module_prefix → package name mapping.
@@ -145,7 +159,11 @@ func (ml *ModuleLoader) Load(path string) (*LoadedModule, error) {
 	} else if strings.HasPrefix(canonPath, "pkg/") {
 		// External package import — resolve via PackageLoader
 		if ml.pkgLoader == nil {
-			return nil, fmt.Errorf("package import %q requires ailang.toml and ailang.lock; run 'ailang init package' and 'ailang lock'", canonPath)
+			reason := ml.pkgResolverAbsentReason
+			if reason == "" {
+				reason = "no package resolver is configured for this compilation"
+			}
+			return nil, fmt.Errorf("package import %q cannot be resolved: %s", canonPath, reason)
 		}
 		// Strip pkg/ prefix for the package resolver
 		pkgImportPath := strings.TrimPrefix(canonPath, "pkg/")

--- a/internal/pipeline/package_resolver.go
+++ b/internal/pipeline/package_resolver.go
@@ -153,3 +153,61 @@ func validateEffectCeiling(surfaceAST *ast.File, modID string) error {
 
 	return nil
 }
+
+// packageSearchDir decides where to look for ailang.toml/ailang.lock.
+//
+// The package manifest belongs to the SOURCE FILE, not to the process CWD.
+// Anchoring the search at "." meant an installed AILANG CLI invoked from
+// anywhere but its own project root could not resolve its own package imports
+// — and the failure blamed a missing ailang.toml/ailang.lock that were sitting
+// next to the source file (ailang#671). The named-test harness already passed
+// PackageDir for exactly this reason; every other entry point (run, check,
+// serve-api, the MCP server, embed) did not.
+//
+// FindManifest walks upward, so anchoring at the file's directory is a superset
+// of the old behaviour for any file inside its own project. An explicit
+// PackageDir always wins.
+func packageSearchDir(explicitPackageDir, loaderBaseDir, entryFilename string) string {
+	if explicitPackageDir != "" {
+		return explicitPackageDir
+	}
+	if dir := entrySourceDir(entryFilename); dir != "" {
+		return dir
+	}
+	return loaderBaseDir
+}
+
+// entrySourceDir returns the directory holding the entry source file, or ""
+// when there is no real file on disk (code compiled from a string, a REPL
+// buffer, or a synthetic "<stdin>"-style name). Returning "" leaves the
+// caller on its previous CWD-anchored behaviour rather than inventing a
+// directory from a name that never named a file.
+func entrySourceDir(filename string) string {
+	if filename == "" {
+		return ""
+	}
+	st, err := os.Stat(filename)
+	if err != nil || st.IsDir() {
+		return ""
+	}
+	return filepath.Dir(filename)
+}
+
+// packageResolverAbsentReason explains why no package resolver could be wired
+// for dir. The two causes need different user actions, and conflating them is
+// what made ailang#671 tell users to create files that already existed.
+func packageResolverAbsentReason(dir string) string {
+	if dir == "" {
+		dir = "."
+	}
+	searched := dir
+	if abs, err := filepath.Abs(dir); err == nil {
+		searched = abs
+	}
+	if manifestDir := pkg.FindManifest(dir); manifestDir != "" {
+		return fmt.Sprintf("the package manifest %s exists but could not be loaded as a package",
+			filepath.Join(manifestDir, pkg.ManifestFile))
+	}
+	return fmt.Sprintf("no %s was found in %s or any parent directory; run 'ailang init package' there, or invoke ailang from inside the package",
+		pkg.ManifestFile, searched)
+}

--- a/internal/pipeline/package_resolver.go
+++ b/internal/pipeline/package_resolver.go
@@ -177,17 +177,24 @@ func packageSearchDir(explicitPackageDir, loaderBaseDir, entryFilename string) s
 	return loaderBaseDir
 }
 
-// entrySourceDir returns the directory holding the entry source file, or ""
-// when there is no real file on disk (code compiled from a string, a REPL
-// buffer, or a synthetic "<stdin>"-style name). Returning "" leaves the
-// caller on its previous CWD-anchored behaviour rather than inventing a
-// directory from a name that never named a file.
+// entrySourceDir returns the directory named by the entry source path, or ""
+// when the name does not locate a directory at all — a bare "service.ail"
+// (already relative to the CWD, so the existing base is correct) or a
+// synthetic label such as "<embedded>". Returning "" leaves the caller on its
+// previous CWD-anchored behaviour rather than inventing a directory from a
+// name that never named one.
+//
+// This is deliberately a PURE path computation: it does not touch the
+// filesystem. FindManifest is where filesystem truth belongs, and it already
+// stats as it walks upward, so probing here would add a second source of
+// truth and a filesystem read of user-supplied input on every compile for no
+// decision this function actually needs.
 func entrySourceDir(filename string) string {
 	if filename == "" {
 		return ""
 	}
-	st, err := os.Stat(filename)
-	if err != nil || st.IsDir() {
+	if !strings.ContainsRune(filename, filepath.Separator) && !strings.ContainsRune(filename, '/') {
+		// No directory component: "service.ail", "<embedded>", "_test.ail".
 		return ""
 	}
 	return filepath.Dir(filename)

--- a/internal/pipeline/pipeline_module.go
+++ b/internal/pipeline/pipeline_module.go
@@ -99,7 +99,9 @@ func runModuleWithContext(ctx context.Context, cfg Config, src Source) (Result, 
 	//
 	// cfg.PackageDir overrides "." so callers (e.g. the named-test harness)
 	// can resolve package manifests relative to the source file rather than CWD.
-	pkgSearchDir := loaderBaseDir
+	// The package manifest belongs to the SOURCE FILE, not the process CWD
+	// (ailang#671). See packageSearchDir.
+	pkgSearchDir := packageSearchDir(cfg.PackageDir, loaderBaseDir, src.Filename)
 	pkgResolver, err := tryLoadPackageResolver(pkgSearchDir)
 	if err != nil {
 		loadErr := fmt.Errorf("package resolution setup failed: %w", err)
@@ -111,6 +113,11 @@ func runModuleWithContext(ctx context.Context, cfg Config, src Source) (Result, 
 	}
 	if pkgResolver == nil {
 		pkgResolver = tryLoadSelfOnlyPackageResolver(pkgSearchDir)
+	}
+	if pkgResolver == nil {
+		// Diagnose here, where the search directory is known; the loader
+		// cannot know, and must not guess (ailang#671).
+		modLoader.SetPackageResolverAbsentReason(packageResolverAbsentReason(pkgSearchDir))
 	}
 	if pkgResolver != nil {
 		modLoader.SetPackageResolver(pkgResolver)

--- a/internal/pipeline/pipeline_module_entry_dir_test.go
+++ b/internal/pipeline/pipeline_module_entry_dir_test.go
@@ -203,8 +203,18 @@ func TestEntrySourceDir_IgnoresNonFiles(t *testing.T) {
 	if got := entrySourceDir("<stdin>"); got != "" {
 		t.Fatalf(`entrySourceDir("<stdin>") = %q, want ""`, got)
 	}
-	if got := entrySourceDir(dir); got != "" {
-		t.Fatalf("entrySourceDir(%q) on a directory = %q, want \"\"", dir, got)
+	if got := entrySourceDir("<embedded>"); got != "" {
+		t.Fatalf(`entrySourceDir("<embedded>") = %q, want ""`, got)
+	}
+	// A bare relative name is already relative to the CWD, so the existing
+	// base is correct and must not be overridden.
+	if got := entrySourceDir("service.ail"); got != "" {
+		t.Fatalf(`entrySourceDir("service.ail") = %q, want ""`, got)
+	}
+	// A name with a directory component yields it even if nothing is there:
+	// this is a pure path computation, and FindManifest owns filesystem truth.
+	if got := entrySourceDir(filepath.Join(dir, "does-not-exist.ail")); got != dir {
+		t.Fatalf("entrySourceDir on a nonexistent path = %q, want %q", got, dir)
 	}
 }
 

--- a/internal/pipeline/pipeline_module_entry_dir_test.go
+++ b/internal/pipeline/pipeline_module_entry_dir_test.go
@@ -1,0 +1,247 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Regression arms for ailang#671.
+//
+// The package manifest belongs to the SOURCE FILE, not to the process CWD.
+// Anchoring the manifest search at "." meant an installed AILANG CLI invoked
+// from anywhere but its own project root could not resolve its own package
+// imports, and the error blamed a missing ailang.toml/ailang.lock that were
+// sitting next to the source file.
+//
+// Note why the existing intra-package suite could not catch this: every arm in
+// pipeline_module_intra_pkg_test.go chdirs INTO the package before running, so
+// all of them exercise the cwd-inside case exclusively. These arms deliberately
+// run from a directory that is not the package and is not one of its parents.
+
+const entryDirManifest = `[package]
+name = "sunholo/entry_dir_test"
+version = "0.1.0"
+edition = "1"
+
+[exports]
+modules = ["sunholo/entry_dir_test/types", "sunholo/entry_dir_test/service"]
+`
+
+const entryDirTypes = `module sunholo/entry_dir_test/types
+
+export pure func name() -> string = "Foo"
+`
+
+// chdirTo moves the process into dir for the duration of the test. The whole
+// point of these arms is that the CWD is NOT the package, so getting this
+// wrong would make them vacuous.
+func chdirTo(t *testing.T, dir string) {
+	t.Helper()
+	original, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir %s: %v", dir, err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(original) })
+}
+
+// assertNotAncestor is the anti-vacuity floor: if the CWD were the package or
+// one of its parents, FindManifest would walk up and find the manifest anyway,
+// and these arms would pass on the unfixed code.
+func assertNotAncestor(t *testing.T, cwd, pkgDir string) {
+	t.Helper()
+	absCwd, err := filepath.Abs(cwd)
+	if err != nil {
+		t.Fatalf("abs cwd: %v", err)
+	}
+	absPkg, err := filepath.Abs(pkgDir)
+	if err != nil {
+		t.Fatalf("abs pkg: %v", err)
+	}
+	rel, err := filepath.Rel(absCwd, absPkg)
+	if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && rel != "." {
+		t.Fatalf("instrument failure: cwd %s is an ancestor of package %s (rel=%q), so this arm would pass without the fix", absCwd, absPkg, rel)
+	}
+}
+
+func TestPackageImport_ResolvesFromEntryFileDir_NotCWD(t *testing.T) {
+	pkgDir := t.TempDir()
+	elsewhere := t.TempDir()
+
+	mustWrite(t, pkgDir, "ailang.toml", entryDirManifest)
+	mustWrite(t, pkgDir, "types.ail", entryDirTypes)
+	mustWrite(t, pkgDir, "service.ail", `module sunholo/entry_dir_test/service
+
+import pkg/sunholo/entry_dir_test/types (name)
+
+export pure func greet() -> string = "Hello ${name()}"
+`)
+
+	chdirTo(t, elsewhere)
+	assertNotAncestor(t, elsewhere, pkgDir)
+
+	src := Source{Filename: filepath.Join(pkgDir, "service.ail")}
+	cfg := Config{Mode: ModeCheck, RelaxModules: true}
+
+	if _, err := Run(cfg, src); err != nil {
+		t.Fatalf("pkg/<self>/sibling import must resolve when the entry file is given by absolute path from an unrelated CWD; got: %v", err)
+	}
+}
+
+func TestRelativeImport_ResolvesFromEntryFileDir_NotCWD(t *testing.T) {
+	pkgDir := t.TempDir()
+	elsewhere := t.TempDir()
+
+	mustWrite(t, pkgDir, "ailang.toml", entryDirManifest)
+	mustWrite(t, pkgDir, "types.ail", entryDirTypes)
+	mustWrite(t, pkgDir, "service.ail", `module sunholo/entry_dir_test/service
+
+import ./types (name)
+
+export pure func greet() -> string = "Hello ${name()}"
+`)
+
+	chdirTo(t, elsewhere)
+	assertNotAncestor(t, elsewhere, pkgDir)
+
+	src := Source{Filename: filepath.Join(pkgDir, "service.ail")}
+	cfg := Config{Mode: ModeCheck, RelaxModules: true}
+
+	if _, err := Run(cfg, src); err != nil {
+		t.Fatalf("./sibling import must resolve when the entry file is given by absolute path from an unrelated CWD; got: %v", err)
+	}
+}
+
+// TestPackageResolverAbsentReason_DistinguishesTheTwoCauses is the arm that
+// pins the *message*. The shipped defect was not that an error was raised —
+// it was that ONE string was raised for two opposite situations, so a user
+// whose manifest existed was told to create it.
+func TestPackageResolverAbsentReason_DistinguishesTheTwoCauses(t *testing.T) {
+	noManifest := t.TempDir()
+	withManifest := t.TempDir()
+	mustWrite(t, withManifest, "ailang.toml", entryDirManifest)
+
+	missing := packageResolverAbsentReason(noManifest)
+	present := packageResolverAbsentReason(withManifest)
+
+	if missing == present {
+		t.Fatalf("one message for two opposite causes — this is the ailang#671 defect:\n  %s", missing)
+	}
+	if !strings.Contains(missing, "no ailang.toml was found") {
+		t.Fatalf("a genuinely absent manifest must say so; got: %s", missing)
+	}
+	if strings.Contains(present, "no ailang.toml was found") {
+		t.Fatalf("message claims no ailang.toml while one exists at %s; got: %s", withManifest, present)
+	}
+	if !strings.Contains(present, filepath.Join(withManifest, "ailang.toml")) {
+		t.Fatalf("message must name the manifest it could not load; got: %s", present)
+	}
+}
+
+// TestPackageResolverAbsentReason_NamesADirectoryThatExists takes the path
+// OUT of the product's own message and stats it, rather than re-deriving what
+// the message ought to say. A message naming a directory the user never
+// searched is exactly as useless as one naming a file that already exists.
+func TestPackageResolverAbsentReason_NamesADirectoryThatExists(t *testing.T) {
+	noManifest := t.TempDir()
+	msg := packageResolverAbsentReason(noManifest)
+
+	// Extract by delimiter, not by whitespace: a temp directory containing a
+	// space (plausible on Windows, invisible from darwin) would silently
+	// truncate a Fields-based split and this arm would pin the wrong string.
+	const lead, tail = "was found in ", " or any parent directory"
+	i := strings.Index(msg, lead)
+	j := strings.Index(msg, tail)
+	// Anti-vacuity floor: the assertions below are meaningless if the message
+	// does not carry a directory at all.
+	if i < 0 || j < 0 || j <= i+len(lead) {
+		t.Fatalf("instrument failure: message carries no directory between %q and %q, so nothing is being pinned; got: %s", lead, tail, msg)
+	}
+	found := msg[i+len(lead) : j]
+	if !filepath.IsAbs(found) {
+		t.Fatalf("message must name an absolute directory so it is unambiguous from any CWD; got %q in: %s", found, msg)
+	}
+
+	st, err := os.Stat(found)
+	if err != nil {
+		t.Fatalf("message names directory %s, which does not exist: %v", found, err)
+	}
+	if !st.IsDir() {
+		t.Fatalf("message names %s as a search directory, but it is not a directory", found)
+	}
+
+	absSearched, err := filepath.Abs(noManifest)
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	if found != absSearched {
+		t.Fatalf("message names %s but the directory actually searched was %s", found, absSearched)
+	}
+}
+
+// TestEntrySourceDir_IgnoresNonFiles pins the guard that keeps synthetic
+// entry names (REPL buffers, "<stdin>", code compiled from a string) on the
+// previous CWD-anchored behaviour instead of inventing a directory from a
+// name that never named a file.
+func TestEntrySourceDir_IgnoresNonFiles(t *testing.T) {
+	dir := t.TempDir()
+	real := filepath.Join(dir, "real.ail")
+	if err := os.WriteFile(real, []byte("module real\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if got := entrySourceDir(real); got != dir {
+		t.Fatalf("entrySourceDir(%q) = %q, want %q", real, got, dir)
+	}
+	if got := entrySourceDir(""); got != "" {
+		t.Fatalf(`entrySourceDir("") = %q, want ""`, got)
+	}
+	if got := entrySourceDir("<stdin>"); got != "" {
+		t.Fatalf(`entrySourceDir("<stdin>") = %q, want ""`, got)
+	}
+	if got := entrySourceDir(dir); got != "" {
+		t.Fatalf("entrySourceDir(%q) on a directory = %q, want \"\"", dir, got)
+	}
+}
+
+// TestUnresolvablePackageImport_ErrorNamesTheSearchedDir pins the whole chain
+// pipeline -> SetPackageResolverAbsentReason -> loader message. Without it the
+// diagnosis is computed and then dropped on the floor, and every arm above
+// still passes: the helper is tested, the wiring is not.
+func TestUnresolvablePackageImport_ErrorNamesTheSearchedDir(t *testing.T) {
+	srcDir := t.TempDir()
+	elsewhere := t.TempDir()
+
+	mustWrite(t, srcDir, "orphan.ail", `module orphan
+
+import pkg/some/other/thing (x)
+
+export pure func use() -> int = x()
+`)
+
+	chdirTo(t, elsewhere)
+	assertNotAncestor(t, elsewhere, srcDir)
+
+	src := Source{Filename: filepath.Join(srcDir, "orphan.ail")}
+	cfg := Config{Mode: ModeCheck, RelaxModules: true}
+
+	_, err := Run(cfg, src)
+	if err == nil {
+		t.Fatalf("instrument failure: importing pkg/some/other/thing with no manifest anywhere must fail")
+	}
+	msg := err.Error()
+
+	absSrc, _ := filepath.Abs(srcDir)
+	if !strings.Contains(msg, absSrc) {
+		t.Fatalf("error must name the directory actually searched (%s) so the user can see where ailang looked; got: %s", absSrc, msg)
+	}
+	// The shipped defect: the message instructed the user to create files
+	// without ever saying where it had looked for them.
+	if strings.Contains(msg, "requires ailang.toml and ailang.lock") {
+		t.Fatalf("error reverted to the ailang#671 wording, which asserts a cause it cannot know; got: %s", msg)
+	}
+}


### PR DESCRIPTION
## What

`ailang#671`: an AILANG program inside a package could not resolve its own imports unless `ailang` was invoked from that package's directory tree — and the error told the user to create an `ailang.toml`/`ailang.lock` that were sitting next to the source file.

The manifest search was anchored at `"."` (the process CWD) while `FindManifest` walks **upward** from wherever it starts. From inside the project it found the manifest; from anywhere else it found nothing, wired no package resolver, and every `pkg/...` **and** `./sibling` import failed. That is the normal case for an installed CLI, which users invoke from wherever their data is.

## Reproduction — a differential whose only variable is the working directory

Same file, same absolute path, at HEAD:

| arm | cwd | result before |
|---|---|---|
| A | inside the package | resolves |
| B | `$HOME` | **fails** |
| C | a subdirectory of the package | resolves (`FindManifest` walks up) |
| D | `$HOME`, with a real `ailang.lock` from `ailang lock` (rc=0) | **fails identically** |

Arm D is what makes the message provably false: both files exist and it still says to create them. And arms B and E (a project with genuinely no manifest anywhere) printed the **identical string** — one message for two opposite situations, so it could not distinguish "you are standing in the wrong directory" from "you have no package".

## Fix — two parts, one root cause

1. **`packageSearchDir()`** anchors the search at the entry source file's directory. Since `FindManifest` walks upward this is a superset of the old behaviour for any file inside its own project; an explicit `PackageDir` still wins; and a synthetic entry name (`<stdin>`, a REPL buffer, code compiled from a string) keeps the previous CWD-anchored behaviour rather than having a directory invented from a name that never named a file.
2. **The loader no longer asserts a cause it cannot know.** The pipeline diagnoses where it searched; the loader reports it. A missing manifest and one that exists but could not be loaded are different user actions and now read differently.

The named-test harness already passed `PackageDir` for exactly this reason (`internal/testing/executor.go`), with a comment naming this hazard. Every other entry point — `run`, `check`, `serve-api`, the MCP server, `embed` — did not. Guard the helper, miss the call site.

Why the existing intra-package suite could not catch it: all three arms in `pipeline_module_intra_pkg_test.go` `chdir` **into** the package before running, so they exercise the cwd-inside case exclusively. The new arms deliberately run from a directory that is neither the package nor one of its parents, with an anti-vacuity floor (`assertNotAncestor`) asserting exactly that — without it these arms would pass on the unfixed code.

## Mutation drills

Each asserted **LANDED** (sha256) and **BUILDS** (`go build` rc=0) *before* any test result was read; sources restored from copies (never `git checkout --`) and verified byte-identical.

| mutant | red set | criterion |
|---|---|---|
| M1 `packageSearchDir` reverts to CWD-anchored | 3 arms: `PackageImport_ResolvesFromEntryFileDir_NotCWD`, `RelativeImport_…`, `UnresolvablePackageImport_ErrorNamesTheSearchedDir` | broad-blast — set membership, every member explained |
| M2 one message for both causes (the shipped defect) | 3 arms: `DistinguishesTheTwoCauses`, `NamesADirectoryThatExists`, `ErrorNamesTheSearchedDir` | broad-blast — same |
| M3 `entrySourceDir` drops the not-a-real-file guard | 1 arm | single-test — inverse `-skip` **rc=0**, sole killer |
| M4 loader drops the plumbed reason | 1 arm | single-test — inverse `-skip` **rc=0**, sole killer |

M1/M2 are broad-blast, so the `rc=0` inverse criterion is inapplicable; their red sets were **enumerated by running them**, not predicted, and every member is explained by the mutant's phenotype.

**M4 exists because the helper was tested and the wiring was not.** Without that arm the diagnosis is computed and then dropped on the floor, and every other arm still passes.

## Gates

`fmt-check` · `vet` · `check-file-sizes` · `check-boundaries` · `check-changelog` · `test-check-changelog` · `check-skills` — all rc=0. `go test` rc=0 on `internal/pipeline`, `internal/loader`, `internal/pkg`, `internal/testing`, `cmd/ailang`. `go build ./internal/... ./cmd/ailang` rc=0 (`go build ./...` fails at base on `cmd/wasm`, pre-existing on untouched dev).

All local gates ran on **darwin/arm64**; the linux and windows legs are unrun locally and settled by CI. The diff is path-handling code, which is per-GOOS sensitive, so one arm's path extraction was deliberately changed from `strings.Fields` to delimiter-based — a temp directory containing a space would silently truncate a whitespace split, which is plausible on Windows and invisible from darwin.

⚠️ **`check-file-sizes` was red at first and it was mine, not pre-existing** — the baseline on untouched `origin/dev` is 792 lines / rc=0, and the first draft pushed `pipeline_module.go` to 813. Resolved by moving the derivation into `package_resolver.go` where the rest of this logic lives; the file now sits at **799**, one line under the cap, so it is a split candidate for a future iteration.

Fixes #671

🤖 Generated with [Claude Code](https://claude.com/claude-code)
