### PR TITLE
fix(cli): `editor install vscode` produced an extension VS Code refuses to load (#694)

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,44 @@
 
 ## [Unreleased]
 
+### Fixed — `ailang editor install vscode` now installs an extension VS Code actually loads
+
+[ailang#694](https://github.com/sunholo-data/ailang/issues/694) (downstream-consumer
+report, mission iteration 232).
+
+`ailang editor install vscode` reported success while producing an extension VS
+Code refused to load: no syntax highlighting, no LSP, in every window and every
+workspace.
+
+Since VS Code 1.74 (profiles), `~/.vscode/extensions/extensions.json` is not a
+cache — it is the registry of which user extensions are installed. The installer
+predated that change and got it wrong in both directions at once. It dropped an
+*unversioned* folder at `~/.vscode/extensions/ailang`, which has no registry
+entry and is therefore never scanned; and it then called
+`invalidateVSCodeExtensionCache` to "force a metadata re-scan", which **removed**
+the `sunholo.ailang` entry. Removing an entry is an uninstall, so VS Code
+flagged the leftover folder in `.obsolete` and skipped it. `ailang editor status`
+verified the install with `os.Stat` on the folder, so a dead install still
+reported `✓`.
+
+The same helper is called by `uninstall`, where removing the entry is exactly
+right. One function, correct on one caller and inverted on the other — the name
+is what made that possible, so it is now `deregisterVSCodeExtension` and only
+uninstall may call it.
+
+`install` now builds a VSIX from the embedded assets (`archive/zip`; no node or
+`vsce` dependency) and hands it to the editor's own CLI — probing `code`,
+`code-insiders`, `cursor`, `windsurf`, `codium` — so VS Code performs the
+registration. With no editor CLI on PATH it installs into a **versioned** folder
+(`sunholo.ailang-<version>`) and **writes** the registry entry itself, clearing
+any stale `.obsolete` flag and removing the old unregistered folder. A failed CLI
+install falls back loudly rather than silently.
+
+`ailang editor status` now reports what the editor will actually load: it asks
+`code --list-extensions` when a CLI is present, and otherwise requires a registry
+entry whose `relativeLocation` exists and is not flagged obsolete. A folder with
+no entry is now reported as broken, naming the fix, instead of as installed.
+
 ### Fixed — package imports now resolve from the source file's directory, not the process CWD
 
 [ailang#671](https://github.com/sunholo-data/ailang/issues/671) (downstream-consumer

--- a/cmd/ailang/editor.go
+++ b/cmd/ailang/editor.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"embed"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -101,181 +101,6 @@ func uninstallEditor(editor string) {
 		fmt.Fprintf(os.Stderr, "%s: unsupported editor '%s'\n", red("Error"), editor)
 		os.Exit(1)
 	}
-}
-
-func installVSCode() {
-	fmt.Printf("%s Installing AILANG VS Code extension...\n", cyan("→"))
-
-	// Determine VS Code extensions directory
-	home, err := os.UserHomeDir()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s: cannot determine home directory: %v\n", red("Error"), err)
-		os.Exit(1)
-	}
-
-	extDir := filepath.Join(home, ".vscode", "extensions", "ailang")
-
-	// Remove old installation if exists
-	if _, err := os.Stat(extDir); err == nil {
-		fmt.Printf("  Removing old installation...\n")
-		if err := os.RemoveAll(extDir); err != nil {
-			fmt.Fprintf(os.Stderr, "%s: cannot remove old extension: %v\n", red("Error"), err)
-			os.Exit(1)
-		}
-	}
-
-	// Create extension directory structure
-	syntaxDir := filepath.Join(extDir, "syntaxes")
-	if err := os.MkdirAll(syntaxDir, 0755); err != nil {
-		fmt.Fprintf(os.Stderr, "%s: cannot create directory: %v\n", red("Error"), err)
-		os.Exit(1)
-	}
-
-	// Copy embedded files
-	files := []struct {
-		src string
-		dst string
-	}{
-		{"editor_assets/vscode/package.json", filepath.Join(extDir, "package.json")},
-		{"editor_assets/vscode/language-configuration.json", filepath.Join(extDir, "language-configuration.json")},
-		{"editor_assets/vscode/extension.js", filepath.Join(extDir, "extension.js")},
-		{"editor_assets/vscode/syntaxes/ailang.tmLanguage.json", filepath.Join(syntaxDir, "ailang.tmLanguage.json")},
-	}
-
-	for _, f := range files {
-		content, err := editorAssets.ReadFile(f.src)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s: cannot read embedded file %s: %v\n", red("Error"), f.src, err)
-			os.Exit(1)
-		}
-		if err := os.WriteFile(f.dst, content, 0644); err != nil {
-			fmt.Fprintf(os.Stderr, "%s: cannot write file %s: %v\n", red("Error"), f.dst, err)
-			os.Exit(1)
-		}
-	}
-
-	fmt.Printf("%s Extension installed to %s\n", green("✓"), extDir)
-
-	// Invalidate VS Code's extension cache so it re-scans on next start.
-	// Without this, the cache file pins the *previous* version's manifest
-	// (incl. missing `main` entry from pre-0.3.0 builds → LSP doesn't
-	// activate). Failure here is non-fatal; we log and continue.
-	if removed, err := invalidateVSCodeExtensionCache(home, "sunholo.ailang"); err != nil {
-		fmt.Printf("  %s could not refresh VS Code extension cache: %v\n", red("⚠"), err)
-		fmt.Println("    You may need to fully quit VS Code (Cmd+Q) and reopen to pick up the new version.")
-	} else if removed {
-		fmt.Printf("  %s refreshed VS Code's extensions.json cache (forces metadata re-scan)\n", green("✓"))
-	}
-
-	fmt.Println()
-	fmt.Println("What you get:")
-	fmt.Println("  • Syntax highlighting + bracket matching for .ail files")
-	fmt.Println("  • Language Server (diagnostics on save, hover types,")
-	fmt.Println("    go-to-definition, find-references, document symbols)")
-	fmt.Println("    — spawns `ailang lsp --stdio` automatically")
-	fmt.Println()
-	fmt.Println("Next steps:")
-	fmt.Println("  1. Fully quit VS Code (Cmd+Q on Mac, File→Exit elsewhere) and reopen")
-	fmt.Println("     (a window reload is NOT enough on first install/upgrade)")
-	fmt.Println("  2. Open any .ail file — diagnostics appear inline on save")
-	fmt.Println()
-	fmt.Println("Troubleshooting:")
-	fmt.Println("  • If no diagnostics: check `which ailang` works (binary on PATH)")
-	fmt.Println("  • Errors surface in View → Output → 'AILANG Language Server'")
-}
-
-// invalidateVSCodeExtensionCache removes the given extension ID from
-// VS Code's ~/.vscode/extensions/extensions.json manifest cache. VS Code
-// reads this file on startup; an out-of-date entry there causes the UI
-// to show the previous version's metadata even after the on-disk
-// package.json has been updated.
-//
-// Returns (true, nil) when an entry was removed, (false, nil) when no
-// matching entry existed, or an error if the file couldn't be read/written.
-func invalidateVSCodeExtensionCache(home, extID string) (bool, error) {
-	cachePath := filepath.Join(home, ".vscode", "extensions", "extensions.json")
-	data, err := os.ReadFile(cachePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			// No cache yet → first-ever extension install. Nothing to invalidate.
-			return false, nil
-		}
-		return false, fmt.Errorf("read %s: %w", cachePath, err)
-	}
-
-	var entries []map[string]interface{}
-	if err := json.Unmarshal(data, &entries); err != nil {
-		return false, fmt.Errorf("parse %s: %w", cachePath, err)
-	}
-
-	want := strings.ToLower(extID)
-	kept := make([]map[string]interface{}, 0, len(entries))
-	removed := false
-	for _, e := range entries {
-		id := ""
-		if ident, ok := e["identifier"].(map[string]interface{}); ok {
-			if s, ok := ident["id"].(string); ok {
-				id = s
-			}
-		}
-		if id == "" {
-			if s, ok := e["id"].(string); ok {
-				id = s
-			}
-		}
-		if strings.ToLower(id) == want {
-			removed = true
-			continue
-		}
-		kept = append(kept, e)
-	}
-
-	if !removed {
-		return false, nil
-	}
-
-	out, err := json.Marshal(kept)
-	if err != nil {
-		return false, fmt.Errorf("encode: %w", err)
-	}
-	// Atomic write so a crash mid-write doesn't corrupt the cache.
-	tmpPath := cachePath + ".ailang-tmp"
-	if err := os.WriteFile(tmpPath, out, 0o644); err != nil {
-		return false, fmt.Errorf("write tmp: %w", err)
-	}
-	if err := os.Rename(tmpPath, cachePath); err != nil {
-		return false, fmt.Errorf("rename: %w", err)
-	}
-	return true, nil
-}
-
-func uninstallVSCode() {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s: cannot determine home directory: %v\n", red("Error"), err)
-		os.Exit(1)
-	}
-
-	extDir := filepath.Join(home, ".vscode", "extensions", "ailang")
-
-	if _, err := os.Stat(extDir); os.IsNotExist(err) {
-		fmt.Println("VS Code extension not installed")
-		return
-	}
-
-	if err := os.RemoveAll(extDir); err != nil {
-		fmt.Fprintf(os.Stderr, "%s: cannot remove extension: %v\n", red("Error"), err)
-		os.Exit(1)
-	}
-
-	// Drop the matching entry from VS Code's extensions.json cache too —
-	// otherwise a stale entry points at the now-deleted dir.
-	if _, err := invalidateVSCodeExtensionCache(home, "sunholo.ailang"); err != nil {
-		fmt.Printf("  %s could not refresh VS Code extension cache: %v\n", red("⚠"), err)
-	}
-
-	fmt.Printf("%s VS Code extension uninstalled\n", green("✓"))
-	fmt.Println("  Fully quit VS Code (Cmd+Q) and reopen to complete the removal.")
 }
 
 func installVim(isNeovim bool) {
@@ -389,12 +214,21 @@ func checkEditorStatus() {
 	fmt.Println("AILANG Editor Status")
 	fmt.Println()
 
-	// VS Code
-	vscodeDir := filepath.Join(home, ".vscode", "extensions", "ailang")
-	if _, err := os.Stat(vscodeDir); err == nil {
-		fmt.Printf("  %s VS Code: %s\n", green("✓"), vscodeDir)
+	// VS Code. Ask the editor whether it will actually load the extension —
+	// stat'ing the folder reports ✓ for an install VS Code has deregistered.
+	if m, mErr := readVSCodeManifest(); mErr != nil {
+		fmt.Printf("  %s VS Code: cannot read embedded extension manifest: %v\n", red("✗"), mErr)
 	} else {
-		fmt.Printf("  %s VS Code: not installed\n", yellow("○"))
+		st := vscodeExtensionStatus(home, m, exec.LookPath, execRunner)
+		if st.Installed {
+			version := st.Version
+			if version == "" {
+				version = "unknown version"
+			}
+			fmt.Printf("  %s VS Code: %s@%s (%s)\n", green("✓"), m.extID(), version, st.Detail)
+		} else {
+			fmt.Printf("  %s VS Code: %s\n", yellow("○"), st.Detail)
+		}
 	}
 
 	// Vim

--- a/cmd/ailang/editor_vscode.go
+++ b/cmd/ailang/editor_vscode.go
@@ -1,0 +1,747 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// VS Code stopped treating ~/.vscode/extensions/extensions.json as a cache in
+// 1.74 (profiles): it is now the registry of which user extensions are
+// installed. Two consequences drive everything in this file:
+//
+//   - Dropping a folder into ~/.vscode/extensions without a matching registry
+//     entry installs nothing. VS Code never scans it.
+//   - REMOVING an entry is an uninstall. It makes VS Code flag the leftover
+//     folder in .obsolete and skip it in every window.
+//
+// So the primary install path hands a VSIX to the editor's own CLI and lets
+// VS Code do the registration. The folder fallback exists only for machines
+// with no editor CLI on PATH, and it WRITES a registry entry — it never
+// removes one.
+
+// vscodeCLIs is the probe order for an editor CLI that can install a VSIX.
+// All are VS Code derivatives and accept --install-extension.
+var vscodeCLIs = []string{"code", "code-insiders", "cursor", "windsurf", "codium"}
+
+// vscodeAssets maps each embedded asset to its path inside the VSIX, relative
+// to the archive's extension/ directory.
+//
+// These are ZIP entry names, so they are always forward-slash separated —
+// filepath.Join would emit backslashes on Windows and produce an archive whose
+// entries VS Code cannot find.
+var vscodeAssets = []struct{ src, rel string }{
+	{"editor_assets/vscode/package.json", "package.json"},
+	{"editor_assets/vscode/language-configuration.json", "language-configuration.json"},
+	{"editor_assets/vscode/extension.js", "extension.js"},
+	{"editor_assets/vscode/syntaxes/ailang.tmLanguage.json", "syntaxes/ailang.tmLanguage.json"},
+}
+
+// vscodeManifest is the subset of the extension's package.json that the
+// installer needs. The embedded package.json is the single source of truth for
+// the extension's identity and version — nothing here is hardcoded.
+type vscodeManifest struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+	Description string `json:"description"`
+	Version     string `json:"version"`
+	Publisher   string `json:"publisher"`
+	Engines     struct {
+		VSCode string `json:"vscode"`
+	} `json:"engines"`
+}
+
+// extID is the identifier VS Code keys the registry by, e.g. "sunholo.ailang".
+func (m vscodeManifest) extID() string { return m.Publisher + "." + m.Name }
+
+// folder is the on-disk directory name VS Code uses for an installed
+// extension, e.g. "sunholo.ailang-0.3.0". It doubles as relativeLocation in
+// the registry, so the two can never disagree.
+func (m vscodeManifest) folder() string { return m.extID() + "-" + m.Version }
+
+// readVSCodeManifest parses the embedded extension package.json.
+//
+// A missing name/publisher/version is fatal rather than defaulted: those three
+// fields decide the extension ID and the versioned folder name, and an install
+// that guessed them would land somewhere VS Code does not look.
+func readVSCodeManifest() (vscodeManifest, error) {
+	var m vscodeManifest
+	data, err := editorAssets.ReadFile("editor_assets/vscode/package.json")
+	if err != nil {
+		return m, fmt.Errorf("read embedded package.json: %w", err)
+	}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return m, fmt.Errorf("parse embedded package.json: %w", err)
+	}
+	var missing []string
+	if m.Name == "" {
+		missing = append(missing, "name")
+	}
+	if m.Publisher == "" {
+		missing = append(missing, "publisher")
+	}
+	if m.Version == "" {
+		missing = append(missing, "version")
+	}
+	if len(missing) > 0 {
+		return m, fmt.Errorf("embedded package.json is missing %s", strings.Join(missing, ", "))
+	}
+	return m, nil
+}
+
+// --- VSIX packaging -------------------------------------------------------
+
+// A VSIX is an OPC zip. VS Code needs three things at the root: the content
+// types part, the manifest, and the extension payload under extension/.
+
+const vsixContentTypes = `<?xml version="1.0" encoding="utf-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="json" ContentType="application/json"/>
+  <Default Extension="vsixmanifest" ContentType="text/xml"/>
+  <Default Extension="js" ContentType="application/javascript"/>
+  <Default Extension="xml" ContentType="text/xml"/>
+</Types>
+`
+
+// vsixManifestXML renders extension.vsixmanifest for the given manifest.
+func vsixManifestXML(m vscodeManifest) ([]byte, error) {
+	esc := func(s string) (string, error) {
+		var b bytes.Buffer
+		if err := xml.EscapeText(&b, []byte(s)); err != nil {
+			return "", err
+		}
+		return b.String(), nil
+	}
+	display, err := esc(m.DisplayName)
+	if err != nil {
+		return nil, fmt.Errorf("escape displayName: %w", err)
+	}
+	desc, err := esc(m.Description)
+	if err != nil {
+		return nil, fmt.Errorf("escape description: %w", err)
+	}
+	engine, err := esc(m.Engines.VSCode)
+	if err != nil {
+		return nil, fmt.Errorf("escape engine: %w", err)
+	}
+	id, err := esc(m.Name)
+	if err != nil {
+		return nil, fmt.Errorf("escape name: %w", err)
+	}
+	publisher, err := esc(m.Publisher)
+	if err != nil {
+		return nil, fmt.Errorf("escape publisher: %w", err)
+	}
+	version, err := esc(m.Version)
+	if err != nil {
+		return nil, fmt.Errorf("escape version: %w", err)
+	}
+	if engine == "" {
+		engine = "*"
+	}
+
+	var b bytes.Buffer
+	fmt.Fprint(&b, xml.Header)
+	fmt.Fprint(&b, `<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">`+"\n")
+	fmt.Fprint(&b, "  <Metadata>\n")
+	fmt.Fprintf(&b, "    <Identity Language=\"en-US\" Id=%q Version=%q Publisher=%q/>\n", id, version, publisher)
+	fmt.Fprintf(&b, "    <DisplayName>%s</DisplayName>\n", display)
+	fmt.Fprintf(&b, "    <Description xml:space=\"preserve\">%s</Description>\n", desc)
+	fmt.Fprint(&b, "  </Metadata>\n")
+	fmt.Fprint(&b, "  <Installation>\n")
+	fmt.Fprint(&b, "    <InstallationTarget Id=\"Microsoft.VisualStudio.Code\"/>\n")
+	fmt.Fprint(&b, "  </Installation>\n")
+	fmt.Fprint(&b, "  <Dependencies/>\n")
+	fmt.Fprint(&b, "  <Assets>\n")
+	fmt.Fprint(&b, "    <Asset Type=\"Microsoft.VisualStudio.Code.Manifest\" Path=\"extension/package.json\" Addressable=\"true\"/>\n")
+	fmt.Fprint(&b, "  </Assets>\n")
+	fmt.Fprintf(&b, "  <Properties>\n    <Property Id=\"Microsoft.VisualStudio.Code.Engine\" Value=%q/>\n  </Properties>\n", engine)
+	fmt.Fprint(&b, "</PackageManifest>\n")
+	return b.Bytes(), nil
+}
+
+// buildVSIX assembles the installable archive in memory from the embedded
+// assets. Go's archive/zip is enough — no node or vsce dependency.
+func buildVSIX(m vscodeManifest) ([]byte, error) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	add := func(name string, data []byte) error {
+		w, err := zw.Create(name)
+		if err != nil {
+			return fmt.Errorf("create vsix entry %s: %w", name, err)
+		}
+		if _, err := w.Write(data); err != nil {
+			return fmt.Errorf("write vsix entry %s: %w", name, err)
+		}
+		return nil
+	}
+
+	if err := add("[Content_Types].xml", []byte(vsixContentTypes)); err != nil {
+		return nil, err
+	}
+	manifest, err := vsixManifestXML(m)
+	if err != nil {
+		return nil, err
+	}
+	if err := add("extension.vsixmanifest", manifest); err != nil {
+		return nil, err
+	}
+	for _, a := range vscodeAssets {
+		data, err := editorAssets.ReadFile(a.src)
+		if err != nil {
+			return nil, fmt.Errorf("read embedded %s: %w", a.src, err)
+		}
+		if err := add("extension/"+a.rel, data); err != nil {
+			return nil, err
+		}
+	}
+	if err := zw.Close(); err != nil {
+		return nil, fmt.Errorf("finalize vsix: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// --- registry (extensions.json) -------------------------------------------
+
+func vscodeExtRoot(home string) string { return filepath.Join(home, ".vscode", "extensions") }
+func vscodeRegistryPath(home string) string {
+	return filepath.Join(vscodeExtRoot(home), "extensions.json")
+}
+func vscodeObsoletePath(home string) string {
+	return filepath.Join(vscodeExtRoot(home), ".obsolete")
+}
+
+// readVSCodeRegistry loads extensions.json as raw maps so that entries we do
+// not own keep every field they arrived with.
+func readVSCodeRegistry(path string) ([]map[string]interface{}, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil, nil
+	}
+	var entries []map[string]interface{}
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return entries, nil
+}
+
+func writeVSCodeRegistry(path string, entries []map[string]interface{}) error {
+	if entries == nil {
+		entries = []map[string]interface{}{}
+	}
+	out, err := json.Marshal(entries)
+	if err != nil {
+		return fmt.Errorf("encode registry: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", filepath.Dir(path), err)
+	}
+	// Atomic write so a crash mid-write cannot corrupt the registry — a
+	// truncated extensions.json would deregister every extension on the box.
+	tmp := path + ".ailang-tmp"
+	if err := os.WriteFile(tmp, out, 0o644); err != nil {
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}
+
+// registryEntryID extracts an entry's extension ID, tolerating both the
+// nested identifier.id form VS Code writes and a flat id.
+func registryEntryID(e map[string]interface{}) string {
+	if ident, ok := e["identifier"].(map[string]interface{}); ok {
+		if s, ok := ident["id"].(string); ok && s != "" {
+			return s
+		}
+	}
+	if s, ok := e["id"].(string); ok {
+		return s
+	}
+	return ""
+}
+
+// vscodeURIPath renders an absolute filesystem path the way VS Code stores it
+// in location.path: a URI path, so a Windows drive letter is preceded by "/".
+func vscodeURIPath(abs string) string {
+	slashed := filepath.ToSlash(abs)
+	if !strings.HasPrefix(slashed, "/") {
+		return "/" + slashed
+	}
+	return slashed
+}
+
+// registerVSCodeExtension adds or replaces this extension's registry entry.
+//
+// This is the inverse of deregisterVSCodeExtension and the only correct thing
+// to do on an install path: without an entry, the extension folder is inert.
+func registerVSCodeExtension(home string, m vscodeManifest, installedAtMillis int64) error {
+	path := vscodeRegistryPath(home)
+	entries, err := readVSCodeRegistry(path)
+	if err != nil {
+		return err
+	}
+	want := strings.ToLower(m.extID())
+	kept := make([]map[string]interface{}, 0, len(entries)+1)
+	for _, e := range entries {
+		if strings.EqualFold(registryEntryID(e), want) {
+			continue // replaced below
+		}
+		kept = append(kept, e)
+	}
+	abs := filepath.Join(vscodeExtRoot(home), m.folder())
+	kept = append(kept, map[string]interface{}{
+		"identifier": map[string]interface{}{"id": m.extID()},
+		"version":    m.Version,
+		"location": map[string]interface{}{
+			"$mid":   1,
+			"path":   vscodeURIPath(abs),
+			"scheme": "file",
+		},
+		"relativeLocation": m.folder(),
+		"metadata": map[string]interface{}{
+			"installedTimestamp":   installedAtMillis,
+			"source":               "vsix",
+			"publisherDisplayName": m.Publisher,
+			"targetPlatform":       "undefined",
+			"updated":              false,
+			"private":              false,
+			"isPreReleaseVersion":  false,
+			"hasPreReleaseVersion": false,
+		},
+	})
+	return writeVSCodeRegistry(path, kept)
+}
+
+// deregisterVSCodeExtension removes the extension's entry from
+// extensions.json.
+//
+// Naming matters here: an earlier version of this function was called
+// invalidateVSCodeExtensionCache and was called on the INSTALL path to "force a
+// metadata re-scan". Since VS Code 1.74 removing an entry is an uninstall, so
+// that call was deregistering the extension it had just written. Only
+// uninstall may call this.
+//
+// Returns (true, nil) when an entry was removed, (false, nil) when none
+// matched.
+func deregisterVSCodeExtension(home, extID string) (bool, error) {
+	path := vscodeRegistryPath(home)
+	entries, err := readVSCodeRegistry(path)
+	if err != nil {
+		return false, err
+	}
+	if entries == nil {
+		return false, nil
+	}
+	want := strings.ToLower(extID)
+	kept := make([]map[string]interface{}, 0, len(entries))
+	removed := false
+	for _, e := range entries {
+		if strings.EqualFold(registryEntryID(e), want) {
+			removed = true
+			continue
+		}
+		kept = append(kept, e)
+	}
+	if !removed {
+		return false, nil
+	}
+	if err := writeVSCodeRegistry(path, kept); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// clearVSCodeObsolete drops folder names from .obsolete, the list VS Code uses
+// to skip directories it believes were uninstalled. A folder we are installing
+// into must not be on it.
+func clearVSCodeObsolete(home string, folders ...string) (bool, error) {
+	path := vscodeObsoletePath(home)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read %s: %w", path, err)
+	}
+	var flags map[string]bool
+	if err := json.Unmarshal(data, &flags); err != nil {
+		return false, fmt.Errorf("parse %s: %w", path, err)
+	}
+	changed := false
+	for _, f := range folders {
+		if _, ok := flags[f]; ok {
+			delete(flags, f)
+			changed = true
+		}
+	}
+	if !changed {
+		return false, nil
+	}
+	out, err := json.Marshal(flags)
+	if err != nil {
+		return false, fmt.Errorf("encode obsolete: %w", err)
+	}
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		return false, fmt.Errorf("write %s: %w", path, err)
+	}
+	return true, nil
+}
+
+// --- install / uninstall / status -----------------------------------------
+
+// lookPathFunc and cmdRunner are seams so the install logic can be exercised
+// without a real editor on the box.
+type lookPathFunc func(string) (string, error)
+type cmdRunner func(name string, args ...string) ([]byte, error)
+
+func execRunner(name string, args ...string) ([]byte, error) {
+	out, err := exec.Command(name, args...).CombinedOutput()
+	return out, err
+}
+
+// findVSCodeCLI returns the first editor CLI found on PATH.
+func findVSCodeCLI(look lookPathFunc) (name, path string, found bool) {
+	for _, c := range vscodeCLIs {
+		if p, err := look(c); err == nil && p != "" {
+			return c, p, true
+		}
+	}
+	return "", "", false
+}
+
+// vscodeInstallResult describes what an install actually did, so the caller
+// can report it truthfully rather than assuming success.
+type vscodeInstallResult struct {
+	Method       string // "cli" or "folder"
+	CLIName      string // editor CLI used, when Method == "cli"
+	Folder       string // extension folder, when Method == "folder"
+	LegacyPurged bool   // the pre-fix unversioned ~/.vscode/extensions/ailang was removed
+	Warnings     []string
+}
+
+// legacyVSCodeFolder is the unversioned directory pre-fix builds installed
+// into. VS Code never registered it, so it is dead weight at best and an
+// ID conflict with a real install at worst.
+const legacyVSCodeFolder = "ailang"
+
+// installVSCodeExtension installs the extension and returns what it did.
+//
+// Order: hand a VSIX to the editor's own CLI if there is one (VS Code then
+// owns registration, which is the only way to be sure it is correct), else
+// write a versioned folder AND its registry entry.
+func installVSCodeExtension(home string, m vscodeManifest, look lookPathFunc, run cmdRunner, installedAtMillis int64) (vscodeInstallResult, error) {
+	var res vscodeInstallResult
+
+	// The pre-fix install site. Removing it is safe precisely because VS Code
+	// never registered it.
+	legacy := filepath.Join(vscodeExtRoot(home), legacyVSCodeFolder)
+	if _, err := os.Stat(legacy); err == nil {
+		if err := os.RemoveAll(legacy); err != nil {
+			res.Warnings = append(res.Warnings, fmt.Sprintf("could not remove stale %s: %v", legacy, err))
+		} else {
+			res.LegacyPurged = true
+		}
+	}
+	if _, err := clearVSCodeObsolete(home, legacyVSCodeFolder, m.folder()); err != nil {
+		res.Warnings = append(res.Warnings, fmt.Sprintf("could not update .obsolete: %v", err))
+	}
+
+	if cliName, cliPath, ok := findVSCodeCLI(look); ok {
+		vsix, err := buildVSIX(m)
+		if err != nil {
+			return res, fmt.Errorf("build vsix: %w", err)
+		}
+		tmp, err := os.CreateTemp("", m.folder()+"-*.vsix")
+		if err != nil {
+			return res, fmt.Errorf("create temp vsix: %w", err)
+		}
+		tmpName := tmp.Name()
+		defer func() { _ = os.Remove(tmpName) }()
+		if _, err := tmp.Write(vsix); err != nil {
+			_ = tmp.Close()
+			return res, fmt.Errorf("write temp vsix: %w", err)
+		}
+		if err := tmp.Close(); err != nil {
+			return res, fmt.Errorf("close temp vsix: %w", err)
+		}
+		out, err := run(cliPath, "--install-extension", tmpName, "--force")
+		if err == nil {
+			res.Method = "cli"
+			res.CLIName = cliName
+			return res, nil
+		}
+		// Fall through to the folder install, but say why — a silent
+		// downgrade is how the original defect stayed invisible.
+		res.Warnings = append(res.Warnings, fmt.Sprintf("%s --install-extension failed (%v); falling back to a direct install: %s",
+			cliName, err, strings.TrimSpace(string(out))))
+	}
+
+	folder := m.folder()
+	extDir := filepath.Join(vscodeExtRoot(home), folder)
+	if err := os.RemoveAll(extDir); err != nil {
+		return res, fmt.Errorf("remove previous %s: %w", extDir, err)
+	}
+	for _, a := range vscodeAssets {
+		data, err := editorAssets.ReadFile(a.src)
+		if err != nil {
+			return res, fmt.Errorf("read embedded %s: %w", a.src, err)
+		}
+		dst := filepath.Join(extDir, filepath.FromSlash(a.rel))
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return res, fmt.Errorf("create %s: %w", filepath.Dir(dst), err)
+		}
+		if err := os.WriteFile(dst, data, 0o644); err != nil {
+			return res, fmt.Errorf("write %s: %w", dst, err)
+		}
+	}
+	if err := registerVSCodeExtension(home, m, installedAtMillis); err != nil {
+		return res, fmt.Errorf("register extension: %w", err)
+	}
+	res.Method = "folder"
+	res.Folder = folder
+	return res, nil
+}
+
+// vscodeStatus is what `ailang editor status` reports for VS Code.
+type vscodeStatus struct {
+	Installed bool
+	Version   string
+	Detail    string
+}
+
+// vscodeExtensionStatus reports whether VS Code will actually load the
+// extension.
+//
+// It asks the editor CLI when there is one, and otherwise reads the registry —
+// never a bare os.Stat of the folder, which is what let a dead install report
+// a green checkmark.
+func vscodeExtensionStatus(home string, m vscodeManifest, look lookPathFunc, run cmdRunner) vscodeStatus {
+	if cliName, cliPath, ok := findVSCodeCLI(look); ok {
+		out, err := run(cliPath, "--list-extensions", "--show-versions")
+		if err == nil {
+			for _, line := range strings.Split(string(out), "\n") {
+				line = strings.TrimSpace(line)
+				id, version, _ := strings.Cut(line, "@")
+				if strings.EqualFold(id, m.extID()) {
+					return vscodeStatus{Installed: true, Version: version, Detail: "registered with " + cliName}
+				}
+			}
+			return vscodeStatus{Detail: "not installed (" + cliName + " --list-extensions)"}
+		}
+		// CLI present but unusable — fall through to the registry rather than
+		// reporting a state we did not establish.
+	}
+
+	entries, err := readVSCodeRegistry(vscodeRegistryPath(home))
+	if err != nil {
+		return vscodeStatus{Detail: fmt.Sprintf("cannot read extensions.json: %v", err)}
+	}
+	for _, e := range entries {
+		if !strings.EqualFold(registryEntryID(e), m.extID()) {
+			continue
+		}
+		version, _ := e["version"].(string)
+		rel, _ := e["relativeLocation"].(string)
+		if rel == "" {
+			return vscodeStatus{Detail: "registry entry has no relativeLocation"}
+		}
+		dir := filepath.Join(vscodeExtRoot(home), rel)
+		if _, err := os.Stat(dir); err != nil {
+			return vscodeStatus{Detail: "registered as " + rel + " but that folder is missing"}
+		}
+		if obsolete, err := vscodeFolderIsObsolete(home, rel); err == nil && obsolete {
+			return vscodeStatus{Detail: rel + " is flagged obsolete — reinstall"}
+		}
+		return vscodeStatus{Installed: true, Version: version, Detail: dir}
+	}
+
+	// A folder with no registry entry is precisely the broken state this
+	// command used to produce, so name it rather than reporting "not
+	// installed".
+	for _, cand := range []string{legacyVSCodeFolder, m.folder()} {
+		if _, err := os.Stat(filepath.Join(vscodeExtRoot(home), cand)); err == nil {
+			return vscodeStatus{Detail: cand + " exists but is not registered in extensions.json — run: ailang editor install vscode"}
+		}
+	}
+	return vscodeStatus{Detail: "not installed"}
+}
+
+func vscodeFolderIsObsolete(home, folder string) (bool, error) {
+	data, err := os.ReadFile(vscodeObsoletePath(home))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	var flags map[string]bool
+	if err := json.Unmarshal(data, &flags); err != nil {
+		return false, err
+	}
+	return flags[folder], nil
+}
+
+// vscodeUninstallResult records what uninstall removed.
+type vscodeUninstallResult struct {
+	CLIName      string
+	Deregistered bool
+	Folders      []string
+	Warnings     []string
+}
+
+// uninstallVSCodeExtension removes the extension by every route it could have
+// been installed by: the editor CLI, the registry entry, and any on-disk
+// folder — including versions other than the one this binary ships.
+func uninstallVSCodeExtension(home string, m vscodeManifest, look lookPathFunc, run cmdRunner) (vscodeUninstallResult, error) {
+	var res vscodeUninstallResult
+
+	if cliName, cliPath, ok := findVSCodeCLI(look); ok {
+		if out, err := run(cliPath, "--uninstall-extension", m.extID()); err != nil {
+			res.Warnings = append(res.Warnings, fmt.Sprintf("%s --uninstall-extension: %v: %s", cliName, err, strings.TrimSpace(string(out))))
+		} else {
+			res.CLIName = cliName
+		}
+	}
+
+	// Removing the registry entry is correct HERE and only here.
+	removed, err := deregisterVSCodeExtension(home, m.extID())
+	if err != nil {
+		res.Warnings = append(res.Warnings, fmt.Sprintf("could not update extensions.json: %v", err))
+	}
+	res.Deregistered = removed
+
+	root := vscodeExtRoot(home)
+	prefix := m.extID() + "-"
+	var doomed []string
+	if entries, err := os.ReadDir(root); err == nil {
+		for _, e := range entries {
+			name := e.Name()
+			if name == legacyVSCodeFolder || strings.HasPrefix(name, prefix) {
+				doomed = append(doomed, name)
+			}
+		}
+	}
+	sort.Strings(doomed)
+	for _, name := range doomed {
+		if err := os.RemoveAll(filepath.Join(root, name)); err != nil {
+			res.Warnings = append(res.Warnings, fmt.Sprintf("could not remove %s: %v", name, err))
+			continue
+		}
+		res.Folders = append(res.Folders, name)
+	}
+	if _, err := clearVSCodeObsolete(home, doomed...); err != nil {
+		res.Warnings = append(res.Warnings, fmt.Sprintf("could not update .obsolete: %v", err))
+	}
+	return res, nil
+}
+
+// --- command entry points -------------------------------------------------
+
+func installVSCode() {
+	fmt.Printf("%s Installing AILANG VS Code extension...\n", cyan("→"))
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: cannot determine home directory: %v\n", red("Error"), err)
+		os.Exit(1)
+	}
+	m, err := readVSCodeManifest()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %v\n", red("Error"), err)
+		os.Exit(1)
+	}
+
+	res, err := installVSCodeExtension(home, m, exec.LookPath, execRunner, time.Now().UnixMilli())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %v\n", red("Error"), err)
+		os.Exit(1)
+	}
+	if res.LegacyPurged {
+		fmt.Printf("  %s removed the old unregistered install at ~/.vscode/extensions/%s\n", green("✓"), legacyVSCodeFolder)
+	}
+	for _, w := range res.Warnings {
+		fmt.Printf("  %s %s\n", yellow("⚠"), w)
+	}
+
+	switch res.Method {
+	case "cli":
+		fmt.Printf("%s Installed %s@%s via `%s --install-extension`\n", green("✓"), m.extID(), m.Version, res.CLIName)
+	default:
+		fmt.Printf("%s Installed %s@%s to ~/.vscode/extensions/%s and registered it in extensions.json\n",
+			green("✓"), m.extID(), m.Version, res.Folder)
+		fmt.Printf("  %s no editor CLI (%s) on PATH — installed directly.\n", cyan("ℹ"), strings.Join(vscodeCLIs, ", "))
+		fmt.Println("    Enabling the `code` command (Cmd+Shift+P → \"Shell Command: Install 'code' command in PATH\")")
+		fmt.Println("    lets future installs go through VS Code itself.")
+	}
+
+	fmt.Println()
+	fmt.Println("What you get:")
+	fmt.Println("  • Syntax highlighting + bracket matching for .ail files")
+	fmt.Println("  • Language Server (diagnostics on save, hover types,")
+	fmt.Println("    go-to-definition, find-references, document symbols)")
+	fmt.Println("    — spawns `ailang lsp --stdio` automatically")
+	fmt.Println()
+	fmt.Println("Next steps:")
+	fmt.Println("  1. Fully quit VS Code (Cmd+Q on Mac, File→Exit elsewhere) and reopen")
+	fmt.Println("     (a window reload is NOT enough on first install/upgrade)")
+	fmt.Println("  2. Open any .ail file — diagnostics appear inline on save")
+	fmt.Println("  3. Confirm with: ailang editor status")
+	fmt.Println()
+	fmt.Println("Troubleshooting:")
+	fmt.Println("  • If no diagnostics: check `which ailang` works (binary on PATH)")
+	fmt.Println("  • Errors surface in View → Output → 'AILANG Language Server'")
+}
+
+func uninstallVSCode() {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: cannot determine home directory: %v\n", red("Error"), err)
+		os.Exit(1)
+	}
+	m, err := readVSCodeManifest()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %v\n", red("Error"), err)
+		os.Exit(1)
+	}
+
+	res, err := uninstallVSCodeExtension(home, m, exec.LookPath, execRunner)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %v\n", red("Error"), err)
+		os.Exit(1)
+	}
+	for _, w := range res.Warnings {
+		fmt.Printf("  %s %s\n", yellow("⚠"), w)
+	}
+	if !res.Deregistered && len(res.Folders) == 0 && res.CLIName == "" {
+		fmt.Println("VS Code extension not installed")
+		return
+	}
+	if res.CLIName != "" {
+		fmt.Printf("  %s uninstalled via `%s --uninstall-extension`\n", green("✓"), res.CLIName)
+	}
+	if res.Deregistered {
+		fmt.Printf("  %s removed the extensions.json entry\n", green("✓"))
+	}
+	for _, f := range res.Folders {
+		fmt.Printf("  %s removed ~/.vscode/extensions/%s\n", green("✓"), f)
+	}
+	fmt.Printf("%s VS Code extension uninstalled\n", green("✓"))
+	fmt.Println("  Fully quit VS Code (Cmd+Q) and reopen to complete the removal.")
+}

--- a/cmd/ailang/editor_vscode_test.go
+++ b/cmd/ailang/editor_vscode_test.go
@@ -1,0 +1,753 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// --- helpers ---------------------------------------------------------------
+
+// noCLI is a lookPathFunc for a machine with no editor CLI on PATH.
+func noCLI(string) (string, error) { return "", fmt.Errorf("not found") }
+
+// fakeCLI reports the named binary as present at a fixed path.
+func fakeCLI(want string) lookPathFunc {
+	return func(name string) (string, error) {
+		if name == want {
+			return "/usr/local/bin/" + want, nil
+		}
+		return "", fmt.Errorf("not found")
+	}
+}
+
+// recordingRunner captures every invocation and returns a canned result.
+type recordingRunner struct {
+	calls [][]string
+	out   []byte
+	err   error
+	// onCall runs before the canned result is returned, so a test can inspect
+	// artifacts (e.g. the .vsix) while they still exist.
+	onCall func(t *testing.T, name string, args []string)
+	t      *testing.T
+}
+
+func (r *recordingRunner) run(name string, args ...string) ([]byte, error) {
+	r.calls = append(r.calls, append([]string{name}, args...))
+	if r.onCall != nil {
+		r.onCall(r.t, name, args)
+	}
+	return r.out, r.err
+}
+
+// mustRunnerNeverCalled fails if anything shells out.
+func mustRunnerNeverCalled(t *testing.T) cmdRunner {
+	t.Helper()
+	return func(name string, args ...string) ([]byte, error) {
+		t.Fatalf("unexpected exec: %s %v", name, args)
+		return nil, nil
+	}
+}
+
+func testManifest(t *testing.T) vscodeManifest {
+	t.Helper()
+	m, err := readVSCodeManifest()
+	if err != nil {
+		t.Fatalf("readVSCodeManifest: %v", err)
+	}
+	return m
+}
+
+func extRoot(t *testing.T, home string) string {
+	t.Helper()
+	root := filepath.Join(home, ".vscode", "extensions")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", root, err)
+	}
+	return root
+}
+
+func writeRegistryFixture(t *testing.T, home string, entries []map[string]interface{}) {
+	t.Helper()
+	data, err := json.Marshal(entries)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(extRoot(t, home), "extensions.json"), data, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+}
+
+func readRegistry(t *testing.T, home string) []map[string]interface{} {
+	t.Helper()
+	entries, err := readVSCodeRegistry(vscodeRegistryPath(home))
+	if err != nil {
+		t.Fatalf("readVSCodeRegistry: %v", err)
+	}
+	return entries
+}
+
+func findEntry(entries []map[string]interface{}, id string) map[string]interface{} {
+	for _, e := range entries {
+		if strings.EqualFold(registryEntryID(e), id) {
+			return e
+		}
+	}
+	return nil
+}
+
+// --- manifest --------------------------------------------------------------
+
+func TestReadVSCodeManifestIdentity(t *testing.T) {
+	m := testManifest(t)
+	if m.Name == "" || m.Publisher == "" || m.Version == "" {
+		t.Fatalf("embedded manifest is missing identity fields: %+v", m)
+	}
+	if got, want := m.extID(), m.Publisher+"."+m.Name; got != want {
+		t.Errorf("extID = %q, want %q", got, want)
+	}
+	if got, want := m.folder(), m.extID()+"-"+m.Version; got != want {
+		t.Errorf("folder = %q, want %q", got, want)
+	}
+	// The folder name is what VS Code stores as relativeLocation. An
+	// unversioned folder is exactly the state that produced #694.
+	if !strings.Contains(m.folder(), "-") || strings.HasSuffix(m.folder(), "-") {
+		t.Errorf("folder %q is not versioned", m.folder())
+	}
+}
+
+// --- VSIX packaging --------------------------------------------------------
+
+func TestBuildVSIXIsAWellFormedArchive(t *testing.T) {
+	m := testManifest(t)
+	data, err := buildVSIX(m)
+	if err != nil {
+		t.Fatalf("buildVSIX: %v", err)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("vsix is not a readable zip: %v", err)
+	}
+
+	names := make([]string, 0, len(zr.File))
+	for _, f := range zr.File {
+		names = append(names, f.Name)
+	}
+	sort.Strings(names)
+
+	want := []string{
+		"[Content_Types].xml",
+		"extension.vsixmanifest",
+		"extension/extension.js",
+		"extension/language-configuration.json",
+		"extension/package.json",
+		"extension/syntaxes/ailang.tmLanguage.json",
+	}
+	sort.Strings(want)
+	if strings.Join(names, ",") != strings.Join(want, ",") {
+		t.Fatalf("vsix entries = %v, want %v", names, want)
+	}
+	// Anti-vacuity: a zip whose entries all happened to be empty would satisfy
+	// the name check above.
+	if len(names) == 0 {
+		t.Fatal("instrument failure: vsix has no entries")
+	}
+	for _, f := range zr.File {
+		if strings.ContainsRune(f.Name, '\\') {
+			t.Errorf("zip entry %q uses a backslash; entry names must be forward-slash separated on every GOOS", f.Name)
+		}
+	}
+}
+
+func TestBuildVSIXPayloadIsByteIdenticalToEmbeddedAssets(t *testing.T) {
+	m := testManifest(t)
+	data, err := buildVSIX(m)
+	if err != nil {
+		t.Fatalf("buildVSIX: %v", err)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("open vsix: %v", err)
+	}
+	checked := 0
+	for _, a := range vscodeAssets {
+		want, err := editorAssets.ReadFile(a.src)
+		if err != nil {
+			t.Fatalf("read embedded %s: %v", a.src, err)
+		}
+		got := zipEntry(t, zr, "extension/"+a.rel)
+		if !bytes.Equal(got, want) {
+			t.Errorf("vsix entry extension/%s differs from embedded %s", a.rel, a.src)
+		}
+		checked++
+	}
+	if checked != len(vscodeAssets) || checked == 0 {
+		t.Fatalf("instrument failure: checked %d assets, expected %d", checked, len(vscodeAssets))
+	}
+}
+
+func TestVSIXManifestIdentityMatchesPackageJSON(t *testing.T) {
+	m := testManifest(t)
+	raw, err := vsixManifestXML(m)
+	if err != nil {
+		t.Fatalf("vsixManifestXML: %v", err)
+	}
+	var parsed struct {
+		Metadata struct {
+			Identity struct {
+				ID        string `xml:"Id,attr"`
+				Version   string `xml:"Version,attr"`
+				Publisher string `xml:"Publisher,attr"`
+			} `xml:"Identity"`
+		} `xml:"Metadata"`
+		Installation struct {
+			Target struct {
+				ID string `xml:"Id,attr"`
+			} `xml:"InstallationTarget"`
+		} `xml:"Installation"`
+	}
+	if err := xml.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("manifest is not well-formed XML: %v\n%s", err, raw)
+	}
+	if parsed.Metadata.Identity.ID != m.Name {
+		t.Errorf("Identity/@Id = %q, want %q", parsed.Metadata.Identity.ID, m.Name)
+	}
+	if parsed.Metadata.Identity.Version != m.Version {
+		t.Errorf("Identity/@Version = %q, want %q", parsed.Metadata.Identity.Version, m.Version)
+	}
+	if parsed.Metadata.Identity.Publisher != m.Publisher {
+		t.Errorf("Identity/@Publisher = %q, want %q", parsed.Metadata.Identity.Publisher, m.Publisher)
+	}
+	if parsed.Installation.Target.ID != "Microsoft.VisualStudio.Code" {
+		t.Errorf("InstallationTarget = %q, want Microsoft.VisualStudio.Code", parsed.Installation.Target.ID)
+	}
+}
+
+func zipEntry(t *testing.T, zr *zip.Reader, name string) []byte {
+	t.Helper()
+	for _, f := range zr.File {
+		if f.Name != name {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open %s: %v", name, err)
+		}
+		defer func() { _ = rc.Close() }()
+		var buf bytes.Buffer
+		if _, err := buf.ReadFrom(rc); err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		return buf.Bytes()
+	}
+	t.Fatalf("vsix has no entry %q", name)
+	return nil
+}
+
+// --- the #694 regression guard ---------------------------------------------
+
+// TestInstallNeverDeregistersAnExistingEntry is the pin for #694.
+//
+// The pre-fix installer called invalidateVSCodeExtensionCache, which STRIPPED
+// the sunholo.ailang entry from extensions.json. Since VS Code 1.74 that is an
+// uninstall: VS Code flags the folder in .obsolete and never loads it. An
+// install that ends with the extension unregistered is the whole defect.
+func TestInstallNeverDeregistersAnExistingEntry(t *testing.T) {
+	home := t.TempDir()
+	m := testManifest(t)
+	root := extRoot(t, home)
+
+	other := map[string]interface{}{
+		"identifier":       map[string]interface{}{"id": "ms-vscode.makefile-tools"},
+		"version":          "0.12.17",
+		"relativeLocation": "ms-vscode.makefile-tools-0.12.17",
+	}
+	mine := map[string]interface{}{
+		"identifier":       map[string]interface{}{"id": m.extID()},
+		"version":          m.Version,
+		"relativeLocation": m.folder(),
+	}
+	writeRegistryFixture(t, home, []map[string]interface{}{other, mine})
+
+	// Anti-vacuity floor: if the fixture did not actually contain our entry,
+	// the post-condition below would pass for the wrong reason.
+	if findEntry(readRegistry(t, home), m.extID()) == nil {
+		t.Fatal("instrument failure: fixture does not contain the extension entry")
+	}
+
+	if _, err := installVSCodeExtension(home, m, noCLI, mustRunnerNeverCalled(t), 1234); err != nil {
+		t.Fatalf("installVSCodeExtension: %v", err)
+	}
+
+	entries := readRegistry(t, home)
+	got := findEntry(entries, m.extID())
+	if got == nil {
+		t.Fatalf("install DEREGISTERED %s — extensions.json now holds %d entries and none is ours (this is #694)", m.extID(), len(entries))
+	}
+	if rel, _ := got["relativeLocation"].(string); rel != m.folder() {
+		t.Errorf("relativeLocation = %q, want %q", rel, m.folder())
+	}
+	if findEntry(entries, "ms-vscode.makefile-tools") == nil {
+		t.Error("install removed an unrelated extension's entry")
+	}
+	if _, err := os.Stat(filepath.Join(root, m.folder())); err != nil {
+		t.Errorf("versioned extension folder was not created: %v", err)
+	}
+}
+
+func TestInstallRegistersWithTheSchemaVSCodeReads(t *testing.T) {
+	home := t.TempDir()
+	m := testManifest(t)
+
+	if _, err := installVSCodeExtension(home, m, noCLI, mustRunnerNeverCalled(t), 1755000000000); err != nil {
+		t.Fatalf("installVSCodeExtension: %v", err)
+	}
+
+	entry := findEntry(readRegistry(t, home), m.extID())
+	if entry == nil {
+		t.Fatal("install wrote no extensions.json entry, so VS Code would never load the folder")
+	}
+
+	// Fields taken from a real ~/.vscode/extensions/extensions.json.
+	ident, ok := entry["identifier"].(map[string]interface{})
+	if !ok || ident["id"] != m.extID() {
+		t.Errorf("identifier = %#v, want id %q", entry["identifier"], m.extID())
+	}
+	if entry["version"] != m.Version {
+		t.Errorf("version = %#v, want %q", entry["version"], m.Version)
+	}
+	rel, _ := entry["relativeLocation"].(string)
+	if rel != m.folder() {
+		t.Errorf("relativeLocation = %q, want %q", rel, m.folder())
+	}
+	loc, ok := entry["location"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("location = %#v, want an object", entry["location"])
+	}
+	if loc["scheme"] != "file" {
+		t.Errorf("location.scheme = %#v, want \"file\"", loc["scheme"])
+	}
+	path, _ := loc["path"].(string)
+	if !strings.HasPrefix(path, "/") {
+		t.Errorf("location.path = %q, want a URI path beginning with /", path)
+	}
+	if !strings.HasSuffix(path, "/"+m.folder()) {
+		t.Errorf("location.path = %q, want it to end in /%s", path, m.folder())
+	}
+	if _, ok := entry["metadata"].(map[string]interface{}); !ok {
+		t.Errorf("metadata = %#v, want an object", entry["metadata"])
+	}
+
+	// relativeLocation must name a directory that exists, or VS Code skips it.
+	if _, err := os.Stat(filepath.Join(extRoot(t, home), rel)); err != nil {
+		t.Errorf("relativeLocation %q does not exist on disk: %v", rel, err)
+	}
+	for _, a := range vscodeAssets {
+		p := filepath.Join(extRoot(t, home), rel, filepath.FromSlash(a.rel))
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("asset %s missing from the install: %v", a.rel, err)
+		}
+	}
+}
+
+func TestInstallPurgesLegacyFolderAndClearsObsolete(t *testing.T) {
+	home := t.TempDir()
+	m := testManifest(t)
+	root := extRoot(t, home)
+
+	legacy := filepath.Join(root, legacyVSCodeFolder)
+	if err := os.MkdirAll(legacy, 0o755); err != nil {
+		t.Fatalf("mkdir legacy: %v", err)
+	}
+	obsolete := map[string]bool{
+		legacyVSCodeFolder:             true,
+		m.folder():                     true,
+		"someone-else.extension-1.0.0": true,
+	}
+	data, _ := json.Marshal(obsolete)
+	if err := os.WriteFile(filepath.Join(root, ".obsolete"), data, 0o644); err != nil {
+		t.Fatalf("write .obsolete: %v", err)
+	}
+
+	res, err := installVSCodeExtension(home, m, noCLI, mustRunnerNeverCalled(t), 1)
+	if err != nil {
+		t.Fatalf("installVSCodeExtension: %v", err)
+	}
+	if !res.LegacyPurged {
+		t.Error("LegacyPurged = false, want true")
+	}
+	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+		t.Errorf("legacy folder still present: %v", err)
+	}
+
+	stale, err := vscodeFolderIsObsolete(home, m.folder())
+	if err != nil {
+		t.Fatalf("vscodeFolderIsObsolete: %v", err)
+	}
+	if stale {
+		t.Error("the folder we just installed into is still flagged obsolete; VS Code would skip it")
+	}
+	// Someone else's obsolete flag is not ours to clear.
+	if other, err := vscodeFolderIsObsolete(home, "someone-else.extension-1.0.0"); err != nil || !other {
+		t.Errorf("unrelated .obsolete entry was cleared (err=%v, present=%v)", err, other)
+	}
+}
+
+// --- editor CLI path -------------------------------------------------------
+
+func TestInstallShellsOutToTheEditorCLIWithAValidVSIX(t *testing.T) {
+	home := t.TempDir()
+	m := testManifest(t)
+
+	rr := &recordingRunner{t: t, onCall: func(t *testing.T, name string, args []string) {
+		// Rule: validate the artifact the product actually produced, while it
+		// still exists — not a reconstruction of it.
+		var vsixPath string
+		for i, a := range args {
+			if a == "--install-extension" && i+1 < len(args) {
+				vsixPath = args[i+1]
+			}
+		}
+		if vsixPath == "" {
+			t.Fatalf("no --install-extension argument in %v", args)
+		}
+		data, err := os.ReadFile(vsixPath)
+		if err != nil {
+			t.Fatalf("the vsix handed to the editor does not exist: %v", err)
+		}
+		if _, err := zip.NewReader(bytes.NewReader(data), int64(len(data))); err != nil {
+			t.Fatalf("the vsix handed to the editor is not a readable zip: %v", err)
+		}
+	}}
+
+	res, err := installVSCodeExtension(home, m, fakeCLI("code"), rr.run, 1)
+	if err != nil {
+		t.Fatalf("installVSCodeExtension: %v", err)
+	}
+	if res.Method != "cli" || res.CLIName != "code" {
+		t.Fatalf("Method/CLIName = %q/%q, want cli/code", res.Method, res.CLIName)
+	}
+	if len(rr.calls) != 1 {
+		t.Fatalf("exec calls = %d, want 1: %v", len(rr.calls), rr.calls)
+	}
+	call := rr.calls[0]
+	if call[0] != "/usr/local/bin/code" {
+		t.Errorf("invoked %q, want the resolved CLI path", call[0])
+	}
+	joined := strings.Join(call, " ")
+	if !strings.Contains(joined, "--install-extension") || !strings.Contains(joined, "--force") {
+		t.Errorf("call = %v, want --install-extension … --force", call)
+	}
+	if !strings.HasSuffix(call[2], ".vsix") {
+		t.Errorf("argument %q does not look like a .vsix", call[2])
+	}
+	// VS Code owns the install now, so we must not also drop a folder — two
+	// installs sharing one extension ID is what the report warns about.
+	if _, err := os.Stat(filepath.Join(extRoot(t, home), m.folder())); !os.IsNotExist(err) {
+		t.Errorf("a folder install also happened alongside the CLI install: %v", err)
+	}
+}
+
+func TestInstallFallsBackLoudlyWhenTheEditorCLIFails(t *testing.T) {
+	home := t.TempDir()
+	m := testManifest(t)
+
+	rr := &recordingRunner{t: t, out: []byte("Unable to install extension"), err: fmt.Errorf("exit status 1")}
+	res, err := installVSCodeExtension(home, m, fakeCLI("cursor"), rr.run, 1)
+	if err != nil {
+		t.Fatalf("installVSCodeExtension: %v", err)
+	}
+	if res.Method != "folder" {
+		t.Fatalf("Method = %q, want folder", res.Method)
+	}
+	if len(res.Warnings) == 0 {
+		t.Fatal("a silent downgrade: the CLI install failed and nothing said so")
+	}
+	if !strings.Contains(strings.Join(res.Warnings, " "), "cursor") {
+		t.Errorf("warnings = %v, want the failing CLI named", res.Warnings)
+	}
+	if findEntry(readRegistry(t, home), m.extID()) == nil {
+		t.Error("fallback install left the extension unregistered")
+	}
+}
+
+// --- status ----------------------------------------------------------------
+
+// TestStatusDoesNotTrustABareFolder pins the second half of #694: `ailang
+// editor status` reported ✓ from an os.Stat, so a deregistered install looked
+// healthy.
+func TestStatusDoesNotTrustABareFolder(t *testing.T) {
+	m := testManifest(t)
+	for _, folder := range []string{legacyVSCodeFolder, m.folder()} {
+		t.Run(folder, func(t *testing.T) {
+			home := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(extRoot(t, home), folder), 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			st := vscodeExtensionStatus(home, m, noCLI, mustRunnerNeverCalled(t))
+			if st.Installed {
+				t.Fatalf("status reports installed for an unregistered folder %q (this is #694)", folder)
+			}
+			if !strings.Contains(st.Detail, "not registered") {
+				t.Errorf("Detail = %q, want it to say the folder is not registered", st.Detail)
+			}
+		})
+	}
+}
+
+func TestStatusReportsRegisteredInstall(t *testing.T) {
+	home := t.TempDir()
+	m := testManifest(t)
+	if _, err := installVSCodeExtension(home, m, noCLI, mustRunnerNeverCalled(t), 1); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	st := vscodeExtensionStatus(home, m, noCLI, mustRunnerNeverCalled(t))
+	if !st.Installed {
+		t.Fatalf("status = not installed after a successful install: %q", st.Detail)
+	}
+	if st.Version != m.Version {
+		t.Errorf("Version = %q, want %q", st.Version, m.Version)
+	}
+}
+
+func TestStatusFlagsAnObsoleteInstall(t *testing.T) {
+	home := t.TempDir()
+	m := testManifest(t)
+	if _, err := installVSCodeExtension(home, m, noCLI, mustRunnerNeverCalled(t), 1); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	// Simulate VS Code having deregistered it out from under us.
+	data, _ := json.Marshal(map[string]bool{m.folder(): true})
+	if err := os.WriteFile(vscodeObsoletePath(home), data, 0o644); err != nil {
+		t.Fatalf("write .obsolete: %v", err)
+	}
+	st := vscodeExtensionStatus(home, m, noCLI, mustRunnerNeverCalled(t))
+	if st.Installed {
+		t.Fatal("status reports installed for a folder VS Code has flagged obsolete")
+	}
+	if !strings.Contains(st.Detail, "obsolete") {
+		t.Errorf("Detail = %q, want it to mention obsolete", st.Detail)
+	}
+}
+
+func TestStatusAsksTheEditorCLIWhenPresent(t *testing.T) {
+	m := testManifest(t)
+	tests := []struct {
+		name      string
+		listing   string
+		installed bool
+		version   string
+	}{
+		{"present", "ms-vscode.makefile-tools@0.12.17\n" + m.extID() + "@" + m.Version + "\n", true, m.Version},
+		{"absent", "ms-vscode.makefile-tools@0.12.17\n", false, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			extRoot(t, home)
+			rr := &recordingRunner{t: t, out: []byte(tc.listing)}
+			st := vscodeExtensionStatus(home, m, fakeCLI("code"), rr.run)
+			if st.Installed != tc.installed {
+				t.Fatalf("Installed = %v, want %v (detail %q)", st.Installed, tc.installed, st.Detail)
+			}
+			if st.Version != tc.version {
+				t.Errorf("Version = %q, want %q", st.Version, tc.version)
+			}
+			if len(rr.calls) != 1 || !strings.Contains(strings.Join(rr.calls[0], " "), "--list-extensions") {
+				t.Errorf("calls = %v, want one --list-extensions", rr.calls)
+			}
+		})
+	}
+}
+
+// --- uninstall -------------------------------------------------------------
+
+func TestUninstallRemovesRegistryEntryAndEveryVersionedFolder(t *testing.T) {
+	home := t.TempDir()
+	m := testManifest(t)
+	root := extRoot(t, home)
+
+	if _, err := installVSCodeExtension(home, m, noCLI, mustRunnerNeverCalled(t), 1); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	// A folder from some other version, plus the pre-fix unversioned one.
+	stray := m.extID() + "-0.9.9"
+	for _, d := range []string{stray, legacyVSCodeFolder} {
+		if err := os.MkdirAll(filepath.Join(root, d), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	keep := "ms-vscode.makefile-tools-0.12.17"
+	if err := os.MkdirAll(filepath.Join(root, keep), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", keep, err)
+	}
+
+	res, err := uninstallVSCodeExtension(home, m, noCLI, mustRunnerNeverCalled(t))
+	if err != nil {
+		t.Fatalf("uninstallVSCodeExtension: %v", err)
+	}
+	if !res.Deregistered {
+		t.Error("Deregistered = false, want true")
+	}
+	if findEntry(readRegistry(t, home), m.extID()) != nil {
+		t.Error("uninstall left the extensions.json entry behind")
+	}
+	for _, d := range []string{m.folder(), stray, legacyVSCodeFolder} {
+		if _, err := os.Stat(filepath.Join(root, d)); !os.IsNotExist(err) {
+			t.Errorf("uninstall left %s on disk: %v", d, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(root, keep)); err != nil {
+		t.Errorf("uninstall removed an unrelated extension %s: %v", keep, err)
+	}
+}
+
+func TestUninstallUsesTheEditorCLIWhenPresent(t *testing.T) {
+	home := t.TempDir()
+	m := testManifest(t)
+	extRoot(t, home)
+
+	rr := &recordingRunner{t: t}
+	res, err := uninstallVSCodeExtension(home, m, fakeCLI("code"), rr.run)
+	if err != nil {
+		t.Fatalf("uninstallVSCodeExtension: %v", err)
+	}
+	if res.CLIName != "code" {
+		t.Errorf("CLIName = %q, want code", res.CLIName)
+	}
+	if len(rr.calls) != 1 {
+		t.Fatalf("calls = %v, want one", rr.calls)
+	}
+	joined := strings.Join(rr.calls[0], " ")
+	if !strings.Contains(joined, "--uninstall-extension") || !strings.Contains(joined, m.extID()) {
+		t.Errorf("call = %v, want --uninstall-extension %s", rr.calls[0], m.extID())
+	}
+}
+
+// --- registry primitives ---------------------------------------------------
+
+func TestDeregisterVSCodeExtension(t *testing.T) {
+	t.Run("removes only the matching entry", func(t *testing.T) {
+		home := t.TempDir()
+		writeRegistryFixture(t, home, []map[string]interface{}{
+			{"identifier": map[string]interface{}{"id": "sunholo.ailang"}},
+			{"identifier": map[string]interface{}{"id": "other.ext"}},
+		})
+		removed, err := deregisterVSCodeExtension(home, "sunholo.ailang")
+		if err != nil || !removed {
+			t.Fatalf("removed=%v err=%v, want true/nil", removed, err)
+		}
+		entries := readRegistry(t, home)
+		if len(entries) != 1 || registryEntryID(entries[0]) != "other.ext" {
+			t.Fatalf("entries = %#v, want just other.ext", entries)
+		}
+	})
+
+	t.Run("case-insensitive match", func(t *testing.T) {
+		home := t.TempDir()
+		writeRegistryFixture(t, home, []map[string]interface{}{
+			{"identifier": map[string]interface{}{"id": "Sunholo.AILang"}},
+		})
+		removed, err := deregisterVSCodeExtension(home, "sunholo.ailang")
+		if err != nil || !removed {
+			t.Fatalf("removed=%v err=%v, want true/nil", removed, err)
+		}
+	})
+
+	t.Run("no entry is not an error", func(t *testing.T) {
+		home := t.TempDir()
+		writeRegistryFixture(t, home, []map[string]interface{}{
+			{"identifier": map[string]interface{}{"id": "other.ext"}},
+		})
+		removed, err := deregisterVSCodeExtension(home, "sunholo.ailang")
+		if err != nil || removed {
+			t.Fatalf("removed=%v err=%v, want false/nil", removed, err)
+		}
+	})
+
+	t.Run("missing registry is not an error", func(t *testing.T) {
+		home := t.TempDir()
+		removed, err := deregisterVSCodeExtension(home, "sunholo.ailang")
+		if err != nil || removed {
+			t.Fatalf("removed=%v err=%v, want false/nil", removed, err)
+		}
+	})
+
+	t.Run("malformed registry is refused, not silently rewritten", func(t *testing.T) {
+		home := t.TempDir()
+		if err := os.WriteFile(filepath.Join(extRoot(t, home), "extensions.json"), []byte("{not json"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if _, err := deregisterVSCodeExtension(home, "sunholo.ailang"); err == nil {
+			t.Fatal("want an error for a malformed extensions.json, got nil")
+		}
+	})
+}
+
+func TestRegisterReplacesRatherThanDuplicates(t *testing.T) {
+	home := t.TempDir()
+	m := testManifest(t)
+	writeRegistryFixture(t, home, []map[string]interface{}{
+		{"identifier": map[string]interface{}{"id": m.extID()}, "version": "0.0.1", "relativeLocation": m.extID() + "-0.0.1"},
+	})
+	if err := registerVSCodeExtension(home, m, 42); err != nil {
+		t.Fatalf("registerVSCodeExtension: %v", err)
+	}
+	entries := readRegistry(t, home)
+	count := 0
+	for _, e := range entries {
+		if strings.EqualFold(registryEntryID(e), m.extID()) {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("entry count for %s = %d, want exactly 1", m.extID(), count)
+	}
+	if rel, _ := findEntry(entries, m.extID())["relativeLocation"].(string); rel != m.folder() {
+		t.Errorf("relativeLocation = %q, want the new %q", rel, m.folder())
+	}
+}
+
+func TestVSCodeURIPath(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"/Users/x/.vscode/extensions/sunholo.ailang-0.3.0", "/Users/x/.vscode/extensions/sunholo.ailang-0.3.0"},
+		{`C:\Users\x\.vscode\extensions\sunholo.ailang-0.3.0`, "/C:/Users/x/.vscode/extensions/sunholo.ailang-0.3.0"},
+	}
+	for _, tc := range tests {
+		// filepath.ToSlash only rewrites separators on Windows, so the second
+		// case asserts the leading-slash rule that applies on every GOOS.
+		got := vscodeURIPath(tc.in)
+		if !strings.HasPrefix(got, "/") {
+			t.Errorf("vscodeURIPath(%q) = %q, want a leading /", tc.in, got)
+		}
+	}
+}
+
+func TestFindVSCodeCLIProbeOrder(t *testing.T) {
+	// The first candidate present wins, in the declared order.
+	look := func(name string) (string, error) {
+		if name == "cursor" || name == "windsurf" {
+			return "/opt/" + name, nil
+		}
+		return "", fmt.Errorf("not found")
+	}
+	name, path, ok := findVSCodeCLI(look)
+	if !ok || name != "cursor" || path != "/opt/cursor" {
+		t.Fatalf("findVSCodeCLI = %q/%q/%v, want cursor//opt/cursor/true", name, path, ok)
+	}
+	if _, _, ok := findVSCodeCLI(noCLI); ok {
+		t.Error("findVSCodeCLI reported a CLI on a machine with none")
+	}
+	// Anti-vacuity: the probe list must be non-empty, or "not found" is
+	// guaranteed regardless of the machine.
+	if len(vscodeCLIs) == 0 {
+		t.Fatal("instrument failure: vscodeCLIs is empty")
+	}
+}

--- a/docs/docs/guides/editor-setup.md
+++ b/docs/docs/guides/editor-setup.md
@@ -47,16 +47,29 @@ Then restart VS Code or run **Developer: Reload Window** (Cmd+Shift+P on Mac, Ct
 
 ### Manual Install
 
-1. Copy the extension folder to your VS Code extensions:
-   ```bash
-   # macOS/Linux
-   cp -r .vscode/extensions/ailang ~/.vscode/extensions/
+:::warning Copying a folder into `~/.vscode/extensions/` does not install anything
 
-   # Windows (PowerShell)
-   Copy-Item -Recurse .vscode\extensions\ailang $env:USERPROFILE\.vscode\extensions\
-   ```
+Since VS Code 1.74, `~/.vscode/extensions/extensions.json` is the registry of
+installed extensions, not a cache. A folder with no entry in it is never scanned,
+so the extension silently does not load. Let VS Code do the install.
 
-2. Restart VS Code
+:::
+
+Use VS Code's own installer:
+
+```bash
+# Command palette: "Extensions: Install from VSIX..." — or, on the CLI:
+code --install-extension <path-to>.vsix --force
+```
+
+`ailang editor install vscode` does exactly this for you: it builds the VSIX from
+the binary's embedded assets and hands it to whichever editor CLI it finds
+(`code`, `code-insiders`, `cursor`, `windsurf`, `codium`). If none is on your
+PATH it falls back to installing the extension directory *and* registering it in
+`extensions.json`, which is the part a manual `cp` misses.
+
+To put `code` on your PATH: Cmd+Shift+P → **Shell Command: Install 'code' command
+in PATH**.
 
 ### Troubleshooting
 
@@ -74,12 +87,21 @@ Then restart VS Code or run **Developer: Reload Window** (Cmd+Shift+P on Mac, Ct
 
 **Extension not loading?**
 ```bash
-# Verify extension is installed
-ls ~/.vscode/extensions/ | grep ailang
+# Verify VS Code will actually load it — this checks the registry, not just
+# whether a folder exists on disk.
+ailang editor status
+
+# Or ask VS Code directly:
+code --list-extensions --show-versions | grep ailang
 
 # Check VS Code output for errors
 # View > Output > Extension Host
 ```
+
+A folder at `~/.vscode/extensions/ailang` with no matching `extensions.json`
+entry is the broken state — `ailang editor status` reports it as such, and
+`ailang editor install vscode` repairs it. Listing the directory is *not* a
+check: it shows folders VS Code has marked obsolete and skips.
 
 ## Vim
 

--- a/editors/README.md
+++ b/editors/README.md
@@ -22,16 +22,23 @@ The CLI embeds all editor files, so it works from anywhere after `ailang` is ins
 
 ## VS Code Manual Install
 
-1. Copy the extension folder to your VS Code extensions:
-   ```bash
-   # macOS/Linux
-   cp -r .vscode/extensions/ailang ~/.vscode/extensions/
+**Do not copy a folder into `~/.vscode/extensions/`.** Since VS Code 1.74 that
+directory's `extensions.json` is the registry of installed extensions, not a
+cache — a folder with no entry in it is never scanned, so nothing loads.
 
-   # Windows (PowerShell)
-   Copy-Item -Recurse .vscode\extensions\ailang $env:USERPROFILE\.vscode\extensions\
-   ```
+Let VS Code install it:
 
-2. Restart VS Code
+```bash
+# Command palette: "Extensions: Install from VSIX..." — or, on the CLI:
+code --install-extension <path-to>.vsix --force
+```
+
+`ailang editor install vscode` builds that VSIX from the binary's embedded
+assets and hands it to whichever editor CLI it finds (`code`, `code-insiders`,
+`cursor`, `windsurf`, `codium`); with none on PATH it installs the directory
+*and* writes the `extensions.json` entry itself.
+
+Then restart VS Code.
 
 ### Workspace Settings (Alternative)
 
@@ -47,12 +54,18 @@ If you only want highlighting when working in the AILANG project, the grammar is
 
 **Extension not loading?**
 ```bash
-# Verify extension is installed
-ls ~/.vscode/extensions/ | grep ailang
+# Checks the registry, not just whether a folder exists on disk
+ailang editor status
+
+# Or ask VS Code directly:
+code --list-extensions --show-versions | grep ailang
 
 # Check VS Code output for errors
 # View > Output > Extension Host
 ```
+
+Listing `~/.vscode/extensions/` is not a check: it shows folders VS Code has
+marked obsolete and skips.
 
 ## Vim/Neovim Manual Install
 


### PR DESCRIPTION
Fixes #694 — a downstream-consumer report, ghost-disciplined at HEAD and **REAL**, with a mechanism sharper than filed.

## The defect

Since VS Code 1.74 (profiles), `~/.vscode/extensions/extensions.json` is the **registry** of installed user extensions, not a cache. `ailang editor install vscode` predated that and got it wrong in both directions at once:

- it wrote an **unversioned** folder `~/.vscode/extensions/ailang`, which has no registry entry and is therefore never scanned; and
- it then called `invalidateVSCodeExtensionCache` to "force a metadata re-scan", which **removed** the `sunholo.ailang` entry. Removing an entry is an uninstall, so VS Code flagged the leftover folder in `.obsolete` and skipped it in every window.

`checkEditorStatus` verified with `os.Stat` on the folder, so a dead install still reported `✓`. Net effect: no highlighting and no LSP anywhere, while the CLI reported success.

## The sharpening the report doesn't make

`uninstall` calls the **same helper**, where removing the entry is exactly right. One function, correct on one caller and inverted on the other — and its **name** is what allowed that: "invalidate cache" reads as a refresh while the operation is a deregistration. It is now `deregisterVSCodeExtension`, and only uninstall may call it.

This is the fourth consecutive consumer report in this group where the *artefact describing the behaviour* is the bug (`#679` a stale warning, `RT_REC_003` a nonexistent option, `#671` an impossible instruction, and now a function name) — the previous three were all emitted strings.

## Verified first-party, not inherited

The registry schema was read off a **real** `~/.vscode/extensions/extensions.json` on this machine (9 entries) rather than from the report's description: `identifier{id,uuid}` · `version` · `location{$mid,path,scheme}` · `relativeLocation` · `metadata`, with `relativeLocation` == a `publisher.name-version` folder. A live `.obsolete` file on the same box carries exactly the flag class the report describes.

Coverage before this: `cmd/ailang/editor.go` had **zero** test references (0 test files naming `installVSCode`/`invalidateVSCodeExtensionCache`, control **77** `_test.go` files in `cmd/ailang`), so nothing could red when it broke.

## The fix

`install` builds a VSIX from the embedded assets (`archive/zip` — no node or `vsce` dependency) and hands it to the editor's own CLI, probing `code`, `code-insiders`, `cursor`, `windsurf`, `codium`, so **VS Code performs the registration**. With no CLI on PATH it installs a versioned folder *and writes the registry entry itself*, clears any stale `.obsolete` flag, and removes the old unregistered folder. A failed CLI install falls back **loudly**.

`status` now reports what the editor will actually load: `code --list-extensions` when a CLI is present, otherwise a registry entry whose `relativeLocation` exists and is not flagged obsolete.

**Same defect, second surface (Principle 3):** `docs/docs/guides/editor-setup.md` and `editors/README.md` both taught the manual recipe `cp -r ... ~/.vscode/extensions/` and verified it with `ls ~/.vscode/extensions/ | grep ailang` — the folder-drop that does not register, and the `os.Stat` false positive, in shell form. Both now point at the editor's own installer and at `ailang editor status`.

## Mutation drills

19 new test functions. **11 drills, every one asserted LANDED (sha256) and BUILDS (`go build` rc=0) before any test result was read**; sources restored from `cp` copies (never `git checkout --`, which would delete uncommitted work) and verified byte-identical.

Blast radius was **classified by running each mutant and reading its red set**, not predicted, so the `rc=0` inverse criterion was applied only where it can succeed:

| Mutant | Red set | Verdict |
|---|---|---|
| M5 status ignores `.obsolete` | 1 | inverse `-skip` rc=0 → **sole killer** |
| M6 CLI path also drops a folder | 1 | inverse `-skip` rc=0 → **sole killer** |
| M7 silent fallback on CLI failure | 1 | inverse `-skip` rc=0 → **sole killer** |
| M9 VSIX identity takes publisher for name | 1 | inverse `-skip` rc=0 → **sole killer** |
| M10 `.obsolete` wiped wholesale | 1 | inverse `-skip` rc=0 → **sole killer** |
| M11 uninstall sweeps only the current version | 1 | inverse `-skip` rc=0 → **sole killer** |
| M1 re-introduce deregistration on install | 6 | broad-blast; includes the `#694` pin |
| M2 folder install writes no entry | 5 | broad-blast |
| M4 status trusts a bare `os.Stat` | 3 | broad-blast; includes the status pin |
| M3 unversioned folder name | 2 | broad-blast |
| M8 VSIX payload at the archive root | 2 | broad-blast |

Every broad-blast member is explained by the mutant's phenotype (a mutant that deregisters on install reds every arm that installs and then expects registration).

**M11's first form did not compile** (unused `prefix`) and was **repaired rather than read** — an `imported and not used` red is not the guard firing.

## Gates

`go test ./cmd/ailang` rc=0 (full package, not `-run` filtered) · `go vet ./cmd/...` rc=0 · `gofmt` clean · `go build ./internal/...` rc=0 · `check-file-sizes` / `check-boundaries` / `check-changelog` / `test-check-changelog` / `check-skills` / `verify-no-shim` all rc=0.

`go build ./...` fails at base on `cmd/wasm` (no native `main`) — **pre-existing on untouched dev**, measured on a pristine worktree before any edit.

All local gates ran on **darwin/arm64**; the linux and windows legs are unrun locally and settled by CI. Two portability notes taken deliberately: VSIX entry names are forward-slash literals rather than `filepath.Join` (which emits backslashes on Windows and would produce an archive VS Code cannot read), and the tests take `home` as a parameter rather than going through `os.UserHomeDir`, so they never depend on `HOME` vs `USERPROFILE`.

## Not closed by this

Whether VS Code *accepts* the generated VSIX cannot be executed here — no editor CLI is on this machine's PATH. What is pinned is that the artefact handed to the CLI is a readable zip with the exact entry set, that its manifest is well-formed XML whose `Identity` matches `package.json`, and that its payload is byte-identical to the embedded assets. The report's own verified workaround packaged these same assets with `@vscode/vsce` and installed cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
