### PR TITLE
fix(motoko): the eval preflight refused EVERY lane on a missing OpenRouter key, including local ollama ones (D1)

### DIFF
--- a/.ailang/state/sprints/sprint_m-motoko-fmt-remeasurement-instrument.json
+++ b/.ailang/state/sprints/sprint_m-motoko-fmt-remeasurement-instrument.json
@@ -1,0 +1,178 @@
+{
+  "sprint_id": "m-motoko-fmt-remeasurement-instrument",
+  "title": "D1 + D1b + D2 + smoke-bank wiring for the motoko fmt re-measurement instrument",
+  "created": "2026-08-20",
+  "branch": "sprint/motoko-iter14-fmt-d1",
+  "worktree": "/Users/voightkampff/.ailang-driver-pin/.wt-motoko-iter14-fmt-d1",
+  "base_commit": "44aa3cab4",
+  "design_doc": "design_docs/planned/m-motoko-fmt-remeasurement-instrument.md",
+  "plan_path": "design_docs/planned/m-motoko-fmt-remeasurement-instrument-sprint-plan.md",
+  "github_issues": [558, 649],
+  "platform": "darwin/arm64 (macOS 26.5.2) — windows and ubuntu CI legs are UNRUN locally; every BASE result below is darwin/arm64 only",
+  "risk_level": "medium",
+  "velocity": {
+    "target_loc_per_day": 500,
+    "estimated_total_loc": 1525,
+    "estimated_days": 3.0
+  },
+  "key_decision": {
+    "question": "Which of design doc s12.2's three D1 options?",
+    "chosen": "option (2), refined — remove the unconditional OPENROUTER_API_KEY refusal from runHealthCheck; add a resolved-provider credential check at the top of MotokoExecutor.ExecuteStreaming keyed on e.getModel(task)",
+    "doc_preference_refuted": "option (1) (set cfg.MotokoModel from models.yml at construction)",
+    "refutation": [
+      "executor.GlobalFactory() builds ONE factory ONCE from DefaultConfig() (factory.go:178-182) and caches executors by NAME (factory.go:96-122). SetGlobalFactory has ZERO non-test callers. So cfg.MotokoModel is a process-global single string.",
+      "models.yml declares 17 lanes with agent_cli: motoko — 10 route via OpenRouter, 7 via ollama. One cached *MotokoExecutor serves all 17. There is no construction-time value that is correct for both halves.",
+      "HealthCheck is sync.Once-cached per executor (motoko.go:131-133, healthcheck.go:31-43). A model-dependent verdict computed there is frozen at whichever model canaried first, converting a loud uniform refusal into a silent order-dependent one."
+    ]
+  },
+  "baselines": [
+    {"command": "go build ./...", "base_result": "RED exit=1 — cmd/wasm: function main is undeclared in the main package. NOT usable as a gate.", "usable_as_gate": false},
+    {"command": "go build ./internal/... ./cmd/ailang/...", "base_result": "PASS exit=0", "usable_as_gate": true},
+    {"command": "go vet ./internal/executor/... ./internal/ai/...", "base_result": "PASS exit=0", "usable_as_gate": true},
+    {"command": "go test ./internal/executor/... ./internal/ai/...", "base_result": "PASS exit=0, 14/14 packages ok", "usable_as_gate": true},
+    {"command": "env -u OPENROUTER_API_KEY go test ./internal/executor/motoko/", "base_result": "PASS exit=0, ok 20.422s", "usable_as_gate": true},
+    {"command": "bash scripts/check_boundaries.sh", "base_result": "PASS exit=0 — 'OK: no architecture boundary violations'", "usable_as_gate": true},
+    {"command": "golangci-lint run ./internal/executor/motoko/... ./internal/eval_analysis/... ./cmd/ailang/...", "base_result": "PASS exit=0, 0 issues", "usable_as_gate": true},
+    {"command": "bash -n tools/launchd/nightly-eval.sh", "base_result": "PASS exit=0", "usable_as_gate": true},
+    {"command": "shellcheck -S warning tools/launchd/nightly-eval.sh", "base_result": "PASS exit=0, 0 findings", "usable_as_gate": true},
+    {"command": "grep -n OPENROUTER_API_KEY internal/executor/motoko/*.go | grep -v _test.go", "base_result": "1 hit (healthcheck.go:64); known-positive control over internal/ai/config.go returns 2 hits (:115,:143)", "usable_as_gate": true},
+    {"command": "go test ./internal/eval_analysis/... ./cmd/ailang/...", "base_result": "NOT BASELINED — executor must baseline before first edit and record the result", "usable_as_gate": true}
+  ],
+  "features": [
+    {
+      "id": "M1_D1_PROVIDER_CONDITIONAL_PREFLIGHT",
+      "description": "Remove the unconditional OPENROUTER_API_KEY refusal from runHealthCheck (healthcheck.go:64-66), keeping the binary/dir/exec-bit checks and the `motoko --version` query that discovers e.motokoRepo. Add internal/executor/motoko/provider_preflight.go with requireProviderCredential(model string) error, expressed as ai.EnvVarForProvider(ai.GuessProvider(model)) — never on the literal string OPENROUTER_API_KEY — and call it at the top of ExecuteStreaming with e.getModel(task). DELETE the now-stale TestHealthCheck_MissingAPIKey (motoko_test.go:141-154) per the no-backward-compatibility testing policy.",
+      "estimated_loc": 290,
+      "dependencies": [],
+      "acceptance_criteria": [
+        "AC-M1-1: `go build ./internal/... ./cmd/ailang/...` exits 0 (BASE: PASS). `go build ./...` is NOT the gate — it is RED at base on cmd/wasm.",
+        "AC-M1-2: `go test ./internal/executor/... ./internal/ai/...` exits 0 (BASE: PASS, 14/14 ok).",
+        "AC-M1-3: `env -u OPENROUTER_API_KEY go test ./internal/executor/motoko/` exits 0 (BASE: PASS, ok 20.422s). Catches the measured hazard that 8 mock-binary Execute tests build with an empty MotokoModel that New() defaults to openrouter/anthropic/claude-haiku-4-5.",
+        "AC-M1-4: `bash scripts/check_boundaries.sh` exits 0 after the new internal/ai import (BASE: PASS).",
+        "AC-M1-5: `grep -n OPENROUTER_API_KEY internal/executor/motoko/*.go | grep -v _test.go` returns ZERO lines; known-positive control in the same sweep: the same grep over internal/ai/config.go returns :115 and :143 (BASE: 1 hit vs 2 control hits — instrument discriminates).",
+        "AC-M1-6: the full refusal-branch mutation matrix passes (T-B1..T-B6b, T-ORDER) and each neutering mutation `if false && <cond>` makes exactly its own row fail."
+      ],
+      "test_rows": [
+        {"id": "T-B1", "branch": "os.Stat error (binary missing)", "mutation": "if false && err != nil", "observable": "error contains 'motoko CLI not found at %q' AND the quoted path equals the configured MotokoPath"},
+        {"id": "T-B2", "branch": "info.IsDir()", "mutation": "if false && info.IsDir()", "observable": "error contains 'is a directory, expected an executable' and names the same path"},
+        {"id": "T-B3", "branch": "non-windows exec-bit clear", "mutation": "if false && (runtime.GOOS != \"windows\" && info.Mode().Perm()&0111 == 0)", "observable": "error contains 'is not executable (chmod +x)' and names the same path. darwin/arm64 only; windows leg unrun."},
+        {"id": "T-B4", "branch": "the DELETED OPENROUTER_API_KEY refusal", "mutation": "n/a — asserted by absence, admissible only because AC-M1-5 pairs it with a known-positive control grep", "observable": "HealthCheck on a mock binary with OPENROUTER_API_KEY unset returns nil AND version/motokoRepo parsing still ran"},
+        {"id": "T-B5", "branch": "resolved provider needs a key and it is unset -> refuse", "mutation": "if false && os.Getenv(envVar) == \"\"", "observable": "error names BOTH the resolved env var AND the model. Table: ollama/qwen3.6:35b-a3b-mxfp8 -> no error; ollama:qwen3.5 -> no error; openrouter/anthropic/claude-haiku-4-5 -> OPENROUTER_API_KEY; anthropic/claude-sonnet-4-6 -> OPENROUTER_API_KEY; claude-3-5-sonnet -> ANTHROPIC_API_KEY; gpt-5-codex -> OPENAI_API_KEY; gemini-3-1-pro -> GOOGLE_API_KEY. Value set = EnvVarForProvider's 5-way switch, in bijection with the mechanism; a boolean error/no-error observable would be decorative."},
+        {"id": "T-B5b", "branch": "key present -> proceed", "mutation": "if false && ... (inverted arm at the same site)", "observable": "for each keyed model, with the CORRECT env var set -> nil; with a DIFFERENT provider's var set instead -> still refuses. Kills an 'any API key is set' mutant."},
+        {"id": "T-B6", "branch": "GuessProvider returns \"\" (unresolvable model)", "mutation": "if false && provider == \"\"", "observable": "EnvVarForProvider(\"\") returns \"\" (config.go:117 default), so a naive impl passes silently. Per CLAUDE.md rule 2 the plan REQUIRES a loud refusal: error contains the model string and 'could not resolve provider'."},
+        {"id": "T-B6b", "branch": "coverage of the refusal against real config", "mutation": "n/a — coverage gate", "observable": "GuessProvider returns non-empty for ALL 17 agent_cli: motoko lanes read out of internal/eval_harness/models.yml, so a future unresolvable lane fails at add-time not rig-time"},
+        {"id": "T-ORDER", "branch": "design doc s12.3 — the resolved-provider check must NOT run ahead of MOTOKO_REPO discovery", "mutation": "move requireProviderCredential into runHealthCheck BEFORE the `motoko --version` query", "observable": "with a mock stub printing motoko_repo=/tmp/fake-repo for --version, the child process env captured by the stub contains MOTOKO_REPO=/tmp/fake-repo (non-empty). Under the mutation with the key unset the process is never spawned and no env is captured. Value set = the observed MOTOKO_REPO path, not a boolean."}
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": null
+    },
+    {
+      "id": "M2_AC_D1_LIVE_CONNECTION_PROOF",
+      "description": "Add tools/eval/motoko_connection_probe.sh: run one motoko canary for a named models.yml lane, sample the ESTABLISHED TCP peer set of the motoko process tree once per second via `lsof -nP -iTCP -sTCP:ESTABLISHED -a -p <pid tree>`, resolve openrouter.ai up front with `dig +short` and record the resolved IP set in the artifact, then classify every observed peer as loopback / OR_IPS member / other. Always emit the full peer set — the artifact is the evidence and the verdict is a function of it. darwin/arm64 only; no root required.",
+      "estimated_loc": 160,
+      "dependencies": ["M1_D1_PROVIDER_CONDITIONAL_PREFLIGHT"],
+      "acceptance_criteria": [
+        "AC-D1-live (VERBATIM from design doc s12.4): With the fix in place, one fmt-lane run reaches localhost:11434 and makes ZERO connections to openrouter.ai. Assert on the connection, not on the absence of an error — an absence is satisfied equally by 'no OpenRouter call' and 'the run never started' (the observable must be unique to the mechanism). Pair it with a known-positive control: an OpenRouter-lane run in the same sweep must show the connection, or the instrument proves nothing.",
+        "AC-M2-treatment: for lane motoko-local-qwen3-6-fmt the observed peer set CONTAINS 127.0.0.1:11434 and contains NO member of OR_IPS. Any non-loopback peer outside OR_IPS does not fail the criterion but MUST be recorded.",
+        "AC-M2-control: for lane motoko-claude-haiku-4-5 with OPENROUTER_API_KEY set, the observed peer set CONTAINS at least one member of OR_IPS. If this control does not fire, AC-M2-treatment is VOID.",
+        "AC-M2-3: the artifact records OR_IPS, both peer sets, both lane names, probe start/end timestamps, and `uname -sm`.",
+        "This criterion may NOT be weakened to 'no error occurred' — the design doc forbids it explicitly."
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": "Only non-local milestone: needs the rig (ollama serving qwen3.6 + motoko binary) and, for the control leg only, OPENROUTER_API_KEY plus a few cents of metered spend. ~15 min wall-clock."
+    },
+    {
+      "id": "M3_D1B_COUNTERBALANCED_WEDNESDAY_BLOCK",
+      "description": "Restructure the fmt block of tools/launchd/nightly-eval.sh (V22 cites lines 492-507; re-verified this session at the same lines) from the whole-arm `for arm in on off` loop wrapping one whole-suite eval-suite call, into the design doc s5.3 per-benchmark interleave: iterate the ELO-selected benchmarks in selection order and for benchmark index i (0-based) run both arms back-to-back — ON then OFF when i is even, OFF then ON when i is odd — each arm as one `eval-suite --benchmarks <b> --trials $FMT_TRIALS` invocation into the same per-arm --output dir. select_ab_benchmarks emits a comma-separated space-stripped list (nightly-eval.sh:225-232) so IFS=',' splitting is safe; repeated invocations into one output dir do not collide because bank filenames embed the bank time (V23). Everything downstream of the loop (eval-paired, count_passes, FMT_VALID, fmt_ab.jsonl) is untouched.",
+      "estimated_loc": 175,
+      "dependencies": ["M1_D1_PROVIDER_CONDITIONAL_PREFLIGHT"],
+      "acceptance_criteria": [
+        "AC-M3-1: `bash -n tools/launchd/nightly-eval.sh` exits 0 (BASE: PASS).",
+        "AC-M3-2: `shellcheck -S warning tools/launchd/nightly-eval.sh` exits 0 with 0 findings (BASE: PASS, 0 findings).",
+        "AC-M3-3: T-D1B order test — with a stub $BIN on PATH that appends \"$*\" to a log and exits 0, a 6-benchmark list produces exactly 12 eval-suite invocations whose (benchmark, arm) sequence is b0:on,b0:off, b1:off,b1:on, b2:on,b2:off, b3:off,b3:on, b4:on,b4:off, b5:off,b5:on, each naming exactly one benchmark.",
+        "AC-M3-4: the same log satisfies M4's order-integrity checker (contiguous same-(benchmark,arm) blocks; each benchmark's two blocks adjacent; |#ON-lead - #OFF-lead| <= 1), so the driver and the analyzer are proven to agree rather than each being right about a different schedule."
+      ],
+      "test_rows": [
+        {"id": "T-D1B-1", "mutation": "revert to `for arm in on off` around a whole-suite call", "observable": "stub invocation log: 2 invocations each naming 6 benchmarks, instead of 12 each naming 1"},
+        {"id": "T-D1B-2", "mutation": "fix the lead arm (ON always first) instead of alternating on i%2", "observable": "the (benchmark, arm) sequence gives #ON-lead=6, #OFF-lead=0, violating <=1. Observable value set = the 2^6 lead assignments, not a boolean."},
+        {"id": "T-D1B-3", "mutation": "pass $FMT_BENCH_LIST (all 6) instead of ${FMT_BENCHES[i]} inside the loop", "observable": "each logged invocation's --benchmarks argument has 6 comma-separated names instead of 1"}
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": null
+    },
+    {
+      "id": "M4_D2_CENSORED_PAIR_ANALYZER",
+      "description": "New SIBLING command `ailang eval-censored-pairs <on-dir> <off-dir>` — NOT an extension of eval-paired, justified by measurement: eval-paired's stdout JSON is a live contract piped through paired_summary at nightly-eval.sh:512 and banked, and the Monday microRAG block calls the same command. Adds internal/eval_analysis/censored.go (design doc s2 verdict, s5 void rules, s7 decision rule), cmd/ailang/eval_censored.go, +1 case in main.go, +1 help line, +1 eval_remote_read.go map entry, and two additive read-side fields on eval_analysis.BenchmarkResult: FmtHookState `json:\"fmt_hook_state,omitempty\"` and FmtHookEvents `json:\"fmt_hook_events,omitempty\"` (measured gap: BenchmarkResult carries MicroRAGState but no fmt field, while Validity/Timestamp/Trial/token fields are already present; the banked keys exist at eval_harness/metrics.go:138,143). Reuses exactBinomialTwoSided/binomialPMF at eval_analysis/paired.go:205-231.",
+      "estimated_loc": 710,
+      "dependencies": [],
+      "acceptance_criteria": [
+        "AC-M4-1: `go test ./internal/eval_analysis/... ./cmd/ailang/...` exits 0. BASE NOT RECORDED — the executor must baseline this before its first edit; a red base is a repo finding, not a sprint failure.",
+        "AC-M4-2: `golangci-lint run ./internal/eval_analysis/... ./cmd/ailang/... ./internal/executor/motoko/...` exits 0 with 0 issues (BASE: PASS, 0 issues).",
+        "AC-M4-3: `ailang eval-paired --with-pairs=true eval_results/ab2_fmt_on eval_results/ab2_fmt_off` produces BYTE-IDENTICAL stdout before and after M4 — proves the sibling command did not disturb the live contract.",
+        "AC-M4-4: the fixture verdict matrix passes (T-D2-VOID-ORDER, T-D2-VOID-TREAT-ON, T-D2-VOID-TREAT-OFF, T-D2-CENSOR, T-D2-MARGIN, T-D2-KEEP-3).",
+        "AC-M4-5: run against the REAL banked AC5 arms eval_results/ab2_fmt_{on,off}, the analyzer reports VOID with an order-integrity reason — known in advance from V19, independently measured, and NOT the happy path."
+      ],
+      "test_rows": [
+        {"id": "T-D2-VOID-ORDER", "mutation": "neuter the order-integrity gate", "observable": "on a perfect-arm-block fixture the (verdict, void_reason) pair changes from (VOID, order_integrity) to a numeric verdict. 4 verdicts x N reasons, not 'did it error'."},
+        {"id": "T-D2-VOID-TREAT-ON", "mutation": "neuter the >20% ON-quarantined rule", "observable": "fixture with 2/6 ON rows validity.valid=false: verdict changes from (VOID, treatment_unproven_rate)"},
+        {"id": "T-D2-VOID-TREAT-OFF", "mutation": "neuter the OFF-contamination rule", "observable": "fixture with 1 OFF row carrying fmt_hook_events: verdict changes from (VOID, control_contaminated)"},
+        {"id": "T-D2-CENSOR", "mutation": "neuter s2 rule 1 (one-passes-wins) so both-fail and one-passes both tie", "observable": "fixture with 10 one-arm-passes pairs: the (n_eff, W, verdict) triple goes 10->0 and KEEP->RETIRE"},
+        {"id": "T-D2-MARGIN", "mutation": "neuter the |log ratio| <= 0.10 practical-equivalence margin", "observable": "fixture of both-pass pairs all within +-5%: n_eff 0->12 with a spurious W"},
+        {"id": "T-D2-KEEP-3", "mutation": "neuter each of the three KEEP conjuncts in turn (sign test / both-pass median token ratio <= 0.90 / McNemar guardrail)", "observable": "three fixtures each failing exactly one conjunct must all be non-KEEP; a mutant dropping any conjunct returns KEEP on its own fixture"},
+        {"id": "T-D2-REAL", "mutation": "none — end-to-end oracle", "observable": "the real banked AC5 arms yield VOID with an order-integrity reason (V19 established this before the analyzer existed)"}
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": "Parallel-safe with M1/M2/M3/M5 — touches internal/eval_analysis + cmd/ailang only. Out of scope this sprint: the s5.1 'void run pages the mission via ailang messages send' wiring; the analyzer emits the void verdict + reason on stdout and exits non-zero, and paging is driver policy."
+    },
+    {
+      "id": "M5_SMOKE_BANK_WIRING",
+      "description": "Wire the design doc s5.2 new-tree contract check into the nightly fmt block immediately before M3's interleave loop: one smoke bank of 1 benchmark x 1 trial on the ON arm, asserting (a) the ported extension still writes <workspace>/.claude/fmt_hook_events.jsonl with the {status,file} schema and (b) the new-tree step-0 broadcast still names the extension `fmt` in resolved_extensions. NO NEW ASSERTION LOGIC IS WRITTEN — check (b) is exactly eval_harness.ResolveFmtArm (fmt_treatment.go:28-47, exact fmt#N name match) and check (a) is exactly AssertFmtTreatmentIntegrity(\"on\", events) (fmt_treatment.go:60-92, which already demands >=1 event AND >=1 with status=formatted). The smoke check reads the banked row's validity and fmt_hook_state. On failure the block logs the specific failing contract, sends `ailang messages send controlplane`, sets RUN_AB_FMT=0 and does NOT enter the measurement loop — modelled on the existing select_ab_benchmarks-returned-nothing path at nightly-eval.sh:480-487.",
+      "estimated_loc": 190,
+      "dependencies": ["M3_D1B_COUNTERBALANCED_WEDNESDAY_BLOCK"],
+      "acceptance_criteria": [
+        "AC-M5-1: `bash -n tools/launchd/nightly-eval.sh` and `shellcheck -S warning tools/launchd/nightly-eval.sh` both exit 0 with 0 findings (BASE: PASS / PASS).",
+        "AC-M5-2: T-D2-SMOKE — when the stub smoke bank produces a row with fmt_hook_state=off, the driver logs the contract failure, sets RUN_AB_FMT=0, and emits ZERO `eval-suite --trials 5` invocations. Killed mutation: neutering the smoke gate (`if false && <smoke_failed>`) yields 12 measurement invocations instead of 0. Observable: the stub's invocation log (value set = the set of invocations, not a boolean).",
+        "AC-M5-3: the happy path — a stub smoke row with fmt_hook_state=on and a status=formatted event — proceeds into M3's interleave and emits the full 12 invocations. Without this row, AC-M5-2 is satisfiable by a driver that always skips."
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": null
+    }
+  ],
+  "deployment_precondition": {
+    "name": "AC-DEPLOY",
+    "gates": "the first measured Wednesday slot, NOT the sprint's merge",
+    "why": "merging to origin/dev does not put the fix on the rig — the installed plist executes nightly-eval.sh IN PLACE from V1's checkout (open issue #558, the stale-checkout defect)",
+    "steps": [
+      "SCRIPT=$(/usr/libexec/PlistBuddy -c \"Print :ProgramArguments\" ~/Library/LaunchAgents/dev.ailang.nightly-eval.plist | sed -n '3p' | tr -d ' ')  — read the path FROM THE INSTALLED PLIST, never from any working-tree path",
+      "confirm the script AT $SCRIPT contains the D1b per-benchmark interleave (no `for arm in on off` wrapping a whole-suite call)",
+      "confirm the `ailang` binary that $SCRIPT invokes as $BIN reports a git rev containing M1's commit (`$BIN --version`)",
+      "until BOTH reads pass, no Wednesday slot counts as a measurement attempt"
+    ],
+    "verified_this_session": "PlistBuddy on dev.ailang.nightly-eval.plist -> {/bin/bash, /Users/voightkampff/dev/sunholo-data/ailang/tools/launchd/nightly-eval.sh}, exit 0. Known-negative control: the same command on a nonexistent plist exits 1 with 'Entry Does Not Exist' — so absence is a measurement, not a silent zero."
+  },
+  "instrument_warnings": [
+    "The go.mod module path is github.com/sunholo-data/ailang, NOT github.com/sunholo/ailang. An import grep anchored on the wrong path returns a confident silent ZERO. Anchor every import grep on the go.mod path and pair it with a known-positive control.",
+    "`go build ./...` is RED at base (cmd/wasm builds only under GOOS=js). Use `go build ./internal/... ./cmd/ailang/...`.",
+    "OPENROUTER_API_KEY is set in the interactive shell on this machine (len 73), so a bare `go test` masks the CI behaviour. Use `env -u OPENROUTER_API_KEY` for the M1 regression gate."
+  ],
+  "risks": [
+    {"id": "R1", "risk": "The 8 mock-binary Execute tests break in CI where OPENROUTER_API_KEY is unset (they pass locally only because the ambient env has it)", "mitigation": "AC-M1-3 (`env -u OPENROUTER_API_KEY go test ./internal/executor/motoko/`) is the gate; green at base"},
+    {"id": "R2", "risk": "T-B6's loud refusal on an unresolvable provider refuses a legitimate lane", "mitigation": "T-B6b asserts GuessProvider resolves all 17 motoko lanes read from models.yml, so a future unresolvable lane fails at add-time"},
+    {"id": "R3", "risk": "AC-M2-control needs OPENROUTER_API_KEY, a few cents of metered spend, and the rig", "mitigation": "one trivial canary on the cheapest OpenRouter motoko lane; if the control does not fire, AC-M2-treatment is VOID and this plan does not soften that"},
+    {"id": "R4", "risk": "D2's shape drifts from the doc's s2/s5/s7 during implementation", "mitigation": "every D2 rule is quoted from the doc, and AC-M4-5 pins the analyzer against the real AC5 dataset whose correct verdict (VOID, order integrity) was established by V19 before the analyzer existed"},
+    {"id": "R5", "risk": "The fix merges but never reaches the rig (issue #558)", "mitigation": "AC-DEPLOY reads the script at the installed-plist path plus the $BIN git rev; until both pass, no slot counts"},
+    {"id": "R6", "risk": "M4's new BenchmarkResult fields collide with the existing loader's strictness", "mitigation": "additive with omitempty and JSON tags copied from the already-banked keys (metrics.go:138,143); AC-M4-3 asserts eval-paired's output is byte-identical before and after"}
+  ],
+  "execution_order": "M1 -> M2 -> M3 -> M5, with M4 parallel-safe (disjoint files). M3 must land before M5.",
+  "scope_note": "The full D1 + D1b + D2 + smoke-bank scope FITS in 3.0 days. Nothing is deferred to a follow-up sprint. The one item that is not purely local is M2's AC-D1-live, which needs the rig and (control leg only) OPENROUTER_API_KEY."
+}

--- a/.ailang/state/sprints/sprint_m-motoko-fmt-remeasurement-instrument.json
+++ b/.ailang/state/sprints/sprint_m-motoko-fmt-remeasurement-instrument.json
@@ -7,7 +7,10 @@
   "base_commit": "44aa3cab4",
   "design_doc": "design_docs/planned/m-motoko-fmt-remeasurement-instrument.md",
   "plan_path": "design_docs/planned/m-motoko-fmt-remeasurement-instrument-sprint-plan.md",
-  "github_issues": [558, 649],
+  "github_issues": [
+    558,
+    649
+  ],
   "platform": "darwin/arm64 (macOS 26.5.2) — windows and ubuntu CI legs are UNRUN locally; every BASE result below is darwin/arm64 only",
   "risk_level": "medium",
   "velocity": {
@@ -26,17 +29,61 @@
     ]
   },
   "baselines": [
-    {"command": "go build ./...", "base_result": "RED exit=1 — cmd/wasm: function main is undeclared in the main package. NOT usable as a gate.", "usable_as_gate": false},
-    {"command": "go build ./internal/... ./cmd/ailang/...", "base_result": "PASS exit=0", "usable_as_gate": true},
-    {"command": "go vet ./internal/executor/... ./internal/ai/...", "base_result": "PASS exit=0", "usable_as_gate": true},
-    {"command": "go test ./internal/executor/... ./internal/ai/...", "base_result": "PASS exit=0, 14/14 packages ok", "usable_as_gate": true},
-    {"command": "env -u OPENROUTER_API_KEY go test ./internal/executor/motoko/", "base_result": "PASS exit=0, ok 20.422s", "usable_as_gate": true},
-    {"command": "bash scripts/check_boundaries.sh", "base_result": "PASS exit=0 — 'OK: no architecture boundary violations'", "usable_as_gate": true},
-    {"command": "golangci-lint run ./internal/executor/motoko/... ./internal/eval_analysis/... ./cmd/ailang/...", "base_result": "PASS exit=0, 0 issues", "usable_as_gate": true},
-    {"command": "bash -n tools/launchd/nightly-eval.sh", "base_result": "PASS exit=0", "usable_as_gate": true},
-    {"command": "shellcheck -S warning tools/launchd/nightly-eval.sh", "base_result": "PASS exit=0, 0 findings", "usable_as_gate": true},
-    {"command": "grep -n OPENROUTER_API_KEY internal/executor/motoko/*.go | grep -v _test.go", "base_result": "1 hit (healthcheck.go:64); known-positive control over internal/ai/config.go returns 2 hits (:115,:143)", "usable_as_gate": true},
-    {"command": "go test ./internal/eval_analysis/... ./cmd/ailang/...", "base_result": "NOT BASELINED — executor must baseline before first edit and record the result", "usable_as_gate": true}
+    {
+      "command": "go build ./...",
+      "base_result": "RED exit=1 — cmd/wasm: function main is undeclared in the main package. NOT usable as a gate.",
+      "usable_as_gate": false
+    },
+    {
+      "command": "go build ./internal/... ./cmd/ailang/...",
+      "base_result": "PASS exit=0",
+      "usable_as_gate": true
+    },
+    {
+      "command": "go vet ./internal/executor/... ./internal/ai/...",
+      "base_result": "PASS exit=0",
+      "usable_as_gate": true
+    },
+    {
+      "command": "go test ./internal/executor/... ./internal/ai/...",
+      "base_result": "PASS exit=0, 14/14 packages ok",
+      "usable_as_gate": true
+    },
+    {
+      "command": "env -u OPENROUTER_API_KEY go test ./internal/executor/motoko/",
+      "base_result": "PASS exit=0, ok 20.422s",
+      "usable_as_gate": true
+    },
+    {
+      "command": "bash scripts/check_boundaries.sh",
+      "base_result": "PASS exit=0 — 'OK: no architecture boundary violations'",
+      "usable_as_gate": true
+    },
+    {
+      "command": "golangci-lint run ./internal/executor/motoko/... ./internal/eval_analysis/... ./cmd/ailang/...",
+      "base_result": "PASS exit=0, 0 issues",
+      "usable_as_gate": true
+    },
+    {
+      "command": "bash -n tools/launchd/nightly-eval.sh",
+      "base_result": "PASS exit=0",
+      "usable_as_gate": true
+    },
+    {
+      "command": "shellcheck -S warning tools/launchd/nightly-eval.sh",
+      "base_result": "PASS exit=0, 0 findings",
+      "usable_as_gate": true
+    },
+    {
+      "command": "grep -n OPENROUTER_API_KEY internal/executor/motoko/*.go | grep -v _test.go",
+      "base_result": "1 hit (healthcheck.go:64); known-positive control over internal/ai/config.go returns 2 hits (:115,:143)",
+      "usable_as_gate": true
+    },
+    {
+      "command": "go test ./internal/eval_analysis/... ./cmd/ailang/...",
+      "base_result": "NOT BASELINED — executor must baseline before first edit and record the result",
+      "usable_as_gate": true
+    }
   ],
   "features": [
     {
@@ -53,26 +100,74 @@
         "AC-M1-6: the full refusal-branch mutation matrix passes (T-B1..T-B6b, T-ORDER) and each neutering mutation `if false && <cond>` makes exactly its own row fail."
       ],
       "test_rows": [
-        {"id": "T-B1", "branch": "os.Stat error (binary missing)", "mutation": "if false && err != nil", "observable": "error contains 'motoko CLI not found at %q' AND the quoted path equals the configured MotokoPath"},
-        {"id": "T-B2", "branch": "info.IsDir()", "mutation": "if false && info.IsDir()", "observable": "error contains 'is a directory, expected an executable' and names the same path"},
-        {"id": "T-B3", "branch": "non-windows exec-bit clear", "mutation": "if false && (runtime.GOOS != \"windows\" && info.Mode().Perm()&0111 == 0)", "observable": "error contains 'is not executable (chmod +x)' and names the same path. darwin/arm64 only; windows leg unrun."},
-        {"id": "T-B4", "branch": "the DELETED OPENROUTER_API_KEY refusal", "mutation": "n/a — asserted by absence, admissible only because AC-M1-5 pairs it with a known-positive control grep", "observable": "HealthCheck on a mock binary with OPENROUTER_API_KEY unset returns nil AND version/motokoRepo parsing still ran"},
-        {"id": "T-B5", "branch": "resolved provider needs a key and it is unset -> refuse", "mutation": "if false && os.Getenv(envVar) == \"\"", "observable": "error names BOTH the resolved env var AND the model. Table: ollama/qwen3.6:35b-a3b-mxfp8 -> no error; ollama:qwen3.5 -> no error; openrouter/anthropic/claude-haiku-4-5 -> OPENROUTER_API_KEY; anthropic/claude-sonnet-4-6 -> OPENROUTER_API_KEY; claude-3-5-sonnet -> ANTHROPIC_API_KEY; gpt-5-codex -> OPENAI_API_KEY; gemini-3-1-pro -> GOOGLE_API_KEY. Value set = EnvVarForProvider's 5-way switch, in bijection with the mechanism; a boolean error/no-error observable would be decorative."},
-        {"id": "T-B5b", "branch": "key present -> proceed", "mutation": "if false && ... (inverted arm at the same site)", "observable": "for each keyed model, with the CORRECT env var set -> nil; with a DIFFERENT provider's var set instead -> still refuses. Kills an 'any API key is set' mutant."},
-        {"id": "T-B6", "branch": "GuessProvider returns \"\" (unresolvable model)", "mutation": "if false && provider == \"\"", "observable": "EnvVarForProvider(\"\") returns \"\" (config.go:117 default), so a naive impl passes silently. Per CLAUDE.md rule 2 the plan REQUIRES a loud refusal: error contains the model string and 'could not resolve provider'."},
-        {"id": "T-B6b", "branch": "coverage of the refusal against real config", "mutation": "n/a — coverage gate", "observable": "GuessProvider returns non-empty for ALL 17 agent_cli: motoko lanes read out of internal/eval_harness/models.yml, so a future unresolvable lane fails at add-time not rig-time"},
-        {"id": "T-ORDER", "branch": "design doc s12.3 — the resolved-provider check must NOT run ahead of MOTOKO_REPO discovery", "mutation": "move requireProviderCredential into runHealthCheck BEFORE the `motoko --version` query", "observable": "with a mock stub printing motoko_repo=/tmp/fake-repo for --version, the child process env captured by the stub contains MOTOKO_REPO=/tmp/fake-repo (non-empty). Under the mutation with the key unset the process is never spawned and no env is captured. Value set = the observed MOTOKO_REPO path, not a boolean."}
+        {
+          "id": "T-B1",
+          "branch": "os.Stat error (binary missing)",
+          "mutation": "if false && err != nil",
+          "observable": "error contains 'motoko CLI not found at %q' AND the quoted path equals the configured MotokoPath"
+        },
+        {
+          "id": "T-B2",
+          "branch": "info.IsDir()",
+          "mutation": "if false && info.IsDir()",
+          "observable": "error contains 'is a directory, expected an executable' and names the same path"
+        },
+        {
+          "id": "T-B3",
+          "branch": "non-windows exec-bit clear",
+          "mutation": "if false && (runtime.GOOS != \"windows\" && info.Mode().Perm()&0111 == 0)",
+          "observable": "error contains 'is not executable (chmod +x)' and names the same path. darwin/arm64 only; windows leg unrun."
+        },
+        {
+          "id": "T-B4",
+          "branch": "the DELETED OPENROUTER_API_KEY refusal",
+          "mutation": "n/a — asserted by absence, admissible only because AC-M1-5 pairs it with a known-positive control grep",
+          "observable": "HealthCheck on a mock binary with OPENROUTER_API_KEY unset returns nil AND version/motokoRepo parsing still ran"
+        },
+        {
+          "id": "T-B5",
+          "branch": "resolved provider needs a key and it is unset -> refuse",
+          "mutation": "if false && os.Getenv(envVar) == \"\"",
+          "observable": "error names BOTH the resolved env var AND the model. Table: ollama/qwen3.6:35b-a3b-mxfp8 -> no error; ollama:qwen3.5 -> no error; openrouter/anthropic/claude-haiku-4-5 -> OPENROUTER_API_KEY; anthropic/claude-sonnet-4-6 -> OPENROUTER_API_KEY; claude-3-5-sonnet -> ANTHROPIC_API_KEY; gpt-5-codex -> OPENAI_API_KEY; gemini-3-1-pro -> GOOGLE_API_KEY. Value set = EnvVarForProvider's 5-way switch, in bijection with the mechanism; a boolean error/no-error observable would be decorative."
+        },
+        {
+          "id": "T-B5b",
+          "branch": "key present -> proceed",
+          "mutation": "if false && ... (inverted arm at the same site)",
+          "observable": "for each keyed model, with the CORRECT env var set -> nil; with a DIFFERENT provider's var set instead -> still refuses. Kills an 'any API key is set' mutant."
+        },
+        {
+          "id": "T-B6",
+          "branch": "GuessProvider returns \"\" (unresolvable model)",
+          "mutation": "if false && provider == \"\"",
+          "observable": "EnvVarForProvider(\"\") returns \"\" (config.go:117 default), so a naive impl passes silently. Per CLAUDE.md rule 2 the plan REQUIRES a loud refusal: error contains the model string and 'could not resolve provider'."
+        },
+        {
+          "id": "T-B6b",
+          "branch": "coverage of the refusal against real config",
+          "mutation": "n/a — coverage gate",
+          "observable": "GuessProvider returns non-empty for ALL 17 agent_cli: motoko lanes read out of internal/eval_harness/models.yml, so a future unresolvable lane fails at add-time not rig-time"
+        },
+        {
+          "id": "T-ORDER",
+          "branch": "design doc s12.3 — the resolved-provider check must NOT run ahead of MOTOKO_REPO discovery",
+          "mutation": "move requireProviderCredential into runHealthCheck BEFORE the `motoko --version` query",
+          "observable": "with a mock stub printing motoko_repo=/tmp/fake-repo for --version, the child process env captured by the stub contains MOTOKO_REPO=/tmp/fake-repo (non-empty). Under the mutation with the key unset the process is never spawned and no env is captured. Value set = the observed MOTOKO_REPO path, not a boolean."
+        }
       ],
-      "passes": null,
-      "started": null,
-      "completed": null,
-      "notes": null
+      "passes": true,
+      "started": "2026-08-20",
+      "completed": "2026-08-20",
+      "notes": "Delivered iteration 14, PR #794. Evaluator PASS 84/100, zero blocking. All six AC-M1-* re-run by the controller outside any sandbox on darwin/arm64. Mutation drill (full-package blast radius, no -run narrowing): neuter-ADMIT 12, neuter-REFUSAL 3, neuter-unresolvable-guard 1, neuter-call-site 1 (SURVIVED as first delivered; T-CALLSITE added and proven sole killer, -skip inverse rc=0). T-ORDER repaired after the evaluator showed its original assertion was a bare nil-vs-error that could not discriminate ordering.",
+      "status": "completed"
     },
     {
       "id": "M2_AC_D1_LIVE_CONNECTION_PROOF",
       "description": "Add tools/eval/motoko_connection_probe.sh: run one motoko canary for a named models.yml lane, sample the ESTABLISHED TCP peer set of the motoko process tree once per second via `lsof -nP -iTCP -sTCP:ESTABLISHED -a -p <pid tree>`, resolve openrouter.ai up front with `dig +short` and record the resolved IP set in the artifact, then classify every observed peer as loopback / OR_IPS member / other. Always emit the full peer set — the artifact is the evidence and the verdict is a function of it. darwin/arm64 only; no root required.",
       "estimated_loc": 160,
-      "dependencies": ["M1_D1_PROVIDER_CONDITIONAL_PREFLIGHT"],
+      "dependencies": [
+        "M1_D1_PROVIDER_CONDITIONAL_PREFLIGHT"
+      ],
       "acceptance_criteria": [
         "AC-D1-live (VERBATIM from design doc s12.4): With the fix in place, one fmt-lane run reaches localhost:11434 and makes ZERO connections to openrouter.ai. Assert on the connection, not on the absence of an error — an absence is satisfied equally by 'no OpenRouter call' and 'the run never started' (the observable must be unique to the mechanism). Pair it with a known-positive control: an OpenRouter-lane run in the same sweep must show the connection, or the instrument proves nothing.",
         "AC-M2-treatment: for lane motoko-local-qwen3-6-fmt the observed peer set CONTAINS 127.0.0.1:11434 and contains NO member of OR_IPS. Any non-loopback peer outside OR_IPS does not fail the criterion but MUST be recorded.",
@@ -83,13 +178,16 @@
       "passes": null,
       "started": null,
       "completed": null,
-      "notes": "Only non-local milestone: needs the rig (ollama serving qwen3.6 + motoko binary) and, for the control leg only, OPENROUTER_API_KEY plus a few cents of metered spend. ~15 min wall-clock."
+      "notes": "Only non-local milestone: needs the rig (ollama serving qwen3.6 + motoko binary) and, for the control leg only, OPENROUTER_API_KEY plus a few cents of metered spend. ~15 min wall-clock. Not started at iteration 14 — named resume point, not dropped.",
+      "status": "not_started"
     },
     {
       "id": "M3_D1B_COUNTERBALANCED_WEDNESDAY_BLOCK",
       "description": "Restructure the fmt block of tools/launchd/nightly-eval.sh (V22 cites lines 492-507; re-verified this session at the same lines) from the whole-arm `for arm in on off` loop wrapping one whole-suite eval-suite call, into the design doc s5.3 per-benchmark interleave: iterate the ELO-selected benchmarks in selection order and for benchmark index i (0-based) run both arms back-to-back — ON then OFF when i is even, OFF then ON when i is odd — each arm as one `eval-suite --benchmarks <b> --trials $FMT_TRIALS` invocation into the same per-arm --output dir. select_ab_benchmarks emits a comma-separated space-stripped list (nightly-eval.sh:225-232) so IFS=',' splitting is safe; repeated invocations into one output dir do not collide because bank filenames embed the bank time (V23). Everything downstream of the loop (eval-paired, count_passes, FMT_VALID, fmt_ab.jsonl) is untouched.",
       "estimated_loc": 175,
-      "dependencies": ["M1_D1_PROVIDER_CONDITIONAL_PREFLIGHT"],
+      "dependencies": [
+        "M1_D1_PROVIDER_CONDITIONAL_PREFLIGHT"
+      ],
       "acceptance_criteria": [
         "AC-M3-1: `bash -n tools/launchd/nightly-eval.sh` exits 0 (BASE: PASS).",
         "AC-M3-2: `shellcheck -S warning tools/launchd/nightly-eval.sh` exits 0 with 0 findings (BASE: PASS, 0 findings).",
@@ -97,14 +195,27 @@
         "AC-M3-4: the same log satisfies M4's order-integrity checker (contiguous same-(benchmark,arm) blocks; each benchmark's two blocks adjacent; |#ON-lead - #OFF-lead| <= 1), so the driver and the analyzer are proven to agree rather than each being right about a different schedule."
       ],
       "test_rows": [
-        {"id": "T-D1B-1", "mutation": "revert to `for arm in on off` around a whole-suite call", "observable": "stub invocation log: 2 invocations each naming 6 benchmarks, instead of 12 each naming 1"},
-        {"id": "T-D1B-2", "mutation": "fix the lead arm (ON always first) instead of alternating on i%2", "observable": "the (benchmark, arm) sequence gives #ON-lead=6, #OFF-lead=0, violating <=1. Observable value set = the 2^6 lead assignments, not a boolean."},
-        {"id": "T-D1B-3", "mutation": "pass $FMT_BENCH_LIST (all 6) instead of ${FMT_BENCHES[i]} inside the loop", "observable": "each logged invocation's --benchmarks argument has 6 comma-separated names instead of 1"}
+        {
+          "id": "T-D1B-1",
+          "mutation": "revert to `for arm in on off` around a whole-suite call",
+          "observable": "stub invocation log: 2 invocations each naming 6 benchmarks, instead of 12 each naming 1"
+        },
+        {
+          "id": "T-D1B-2",
+          "mutation": "fix the lead arm (ON always first) instead of alternating on i%2",
+          "observable": "the (benchmark, arm) sequence gives #ON-lead=6, #OFF-lead=0, violating <=1. Observable value set = the 2^6 lead assignments, not a boolean."
+        },
+        {
+          "id": "T-D1B-3",
+          "mutation": "pass $FMT_BENCH_LIST (all 6) instead of ${FMT_BENCHES[i]} inside the loop",
+          "observable": "each logged invocation's --benchmarks argument has 6 comma-separated names instead of 1"
+        }
       ],
       "passes": null,
       "started": null,
       "completed": null,
-      "notes": null
+      "notes": " Not started at iteration 14 — named resume point, not dropped.",
+      "status": "not_started"
     },
     {
       "id": "M4_D2_CENSORED_PAIR_ANALYZER",
@@ -119,24 +230,55 @@
         "AC-M4-5: run against the REAL banked AC5 arms eval_results/ab2_fmt_{on,off}, the analyzer reports VOID with an order-integrity reason — known in advance from V19, independently measured, and NOT the happy path."
       ],
       "test_rows": [
-        {"id": "T-D2-VOID-ORDER", "mutation": "neuter the order-integrity gate", "observable": "on a perfect-arm-block fixture the (verdict, void_reason) pair changes from (VOID, order_integrity) to a numeric verdict. 4 verdicts x N reasons, not 'did it error'."},
-        {"id": "T-D2-VOID-TREAT-ON", "mutation": "neuter the >20% ON-quarantined rule", "observable": "fixture with 2/6 ON rows validity.valid=false: verdict changes from (VOID, treatment_unproven_rate)"},
-        {"id": "T-D2-VOID-TREAT-OFF", "mutation": "neuter the OFF-contamination rule", "observable": "fixture with 1 OFF row carrying fmt_hook_events: verdict changes from (VOID, control_contaminated)"},
-        {"id": "T-D2-CENSOR", "mutation": "neuter s2 rule 1 (one-passes-wins) so both-fail and one-passes both tie", "observable": "fixture with 10 one-arm-passes pairs: the (n_eff, W, verdict) triple goes 10->0 and KEEP->RETIRE"},
-        {"id": "T-D2-MARGIN", "mutation": "neuter the |log ratio| <= 0.10 practical-equivalence margin", "observable": "fixture of both-pass pairs all within +-5%: n_eff 0->12 with a spurious W"},
-        {"id": "T-D2-KEEP-3", "mutation": "neuter each of the three KEEP conjuncts in turn (sign test / both-pass median token ratio <= 0.90 / McNemar guardrail)", "observable": "three fixtures each failing exactly one conjunct must all be non-KEEP; a mutant dropping any conjunct returns KEEP on its own fixture"},
-        {"id": "T-D2-REAL", "mutation": "none — end-to-end oracle", "observable": "the real banked AC5 arms yield VOID with an order-integrity reason (V19 established this before the analyzer existed)"}
+        {
+          "id": "T-D2-VOID-ORDER",
+          "mutation": "neuter the order-integrity gate",
+          "observable": "on a perfect-arm-block fixture the (verdict, void_reason) pair changes from (VOID, order_integrity) to a numeric verdict. 4 verdicts x N reasons, not 'did it error'."
+        },
+        {
+          "id": "T-D2-VOID-TREAT-ON",
+          "mutation": "neuter the >20% ON-quarantined rule",
+          "observable": "fixture with 2/6 ON rows validity.valid=false: verdict changes from (VOID, treatment_unproven_rate)"
+        },
+        {
+          "id": "T-D2-VOID-TREAT-OFF",
+          "mutation": "neuter the OFF-contamination rule",
+          "observable": "fixture with 1 OFF row carrying fmt_hook_events: verdict changes from (VOID, control_contaminated)"
+        },
+        {
+          "id": "T-D2-CENSOR",
+          "mutation": "neuter s2 rule 1 (one-passes-wins) so both-fail and one-passes both tie",
+          "observable": "fixture with 10 one-arm-passes pairs: the (n_eff, W, verdict) triple goes 10->0 and KEEP->RETIRE"
+        },
+        {
+          "id": "T-D2-MARGIN",
+          "mutation": "neuter the |log ratio| <= 0.10 practical-equivalence margin",
+          "observable": "fixture of both-pass pairs all within +-5%: n_eff 0->12 with a spurious W"
+        },
+        {
+          "id": "T-D2-KEEP-3",
+          "mutation": "neuter each of the three KEEP conjuncts in turn (sign test / both-pass median token ratio <= 0.90 / McNemar guardrail)",
+          "observable": "three fixtures each failing exactly one conjunct must all be non-KEEP; a mutant dropping any conjunct returns KEEP on its own fixture"
+        },
+        {
+          "id": "T-D2-REAL",
+          "mutation": "none — end-to-end oracle",
+          "observable": "the real banked AC5 arms yield VOID with an order-integrity reason (V19 established this before the analyzer existed)"
+        }
       ],
       "passes": null,
       "started": null,
       "completed": null,
-      "notes": "Parallel-safe with M1/M2/M3/M5 — touches internal/eval_analysis + cmd/ailang only. Out of scope this sprint: the s5.1 'void run pages the mission via ailang messages send' wiring; the analyzer emits the void verdict + reason on stdout and exits non-zero, and paging is driver policy."
+      "notes": "Parallel-safe with M1/M2/M3/M5 — touches internal/eval_analysis + cmd/ailang only. Out of scope this sprint: the s5.1 'void run pages the mission via ailang messages send' wiring; the analyzer emits the void verdict + reason on stdout and exits non-zero, and paging is driver policy. Not started at iteration 14 — named resume point, not dropped.",
+      "status": "not_started"
     },
     {
       "id": "M5_SMOKE_BANK_WIRING",
       "description": "Wire the design doc s5.2 new-tree contract check into the nightly fmt block immediately before M3's interleave loop: one smoke bank of 1 benchmark x 1 trial on the ON arm, asserting (a) the ported extension still writes <workspace>/.claude/fmt_hook_events.jsonl with the {status,file} schema and (b) the new-tree step-0 broadcast still names the extension `fmt` in resolved_extensions. NO NEW ASSERTION LOGIC IS WRITTEN — check (b) is exactly eval_harness.ResolveFmtArm (fmt_treatment.go:28-47, exact fmt#N name match) and check (a) is exactly AssertFmtTreatmentIntegrity(\"on\", events) (fmt_treatment.go:60-92, which already demands >=1 event AND >=1 with status=formatted). The smoke check reads the banked row's validity and fmt_hook_state. On failure the block logs the specific failing contract, sends `ailang messages send controlplane`, sets RUN_AB_FMT=0 and does NOT enter the measurement loop — modelled on the existing select_ab_benchmarks-returned-nothing path at nightly-eval.sh:480-487.",
       "estimated_loc": 190,
-      "dependencies": ["M3_D1B_COUNTERBALANCED_WEDNESDAY_BLOCK"],
+      "dependencies": [
+        "M3_D1B_COUNTERBALANCED_WEDNESDAY_BLOCK"
+      ],
       "acceptance_criteria": [
         "AC-M5-1: `bash -n tools/launchd/nightly-eval.sh` and `shellcheck -S warning tools/launchd/nightly-eval.sh` both exit 0 with 0 findings (BASE: PASS / PASS).",
         "AC-M5-2: T-D2-SMOKE — when the stub smoke bank produces a row with fmt_hook_state=off, the driver logs the contract failure, sets RUN_AB_FMT=0, and emits ZERO `eval-suite --trials 5` invocations. Killed mutation: neutering the smoke gate (`if false && <smoke_failed>`) yields 12 measurement invocations instead of 0. Observable: the stub's invocation log (value set = the set of invocations, not a boolean).",
@@ -145,7 +287,8 @@
       "passes": null,
       "started": null,
       "completed": null,
-      "notes": null
+      "notes": " Not started at iteration 14 — named resume point, not dropped.",
+      "status": "not_started"
     }
   ],
   "deployment_precondition": {
@@ -166,13 +309,38 @@
     "OPENROUTER_API_KEY is set in the interactive shell on this machine (len 73), so a bare `go test` masks the CI behaviour. Use `env -u OPENROUTER_API_KEY` for the M1 regression gate."
   ],
   "risks": [
-    {"id": "R1", "risk": "The 8 mock-binary Execute tests break in CI where OPENROUTER_API_KEY is unset (they pass locally only because the ambient env has it)", "mitigation": "AC-M1-3 (`env -u OPENROUTER_API_KEY go test ./internal/executor/motoko/`) is the gate; green at base"},
-    {"id": "R2", "risk": "T-B6's loud refusal on an unresolvable provider refuses a legitimate lane", "mitigation": "T-B6b asserts GuessProvider resolves all 17 motoko lanes read from models.yml, so a future unresolvable lane fails at add-time"},
-    {"id": "R3", "risk": "AC-M2-control needs OPENROUTER_API_KEY, a few cents of metered spend, and the rig", "mitigation": "one trivial canary on the cheapest OpenRouter motoko lane; if the control does not fire, AC-M2-treatment is VOID and this plan does not soften that"},
-    {"id": "R4", "risk": "D2's shape drifts from the doc's s2/s5/s7 during implementation", "mitigation": "every D2 rule is quoted from the doc, and AC-M4-5 pins the analyzer against the real AC5 dataset whose correct verdict (VOID, order integrity) was established by V19 before the analyzer existed"},
-    {"id": "R5", "risk": "The fix merges but never reaches the rig (issue #558)", "mitigation": "AC-DEPLOY reads the script at the installed-plist path plus the $BIN git rev; until both pass, no slot counts"},
-    {"id": "R6", "risk": "M4's new BenchmarkResult fields collide with the existing loader's strictness", "mitigation": "additive with omitempty and JSON tags copied from the already-banked keys (metrics.go:138,143); AC-M4-3 asserts eval-paired's output is byte-identical before and after"}
+    {
+      "id": "R1",
+      "risk": "The 8 mock-binary Execute tests break in CI where OPENROUTER_API_KEY is unset (they pass locally only because the ambient env has it)",
+      "mitigation": "AC-M1-3 (`env -u OPENROUTER_API_KEY go test ./internal/executor/motoko/`) is the gate; green at base"
+    },
+    {
+      "id": "R2",
+      "risk": "T-B6's loud refusal on an unresolvable provider refuses a legitimate lane",
+      "mitigation": "T-B6b asserts GuessProvider resolves all 17 motoko lanes read from models.yml, so a future unresolvable lane fails at add-time"
+    },
+    {
+      "id": "R3",
+      "risk": "AC-M2-control needs OPENROUTER_API_KEY, a few cents of metered spend, and the rig",
+      "mitigation": "one trivial canary on the cheapest OpenRouter motoko lane; if the control does not fire, AC-M2-treatment is VOID and this plan does not soften that"
+    },
+    {
+      "id": "R4",
+      "risk": "D2's shape drifts from the doc's s2/s5/s7 during implementation",
+      "mitigation": "every D2 rule is quoted from the doc, and AC-M4-5 pins the analyzer against the real AC5 dataset whose correct verdict (VOID, order integrity) was established by V19 before the analyzer existed"
+    },
+    {
+      "id": "R5",
+      "risk": "The fix merges but never reaches the rig (issue #558)",
+      "mitigation": "AC-DEPLOY reads the script at the installed-plist path plus the $BIN git rev; until both pass, no slot counts"
+    },
+    {
+      "id": "R6",
+      "risk": "M4's new BenchmarkResult fields collide with the existing loader's strictness",
+      "mitigation": "additive with omitempty and JSON tags copied from the already-banked keys (metrics.go:138,143); AC-M4-3 asserts eval-paired's output is byte-identical before and after"
+    }
   ],
   "execution_order": "M1 -> M2 -> M3 -> M5, with M4 parallel-safe (disjoint files). M3 must land before M5.",
-  "scope_note": "The full D1 + D1b + D2 + smoke-bank scope FITS in 3.0 days. Nothing is deferred to a follow-up sprint. The one item that is not purely local is M2's AC-D1-live, which needs the rig and (control leg only) OPENROUTER_API_KEY."
+  "scope_note": "The full D1 + D1b + D2 + smoke-bank scope FITS in 3.0 days. Nothing is deferred to a follow-up sprint. The one item that is not purely local is M2's AC-D1-live, which needs the rig and (control leg only) OPENROUTER_API_KEY.",
+  "delivery_status": "M1 of 5 delivered (iteration 14); M2-M5 are the resume point"
 }

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -41,6 +41,28 @@ install falls back loudly rather than silently.
 `code --list-extensions` when a CLI is present, and otherwise requires a registry
 entry whose `relativeLocation` exists and is not flagged obsolete. A folder with
 no entry is now reported as broken, naming the fix, instead of as installed.
+### Fixed — motoko pre-flight no longer refuses all lanes on a missing provider key; the refusal is now per-lane at the per-task choke point
+
+M-MOTOKO-FMT-REMEASUREMENT-INSTRUMENT D1 (iteration 14). The motoko executor's
+`HealthCheck` (and hence every canary) previously returned a hard error whenever
+`OPENROUTER_API_KEY` was unset — unconditionally, regardless of the lane. Two
+Wednesday A/B fmt lanes banked zero data since AC5 because of it, and the check
+fired for ollama/ local lanes where no provider key exists to verify.
+
+The preflight's presence was also the wrong tier: a provider-conditional check
+cannot be expressed in `HealthCheck` because that shared executor method sees no
+task and therefore no lane model (the executor's `e.model` is a single
+process-global default that is never one of the 17 distinct motoko lanes). The
+refusal moved to `MotokoExecutor.ExecuteStreaming` — the per-task choke point
+through which all motoko work passes — and is expressed on the RESOLVED PROVIDER
+(`ai.EnvVarForProvider(ai.GuessProvider(model))`), so it covers ollama / OpenAI /
+Anthropic / Google / OpenRouter in one check. A credential key is required only
+for a provider that declares one; an ollama lane passes with every key unset.
+
+The check runs strictly DOWNSTREAM of repo discovery (`HealthCheck`'s
+`motoko --version` query), so the profile cannot degrade to
+`extensions.order=[]` and drop the fmt extension the instrument exists to
+measure.
 
 ### Fixed — package imports now resolve from the source file's directory, not the process CWD
 

--- a/design_docs/planned/m-motoko-fmt-remeasurement-instrument-sprint-plan.md
+++ b/design_docs/planned/m-motoko-fmt-remeasurement-instrument-sprint-plan.md
@@ -1,0 +1,465 @@
+# Sprint plan — M-MOTOKO-FMT-REMEASUREMENT-INSTRUMENT (D1 + D1b + D2 + smoke-bank)
+
+**Design doc (authority):** `design_docs/planned/m-motoko-fmt-remeasurement-instrument.md`
+The design doc WINS over this plan wherever they disagree. This plan adds only *how* and *in what
+order*, plus the measurements that were run to choose among the options the doc left open.
+
+**Created:** 2026-08-20 (motoko mission iteration 14, Gate 3)
+**Branch / worktree:** `sprint/motoko-iter14-fmt-d1` @ `/Users/voightkampff/.ailang-driver-pin/.wt-motoko-iter14-fmt-d1`, branched from `origin/dev` at `44aa3cab4`
+**Scope, from the doc's §6 "Sequencing":** D1 + D1b + D2 + smoke-bank wiring
+**Estimated:** 5 milestones, ~1,515 LOC (≈475 impl + ≈1,040 test/harness), **≈3.0 days** — fits the doc's ≤3–4 day discipline. **Nothing is deferred to a follow-up sprint.**
+**Platform of every measurement in this plan:** **darwin/arm64** (`uname -sm` → `Darwin arm64`, macOS 26.5.2). The windows and ubuntu CI legs are **unrun locally**; every "BASE" result below is a darwin/arm64 result only. The one place this is load-bearing is `runHealthCheck`'s exec-bit branch, which is guarded `runtime.GOOS != "windows"` — its mutation row (T-B3) is therefore darwin-only and its windows behaviour is asserted by construction, not by execution.
+
+---
+
+## 0. The finding that re-shapes D1 — the doc's preferred option is UNSOUND
+
+The design doc's §12.2 lists three options and leans to **option (1)** ("set `cfg.MotokoModel` from
+`models.yml` at construction — smallest true fix"). **Option (1) cannot work.** Two independent
+measurements, either one fatal:
+
+### 0.1 There is no per-model construction, and no singular model to set
+
+`executor.GlobalFactory()` builds **one** factory, **once**, from `DefaultConfig()`:
+
+```
+internal/executor/factory.go:178-182   GlobalFactory() → globalFactoryOnce.Do(func(){ globalFactory = NewFactory(nil) })
+internal/executor/factory.go:79-87     NewFactory(nil) → cfg = DefaultConfig()
+internal/executor/factory.go:96-122    GetExecutor(name) caches by EXECUTOR NAME: f.executors[name]
+```
+
+`SetGlobalFactory` has **zero non-test callers** (measured: `grep -rn 'SetGlobalFactory\|NewFactory(' --include='*.go' . | grep -v _test.go` → 4 hits, all inside `factory.go` itself: the declaration, the `GlobalFactory` body, and the doc comment). So `cfg` is a process-global singleton and `cfg.MotokoModel` is a **single string**.
+
+But `agent_cli: "motoko"` names **17 distinct lanes** in `internal/eval_harness/models.yml`, split across two providers:
+
+| provider | lanes | example `agent_model_name` |
+|---|---|---|
+| OpenRouter-routed | **10** | `openrouter/anthropic/claude-haiku-4-5`, `openrouter/z-ai/glm-5.1`, … |
+| ollama (local) | **7** | `ollama/qwen3.6:35b-a3b-mxfp8` (`motoko-local-qwen3-6-fmt`, profile `ollama_fmt` — the treatment arm) |
+
+`GetExecutor("motoko")` hands **the same cached `*MotokoExecutor`** to all 17. There is no
+construction event per model, so "set `cfg.MotokoModel` from models.yml" has no well-defined
+value: 10 lanes need `OPENROUTER_API_KEY` and 7 need nothing, and the field can hold one string.
+
+### 0.2 Even granted a value, `HealthCheck` is `sync.Once`-cached — a per-model verdict frozen at the first model
+
+```
+internal/executor/motoko/motoko.go:131-133   healthCheckOnce sync.Once; healthCheckErr error
+internal/executor/motoko/healthcheck.go:31-43 HealthCheck → e.healthCheckOnce.Do(...); return e.healthCheckErr
+```
+
+The canary loop calls `GetExecutor` **per model** (`internal/eval_harness/canary_filter.go:62`) and
+gets the same instance, so the first model canaried decides for every later one. A model-dependent
+condition evaluated inside a once-cached method is a category error: on a night that canaries both
+`motoko-local-qwen3-6-fmt` (ollama) and any of the 10 OpenRouter motoko lanes, one lane's provider
+answer would be applied to the other. Option (1) would convert today's *loud, uniform* refusal into
+a *silent, order-dependent* one — strictly worse under CLAUDE.md rule 2.
+
+### 0.3 Chosen: **option (2), refined** — the check moves to the per-task choke point
+
+> **D1 = remove the unconditional key refusal from `runHealthCheck`; add a resolved-provider
+> credential check at the top of `MotokoExecutor.ExecuteStreaming`, keyed on `e.getModel(task)`.**
+
+Option (3) (widen the `HealthCheck` signature) is rejected without further measurement: it is a
+change to `executor.Executor` (`internal/executor/executor.go:31`) with 6 implementors, and the
+trace gives no reason to prefer it.
+
+**Why `ExecuteStreaming` and not `Execute` or `CanaryCheck`:** `Execute` delegates
+(`motoko.go:166-168 → ExecuteStreaming`), so `ExecuteStreaming` is the single choke point through
+which *all* motoko work passes. Placing it in `CanaryCheck` would miss
+`agent_runner_multi.go`'s path; placing it in `Execute` would miss direct `ExecuteStreaming`
+callers.
+
+**Why this satisfies §12.3's ordering requirement for free.** The doc requires that the
+resolved-provider check must NOT run ahead of `MOTOKO_REPO` / repo discovery, or the profile
+degrades to `extensions.order=[]` and drops the `fmt` extension that IS the treatment. Measured:
+`e.motokoRepo` is populated by `HealthCheck`'s `motoko --version` query
+(`healthcheck.go:70-77`), and the code comment at `motoko.go:364-365` states it directly — *"e.motokoRepo
+is discovered by HealthCheck from `motoko --version`, which the eval path and the canary both run
+before Execute"* — confirmed at both call sites (`internal/eval_harness/agent_runner_multi.go:107`,
+`internal/executor/motoko/canary.go:67`). A check inside `ExecuteStreaming` is therefore **strictly
+downstream** of repo discovery in both production paths. This is an ordering property to be
+*asserted*, not assumed — see test row **T-ORDER**.
+
+**Cost of the doc's stated downside, measured rather than accepted.** §12.2 says option (2) "loses
+fail-fast-before-workspace-setup". What is actually lost:
+- canary path (`canary.go:95-103`): one `os.MkdirTemp` + one 3-byte `os.WriteFile` before `Execute`;
+- eval path (`agent_runner_multi.go:112-122`): one `os.MkdirAll` + a stub `.git` dir.
+
+Both are local filesystem operations of microsecond order. Everything expensive (bun startup, the
+LLM call) happens *inside* `ExecuteStreaming`, after the check. Attribution is preserved end to end:
+an `Execute` error propagates `canary.go:118 evaluateCanaryResult → "canary task failed: %w" →
+executor.CanaryError → eval_harness.CanarySkip`, i.e. the model is still dropped from the run matrix
+with a named reason, exactly as today.
+
+### 0.4 The condition is expressed on the RESOLVED PROVIDER, never on a literal env-var name
+
+```go
+// internal/executor/motoko/provider_preflight.go (new)
+provider := ai.GuessProvider(model)          // internal/ai/config.go:45-101
+envVar  := ai.EnvVarForProvider(provider)    // internal/ai/config.go:104-119
+```
+
+One check covers ollama / OpenAI / Anthropic / Google / OpenRouter. The literal string
+`OPENROUTER_API_KEY` must not appear in the new predicate (it may appear only in a test's
+*expectation table*, which is the mechanism's own value set — see §3).
+
+**Import-boundary check (controller fact 4, re-verified this session, plus the missing half).**
+`internal/executor/motoko` imports exactly two in-module packages today:
+
+```
+$ grep -rho '"github.com/sunholo-data/ailang/internal/[a-z_/]*"' --include='*.go' internal/executor/motoko/ | sort -u
+"github.com/sunholo-data/ailang/internal/executor"
+"github.com/sunholo-data/ailang/internal/telemetry"
+```
+
+Non-empty, so the instrument fires. `internal/ai` does **not** import `internal/executor` (same
+anchored grep over `internal/ai/`), so no cycle. `scripts/check_boundaries.sh` polices only
+`CORE_PKGS=(parser types eval core elaborate effects builtins lexer ast pipeline runtime link iface)`
+and `DASHBOARD_PKGS=(server coordinator observatory messaging)` — neither `executor` nor `ai` is in
+either set, and five files already import `internal/ai` (`internal/feedbackgate/classifier.go`,
+`internal/coordinator/provider_gemini.go`, `internal/eval_harness/ai_provider.go`, + tests), so the
+grep sees this class of hit. §12.2's caveat *"confirm the boundary allows it"* is **ANSWERED: it
+does.** Gate command and BASE result in §4.
+
+> ⚠ **Instrument warning inherited from the controller and re-confirmed.** The module path is
+> `github.com/sunholo-data/ailang`, **not** `github.com/sunholo/ailang`. An import grep anchored on
+> the wrong path returns a confident, silent **0**. Every import grep in this sprint must be
+> anchored on the `go.mod` path and paired with a known-positive control.
+
+---
+
+## 1. Milestones
+
+Each milestone is independently committable, independently bisectable, and leaves the tree green on
+the §4 gates. Order is the doc's §6 order: **D1 first** — it is the only item that unblocks anything
+else, and it un-breaks the current tree's Wednesday A/B lane regardless of the rest.
+
+| # | milestone | impl LOC | test LOC | days | depends on |
+|---|---|---|---|---|---|
+| M1 | **D1** — provider-conditional preflight | 70 | 220 | 0.75 | — |
+| M2 | **AC-D1-live** — live provider-connection proof | 130 | 30 | 0.25 (+~15 min rig) | M1 |
+| M3 | **D1b** — counterbalanced Wednesday block | 55 | 120 | 0.25 | M1 |
+| M4 | **D2** — censored-pair analyzer | 380 | 330 | 1.25 | — (parallel-safe with M1–M3) |
+| M5 | **smoke-bank wiring** (§5.2) | 110 | 80 | 0.5 | M3 |
+| | **total** | **745** | **780** | **3.0** | |
+
+---
+
+### M1 — D1: provider-conditional preflight
+
+**Files**
+- `internal/executor/motoko/healthcheck.go` — DELETE the unconditional refusal at :64-66. Keep the binary/dir/exec-bit checks and, crucially, keep the `motoko --version` query that populates `e.motokoRepo`.
+- `internal/executor/motoko/provider_preflight.go` — NEW. `func requireProviderCredential(model string) error`.
+- `internal/executor/motoko/motoko.go` — call it at the top of `ExecuteStreaming`, before the span/workspace/subprocess work, with `e.getModel(task)`.
+- `internal/executor/motoko/motoko_test.go` — **DELETE** `TestHealthCheck_MissingAPIKey` (:141-154). Per `.claude/rules/coding-standards.md` ("ALWAYS remove out-of-date tests. No backward compatibility."), it asserts the exact behaviour this milestone removes. Its replacement is T-B5 below. Also drop the now-false `t.Setenv("OPENROUTER_API_KEY", …)` scaffolding and stale comment at :130-132.
+- `internal/executor/motoko/execute_test.go` — see the migration hazard below.
+
+**Measured migration hazard (do not discover this at CI time).** Eight of the nine `Execute` tests
+build the executor as `New(&executor.Config{MotokoPath: mockMotoko})`
+(`execute_test.go:131,204,285,360,402,445,497,547`), leaving `MotokoModel` empty, which `New`
+defaults to `"openrouter/anthropic/claude-haiku-4-5"` (`motoko.go:145-148`). Under M1 those tasks
+resolve to provider `openrouter` and will be **refused** wherever `OPENROUTER_API_KEY` is unset —
+i.e. CI. They pass on this machine today only because the ambient env has the key set
+(`${#OPENROUTER_API_KEY}` = 73). The fix is per-test and deliberate: give each mock task an
+`ollama/…` model (matching what the mock actually simulates), or `t.Setenv` the key where the test
+is genuinely about an OpenRouter lane. The regression gate for exactly this is **AC-M1-3**.
+
+**Acceptance criteria**
+- **AC-M1-1** `go build ./internal/... ./cmd/ailang/...` exits 0. *(BASE: PASS — see §4 for why `go build ./...` is NOT the gate.)*
+- **AC-M1-2** `go test ./internal/executor/... ./internal/ai/...` exits 0. *(BASE: PASS, 14/14 packages ok.)*
+- **AC-M1-3** `env -u OPENROUTER_API_KEY go test ./internal/executor/motoko/` exits 0. *(BASE: PASS, `ok … 20.422s`.)* This is the gate that catches the 8-test hazard above; it must stay green.
+- **AC-M1-4** `bash scripts/check_boundaries.sh` exits 0 after the new `internal/ai` import. *(BASE: PASS, "OK: no architecture boundary violations".)*
+- **AC-M1-5** `grep -n 'OPENROUTER_API_KEY' internal/executor/motoko/*.go | grep -v _test.go` returns **zero** lines. Known-positive control in the same sweep: the same grep over `internal/ai/config.go` returns lines 115 and 143, so the grep sees this class of hit. *(BASE: 1 hit at `healthcheck.go:64`; control: 2 hits — so the instrument discriminates.)*
+- **AC-M1-6** The full refusal-branch mutation matrix (§3, rows T-B1…T-B6 + T-ORDER) passes, and each listed neutering mutation makes exactly its own row fail.
+
+---
+
+### M2 — AC-D1-live: the live provider-connection proof
+
+**The design doc's criterion, carried VERBATIM (§12.4):**
+
+> **AC-D1-live.** With the fix in place, one fmt-lane run reaches `localhost:11434` and makes **zero**
+> connections to `openrouter.ai`. Assert on the connection, not on the absence of an error — an
+> absence is satisfied equally by "no OpenRouter call" and "the run never started" (the observable
+> must be unique to the mechanism). Pair it with a known-positive control: an OpenRouter-lane run in
+> the same sweep must show the connection, or the instrument proves nothing.
+
+**This criterion may NOT be weakened to "no error occurred".** The doc forbids it explicitly, for
+the stated reason. It is satisfied only by an *observed connection*, in both directions.
+
+**Files**
+- `tools/eval/motoko_connection_probe.sh` — NEW. Runs one motoko canary for a named models.yml lane, samples the connection table of the motoko process tree once per second for the run's duration, and writes the union of ESTABLISHED peers to a JSON artifact.
+
+**Instrument (darwin/arm64 only; no root required).**
+1. Resolve the target set once, up front: `dig +short openrouter.ai` → `OR_IPS`. Record it in the artifact — a criterion computed from an unrecorded resolution is unauditable.
+2. Launch `ailang eval-suite --agent --models <lane> --benchmarks <one> --trials 1 --dry-run=false` (or the canary path directly), capture the driver PID.
+3. Poll `lsof -nP -iTCP -sTCP:ESTABLISHED -a -p "$(pgrep -d, -P <pid> ; echo <pid>)"` each second; union all `NAME` peer endpoints.
+4. Classify each peer as loopback / `OR_IPS` member / other. **Emit the full peer set**, always — the artifact is the evidence, the verdict is a function of it.
+
+**Acceptance criteria (both must hold, in the same sweep, same day)**
+- **AC-M2-treatment** For lane `motoko-local-qwen3-6-fmt`: the peer set **contains** `127.0.0.1:11434`, and **contains no member of `OR_IPS`**. (The probe additionally reports any non-loopback peer for human review; a non-loopback peer that is not in `OR_IPS` does not fail the criterion but must be recorded.)
+- **AC-M2-control** For an OpenRouter lane (`motoko-claude-haiku-4-5`, cheapest of the 10) with `OPENROUTER_API_KEY` set: the peer set **contains at least one member of `OR_IPS`**. If this control does not fire, **AC-M2-treatment is void** — the probe proved nothing.
+- **AC-M2-3** The artifact records `OR_IPS`, both peer sets, both lane names, the probe start/end timestamps, and `uname -sm`.
+
+**Why this is not a weakened absence.** The treatment leg's verdict rests on a *positive*
+observation (`127.0.0.1:11434` present) conjoined with a negative one, and the negative one is only
+admissible because the control leg demonstrates, on the same instrument and the same day, that the
+probe can see a remote connection when there is one. "The run never started" fails
+AC-M2-treatment's positive half.
+
+**Dependencies / cost.** Needs the rig (or any host with ollama serving qwen3.6 and the motoko
+binary present) and, for the control leg only, `OPENROUTER_API_KEY` and a few cents of metered
+spend on one trivial canary task. ~15 min wall-clock. This is the one milestone whose completion is
+not purely local.
+
+---
+
+### M3 — D1b: counterbalanced Wednesday block (doc §5.3)
+
+**File:** `tools/launchd/nightly-eval.sh`, the fmt block. V22 cites lines **492-507**; re-verified
+this session at the same lines — the whole-arm `for arm in on off; do … "$BIN" eval-suite --agent
+--models "$m" --benchmarks "$FMT_BENCH_LIST" … --trials "$FMT_TRIALS" … done` is one whole-suite
+call per arm.
+
+**Replacement, per §5.3 exactly:** iterate the ELO-selected benchmarks *in selection order*; for
+benchmark index `i` (0-based) run both arms back-to-back — **ON then OFF when `i` is even, OFF then
+ON when `i` is odd** — each arm as one `eval-suite --benchmarks <b> --trials "$FMT_TRIALS"`
+invocation into the same per-arm `--output` dir.
+
+**Two mechanics confirmed by measurement, so this is expressible:**
+- `select_ab_benchmarks` (`nightly-eval.sh:225-232`) emits a **comma-separated, space-stripped** list (`… | grep '^Benchmarks:' | sed 's/^Benchmarks:[[:space:]]*//' | tr -d ' '`), so `IFS=',' read -ra FMT_BENCHES <<< "$FMT_BENCH_LIST"` splits it safely.
+- Repeated invocations into one output dir do not collide: bank filenames embed the bank time (`<id>[_trialN]_<lang>_<model>_<timestamp>.json`, `internal/eval_harness/metrics.go`, V23).
+
+Everything downstream of the loop (the `eval-paired` call, `count_passes`, `FMT_VALID`, the
+`fmt_ab.jsonl` bank) reads the two output dirs and is **untouched**.
+
+**Acceptance criteria**
+- **AC-M3-1** `bash -n tools/launchd/nightly-eval.sh` exits 0. *(BASE: PASS.)*
+- **AC-M3-2** `shellcheck -S warning tools/launchd/nightly-eval.sh` exits 0 with 0 findings. *(BASE: PASS, exit 0, 0 findings.)*
+- **AC-M3-3** Order test T-D1B (§3) passes: with a stub `$BIN` on `PATH` that appends `"$*"` to a log and exits 0, sourcing the fmt block over a 6-benchmark list produces **12** `eval-suite` invocations whose (benchmark, arm) sequence is `b0:on,b0:off, b1:off,b1:on, b2:on,b2:off, b3:off,b3:on, b4:on,b4:off, b5:off,b5:on`, and each invocation names exactly one benchmark.
+- **AC-M3-4** The same log satisfies the §5.3 gate's own predicate: contiguous same-(benchmark,arm) blocks, each benchmark's two blocks adjacent, `|#ON-lead − #OFF-lead| ≤ 1`. Asserted by calling **M4's** order-integrity checker on synthesised rows, so the driver and the analyzer are proven to agree rather than each being right about a different schedule.
+
+---
+
+### M4 — D2: the censored-pair analyzer
+
+**Decision: a SIBLING command, not an extension of `eval-paired`.** Justified by measurement, not
+taste: `eval-paired`'s stdout JSON is a live contract — `nightly-eval.sh:512` pipes it through
+`paired_summary` and it is banked, and the **Monday microRAG** block calls the same command. Changing
+its shape would silently re-point an unrelated experiment's bank. `cmd/ailang/eval_paired.go` is 73
+lines and stays byte-identical.
+
+**Files**
+- `internal/eval_analysis/types.go` — ADD two read-side fields to `BenchmarkResult` (additive, `omitempty`, JSON tags matching the already-banked keys at `internal/eval_harness/metrics.go:138,143`): `FmtHookState string \`json:"fmt_hook_state,omitempty"\`` and `FmtHookEvents []eval_harness.FmtHookEvent \`json:"fmt_hook_events,omitempty"\``. Measured gap: `BenchmarkResult` today carries `MicroRAGState` but **no** fmt field, while `Validity` and `Timestamp` and `Trial` and the token fields are already present.
+- `internal/eval_analysis/censored.go` — NEW. The §2 verdict, the §5 void rules, the §7 decision rule.
+- `cmd/ailang/eval_censored.go` — NEW. `ailang eval-censored-pairs [flags] <on-dir> <off-dir>`.
+- `cmd/ailang/main.go` (+1 case), `cmd/ailang/help.go` (+1 line), `cmd/ailang/eval_remote_read.go` (+1 map entry, matching how `eval-paired` is registered).
+
+**What it implements — the doc's own words, not a paraphrase**
+- §2 verdict per (benchmark, trial) pair: one-passes → passing arm **wins**; both pass → fewer total tokens (input cache-inclusive + output, as banked) wins with `|log ratio| ≤ 0.10` a **tie**; both fail → **tie**.
+- Primary: one-sided exact sign test on non-tied pairs, α = 0.05, H₁ = ON wins more often. (`internal/eval_analysis/paired.go:205-231` already has `exactBinomialTwoSided` + `binomialPMF` to build on.)
+- Secondaries, reported never deciding: mean paired log token ratio on both-pass pairs with 95% CI; and the existing `PairArms` McNemar + headroom as a pass-rate guardrail.
+- §5 **treatment integrity**: refuse quarantined input. A pair whose ON row is quarantined is dropped **and counted**. `> 20%` of ON rows quarantined, or **any** OFF-row contamination → **VOID, no numbers reported at all**, void reason is the output.
+- §5.3 **order integrity**: sort a slot's rows by `timestamp`; require (a) contiguous same-(benchmark, arm) blocks, (b) each benchmark's two blocks adjacent, (c) lead arm alternates (`|#ON-lead − #OFF-lead| ≤ 1`). Any failure → **VOID, no numbers reported**.
+- §7 decision rule verdicts: `VOID` / `KEEP` / `RETIRE` / `INCONCLUSIVE`, with the exact thresholds (`n_eff < 24`; KEEP iff sign test rejects at α=0.05 **and** both-pass median token ratio ≤ 0.90 **and** McNemar shows no significant ON pass-rate loss; RETIRE iff opposite-direction rejection **or** KEEP fails with `n_eff ≥ 40`).
+
+**Explicitly out of scope for this sprint:** the "void run pages the mission via `ailang messages
+send`" wiring from §5.1. The analyzer must *emit* the void verdict and reason on stdout and exit
+non-zero; who pages is driver policy and belongs in the nightly block, where M5 already adds a
+failure path.
+
+**Acceptance criteria**
+- **AC-M4-1** `go test ./internal/eval_analysis/... ./cmd/ailang/...` exits 0. *(BASE: to be recorded by the executor as its first action — this plan baselined `./internal/executor/... ./internal/ai/...` and the scoped lint, not this pair. Treat a red base here as a repo finding, not a sprint failure.)*
+- **AC-M4-2** `golangci-lint run ./internal/eval_analysis/... ./cmd/ailang/... ./internal/executor/motoko/...` exits 0 with 0 issues. *(BASE: PASS, "0 issues".)*
+- **AC-M4-3** `ailang eval-paired --with-pairs=true <on> <off>` produces **byte-identical** stdout before and after M4, on the banked AC5 arms `eval_results/ab2_fmt_on` / `eval_results/ab2_fmt_off`. Proves the sibling command did not disturb the live contract.
+- **AC-M4-4** Fixture-driven verdict matrix (§3, rows T-D2-*) passes, including the two void rules and each of the four §7 verdicts.
+- **AC-M4-5** Run against the real banked AC5 arms, the analyzer reports **VOID with an order-integrity reason** (V19 established those 12 rows are a perfect arm block). This is the strongest available end-to-end check: a real, independently-measured dataset whose correct verdict is known in advance and is *not* the happy path.
+
+---
+
+### M5 — smoke-bank wiring (doc §5.2)
+
+**File:** `tools/launchd/nightly-eval.sh` (fmt block, immediately before M3's interleave loop) plus a
+small checker.
+
+**What §5.2 asks for:** before the first measured slot, one smoke bank of **1 benchmark × 1 trial,
+ON arm** verifying (a) the ported extension still writes `<workspace>/.claude/fmt_hook_events.jsonl`
+with the `{status,file}` schema, and (b) the new-tree step-0 broadcast still names the extension
+`fmt` in `resolved_extensions`. Cost ~5 min rig.
+
+**Design.** Reuse the machinery that already exists rather than re-deriving it: check (b) is exactly
+`eval_harness.ResolveFmtArm(flagMode, resolvedExtensions) == "on"` (`internal/eval_harness/fmt_treatment.go:28-47`, exact `fmt#N` name match), and check (a) is exactly
+`AssertFmtTreatmentIntegrity("on", events) == nil` (`:60-92`, which already demands ≥1 event **and**
+≥1 with `status=formatted` — "firing is not delivering"). So the smoke check is: bank one ON row,
+then assert the banked row's `validity` is absent/valid and its `fmt_hook_state` is `on`. **No new
+assertion logic is written**; the smoke bank is a *driver* change that runs the existing gate early
+and cheaply.
+
+**Failure behaviour, per §5.2's "failure direction is loud either way":** the fmt block logs the
+specific failing contract, sends `ailang messages send controlplane`, sets `RUN_AB_FMT=0`, and does
+**not** enter the measurement loop. Modelled on the existing `select_ab_benchmarks`-returned-nothing
+path (`nightly-eval.sh:480-487`), which is the repo's own precedent for "no silent fallback: skip
+loudly rather than measure something uninterpretable".
+
+**Acceptance criteria**
+- **AC-M5-1** `bash -n` + `shellcheck -S warning` on `nightly-eval.sh` both exit 0 with 0 findings. *(BASE: PASS/PASS.)*
+- **AC-M5-2** Stub-`$BIN` test T-D2-SMOKE: when the smoke bank produces a row with `fmt_hook_state=off`, the driver logs the contract failure, sets `RUN_AB_FMT=0`, and emits **zero** `eval-suite --trials 5` invocations. Killed mutation: neutering the smoke gate (`if false && <smoke_failed>`) yields 12 measurement invocations instead of 0. Observable: the stub's invocation log (value set = the set of invocations, not a boolean).
+- **AC-M5-3** The happy path — a stub smoke row with `fmt_hook_state=on` and a `status=formatted` event — proceeds into M3's interleave and emits the full 12 invocations. Without this row, AC-M5-2 is satisfiable by a driver that always skips.
+
+---
+
+## 2. Deployment precondition (doc §6) — a checkable step, not a note
+
+Merging D1 + D1b to `origin/dev` does **not** put them on the rig. The installed plist executes
+`nightly-eval.sh` **in place from V1's checkout**, and that checkout is not this mission's
+(open issue **#558**, the stale-checkout defect).
+
+**Re-verified this session, with a known-negative control:**
+
+```
+$ /usr/libexec/PlistBuddy -c "Print :ProgramArguments" ~/Library/LaunchAgents/dev.ailang.nightly-eval.plist
+Array {
+    /bin/bash
+    /Users/voightkampff/dev/sunholo-data/ailang/tools/launchd/nightly-eval.sh
+}                                                                          # exit 0
+$ /usr/libexec/PlistBuddy -c "Print :ProgramArguments" ~/Library/LaunchAgents/dev.ailang.NOT-REAL.plist
+Print: Entry, ":ProgramArguments", Does Not Exist                          # exit 1  ← control: absence is a measurement
+```
+
+**AC-DEPLOY (blocks the first measured slot, not the sprint's merge):**
+1. `SCRIPT=$(/usr/libexec/PlistBuddy -c "Print :ProgramArguments" ~/Library/LaunchAgents/dev.ailang.nightly-eval.plist | sed -n '3p' | tr -d ' ')` — read the path **from the installed plist**, never from a working-tree path.
+2. `grep -c 'requireProviderCredential\|fmt smoke' "$SCRIPT"` is not the check (the Go fix isn't in the script). The two reads are:
+   - the script at `$SCRIPT` contains the D1b per-benchmark interleave (no `for arm in on off` wrapping a whole-suite call);
+   - the `ailang` binary that `$SCRIPT` invokes as `$BIN` reports a build containing D1 — assert by running `"$BIN" --version` and comparing its git rev to a rev that contains M1's commit.
+3. Until **both** reads pass, **no Wednesday slot counts as a measurement attempt** (doc §6, verbatim intent).
+
+This step is deliberately *not* an acceptance criterion of M1 or M3: the sprint cannot make V1's
+clone pull. It is a gate on the measurement, owned by whoever fires the first slot, and it is
+recorded here so it cannot be forgotten.
+
+---
+
+## 3. Test plan — one mutation per refusal branch, with its observable
+
+**Rules applied to every row below.** (i) The row names the **mutation** it kills. (ii) Mutations are
+**neutering, never deleting**: `if false && <cond>` keeps the mutant compiling, so a "test passed"
+result cannot be an artifact of a broken build. (iii) The **observable** is named, and is checked to
+be *downstream* of the mechanism (not adjacent to it) with a value set in **bijection with the
+mechanism's branch set** — a row asserting only "an error was returned" / "no error was returned"
+has a 2-valued observable against a 6-valued mechanism and is decorative; such rows are excluded.
+
+The preflight is a **REFUSAL**, so its branches are enumerated exhaustively.
+
+### 3.1 Refusal branches of `runHealthCheck` after M1
+
+| id | branch | mutation | observable | value set |
+|---|---|---|---|---|
+| **T-B1** | `os.Stat` error → binary missing | `if false && err != nil` | error string contains `motoko CLI not found at %q` **and** the quoted path equals the configured `MotokoPath` | the path — arbitrary strings, ⊇ the branch |
+| **T-B2** | `info.IsDir()` | `if false && info.IsDir()` | error contains `is a directory, expected an executable` and names the same path | as above |
+| **T-B3** | non-windows, `perm&0111 == 0` | `if false && (runtime.GOOS != "windows" && …)` | error contains `is not executable (chmod +x)` and names the same path. **darwin/arm64 only**; the windows leg is unrun locally | as above |
+| **T-B4** | *(the deleted `OPENROUTER_API_KEY` branch)* | n/a — asserted by **absence**, which is only admissible because AC-M1-5 pairs it with a known-positive control grep | `HealthCheck` on a mock binary with `OPENROUTER_API_KEY` unset returns **nil** (this is the behaviour change), and `e.motokoRepo`/version parsing still runs | nil vs error — admissible here only because the *positive* half (T-ORDER) proves the version query fired |
+
+### 3.2 Refusal branches of `requireProviderCredential`
+
+The mechanism's value set is `ai.EnvVarForProvider`'s 5-way switch (`internal/ai/config.go:104-119`).
+The test is therefore a **table over models → expected env-var name**, which is exactly that value
+set — not a boolean.
+
+| id | branch | mutation | observable | why the observable is downstream, not adjacent |
+|---|---|---|---|---|
+| **T-B5** | provider needs a key and it is unset → refuse | `if false && os.Getenv(envVar) == ""` | the returned error names **both** the resolved env var **and** the model string. Table (each row with the key `t.Setenv("", …)`-cleared): `ollama/qwen3.6:35b-a3b-mxfp8` → **no error**; `ollama:qwen3.5` → **no error**; `openrouter/anthropic/claude-haiku-4-5` → error naming `OPENROUTER_API_KEY`; `anthropic/claude-sonnet-4-6` → error naming `OPENROUTER_API_KEY` (vendor/model routes to OpenRouter, V26); `claude-3-5-sonnet` → error naming `ANTHROPIC_API_KEY`; `gpt-5-codex` → error naming `OPENAI_API_KEY`; `gemini-3-1-pro` → error naming `GOOGLE_API_KEY` | the env-var **name** is produced *by* the resolution chain `GuessProvider → EnvVarForProvider`; nothing else in the function can produce it. A hardcoded `OPENROUTER_API_KEY` string would fail the `claude-3-5-sonnet` / `gpt-5-codex` / `gemini-3-1-pro` rows |
+| **T-B5b** | key present → proceed | `if false && …` (same site, inverted arm) | for each keyed model above, with the correct env var **set**, `requireProviderCredential` returns nil; with a *different* provider's var set instead, it still refuses. Kills a mutant that checks "any API key is set" | the pairing (model, which var was set) is 2-dimensional; a single-var check collapses it |
+| **T-B6** | `GuessProvider` returns `""` (unrecognised model string) | `if false && provider == ""` | **DECISION, flagged for the executor:** `EnvVarForProvider("")` returns `""` (`config.go:117 default:`), so the naive implementation would **pass** an unrecognised model silently. Per CLAUDE.md rule 2 (no silent fallbacks where data integrity is at stake — this decides whether a run is admitted), the plan requires a **loud refusal** naming the model and the fact that its provider could not be resolved. Observable: error contains the model string and the substring `could not resolve provider` | the message is produced only on the `provider == ""` path; the *model string* in it distinguishes this branch from T-B5's, whose message names an env var instead |
+
+**Risk note attached to T-B6:** a loud refusal on unknown providers could refuse a lane whose
+`agent_model_name` is a bare local alias. Measured mitigation: all 17 motoko lanes' `agent_model_name`
+values were enumerated this session and every one begins with `ollama/` or `openrouter/`, both of
+which `GuessProvider` resolves (V25/V26). Coverage gate: **T-B6b** asserts, as a table, that
+`GuessProvider` returns non-empty for **all 17** `agent_cli: "motoko"` lanes read out of
+`internal/eval_harness/models.yml` — so the day a new motoko lane is added with an unresolvable
+model string, the test fails at add-time rather than at rig-time.
+
+### 3.3 Ordering (doc §12.3)
+
+| id | claim | mutation | observable |
+|---|---|---|---|
+| **T-ORDER** | the resolved-provider refusal never runs ahead of `MOTOKO_REPO` discovery | move `requireProviderCredential` from `ExecuteStreaming` into `runHealthCheck` **before** the version query (the exact defect §12.3 warns about) | with a mock `motoko` stub that prints `motoko_repo=/tmp/fake-repo` for `--version`: after `HealthCheck` + `Execute` on an ollama-model task, the child process env captured by the stub contains `MOTOKO_REPO=/tmp/fake-repo` (**non-empty**). Under the mutation with the key unset, the process is never spawned, so no env is captured at all — the row fails. Value set = the observed `MOTOKO_REPO` value (path strings), not a boolean |
+
+### 3.4 D1b schedule (M3)
+
+| id | mutation | observable |
+|---|---|---|
+| **T-D1B-1** | revert to `for arm in on off` around a whole-suite call | the stub-`$BIN` invocation log: 2 invocations each naming 6 benchmarks, instead of 12 each naming 1 |
+| **T-D1B-2** | fix the lead arm (`ON` always first) instead of alternating on `i%2` | the (benchmark, arm) sequence: `#ON-lead = 6, #OFF-lead = 0`, violating `≤ 1`. Observable is the **sequence**, whose value set is the 2^6 lead assignments |
+| **T-D1B-3** | pass `$FMT_BENCH_LIST` (all 6) instead of `${FMT_BENCHES[i]}` inside the loop | each logged invocation's `--benchmarks` argument has 6 comma-separated names instead of 1 |
+
+### 3.5 D2 verdicts (M4) — fixture-driven
+
+| id | mutation | observable |
+|---|---|---|
+| **T-D2-VOID-ORDER** | neuter the order-integrity gate | on a fixture that is a perfect arm block: verdict changes from `VOID`/`order_integrity` to a numeric verdict. Observable = the `verdict` + `void_reason` pair (4 verdicts × N reasons), not "did it error" |
+| **T-D2-VOID-TREAT-ON** | neuter the `>20% ON quarantined` rule | fixture with 2/6 ON rows `validity.valid=false`: verdict changes from `VOID`/`treatment_unproven_rate` |
+| **T-D2-VOID-TREAT-OFF** | neuter the OFF-contamination rule | fixture with 1 OFF row carrying `fmt_hook_events`: verdict changes from `VOID`/`control_contaminated` |
+| **T-D2-CENSOR** | neuter rule 1 (one-passes-wins) so both-fail and one-passes both tie | fixture with 10 one-arm-passes pairs: `n_eff` drops 10→0 and verdict flips `KEEP`→`RETIRE` (n_eff<24 after slots). Observable = `(n_eff, W, verdict)` triple |
+| **T-D2-MARGIN** | neuter the `\|log ratio\| ≤ 0.10` tie margin | fixture of both-pass pairs all within ±5%: `n_eff` 0→12 and a spurious `W` |
+| **T-D2-KEEP-3** | neuter each of the three KEEP conjuncts in turn (sign test / median ratio ≤ 0.90 / McNemar guardrail) | three fixtures, each failing exactly one conjunct: verdict must be non-`KEEP` in all three; a mutant dropping any conjunct returns `KEEP` on its fixture |
+| **T-D2-REAL** | *(no mutation — an end-to-end oracle)* | the real banked AC5 arms `eval_results/ab2_fmt_{on,off}` → `VOID` with an order-integrity reason. Known in advance from V19, independently measured, and **not** the happy path |
+
+---
+
+## 4. Baselines — every acceptance command run on the UNMODIFIED tree first
+
+Run 2026-08-20 on **darwin/arm64** (macOS 26.5.2) in
+`/Users/voightkampff/.ailang-driver-pin/.wt-motoko-iter14-fmt-d1` at `44aa3cab4`, clean tree.
+
+| command | BASE result | note |
+|---|---|---|
+| `go build ./...` | ❌ **exit 1** | `# github.com/sunholo-data/ailang/cmd/wasm` / `runtime.main_main·f: function main is undeclared in the main package`. **`go build ./...` is RED at base** (the wasm package builds only under `GOOS=js`), so it cannot be an acceptance gate — it would measure the repo, not the change |
+| `go build ./internal/... ./cmd/ailang/...` | ✅ exit 0 | **this is the build gate** |
+| `go vet ./internal/executor/... ./internal/ai/...` | ✅ exit 0 | |
+| `go test ./internal/executor/... ./internal/ai/...` | ✅ exit 0 | 14/14 packages `ok` (motoko 27.1 s) |
+| `env -u OPENROUTER_API_KEY go test ./internal/executor/motoko/` | ✅ exit 0, `ok … 20.422s` | the M1 regression gate; green at base, must stay green |
+| `bash scripts/check_boundaries.sh` | ✅ exit 0, "OK: no architecture boundary violations" | |
+| `golangci-lint run ./internal/executor/motoko/... ./internal/eval_analysis/... ./cmd/ailang/...` | ✅ exit 0, "0 issues" | |
+| `bash -n tools/launchd/nightly-eval.sh` | ✅ exit 0 | |
+| `shellcheck -S warning tools/launchd/nightly-eval.sh` | ✅ exit 0, 0 findings | shellcheck present at `/opt/homebrew/bin/shellcheck` |
+| `grep -n OPENROUTER_API_KEY internal/executor/motoko/*.go \| grep -v _test.go` | 1 hit (`healthcheck.go:64`) | control: same grep over `internal/ai/config.go` → 2 hits (`:115`, `:143`) — instrument discriminates |
+| `PlistBuddy … dev.ailang.nightly-eval.plist` | ✅ exit 0, path = V1's checkout | control: nonexistent plist → exit 1 |
+| `jq -e . .ailang/state/sprints/sprint_m-motoko-fmt-remeasurement-instrument.json` | — | produced by this sprint plan; validated on write |
+
+**Not baselined here** (the executor must baseline them before its first edit, and record the
+result): `go test ./internal/eval_analysis/... ./cmd/ailang/...` (AC-M4-1). A red base there is a
+repo finding, not a sprint failure.
+
+---
+
+## 5. Risks
+
+| # | risk | mitigation |
+|---|---|---|
+| R1 | The 8 mock-binary `Execute` tests break in CI where `OPENROUTER_API_KEY` is unset (they pass locally only because the ambient env has it) | Measured and named in M1; **AC-M1-3** (`env -u OPENROUTER_API_KEY go test ./internal/executor/motoko/`) is the gate, green at base |
+| R2 | T-B6's loud refusal on an unresolvable provider refuses a legitimate lane | **T-B6b** asserts `GuessProvider` resolves all 17 motoko lanes read from `models.yml`, so a future unresolvable lane fails at add-time |
+| R3 | AC-M2-control needs `OPENROUTER_API_KEY` + a few cents of metered spend, and the rig | Flagged as M2's only non-local dependency; the control leg is one trivial canary on the cheapest OpenRouter motoko lane. If the control does not fire, AC-M2-treatment is **void** — the doc says so and this plan does not soften it |
+| R4 | D2's shape drifts from the doc's §2/§5/§7 during implementation | Every D2 rule is quoted from the doc in M4, and **AC-M4-5** pins the analyzer against a real, independently-measured dataset (AC5) whose correct verdict (`VOID`, order integrity) was established by V19 before the analyzer existed |
+| R5 | The fix merges but never reaches the rig (issue #558) | **AC-DEPLOY** (§2) reads the script at the path named in the *installed plist*, plus the `$BIN` git rev. Until both pass, no slot counts |
+| R6 | M4's new `BenchmarkResult` fields collide with the existing loader's strictness | Fields are additive with `omitempty` and JSON tags copied from the already-banked keys (`metrics.go:138,143`); **AC-M4-3** asserts `eval-paired`'s output is byte-identical before and after |
+
+---
+
+## 6. Documentation obligations (`.claude/rules/coding-standards.md`)
+
+- `CHANGELOG.md` — one entry per milestone, grouped.
+- `docs/docs/guides/evaluation/` — document `ailang eval-censored-pairs` (M4).
+- `cmd/ailang/help.go` — `eval-censored-pairs` line (M4), per the `cli-doc-maintainer` convention that help is the source of truth.
+- The design doc's §12.5 Verification Log gains rows for whatever the sprint measures live (AC-M2 especially): the doc's §12.4 explicitly moved the live arm into acceptance, so the result is owed back to the doc.
+- No `examples/*.ail` obligation: **no AILANG language feature is added** — mission default bias holds, this is entirely harness lane.
+
+---
+
+## 7. Handoff
+
+Sprint JSON: `.ailang/state/sprints/sprint_m-motoko-fmt-remeasurement-instrument.json`
+Execute milestones **in order M1 → M2 → M3 → M5**, with **M4 parallel-safe** (it touches
+`internal/eval_analysis` + `cmd/ailang` only, disjoint from M1–M3, M5). M3 must land before M5
+(M5 inserts into the block M3 restructures).

--- a/internal/executor/motoko/README.md
+++ b/internal/executor/motoko/README.md
@@ -14,7 +14,8 @@ Spawns `motoko "<task>"` as a subprocess with `WORKDIR` / `MODEL` / `MOTOKO_CONF
 motoko "<directive>"           # task as positional arg
 # Env var inputs:
 #   WORKDIR=/path/to/workspace          # working directory motoko writes JSONL into
-#   MODEL=openrouter/anthropic/claude-haiku-4-5   # model id (always openrouter/* for motoko)
+#   MODEL=ollama/qwen3.6:35b-a3b-mxfp8            # model id; the resolved PROVIDER decides the
+#                                                 # credential (7 of 17 motoko lanes are ollama/*)
 #   MOTOKO_CONFIG=dogfood                          # profile name (matches a directory under .motoko/config/)
 #   MOTOKO_SESSION_ID=session_<task_id>            # the adapter sets this so it can find the JSONL
 ```
@@ -23,10 +24,19 @@ The adapter never invokes any motoko sub-command beyond `--version` / `--help` (
 
 ## Auth
 
-- **Required**: `OPENROUTER_API_KEY` — motoko routes ALL models via OpenRouter, so this is the canonical auth surface.
+- **Per-lane, not global** (D1, 2026-08-20). The credential required is a function of the model's
+  RESOLVED PROVIDER, checked in `provider_preflight.go` at the top of `ExecuteStreaming`:
+  `ai.EnvVarForProvider(ai.GuessProvider(model))` returns that provider's variable, or `""` for a
+  provider that needs none. `OPENROUTER_API_KEY` is required only for an OpenRouter-routed lane
+  (10 of the 17 `agent_cli: "motoko"` entries in `models.yml`); the 7 `ollama/*` lanes require
+  nothing and run with every credential variable unset.
+  This section previously read *"motoko routes ALL models via OpenRouter"*, matching an
+  unconditional refusal in `HealthCheck`. That claim was false for the ollama lanes and is why two
+  Wednesday fmt A/B slots banked no data.
 - **NOT bound in cloud Job** (per [EXECUTOR_SHAPE.md §8](../../../docs/internal/EXECUTOR_SHAPE.md) cost-control rule): `ANTHROPIC_API_KEY`. Anthropic API-key billing is pay-per-token; the cloud Job binds only OpenRouter + OpenAI + Gemini keys, matching the Pi-precedent. `motoko-claude-*` models stay LOCAL-only for cost-control.
 
-For local dev, `OPENROUTER_API_KEY` in your shell environment is sufficient. The adapter does not manage credentials — it inherits the parent process's environment via `executor.BuildEnvironment`.
+For local dev, the variable your lane's provider declares is sufficient — `OPENROUTER_API_KEY` for an
+OpenRouter lane, nothing at all for an `ollama/*` one. The adapter does not manage credentials — it inherits the parent process's environment via `executor.BuildEnvironment`.
 
 ## Event schema (motoko session JSONL v1)
 

--- a/internal/executor/motoko/execute_test.go
+++ b/internal/executor/motoko/execute_test.go
@@ -52,8 +52,14 @@ exit 0
 	}
 
 	exec, err := New(&executor.Config{
-		MotokoPath:    mockMotoko,
-		MotokoModel:   "openrouter/anthropic/claude-haiku-4-5",
+		MotokoPath: mockMotoko,
+		// D1 (M-MOTOKO-FMT-REMEASUREMENT-INSTRUMENT): this test exercises the mock
+		// JSONL pipeline, not any provider binding — the mock is a bash stub that
+		// never dials a provider. Agent the ollama lane model so the run is not
+		// refused by the per-task pre-flight when OPENROUTER_API_KEY is unset
+		// (CI). An explicit openrouter model here would re-fragilize the whole
+		// test on the ambient key.
+		MotokoModel:   "ollama/qwen3.6:35b-a3b-mxfp8",
 		MotokoProfile: "dogfood",
 	})
 	if err != nil {
@@ -128,7 +134,8 @@ exit 0
 		t.Fatal(err)
 	}
 
-	exec, _ := New(&executor.Config{MotokoPath: mockMotoko})
+	exec, _ := New(&executor.Config{MotokoPath: mockMotoko,
+		MotokoModel: "ollama/qwen3.6:35b-a3b-mxfp8"})
 	res, err := exec.Execute(context.Background(), &executor.Task{
 		Workspace: wsDir,
 		Directive: "any",
@@ -201,7 +208,8 @@ exit 0
 		t.Fatal(err)
 	}
 
-	exec, _ := New(&executor.Config{MotokoPath: mockMotoko})
+	exec, _ := New(&executor.Config{MotokoPath: mockMotoko,
+		MotokoModel: "ollama/qwen3.6:35b-a3b-mxfp8"})
 
 	if _, err := exec.Execute(context.Background(), &executor.Task{
 		Workspace: wsDir,
@@ -282,7 +290,8 @@ exit 0
 		t.Fatalf("creating workspace: %v", err)
 	}
 
-	exec, err := New(&executor.Config{MotokoPath: mockMotoko})
+	exec, err := New(&executor.Config{MotokoPath: mockMotoko,
+		MotokoModel: "ollama/qwen3.6:35b-a3b-mxfp8"})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -357,7 +366,8 @@ exit 0
 	if err := os.MkdirAll(wsDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	exec, _ := New(&executor.Config{MotokoPath: mockMotoko})
+	exec, _ := New(&executor.Config{MotokoPath: mockMotoko,
+		MotokoModel: "ollama/qwen3.6:35b-a3b-mxfp8"})
 	_, err := exec.Execute(context.Background(), &executor.Task{
 		Workspace: wsDir,
 		Directive: "any",
@@ -399,7 +409,8 @@ func TestExecute_NoJSONLFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	exec, _ := New(&executor.Config{MotokoPath: mockMotoko})
+	exec, _ := New(&executor.Config{MotokoPath: mockMotoko,
+		MotokoModel: "ollama/qwen3.6:35b-a3b-mxfp8"})
 	res, err := exec.Execute(context.Background(), &executor.Task{
 		Workspace: wsDir,
 		Directive: "any",
@@ -442,7 +453,8 @@ exit 1
 		t.Fatal(err)
 	}
 
-	exec, _ := New(&executor.Config{MotokoPath: mockMotoko})
+	exec, _ := New(&executor.Config{MotokoPath: mockMotoko,
+		MotokoModel: "ollama/qwen3.6:35b-a3b-mxfp8"})
 	res, err := exec.Execute(context.Background(), &executor.Task{
 		Workspace: wsDir,
 		Directive: "any",
@@ -494,7 +506,8 @@ exit 1
 		t.Fatal(err)
 	}
 
-	exec, _ := New(&executor.Config{MotokoPath: mockMotoko})
+	exec, _ := New(&executor.Config{MotokoPath: mockMotoko,
+		MotokoModel: "ollama/qwen3.6:35b-a3b-mxfp8"})
 	res, err := exec.Execute(context.Background(), &executor.Task{
 		Workspace: wsDir,
 		Directive: "any",
@@ -544,7 +557,8 @@ exit 1
 		t.Fatal(err)
 	}
 
-	exec, _ := New(&executor.Config{MotokoPath: mockMotoko})
+	exec, _ := New(&executor.Config{MotokoPath: mockMotoko,
+		MotokoModel: "ollama/qwen3.6:35b-a3b-mxfp8"})
 	res, err := exec.Execute(context.Background(), &executor.Task{
 		Workspace:    wsDir,
 		Directive:    "any",
@@ -616,4 +630,96 @@ func TestLiveRun_Motoko(t *testing.T) {
 	t.Logf("live result: success=%v turns=%d cost=$%.6f tokens=%d/%d cache=%d/%d",
 		res.Success, res.NumTurns, res.CostUSD, res.InputTokens, res.OutputTokens,
 		res.CacheReadInputTokens, res.CacheCreationInputTokens)
+}
+
+// TestExecuteOrdering_RepoDiscoveryBeforeCredentialCheck pins the plan §3.3
+// ordering property (design doc §12.3): the per-task resolved-provider credential
+// check must NOT run ahead of repo discovery. If it did (the mutation the plan
+// names), an openrouter-default executor would refuse at HealthCheck BEFORE the
+// `motoko --version` query runs, so e.motokoRepo would never be populated and
+// the child process (which captures MOTOKO_REPO) would never be spawned.
+//
+// The observable is the child's captured MOTOKO_REPO value — a path string, not
+// a boolean: with the unmutated engine it is the repo the mock version query
+// reported; under the mutation it is absent/UNSET because no subprocess runs.
+//
+// KEY TRICK for the mutation to be fatal: the executor is built WITHOUT an
+// explicit model (New defaults to openrouter/anthropic/claude-haiku-4-5), while
+// the TASK carries an ollama model. The unmütated engine admits the ollama task
+// and spawns the child; a mutation that checks creds before the version query
+// uses the executor's openrouter model with the key unset -> refuses -> no repo,
+// no child, row fails.
+func TestExecuteOrdering_RepoDiscoveryBeforeCredentialCheck(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash mock binary requires POSIX shell")
+	}
+
+	tmp := t.TempDir()
+	mockMotoko := filepath.Join(tmp, "motoko")
+	envDump := filepath.Join(tmp, "received-env.txt")
+	mockScript := `#!/bin/bash
+set -e
+for arg in "$@"; do
+  if [ "$arg" = "--version" ]; then
+    echo "motoko_repo=/tmp/fake-motoko-repo"
+    echo "git_rev=abc123"
+    echo "ailang_built=1"
+    echo "tui_version=1.2.3"
+    exit 0
+  fi
+done
+LOGDIR="$WORKDIR/.motoko/logfile"
+mkdir -p "$LOGDIR"
+SESSION="${MOTOKO_SESSION_ID:-session_unknown}"
+echo "MOTOKO_REPO=${MOTOKO_REPO:-UNSET}" > "` + envDump + `"
+cat > "$LOGDIR/$SESSION.jsonl" <<EOF
+{"schema_version":"1","session_id":"$SESSION","type":"session_start","task":"x","model":"x","brainVersion":"0.2.0"}
+{"schema_version":"1","session_id":"$SESSION","type":"run_summary","finish_reason":"stop","duration_ms":1,"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}
+EOF
+exit 0
+`
+	if err := os.WriteFile(mockMotoko, []byte(mockScript), 0755); err != nil {
+		t.Fatalf("writing mock binary: %v", err)
+	}
+	wsDir := filepath.Join(tmp, "ws")
+	if err := os.MkdirAll(wsDir, 0755); err != nil {
+		t.Fatalf("creating workspace: %v", err)
+	}
+
+	// Force the key-unset leg so a mutation that checks the e-model's credential
+	// BEFORE the version query actually refuses.
+	t.Setenv("OPENROUTER_API_KEY", "")
+
+	// No explicit MotokoModel: New defaults e.model to openrouter (V31). This is
+	// load-bearing for the mutation's refusal.
+	exec, _ := New(&executor.Config{MotokoPath: mockMotoko})
+	if err := exec.HealthCheck(context.Background()); err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if exec.motokoRepo != "/tmp/fake-motoko-repo" {
+		t.Fatalf("motokoRepo = %q, want /tmp/fake-motoko-repo (version query must have fired first)", exec.motokoRepo)
+	}
+
+	res, err := exec.Execute(context.Background(), &executor.Task{
+		Workspace: wsDir,
+		Directive: "any",
+		// The per-task model is ollama (the rooted lane); the executor-level default
+		// being openrouter is what makes the mutation predictable.
+		Model: "ollama/qwen3.6:35b-a3b-mvp",
+	})
+	if err != nil {
+		t.Fatalf("Execute of ollama task: %v", err)
+	}
+	if !res.Success {
+		t.Fatalf("ollama task did not succeed: %s", res.Error)
+	}
+
+	dump, err := os.ReadFile(envDump)
+	if err != nil {
+		t.Fatalf("reading env dump: %v", err)
+	}
+	got := strings.TrimSpace(string(dump))
+	if got != "MOTOKO_REPO=/tmp/fake-motoko-repo" {
+		t.Errorf("child MOTOKO_REPO = %q — repo discovery must run ahead of the credential refusal (plan T-ORDER)", got)
+	}
 }

--- a/internal/executor/motoko/execute_test.go
+++ b/internal/executor/motoko/execute_test.go
@@ -693,11 +693,29 @@ exit 0
 	// No explicit MotokoModel: New defaults e.model to openrouter (V31). This is
 	// load-bearing for the mutation's refusal.
 	exec, _ := New(&executor.Config{MotokoPath: mockMotoko})
-	if err := exec.HealthCheck(context.Background()); err != nil {
-		t.Fatalf("HealthCheck: %v", err)
-	}
+
+	// DO NOT Fatal on HealthCheck's error here. Repaired at iteration 14 after the
+	// evaluator showed this row was decorative: a `t.Fatalf("HealthCheck: %v", err)`
+	// fires identically for a credential check placed BEFORE the version query
+	// (which violates doc §12.3) and for one placed AFTER it (which does not), so
+	// the assertion that actually killed the mutant was a bare nil-vs-error — a
+	// 2-valued observable the sprint plan's own §3 rules exclude, and the
+	// motokoRepo assertion below was never reached under either mutant.
+	//
+	// The DISCRIMINATING observable is whether repo discovery COMPLETED, read
+	// independently of whatever HealthCheck returned. A check placed ahead of the
+	// version query leaves motokoRepo empty; a check placed after it (or, as
+	// shipped, not in HealthCheck at all) leaves it populated.
+	hcErr := exec.HealthCheck(context.Background())
 	if exec.motokoRepo != "/tmp/fake-motoko-repo" {
-		t.Fatalf("motokoRepo = %q, want /tmp/fake-motoko-repo (version query must have fired first)", exec.motokoRepo)
+		t.Fatalf("motokoRepo = %q, want /tmp/fake-motoko-repo — repo discovery did not complete, so a credential refusal ran AHEAD of the `motoko --version` query (doc §12.3). HealthCheck returned: %v",
+			exec.motokoRepo, hcErr)
+	}
+	// As shipped, HealthCheck makes no credential decision at all, so it must be nil.
+	// Checked second and separately: this pins the delivered behaviour without being
+	// the assertion that carries the ordering claim.
+	if hcErr != nil {
+		t.Fatalf("HealthCheck returned %v; as shipped it makes no provider-credential decision", hcErr)
 	}
 
 	res, err := exec.Execute(context.Background(), &executor.Task{

--- a/internal/executor/motoko/healthcheck.go
+++ b/internal/executor/motoko/healthcheck.go
@@ -23,7 +23,11 @@ import (
 //
 // HealthCheck:
 //  1. Verifies binary existence + executability (always required)
-//  2. Verifies OPENROUTER_API_KEY is set (wrapper pre-flight requirement)
+//  2. (D1, M-MOTOKO-FMT-REMEASUREMENT-INSTRUMENT) the provider-credential
+//     refusal moved OUT of this check and into a per-task preflight at the
+//     top of ExecuteStreaming (provider_preflight.go). HealthCheck no longer
+//     inspects any provider's env var: it cannot, because it sees no task and
+//     therefore no lane model (design doc §12.2).
 //  3. Calls `motoko --version` with a 5s timeout — if it succeeds, the
 //     version + git_rev are stashed in MotokoExecutor for telemetry.
 //     Failure here is NON-FATAL (older motoko binaries pre-M2c hang on
@@ -60,9 +64,6 @@ func (e *MotokoExecutor) runHealthCheck(ctx context.Context) error {
 	}
 	if runtime.GOOS != "windows" && info.Mode().Perm()&0111 == 0 {
 		return fmt.Errorf("motoko binary at %q is not executable (chmod +x)", motokoPath)
-	}
-	if os.Getenv("OPENROUTER_API_KEY") == "" {
-		return fmt.Errorf("OPENROUTER_API_KEY not set — motoko routes ALL models via OpenRouter; set this env var or expect every Execute to fail at the wrapper's pre-flight check")
 	}
 
 	// Best-effort version query (M-MOTOKO-EVAL-HARNESS-HARDENING M2c). Older

--- a/internal/executor/motoko/motoko.go
+++ b/internal/executor/motoko/motoko.go
@@ -174,6 +174,17 @@ func (e *MotokoExecutor) Execute(ctx context.Context, task *executor.Task) (*exe
 // JSONL file as it grows (M2 will add the streaming goroutine; M1 ships with
 // post-completion parse only).
 func (e *MotokoExecutor) ExecuteStreaming(ctx context.Context, task *executor.Task, handler executor.EventHandler) (*executor.Result, error) {
+	// D1 (M-MOTOKO-FMT-REMEASUREMENT-INSTRUMENT §12.2): per-task resolved-
+	// provider credential refusal, at the choke point through which ALL motoko
+	// work passes. Runs STRICTLY DOWNSTREAM of repo discovery: the eval harness
+	// and the canary both run HealthCheck (which populates e.motokoRepo via
+	// `motoko --version`) BEFORE ever reaching Execute, so refusing here cannot
+	// degrade the profile to extensions.order=[] and drop the fmt extension
+	// (design doc §12.3 ordering requirement).
+	if err := requireProviderCredential(e.getModel(task)); err != nil {
+		return nil, fmt.Errorf("motoko provider preflight refused: %w", err)
+	}
+
 	effectiveProfile := e.profile
 	if p := task.Metadata["motoko_profile"]; p != "" {
 		effectiveProfile = p

--- a/internal/executor/motoko/motoko_test.go
+++ b/internal/executor/motoko/motoko_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/sunholo-data/ailang/internal/executor"
@@ -106,50 +108,93 @@ func TestCapabilities(t *testing.T) {
 	}
 }
 
-// TestHealthCheck_BinaryMissing verifies HealthCheck returns a clear error
-// when the configured motoko path does not exist.
+// TestHealthCheck_BinaryMissing verifies HealthCheck refuses a missing
+// binary, and the error names + QUOTES the configured path (the refusal-branch
+// rule: an error value is reachable from every branch, so the observable must
+// be the path — plan §3.1, row T-B1).
 func TestHealthCheck_BinaryMissing(t *testing.T) {
 	exec, _ := New(&executor.Config{MotokoPath: "/definitely/not/a/real/binary/motoko-xyz"})
 	err := exec.HealthCheck(context.Background())
 	if err == nil {
 		t.Fatal("HealthCheck succeeded for missing binary; expected error")
 	}
+	msg := err.Error()
+	if !strings.Contains(msg, "motoko CLI not found at") ||
+		!strings.Contains(msg, `"/definitely/not/a/real/binary/motoko-xyz"`) {
+		t.Errorf("missing-binary error must name + quote the configured path; got: %q", msg)
+	}
 }
 
-// TestHealthCheck_MockBinary verifies the binary-existence + executability
-// check passes against a POSIX shell stub. motoko has no --version mode (any
-// flag becomes task input), so HealthCheck deliberately doesn't run the
-// binary — just verifies it exists, is a regular file, and is executable.
-func TestHealthCheck_MockBinary(t *testing.T) {
+// TestHealthCheck_PathIsDirectory covers the info.IsDir() branch (T-B2): the
+// error must name the configured path AND the "is a directory" diagnosis.
+func TestHealthCheck_PathIsDirectory(t *testing.T) {
+	tmpdir := t.TempDir()
+	dirPath := filepath.Join(tmpdir, "motoko")
+	if err := os.MkdirAll(dirPath, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	exec, _ := New(&executor.Config{MotokoPath: dirPath})
+	err := exec.HealthCheck(context.Background())
+	if err == nil {
+		t.Fatal("HealthCheck succeeded against a directory; expected error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "is a directory") || !strings.Contains(msg, dirPath) {
+		t.Errorf("directory-path error must name the path and diagnosis; got: %q", msg)
+	}
+}
+
+// TestHealthCheck_NotExecutable covers the exec-bit branch (T-B3). The branch
+// is guarded runtime.GOOS != "windows", so this row is darwin/posix-only by
+// construction — same skip pattern the plan assigns to it.
+func TestHealthCheck_NotExecutable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exec-bit refusal branch is darwin/posix-only (runtime.GOOS != windows)")
+	}
 	tmpdir := t.TempDir()
 	mockPath := filepath.Join(tmpdir, "motoko")
-	if err := os.WriteFile(mockPath, []byte("#!/bin/bash\nexit 0\n"), 0755); err != nil {
+	if err := os.WriteFile(mockPath, []byte("#!/bin/bash\nnot a real binary\n"), 0o644); err != nil {
+		t.Fatalf("write non-executable file: %v", err)
+	}
+	exec, _ := New(&executor.Config{MotokoPath: mockPath})
+	err := exec.HealthCheck(context.Background())
+	if err == nil {
+		t.Fatal("HealthCheck succeeded for a non-executable file; expected error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "is not executable (chmod +x)") || !strings.Contains(msg, mockPath) {
+		t.Errorf("non-executable error must name the diagnosis and path; got: %q", msg)
+	}
+}
+
+// TestHealthCheck_MockBinary_VersionQueryAndNoKeyRefusal covers T-B4: on a
+// mock that answers `motoko --version`, HealthCheck returns NIL even with the
+// key UNSET (the behaviour change — this is the exact refusal M1 deleted), and
+// the version query still fires -> e.motokoRepo is populated. The motokoRepo
+// assertion is the positive half: "no error" is satisfiable by a HealthCheck
+// that never ran its version query at all.
+func TestHealthCheck_MockBinary_VersionQueryAndNoKeyRefusal(t *testing.T) {
+	tmpdir := t.TempDir()
+	mockPath := filepath.Join(tmpdir, "motoko")
+	// Deterministic: whatever the ambient shell holds, this row runs key-unset.
+	t.Setenv("OPENROUTER_API_KEY", "")
+	mock := "#!/bin/bash\n" +
+		"echo \"tui_version=1.2.3\"\n" +
+		"echo \"git_rev=abc123\"\n" +
+		"echo \"ailang_built=1\"\n" +
+		"echo \"motoko_repo=/tmp/fake-motoko-repo\"\n" +
+		"exit 0\n"
+	if err := os.WriteFile(mockPath, []byte(mock), 0755); err != nil {
 		t.Fatalf("failed to write mock binary: %v", err)
 	}
-
-	// HealthCheck also requires OPENROUTER_API_KEY to be set (wrapper
-	// pre-flight requirement). Set a placeholder for this test.
-	t.Setenv("OPENROUTER_API_KEY", "sk-or-test-stub-not-real")
 
 	exec, _ := New(&executor.Config{MotokoPath: mockPath})
 	if err := exec.HealthCheck(context.Background()); err != nil {
-		t.Errorf("HealthCheck against mock binary failed: %v", err)
+		t.Errorf("HealthCheck failed with key unset (was nil refusal): %v", err)
 	}
-}
-
-// TestHealthCheck_MissingAPIKey verifies HealthCheck fails clearly when
-// OPENROUTER_API_KEY is not set (motoko's wrapper requires it up-front).
-func TestHealthCheck_MissingAPIKey(t *testing.T) {
-	tmpdir := t.TempDir()
-	mockPath := filepath.Join(tmpdir, "motoko")
-	if err := os.WriteFile(mockPath, []byte("#!/bin/bash\nexit 0\n"), 0755); err != nil {
-		t.Fatalf("failed to write mock binary: %v", err)
-	}
-
-	t.Setenv("OPENROUTER_API_KEY", "")
-	exec, _ := New(&executor.Config{MotokoPath: mockPath})
-	if err := exec.HealthCheck(context.Background()); err == nil {
-		t.Errorf("HealthCheck succeeded with empty OPENROUTER_API_KEY; expected error")
+	if exec.motokoRepo != "/tmp/fake-motoko-repo" {
+		t.Errorf("version query did not populate motokoRepo (got %q, want /tmp/fake-motoko-repo)",
+			exec.motokoRepo)
 	}
 }
 

--- a/internal/executor/motoko/motoko_test.go
+++ b/internal/executor/motoko/motoko_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -139,8 +140,13 @@ func TestHealthCheck_PathIsDirectory(t *testing.T) {
 		t.Fatal("HealthCheck succeeded against a directory; expected error")
 	}
 	msg := err.Error()
-	if !strings.Contains(msg, "is a directory") || !strings.Contains(msg, dirPath) {
-		t.Errorf("directory-path error must name the path and diagnosis; got: %q", msg)
+	// Compare against the %q-QUOTED path, not the raw one. The refusal formats the
+	// path with %q, and on windows a path contains backslashes which %q escapes —
+	// so `strings.Contains(msg, dirPath)` can never match there even though the
+	// message names the path correctly. Caught by Gate 3b's windows leg, which is
+	// the only instrument that sees the whole matrix.
+	if !strings.Contains(msg, "is a directory") || !strings.Contains(msg, strconv.Quote(dirPath)) {
+		t.Errorf("directory-path error must name the path and diagnosis; got: %q (wanted quoted path %s)", msg, strconv.Quote(dirPath))
 	}
 }
 
@@ -174,6 +180,15 @@ func TestHealthCheck_NotExecutable(t *testing.T) {
 // assertion is the positive half: "no error" is satisfiable by a HealthCheck
 // that never ran its version query at all.
 func TestHealthCheck_MockBinary_VersionQueryAndNoKeyRefusal(t *testing.T) {
+	// The mock is a `#!/bin/bash` script named `motoko` with no `.exe` suffix, so
+	// windows cannot execute it: the version query fails and motokoRepo stays
+	// empty, failing for the PLATFORM rather than for the code. This row is
+	// therefore darwin/posix-only by construction — the same skip the 10 bash-mock
+	// arms in execute_test.go already carry. The no-key-refusal half of T-B4 is
+	// covered platform-independently by the provider_preflight tests.
+	if runtime.GOOS == "windows" {
+		t.Skip("bash mock binary requires POSIX shell")
+	}
 	tmpdir := t.TempDir()
 	mockPath := filepath.Join(tmpdir, "motoko")
 	// Deterministic: whatever the ambient shell holds, this row runs key-unset.

--- a/internal/executor/motoko/provider_preflight.go
+++ b/internal/executor/motoko/provider_preflight.go
@@ -1,0 +1,57 @@
+package motoko
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sunholo-data/ailang/internal/ai"
+)
+
+// D1 (M-MOTOKO-FMT-REMEASUREMENT-INSTRUMENT, design doc §12.2/§12.4): the
+// motoko health check can no longer make a provider-credential decision,
+// because HealthCheck sees no task and therefore no lane model (it is the
+// once-cached shared executor method; e.model is a single process-global
+// default that is never the 17 distinct lanes' models). The refusal moved
+// HERE, to the per-task choke point: ExecuteStreaming, through which ALL
+// motoko work passes (CanaryCheck and agent_runner_multi both reach it via
+// Execute). Placed there, the check is strictly DOWNSTREAM of repo discovery
+// (HealthCheck's `motoko --version` query already populated e.motokoRepo),
+// which the design doc §12.3 requires so the profile cannot degrade to
+// extensions.order=[] and drop the fmt extension that is the treatment.
+//
+// The condition is expressed on the RESOLVED PROVIDER, never on a literal
+// env-var name: ai.GuessProvider(model) returns the provider, and
+// ai.EnvVarForProvider(provider) returns that provider's required key or ""
+// for providers that need none (ollama). One check covers ollama / OpenAI /
+// Anthropic / Google / OpenRouter.
+func requireProviderCredential(model string) error {
+	provider := ai.GuessProvider(model)
+
+	// Unresolvable-model guard (plan §3.2, T-B6). Measured: ai.GuessProvider
+	// returns the EMPTY ProviderType (`""`) for any model it cannot classify —
+	// ai.GuessProvider("") yields "" (internal/ai/config.go: the terminal
+	// `return ""`), and the vendor/model + prefix checks all miss. KEYING ON
+	// THIS OBSERVED VALUE: an empty provider string can only mean "could not
+	// resolve", and never "a real provider that happens to need no key",
+	// because the only no-key provider (ollama) is returned as the NON-empty
+	// ProviderType "ollama" by the explicit ollama-prefix branch above the
+	// fallthrough. So `provider == ""` is a contradiction by construction and
+	// must be a loud refusal, not a silent pass: an admitted unresolvable
+	// model could later bind to OpenRouter at runtime and burn wall-clock
+	// before failing — exactly the false fail-fast O4 set D1 up to kill.
+	if model == "" || provider == "" {
+		return fmt.Errorf("could not resolve provider for motoko model %q — refusing run (no provider to bind a credential to)",
+			model)
+	}
+
+	envVar := ai.EnvVarForProvider(provider)
+	if envVar == "" {
+		// Provider needs no credential (example: ollama local). Admit.
+		return nil
+	}
+	if os.Getenv(envVar) == "" {
+		return fmt.Errorf("motoko model %q resolves to provider %q, which requires %s (unset) — refusing run",
+			model, provider.String(), envVar)
+	}
+	return nil
+}

--- a/internal/executor/motoko/provider_preflight_test.go
+++ b/internal/executor/motoko/provider_preflight_test.go
@@ -1,0 +1,334 @@
+package motoko
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/ai"
+	"github.com/sunholo-data/ailang/internal/executor"
+)
+
+// D1 provider-preflight refusal-branch matrix (sprint plan §3.2). The
+// mechanism's value set is ai.EnvVarForProvider's switch over providers, so
+// these tests are TABLES over (model → expected env var), not booleans. Every
+// row names the mutation that would kill it, and asserts on a string UNIQUE to
+// the branch (the resolved provider + missing variable, never just "an error
+// was returned").
+//
+// Requirement (earned by D1's whole point): a row with a provider that needs
+// NO credential (ollama), asserted to PASS with every credential env var
+// cleared. That is the one row the deleted unconditional refusal could not
+// make pass — it is the row the original bug fails and this matrix guards.
+
+// preflightCases: model -> expected env var ("" = no credential required).
+// VERIFY these against internal/ai/config.go GuessProvider + EnvVarForProvider
+// on 2026-08-20:
+//
+//	ollama/qwen3.6:35b-a3b-mxfp8  -> "ollama:" prefix     -> provider ollama -> env ""
+//	ollama:qwen3.5                -> "ollama:" prefix     -> provider ollama -> env ""
+//	openrouter/anthropic/claude-haiku-4-5 -> vendor/model -> openrouter -> OPENROUTER_API_KEY
+//	anthropic/claude-sonnet-4-6            -> vendor/model -> openrouter (NOT direct anthropic) -> OPENROUTER_API_KEY
+//	claude-3-5-sonnet             -> bare claude- prefix -> anthropic -> ANTHROPIC_API_KEY
+//	gpt-5-codex                   -> bare gpt- prefix    -> openai    -> OPENAI_API_KEY
+//	gemini-3-1-pro                -> bare gemini- prefix -> google    -> GOOGLE_API_KEY
+var preflightCases = []struct {
+	model    string
+	envVar   string
+	provider string
+}{
+	{"ollama/qwen3.6:35b-a3b-mvp", "", "ollama"},
+	{"ollama:qwen3.5", "", "ollama"},
+	{"openrouter/anthropic/claude-haiku-4-5", "OPENROUTER_API_KEY", "openrouter"},
+	{"anthropic/claude-sonnet-4-6", "OPENROUTER_API_KEY", "openrouter"},
+	{"claude-3-5-sonnet", "ANTHROPIC_API_KEY", "anthropic"},
+	{"gpt-5-codex", "OPENAI_API_KEY", "openai"},
+	{"gemini-3-1-pro", "GOOGLE_API_KEY", "google"},
+}
+
+// TestRequireProviderCredential_NoKeyRefusalMatrix (T-B5) is the primary
+// table: each row with its env var cleared must either pass (no env required)
+// or refuse naming the model AND the specific missing variable.
+func TestRequireProviderCredential_Row_KeyedRefusalTable(t *testing.T) {
+	for _, c := range preflightCases {
+		envVar := c.envVar
+		if envVar != "" {
+			t.Setenv(envVar, "")
+		}
+		err := requireProviderCredential(c.model)
+		if envVar == "" {
+			if err != nil {
+				t.Errorf("model %q needs no credential; requireProviderCredential refused: %v", c.model, err)
+			}
+			continue
+		}
+		if err == nil {
+			t.Errorf("model %q requires %s (unset) but requireProviderCredential passed", c.model, envVar)
+			continue
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, c.model) {
+			t.Errorf("model %q refusal does not name the model; got: %q", c.model, msg)
+		}
+		if !strings.Contains(msg, envVar) {
+			t.Errorf("model %q refusal does not name the missing variable %s; got: %q", c.model, envVar, msg)
+		}
+	}
+}
+
+// TestRequireProviderCredential_KeyPresent_T_B5b prohibits the naive
+// "any API key is set" mutant: setting the CORRECT variable for a keyed model
+// must admit, but setting a DIFFERENT provider's variable must still refuse.
+// The observable is the (model, which-var-was-set) pairing — two-dimensional,
+// so a single-var check collapses it.
+func TestRequireProviderCredential_KeyPresent_AndWrongKeyStillRefuses(t *testing.T) {
+	keyed := []struct{ model, envVar string }{
+		{"openrouter/anthropic/claude-haiku-4-5", "OPENROUTER_API_KEY"},
+		{"claude-3-5-sonnet", "ANTHROPIC_API_KEY"},
+		{"gpt-5-codex", "OPENAI_API_KEY"},
+		{"gemini-3-1-pro", "GOOGLE_API_KEY"},
+	}
+	for _, c := range keyed {
+		// Correct var set -> admit.
+		for _, other := range []string{"OPENROUTER_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY"} {
+			// set ALL keys to empty first, then set only the correct one —
+			// so only the correct var being present is what admits the run.
+			t.Setenv(other, "")
+		}
+		t.Setenv(c.envVar, "sk-test-key")
+		if err := requireProviderCredential(c.model); err != nil {
+			t.Errorf("model %q with %s set must pass; refused: %v", c.model, c.envVar, err)
+		}
+		// A DIFFERENT provider's var set (correct one cleared) -> must refuse.
+		for _, k := range []string{"OPENROUTER_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY"} {
+			t.Setenv(k, "")
+		}
+		t.Setenv(differentVarFor(c.envVar), "sk-test-key")
+		err := requireProviderCredential(c.model)
+		if err == nil {
+			t.Errorf("model %q must refuse when only a DIFFERENT provider's var is set (got a pass)", c.model)
+		}
+	}
+}
+
+// differentVarFor returns any credential env var that is NOT the one given.
+// Used to prove the check keys on the resolved provider, not on "some key is set".
+func differentVarFor(envVar string) string {
+	switch envVar {
+	case "OPENROUTER_API_KEY":
+		return "OPENAI_API_KEY"
+	case "OPENAI_API_KEY":
+		return "ANTHROPIC_API_KEY"
+	case "ANTHROPIC_API_KEY":
+		return "GOOGLE_API_KEY"
+	default:
+		return "OPENROUTER_API_KEY"
+	}
+}
+
+// TestRequireProviderCredential_UnresolvableModel_T_B6: GuessProvider returns
+// "" for an unresolvable model string — measured ai.GuessProvider("") == ""
+// (internal/ai/config.go terminal `return ""`). EnvVarForProvider("") then
+// returns "", which a naive implementation would silently PASS. D1 requires a
+// loud refusal HERE instead, naming the model and the unresolvable-provider
+// fact.
+func TestRequireProviderCredential_UnresolvableModel_LoudRefusal(t *testing.T) {
+	// Never leave a real key lying around while asserting the unresolvable leg.
+	for _, c := range preflightCases {
+		if c.envVar != "" {
+			t.Setenv(c.envVar, "")
+		}
+	}
+	for _, model := range []string{"", "not-a-real-model-xyz", "gibberish"} {
+		err := requireProviderCredential(model)
+		if err == nil {
+			t.Errorf("unresolvable model %q passed; must REFUSE loudly (no silent fallback)", model)
+			continue
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "could not resolve provider") {
+			t.Errorf("unresolvable-model error does not say the provider could not be resolved; got: %q", msg)
+		}
+		if model != "" && !strings.Contains(msg, model) {
+			t.Errorf("unresolvable-model error does not name the model; got: %q", msg)
+		}
+	}
+}
+
+// TestRequireProviderCredential_AllMotokoLanesResolve (T-B6b): every
+// agent_model_name across the 17 `agent_cli: "motoko"` lanes in
+// internal/eval_harness/models.yml must resolve to a non-empty provider via
+// ai.GuessProvider. This is the coverage gate that fails a future motoko lane
+// whose model string is unresolvable — TODAY, all 17 begin with ollama/ or
+// openrouter/ (measured this session; design doc §12.2 enumerates them).
+func TestRequireProviderCredential_AllMotokoLanesResolve(t *testing.T) {
+	lanes := motokoLaneModels(t)
+	if len(lanes) == 0 {
+		t.Skip("could not locate internal/eval_harness/models.yml; lane-coverage gate not run")
+	}
+	if len(lanes) != 17 {
+		t.Errorf("expected 17 motoko lanes in models.yml, found %d", len(lanes))
+	}
+	for _, m := range lanes {
+		if ai.GuessProvider(m) == "" {
+			t.Errorf("motoko lane model %q is unresolvable by GuessProvider; a future motoko lane must not ship unresolvable", m)
+		}
+	}
+}
+
+// findRepoRoot walks up from the test cwd until it finds internal/eval_harness/models.yml.
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for i := 0; i < 8; i++ {
+		if _, statErr := os.Stat(filepath.Join(dir, "internal", "eval_harness", "models.yml")); statErr == nil {
+			return dir
+		}
+		next := filepath.Dir(dir)
+		if next == dir {
+			break
+		}
+		dir = next
+	}
+	return ""
+}
+
+// motokoLaneModels reads the agent_model_name values of every `agent_cli:
+// "motoko"` block in the repo models.yml.
+func motokoLaneModels(t *testing.T) []string {
+	repo := findRepoRoot(t)
+	if repo == "" {
+		return []string{}
+	}
+	data, err := os.ReadFile(filepath.Join(repo, "internal", "eval_harness", "models.yml"))
+	if err != nil {
+		return []string{}
+	}
+	var lanes []string
+	inMotoko := false
+	for _, line := range strings.Split(string(data), "\n") {
+		tr := strings.TrimSpace(line)
+		if strings.HasPrefix(tr, "agent_cli:") {
+			inMotoko = strings.Contains(tr, "\"motoko\"")
+		} else if inMotoko && strings.HasPrefix(tr, "agent_model_name:") {
+			val := tr[len("agent_model_name:"):]
+			// Drop an inline YAML comment ("...  # note") before parsing the value.
+			if ci := strings.Index(val, "#"); ci >= 0 {
+				val = val[:ci]
+			}
+			val = strings.TrimSpace(val)
+			val = strings.Trim(val, "\"")
+			lanes = append(lanes, val)
+		}
+	}
+	return lanes
+}
+
+// T-CALLSITE — the WIRING arm, added by the controller at iteration 14 after
+// mutation MUT-4 SURVIVED. MUT-4 neutered the requireProviderCredential call in
+// ExecuteStreaming (`if err := error(nil); err != nil {`) and the ENTIRE package
+// stayed green (rc=0, 43.9s): every other arm calls the helper DIRECTLY, and the
+// one Execute-level arm (T-ORDER in execute_test.go) drives an `ollama/…` task,
+// which the guard ADMITS — so its observable is not downstream of the wiring at
+// all. That is this repo's named recurring shape, guard the helper and miss the
+// call site, reproduced inside the milestone whose whole subject is a guard.
+//
+// The discriminating observable is a REFUSAL that reaches Execute, asserted two
+// independent ways, neither of which "the run never started" can satisfy:
+//
+//	(a) the error text names the resolved provider AND the missing variable AND
+//	    the ExecuteStreaming wrapper's own prefix — a string only this code path
+//	    produces, never a bare "an error was returned";
+//	(b) the mock binary must NOT have run. That half is an ABSENCE, so it is
+//	    admissible only because the control arm below proves, on the same
+//	    instrument in the same test, that the marker DOES appear when the task
+//	    is admitted. Without the control, (b) would be satisfied equally by a
+//	    preflight that refused and by a mock that was never wired up.
+func TestExecuteStreaming_CallSite_RefusesKeyRequiringLane(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash mock binary requires POSIX shell")
+	}
+	tmp := t.TempDir()
+	mockMotoko := filepath.Join(tmp, "motoko")
+	marker := filepath.Join(tmp, "mock-was-invoked")
+
+	// The mock records that it ran, then emits the minimal JSONL a successful
+	// parse needs. Reaching it at all means the preflight did not refuse.
+	mockScript := `#!/bin/bash
+set -e
+echo ran > "` + marker + `"
+for arg in "$@"; do
+  if [ "$arg" = "--version" ]; then
+    echo "motoko_repo=/tmp/fake-motoko-repo"
+    exit 0
+  fi
+done
+LOGDIR="$WORKDIR/.motoko/logfile"
+mkdir -p "$LOGDIR"
+SESSION="${MOTOKO_SESSION_ID:-session_unknown}"
+cat > "$LOGDIR/$SESSION.jsonl" <<EOF
+{"schema_version":"1","session_id":"$SESSION","type":"session_start","task":"x","model":"x","brainVersion":"0.2.0"}
+{"schema_version":"1","session_id":"$SESSION","type":"run_summary","finish_reason":"stop","duration_ms":1,"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}
+EOF
+exit 0
+`
+	if err := os.WriteFile(mockMotoko, []byte(mockScript), 0755); err != nil {
+		t.Fatalf("writing mock binary: %v", err)
+	}
+	wsDir := filepath.Join(tmp, "ws")
+	if err := os.MkdirAll(wsDir, 0755); err != nil {
+		t.Fatalf("creating workspace: %v", err)
+	}
+
+	t.Setenv("OPENROUTER_API_KEY", "")
+	exe, err := New(&executor.Config{MotokoPath: mockMotoko, MotokoModel: "ollama/qwen3.6:35b-a3b-mxfp8"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// TREATMENT: a key-requiring per-task lane with the key unset.
+	_, err = exe.Execute(context.Background(), &executor.Task{
+		Workspace: wsDir,
+		Directive: "any",
+		Model:     "openrouter/anthropic/claude-haiku-4-5",
+	})
+	if err == nil {
+		t.Fatal("Execute admitted an openrouter lane with OPENROUTER_API_KEY unset — the ExecuteStreaming call site is not wired (MUT-4 would survive)")
+	}
+	for _, want := range []string{
+		"motoko provider preflight refused",
+		`resolves to provider "openrouter"`,
+		"requires OPENROUTER_API_KEY",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal text missing %q; got: %v", want, err)
+		}
+	}
+	if _, statErr := os.Stat(marker); statErr == nil {
+		t.Error("the mock motoko binary RAN — the refusal happened after the subprocess, not before it")
+	}
+
+	// CONTROL, same instrument, same test: an admitted lane must reach the mock.
+	// This is what makes the marker-absence above a measurement rather than a
+	// vacuous pass.
+	wsDir2 := filepath.Join(tmp, "ws2")
+	if err := os.MkdirAll(wsDir2, 0755); err != nil {
+		t.Fatalf("creating control workspace: %v", err)
+	}
+	if _, err := exe.Execute(context.Background(), &executor.Task{
+		Workspace: wsDir2,
+		Directive: "any",
+		Model:     "ollama/qwen3.6:35b-a3b-mxfp8",
+	}); err != nil {
+		t.Fatalf("control: admitted ollama lane failed: %v", err)
+	}
+	if _, statErr := os.Stat(marker); statErr != nil {
+		t.Fatal("CONTROL DID NOT FIRE: the mock never ran even for an admitted lane, so the marker proves nothing about the treatment arm")
+	}
+}


### PR DESCRIPTION
Motoko mission iteration 14. Queue item 6 (`m-motoko-fmt-remeasurement-instrument`), un-parked at iteration 13 by Mark's `D-MOTOKO-FMT-1` ruling. Milestone **M1 (D1)** of a 5-milestone sprint; M2–M5 are the named resume point, not silently dropped.

## What was broken

`MotokoExecutor.HealthCheck` refused unconditionally whenever `OPENROUTER_API_KEY` was unset (`healthcheck.go:64`), with the error text *"motoko routes ALL models via OpenRouter"*. That text is false for the two fmt A/B arms, which declare `provider: "ollama"`, `env_var: ""` — and this refusal is why both Wednesday fmt slots (08-05, 08-12) banked nothing.

## Why the obvious fix does not work

The design doc's §12.2 preferred option — set `cfg.MotokoModel` from models.yml at construction — is **unsound**, refuted by the planner and re-verified first-party:

- `ExecutorFactory.GetExecutor` caches by executor **name** (`factory.go:96-122`), so one `*MotokoExecutor` serves all **17** `agent_cli: "motoko"` lanes: **7 ollama** (no credential) and **10** that require one. One string cannot be right for both.
- `HealthCheck` is `sync.Once`-cached (`motoko.go:134`, `healthcheck.go:40`), so a model-dependent verdict there freezes at whichever model canaried first — turning a loud uniform refusal into a silent order-dependent one.

So the refusal moved to `ExecuteStreaming`, the per-task choke point, keyed on `e.getModel(task)` — which is also strictly downstream of repo discovery, satisfying §12.3's ordering requirement for free.

The condition is on the **resolved provider** (`ai.EnvVarForProvider(ai.GuessProvider(model))`), never a literal env-var name, so one check covers ollama / OpenAI / Anthropic / Google / OpenRouter. An unresolvable model is a loud refusal, not a silent admit.

## The mutation that survived

| mutant (all asserted LANDED via sha256, and BUILDING) | full-package failing tests |
|---|---|
| neuter the no-credential ADMIT branch | 12 |
| neuter the credential-missing REFUSAL | 3 |
| neuter the unresolvable-model guard | 1 (sole killer) |
| neuter the `ExecuteStreaming` **call site** | **SURVIVED as first delivered**; now 1 (sole killer, `-skip` inverse rc=0) |
| move the check into `HealthCheck` **before** the version query | 1 — `T-ORDER` at `execute_test.go:711`, on `motokoRepo == ""` |
| move it into `HealthCheck` **after** the version query | 1 — `T-ORDER` at `execute_test.go:718`, a *different* assertion |

**Correction to the first push of this PR.** The table originally reported blast radii of 1/2/1/0. Those first three numbers came from runs scoped `-run 'TestRequireProviderCredential'`, and the narrowing was dropped when the numbers were quoted — a `-run`-narrowed result cited for a whole-package sentence. The figures above are full-package, no narrowing.

Every arm called the helper directly, and the one `Execute`-level arm drives an `ollama/…` task the guard *admits* — so neutering the wiring left the entire package green. That is this repo's named recurring shape (guard the helper, miss the call site), reproduced inside the milestone whose subject is a guard.

The **row** was repaired, not the code. `T-CALLSITE` asserts a refusal that reaches `Execute`, on the resolved provider name and the missing variable, plus a mock-not-invoked marker whose absence is admissible only because a control arm *in the same test* proves the marker fires for an admitted lane. MUT-4 now dies with `T-CALLSITE` as **sole killer** (`-skip TestExecuteStreaming_CallSite` → rc=0 under the same mutant).

## Evaluator

Sprint-evaluator (sonnet — distinct provider from the pi/DeepSeek executor, so generator≠judge holds): **PASS 84/100, zero blocking**. Its three non-blocking findings were all reproduced first-party and fixed in `4a2012f4b`:

1. **`T-ORDER` was decorative.** Its surviving assertion was a bare nil-vs-error on `HealthCheck`, which fires identically whether the credential check is placed before the version query (violating doc §12.3) or after it (not violating it) — and the `MOTOKO_REPO` observable the plan calls the pin was never reached under either mutant. Repaired so the ordering claim rests on `e.motokoRepo`, read independently of the returned error; both placements now fail at *different* assertions (see the table).
2. **The same false claim was left one file over.** `internal/executor/motoko/README.md` still read *"motoko routes ALL models via OpenRouter"* — the exact sentence the deleted refusal encoded, false for 7 of 17 lanes. CLAUDE.md rule 3 (audit before patching) had been applied to the code and not the docs.
3. **Stale mutation table** — see the correction above; the real number was worse than the evaluator caught.

## Gates

All re-run by the controller **outside any sandbox**, on **darwin/arm64 only** — windows and ubuntu legs unrun locally:

`go build ./internal/... ./cmd/ailang/...` · `go test ./internal/executor/... ./internal/ai/...` · `env -u OPENROUTER_API_KEY go test ./internal/executor/motoko/` · `make fmt-check check-boundaries check-changelog check-file-sizes check-skills` · `go vet ./internal/executor/motoko/` — all rc=0.

Note `go build ./...` is **red at base** (`cmd/wasm` has no native `main`; it builds only under `GOOS=js`), so it is not a usable gate here.

`TestHealthCheck_MissingAPIKey` deleted per the no-backward-compatibility testing policy — it asserted exactly the behaviour this removes.

Refs #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)
