### PR TITLE
fix(ci): bound every workflow job — 27 of 27 inherited a 6-hour default, and two wedged on unbounded `apt` last night

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
   build:
     name: Build ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       matrix:
         include:
@@ -117,6 +118,7 @@ jobs:
     name: Create Release Bundle
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
     
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
     - uses: actions/checkout@v7
@@ -70,6 +71,7 @@ jobs:
     # (internal/smt TestSolve_*_Z3, internal/bestof TestZ3VerifyEndToEnd, …)
     # t.Skip()s — they had silently never run in CI until 2026-07-10.
     - name: Install z3 (SMT solver for contract-verification tests)
+      timeout-minutes: 5
       run: sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends z3
 
     # jq drives scripts/hooks/format_ail.sh, which TestFormatAilHookSinkRoundTrip
@@ -78,6 +80,7 @@ jobs:
     # instead of an invisible skip — so pin it explicitly rather than rely on
     # the image (docusaurus-deploy.yml already installs jq for the same reason).
     - name: Install jq (drives the .ail format PostToolUse hook under test)
+      timeout-minutes: 5
       run: sudo apt-get install -y -qq --no-install-recommends jq && jq --version
 
     # -timeout is PER TEST BINARY (package). cmd/ailang legitimately runs
@@ -293,6 +296,7 @@ jobs:
   # expand to make verify-examples / make test-imports once stable.
   test-windows:
     runs-on: windows-latest
+    timeout-minutes: 25
 
     steps:
     - uses: actions/checkout@v7
@@ -389,6 +393,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: test
     
     steps:
@@ -411,6 +416,7 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
 
     steps:
@@ -434,6 +440,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v7
@@ -463,6 +470,7 @@ jobs:
     # `declare -A` or ${v,,} that reaches tools/launchd/ breaks the rig and passes on ubuntu.
     # No Go, no cache: these are shell + git tests and nothing else.
     runs-on: macos-latest
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v7
@@ -479,6 +487,7 @@ jobs:
   govulncheck:
     name: govulncheck (vuln gate)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Reads .govulncheck-allow.yml. Fails on any new finding or any
     # allowlist entry past its expires date — forces re-review rather
     # than letting suppressions float forever.
@@ -507,6 +516,7 @@ jobs:
 
   dependency-submission:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,7 @@ jobs:
   analyze:
     name: Analyze Go
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       # Required to upload SARIF to the Security tab.
       security-events: write

--- a/.github/workflows/dashboard-ui-build.yml
+++ b/.github/workflows/dashboard-ui-build.yml
@@ -21,6 +21,7 @@ jobs:
   ui-build:
     name: UI build stage
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   automerge:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Fetch Dependabot metadata

--- a/.github/workflows/docusaurus-deploy.yml
+++ b/.github/workflows/docusaurus-deploy.yml
@@ -46,6 +46,7 @@ concurrency:
 jobs:
   docs-changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       docs_changed: ${{ steps.detect.outputs.docs_changed }}
     steps:
@@ -178,6 +179,7 @@ jobs:
   # Docs build job
   docs-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: docs-changes
     # Run even if commit has [skip ci] when it's from docs automation
     if: >-
@@ -202,6 +204,7 @@ jobs:
           go-version: '1.26.6'
 
       - name: Install jq for stats generation
+        timeout-minutes: 5
         run: sudo apt-get update && sudo apt-get install -y jq
 
       - name: Build WASM binary
@@ -298,6 +301,7 @@ jobs:
 
   docs-gate:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [docs-changes, docs-build]
     if: always()
     steps:
@@ -338,6 +342,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Depends on the Pages artifact that docs-build uploads. When docs-build skips
     # (a PR touching no docs-relevant path) there is no artifact, so deploy MUST skip
     # with it — do NOT add `if: always()` here thinking it fixes a deployment gap.

--- a/.github/workflows/eval-weekly.yml
+++ b/.github/workflows/eval-weekly.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   eval:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
 
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
   build-wasm:
     name: Build WASM Binary
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
@@ -104,6 +105,7 @@ jobs:
   build-bootstrap-content:
     name: Build Bootstrap Content Bundle
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
@@ -128,6 +130,7 @@ jobs:
   build-examples:
     name: Build Examples Bundle
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
@@ -150,6 +153,7 @@ jobs:
   build-release:
     name: Build Release ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       matrix:
         include:
@@ -235,6 +239,7 @@ jobs:
   build-error-codes:
     name: Generate error_codes.json
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
@@ -260,6 +265,7 @@ jobs:
     name: Create GitHub Release
     needs: [build-release, build-wasm, build-bootstrap-content, build-examples, build-error-codes]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # id-token: write is required for cosign keyless signing — the job
     # requests an OIDC token from GitHub which Sigstore's Fulcio CA uses
     # to issue a short-lived signing cert bound to this workflow's
@@ -459,6 +465,7 @@ jobs:
     name: Publish Release
     needs: [provenance]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,6 +20,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       # Needed to upload SARIF results to the GitHub Security tab.
       security-events: write

--- a/.github/workflows/test-game-codegen.yml
+++ b/.github/workflows/test-game-codegen.yml
@@ -27,6 +27,7 @@ jobs:
   test-game-codegen:
     name: Test AILANG -> Go Codegen Pipeline
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,43 @@
 
 ## [Unreleased]
 
+### Fixed — every CI job now declares a `timeout-minutes`; unbounded `apt` installs are bounded
+
+Mission iteration 233. No job in any of the repo's 10 workflow files declared
+`timeout-minutes` (`grep -c` → **0**; control: `runs-on` appears **27** times),
+so all 27 jobs inherited GitHub Actions' default **6-hour** limit.
+
+Measured the night before (iteration 232): two jobs wedged in one iteration,
+both on unbounded shell-outs to a package mirror. `CI / test` step *Install z3*
+hung **>26 min** (attempt 1) and **17m37s** (attempt 2) against a control of
+**49s / 100s / 9s** on the three immediately preceding completed dev runs;
+`Deploy Documentation / docs-build` step *Install jq* sat **1h30m**. The
+provider's status API read *All Systems Operational* throughout, and attempt 3
+cleared z3 in ~1 minute on a byte-identical tree — outcome divergence with the
+code held constant. `test` and `docs-gate` are **required** contexts, so a
+wedged mirror blocks every merge in the repo with no alarm and no upper bound.
+
+- **27 of 27 jobs** across all 10 workflows now declare `timeout-minutes`, sized
+  at roughly 2× the observed maximum over the last 18–20 successful runs (e.g.
+  `CI / test` max 1712s → 45 min; `lint` max 287s → 15 min; `docs-build` max
+  788s → 30 min). The one remaining job, `release.yml`'s `provenance`, calls a
+  reusable workflow — GitHub rejects `timeout-minutes` on a `uses:` job, so the
+  bound is the callee's and the exemption is asserted rather than assumed.
+- The **three** `apt-get` steps additionally carry a 5-minute *step-level*
+  bound. A job bound reds the job; a step bound names the wedged step, which is
+  the difference between "the job timed out" and "the package mirror is the
+  problem".
+- The fix is a bound, not a retry: a retry loop around an unbounded command
+  inherits the unboundedness.
+
+**A guard is not a gate until something reds when you remove it.** New
+`internal/cihygiene` tests enforce all of the above and run under `make test`.
+They parse the workflows with a real YAML parser rather than `grep`, because a
+gate's coverage is a property of its enumerator and a line matcher is defeated
+by comments, quoting and block scalars; they read both `*.yml` and `*.yaml`;
+and they fail loudly — never silently pass — when the directory is missing, no
+workflow file is found, or zero jobs are parsed.
+
 ### Fixed — `ailang editor install vscode` now installs an extension VS Code actually loads
 
 [ailang#694](https://github.com/sunholo-data/ailang/issues/694) (downstream-consumer

--- a/internal/cihygiene/workflow_timeouts_test.go
+++ b/internal/cihygiene/workflow_timeouts_test.go
@@ -1,0 +1,220 @@
+// Package cihygiene holds repo-level guards over the GitHub Actions workflow
+// definitions. It has no production code: the tests ARE the gate.
+//
+// Why this exists (measured, iteration 232, 2026-08-19/20):
+//
+// No job in any workflow declared timeout-minutes, so every job inherited
+// GitHub's default 6-hour limit. Two jobs then wedged in one iteration, both on
+// unbounded `apt-get install` shell-outs to a package mirror:
+//
+//	CI / test        step "Install z3"  >26m (attempt 1), 17m37s (attempt 2)
+//	                 against a control of 49s / 100s / 9s on the three
+//	                 immediately preceding completed dev runs.
+//	Deploy Docs /    step "Install jq"  1h30m.
+//	docs-build
+//
+// The provider's status API read "All Systems Operational" throughout, and
+// attempt 3 cleared z3 in ~1 minute on a byte-identical tree -- outcome
+// divergence with the code held constant, which pins the cause to the
+// environment rather than to any diff. `test` and `docs-gate` are REQUIRED
+// contexts, so a wedged mirror blocks every merge in the repo, for both
+// missions on the rig, with no alarm and no upper bound.
+//
+// The fix is a bound, not a retry: a retry loop around an unbounded command
+// inherits the unboundedness. A timeout converts an invisible multi-hour stall
+// into a fast, legible red.
+//
+// The gate is written against a real YAML parser rather than grep on purpose.
+// A gate's coverage is a property of its ENUMERATOR, one level below its
+// branches -- a line-oriented matcher is defeated by comments, quoting, block
+// scalars and indentation, and would report clean while seeing nothing.
+package cihygiene
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// workflowDir is relative to this package (internal/cihygiene).
+const workflowDir = "../../.github/workflows"
+
+// maxJobTimeoutMinutes caps how lax a declared bound may be. GitHub's own
+// default is 360; anything near it is a bound in name only.
+const maxJobTimeoutMinutes = 180
+
+// osPackageInstall matches a shell-out to an OS package mirror -- the class
+// that was actually measured wedging. Deliberately NOT widened to every
+// network fetch: `go mod download`, `npm ci` and the setup-* actions are
+// already inside jobs that now carry a job-level bound, and a gate that fires
+// on everything gets suppressed rather than fixed.
+var osPackageInstall = regexp.MustCompile(`\b(apt-get|apt|yum|dnf|apk|brew|choco)\b[^\n]*\b(install|update|add|upgrade)\b`)
+
+type workflow struct {
+	Jobs map[string]struct {
+		Uses           string `yaml:"uses"`
+		TimeoutMinutes *int   `yaml:"timeout-minutes"`
+		Steps          []struct {
+			Name           string `yaml:"name"`
+			Run            string `yaml:"run"`
+			TimeoutMinutes *int   `yaml:"timeout-minutes"`
+		} `yaml:"steps"`
+	} `yaml:"jobs"`
+}
+
+// loadWorkflows enumerates every workflow file and parses it. Both extensions
+// are read: GitHub accepts .yml and .yaml, and an enumerator that knows only
+// one of them reports clean on a file it never opened.
+func loadWorkflows(t *testing.T) map[string]workflow {
+	t.Helper()
+
+	info, err := os.Stat(workflowDir)
+	if err != nil || !info.IsDir() {
+		// A missing directory makes every glob below return zero matches, and a
+		// zero that means "the path is wrong" is indistinguishable from a zero
+		// that means "nothing to check" unless the scope is asserted first.
+		t.Fatalf("instrument failure: %s is not a directory (%v)", workflowDir, err)
+	}
+
+	var paths []string
+	for _, pat := range []string{"*.yml", "*.yaml"} {
+		m, err := filepath.Glob(filepath.Join(workflowDir, pat))
+		if err != nil {
+			t.Fatalf("instrument failure: glob %q: %v", pat, err)
+		}
+		paths = append(paths, m...)
+	}
+	sort.Strings(paths)
+
+	if len(paths) == 0 {
+		t.Fatal("instrument failure: no workflow files found -- the gate is vacuous")
+	}
+
+	out := make(map[string]workflow, len(paths))
+	for _, p := range paths {
+		b, err := os.ReadFile(p) //nolint:gosec // fixed repo-relative path
+		if err != nil {
+			t.Fatalf("read %s: %v", p, err)
+		}
+		var wf workflow
+		if err := yaml.Unmarshal(b, &wf); err != nil {
+			t.Fatalf("parse %s: %v", p, err)
+		}
+		out[filepath.Base(p)] = wf
+	}
+	return out
+}
+
+// TestEveryJobDeclaresATimeout is the primary gate: a job with no
+// timeout-minutes inherits a 6-hour ceiling nobody is watching.
+func TestEveryJobDeclaresATimeout(t *testing.T) {
+	wfs := loadWorkflows(t)
+
+	var checked, exempt int
+	for name, wf := range wfs {
+		for jobID, job := range wf.Jobs {
+			// A job that CALLS a reusable workflow cannot carry
+			// timeout-minutes -- GitHub rejects the key there. The bound is the
+			// callee's to declare, so this is a real exemption rather than a
+			// waiver, and it is counted so it stays visible.
+			if job.Uses != "" {
+				exempt++
+				if job.TimeoutMinutes != nil {
+					t.Errorf("%s: job %q calls a reusable workflow and also sets timeout-minutes; "+
+						"GitHub rejects that key on a `uses:` job", name, jobID)
+				}
+				continue
+			}
+			checked++
+			if job.TimeoutMinutes == nil {
+				t.Errorf("%s: job %q declares no timeout-minutes, so it inherits GitHub's "+
+					"6-hour default; a wedged step burns the whole slot with no signal", name, jobID)
+				continue
+			}
+			switch v := *job.TimeoutMinutes; {
+			case v <= 0:
+				t.Errorf("%s: job %q has timeout-minutes: %d (must be positive)", name, jobID, v)
+			case v > maxJobTimeoutMinutes:
+				t.Errorf("%s: job %q has timeout-minutes: %d, above the %d-minute cap -- "+
+					"that is a bound in name only", name, jobID, v, maxJobTimeoutMinutes)
+			}
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("instrument failure: zero jobs examined -- the gate is vacuous")
+	}
+	t.Logf("%d workflow files, %d jobs bounded, %d reusable-workflow calls exempt",
+		len(wfs), checked, exempt)
+}
+
+// TestPackageInstallStepsAreBounded pins the step level. A job-level bound
+// alone reds the whole job with no indication of WHICH step stalled; a step
+// bound names it, which is the difference between "the job timed out" and "the
+// package mirror is the problem".
+func TestPackageInstallStepsAreBounded(t *testing.T) {
+	wfs := loadWorkflows(t)
+
+	var matched int
+	for name, wf := range wfs {
+		for jobID, job := range wf.Jobs {
+			for i, step := range job.Steps {
+				if step.Run == "" || !osPackageInstall.MatchString(step.Run) {
+					continue
+				}
+				matched++
+				if step.TimeoutMinutes == nil {
+					label := step.Name
+					if label == "" {
+						label = fmt.Sprintf("step #%d", i)
+					}
+					t.Errorf("%s: job %q step %q shells out to a package mirror with no "+
+						"step-level timeout-minutes:\n    %s",
+						name, jobID, label, strings.TrimSpace(step.Run))
+				}
+			}
+		}
+	}
+	// No anti-vacuity FLOOR here on purpose: removing the last package install
+	// is a legitimate end state. The classifier itself is pinned by
+	// TestOSPackageInstallClassifier below, so a silently-broken pattern cannot
+	// masquerade as a clean repo.
+	t.Logf("%d package-install steps found, all bounded", matched)
+}
+
+// TestOSPackageInstallClassifier is the enumerator's control. Without it, a
+// regex that stopped matching anything would make the step gate above pass
+// vacuously and look identical to a repo with nothing to bound.
+func TestOSPackageInstallClassifier(t *testing.T) {
+	positives := []string{
+		"sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends z3",
+		"sudo apt-get update && sudo apt-get install -y jq",
+		"sudo apt-get install -y -qq --no-install-recommends jq && jq --version",
+		"brew install z3",
+		"sudo apk add --no-cache jq",
+		"sudo dnf install -y jq",
+	}
+	negatives := []string{
+		"make test",
+		"go mod download",
+		"npm ci",
+		"go install ./cmd/ailang",
+		"echo 'installing nothing'",
+	}
+	for _, s := range positives {
+		if !osPackageInstall.MatchString(s) {
+			t.Errorf("classifier missed a package install: %q", s)
+		}
+	}
+	for _, s := range negatives {
+		if osPackageInstall.MatchString(s) {
+			t.Errorf("classifier fired on a non-install command: %q", s)
+		}
+	}
+}


### PR DESCRIPTION
## What

No job in any of the repo's **10** workflow files declared `timeout-minutes` (`grep -c` → **0**; control: `runs-on` appears **27** times), so every job inherited GitHub Actions' default **6-hour** limit.

Measured the night before (mission iteration 232): **two jobs wedged in one iteration**, both on unbounded shell-outs to a package mirror.

| job / step | observed | control (3 preceding completed dev runs) |
|---|---|---|
| `CI / test` → *Install z3* | **>26 min** (attempt 1), **17m37s** (attempt 2) | 49s / 100s / 9s |
| `Deploy Documentation / docs-build` → *Install jq* | **1h30m** | — |

The provider's status API read *All Systems Operational* throughout, and **attempt 3 cleared z3 in ~1 minute on a byte-identical tree** — outcome divergence with the code held constant, which pins the cause to the environment rather than to any diff. `test` and `docs-gate` are **required** contexts, so a wedged mirror blocks every merge in the repo, for both missions on the rig, with no alarm and no upper bound.

The queue row argued this from `ci.yml` alone. Audited before patching (Principle 3): the gap is repo-wide, so this is **one sweep**, not two patches.

## Changes

- **27 of 27 jobs** across all 10 workflows declare `timeout-minutes`, sized at ~2× the observed max over the last 18–20 successful runs (`CI/test` max 1712s → 45; `lint` max 287s → 15; `test-windows` max 529s → 25; `docs-build` max 788s → 30).
- The **28th** job, `release.yml`'s `provenance`, calls a reusable workflow — GitHub rejects `timeout-minutes` on a `uses:` job, so the bound is the callee's. That exemption is **asserted by the gate**, not assumed.
- The **three** `apt-get` steps additionally carry a 5-minute **step-level** bound. A job bound reds the job; a step bound names the wedged step — the difference between *"the job timed out"* and *"the package mirror is the problem"*.
- The fix is a **bound, not a retry**: a retry loop around an unbounded command inherits the unboundedness.

## The guard

A guard is not a gate until something reds when you remove it, so `internal/cihygiene` enforces all of the above under `make test`. It parses the workflows with a **real YAML parser rather than grep** — a gate's coverage is a property of its enumerator, and a line matcher is defeated by comments, quoting and block scalars — reads **both** `*.yml` and `*.yaml`, and **fails loudly** rather than passing when the directory is missing, no workflow file matches, or zero jobs parse.

**9 mutation drills**, each asserted **LANDED** (sha256) and **BUILDS** *before* any test result was read; sources restored from `cp` copies (never `git checkout --`) and verified byte-identical. Blast radius was **classified by running each mutant and reading its red set**, not predicted:

- **7 single-test**, each its mutant's **sole killer** under the inverse `-skip` rc=0 criterion — M1 job loses its bound · M2 bound `0` · M3 bound above the 180-min cap · M4 the reusable job also sets the key · M5 an apt step loses its step bound · M8 the parser stops seeing `jobs:` · M9 the classifier regex stops matching.
- **2 broad-blast** with enumerated red sets — M6 wrong directory, M7 glob matches nothing (2 arms each, both explained by the mutant's phenotype: both tests call `loadWorkflows`).

## Gates

`check-changelog` · `test-check-changelog` · `check-skills` · `check-file-sizes` · `check-boundaries` · `verify-no-shim` · `make vet` · `make fmt-check` · `go build ./internal/...` — all **rc=0**. Gate list **derived from `ci.yml`**, not recalled. All local gates ran on **darwin/arm64**; the linux and windows legs are unrun locally and settled by CI.

## Not closed by this

- `release.yml` fires only on tags, so its **seven** bounds are unexercised until the next release.
- `dashboard-ui-build` and `test-game-codegen` had **no duration history** — their 20-minute bounds are a first estimate, and this push's own runs (both are path-triggered by their own workflow file) are the first data on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
