### PR TITLE
docs(mission): Gate-5 skill edit — a half-built worktree reports its whole tree as deleted, and the lock you remove may be live

### DIFF
--- a/.claude/skills/mission-control/SKILL.md
+++ b/.claude/skills/mission-control/SKILL.md
@@ -2073,6 +2073,37 @@ Sonnet, inline, is fine.
   `/tmp` scratch trees created to establish a baseline. The generalisable point is the one rule 3c
   already makes about services, aimed at the filesystem: **the location you run a check FROM is
   part of the instrument**, so a red that moves when you move the tree is a fact about the tree.
+  **AND CREATING THE WORKTREE IS ITSELF A LONG OPERATION THAT THE TOOL LAYER WILL KILL — A
+  HALF-BUILT WORKTREE THEN REPORTS ITS WHOLE TREE AS DELETED, WHICH READS AS CATASTROPHE RATHER THAN
+  AS AN UNFINISHED INSTRUMENT** (added 2026-08-20 V1 iteration 234; two first-party frictions in one
+  iteration). Every worktree rule above is about WHERE to put it. None is about the fact that making
+  one is a full checkout — **23,796 files** in this repo, measured at ~2 minutes — which exceeds the
+  foreground `Bash` limit, so the natural `git worktree add …` call is **killed mid-checkout**.
+  Friction 1: the foreground call timed out having already created the **branch** but no directory,
+  so the retry failed on an existing branch and needed `git worktree prune` + `git branch -D` first.
+  Friction 2 is the dangerous one. An interrupted `worktree add` leaves an index that stages
+  **every file as deleted** while the files sit on disk — `git status --porcelain | wc -l` returned
+  **23,835** on a tree with nothing wrong but incompleteness — plus a live `index.lock`. That count
+  is rule 3a's trap in its most alarming form: it is not a measurement of dirtiness, it is the
+  instrument still being built, and it looks exactly like a tree someone has wrecked.
+  **The recovery instinct is what actually breaks something.** `index.lock` invites you to declare
+  the lock stale and remove it. Iteration 234 ran `pgrep`, which printed the owning
+  `git worktree add` **alive** with its PID, wrote "owner process confirmed dead", and removed the
+  lock anyway — killing a checkout that was 54% done and would have finished on its own. The control
+  fired and was read backwards, which is worse than not running it: no repo damage here (the merged
+  work and the main checkout both verified intact afterwards), but only because the casualty was a
+  throwaway tree. Rules: **(a)** always create a worktree with `run_in_background: true`, and poll
+  until the **process exits** — `pgrep -f <worktree-name>` — before reading, staging or committing
+  anything in it; a directory that exists is not a checkout that finished. **(b)** Treat a giant
+  all-deleted `git status` in a fresh worktree as *incomplete*, never as dirty, and never "fix" it
+  with `git reset`/`checkout` while the creating process may still be running. **(c)** An
+  `index.lock` is a claim that a process holds it — run `pgrep` and **believe the output**; if a PID
+  comes back, the lock is not stale and the only correct action is to wait. **(d)** If a creation
+  really was killed, clean up with `git worktree prune` and `git branch -D <branch>` and start
+  again, rather than repairing the corpse. Mission-independent: the file count is per-repo, the
+  trap is not. The tell: you are about to act on a `git status` from a worktree you created less
+  than a couple of minutes ago, or you are about to delete a lock file you have not proven is
+  unowned.
 - Execution complete → **sprint-evaluator** as a `$MISSION_EVALUATOR_MODEL`-pinned Agent sub-agent
   (distinct from the executor model → generator≠judge). Max 3 rounds; on round-3 fail →
   `needs-human-review`, park, message controlplane.

--- a/design_docs/v1-mission.md
+++ b/design_docs/v1-mission.md
@@ -2361,6 +2361,26 @@ on `D-19` only in that answer **B** (cons cells) may change what the evaluator w
 > converted into a fast, legible red.
 (first-party, iteration 227). `ci.yml` declares **`timeout-minutes` on no job at all** (`grep -c` → 0 over the file; control: `runs-on` appears throughout), so every job inherits GitHub's default **6-hour** limit. Measured today: `Install z3 …` — `sudo apt-get update && apt-get install z3`, an unbounded shell-out to a package mirror — hung **39+ minutes** on the `#784` run, having taken **1m41s** on the immediately preceding run (`32206877998`, 02:01:11Z → 02:02:52Z). Attribution is not a guess: the **dev** run for `171e2f2ef`, a SKILL.md-only docs commit touching no Go code, was wedged on the **identical step** in the same window, and a cancel+re-run of both cleared it on a byte-identical tree — outcome divergence with the code held constant. Provider status read *All Systems Operational* throughout, so a status-API check would NOT have caught it. Two consequences worth the row: (a) the loop's own Gate-3b bounded poll expires and reports a non-verdict while the run is neither green nor red for hours, and Standing rule 6 then costs an iteration; (b) `test` is a **required** context, so a wedged mirror blocks every merge in the repo, for both missions, with no alarm. Scope: add `timeout-minutes` to each job sized from observed p95 (the `test` job's own history is the data), and give the apt step its own bound — a package install that cannot finish in minutes will not finish. Do NOT simply retry: the failure to fix is the *unboundedness*, and a retry loop around an unbounded command inherits it. Note this is the same shape as the `AILANG_OLLAMA_*` streaming-deadline work — an unbounded external wait inside a job nobody is watching.
 
+**[NEXT — bookkeeping, cheap, first-party iteration 234] m-mission-log-entry-numbering — the mission
+log's entry numbers are no longer a usable index: there are TWO entries numbered `## 232`, and
+230–233 are out of chronological order.**
+
+> Measured at `746686cb6`: `grep -c '^## 232 — ' design_docs/v1-mission-log.md` → **2** (control:
+> `'^## 233 — '` → 1). The collision is the iteration-232 record (`editor install vscode`, dated
+> 2026-08-20) and the iteration-231 record (package imports, dated 2026-08-19); reading the headings
+> in file order gives 225, 226, 227, 228, 229, **232**, 231, 230, **232**, 233, 234, so neither the
+> number nor the position orders the log. Note also that entry number and iteration number drifted
+> apart earlier (entry 230 = Iteration 229, entry 231 = Iteration 230) and then re-converged, so the
+> two are not reliably offset by a constant either.
+>
+> Why this is a row and not an inline fix: renumbering historical entries would invalidate every
+> cross-reference already written against them — the charter, the status archive and prior issue
+> comments all cite entries by number. The durable options are (a) leave the numbers alone and add a
+> generated index keyed on the `Iteration N` token that already appears in each heading, or (b)
+> renumber once with a redirect table recorded in the archive. Choosing needs a design pass, not a
+> controller edit. Cheap to close and it protects the loop's own memory: Gate 4 appends by "highest
+> existing number", which a duplicate silently corrupts.
+
 **[NEXT] m-ui-dependency-tree-unbuildable — `ui/` has not installed since 2026-07-10, and the check
 that would have said so is path-filtered and non-required** ([`#503`](https://github.com/sunholo-data/ailang/issues/503),
 whose title names the MECHANISM; this row is the measured consequence, filed as a comment there rather


### PR DESCRIPTION
Iteration 234's Gate-5 retro. Docs-only: the shared mission-control skill + one queue row.

## The gap

The skill prescribes `git worktree add` at Gate 3, Gate 4 and the planner recipe, and says only **where** to put it (never `/tmp`). Nothing says that *creating* one is a full checkout — **23,796 files, ~2 minutes measured** — which exceeds the foreground `Bash` limit, so the natural call is **killed mid-checkout**.

**Friction 1.** The foreground call timed out having already created the **branch** but no directory; the retry then failed on an existing branch and needed `git worktree prune` + `git branch -D`.

**Friction 2 — the dangerous one.** An interrupted `worktree add` leaves an index staging **every file as deleted** while the files are on disk. `git status --porcelain | wc -l` returned **23,835** on a tree whose only problem was incompleteness — rule 3a's trap in its most alarming form: not a measurement of dirtiness, an instrument still being built, and indistinguishable from a tree someone has wrecked.

**And the recovery instinct is what actually breaks something.** The stale-looking `index.lock` invites removal. This iteration ran `pgrep`, which printed the owning `git worktree add` **alive with its PID**, wrote *"owner process confirmed dead"*, and removed the lock anyway — killing a checkout that was 54% done and would have finished on its own. The control fired and was read backwards, which is worse than not running it. **No repo damage**: the merged deliverable (#798) and the main checkout were both verified intact afterwards, and the casualty was a throwaway tree — luck, not design.

## The rule

- Create every worktree with `run_in_background: true` and poll until the **process exits** (`pgrep -f <name>`) before reading, staging or committing in it — a directory that exists is not a checkout that finished.
- Treat a giant all-deleted `git status` in a fresh worktree as **incomplete**, never dirty, and never "fix" it while the creating process may still be running.
- An `index.lock` is a claim that a process holds it — run `pgrep` and **believe the output**. A PID means wait.
- Clean up a killed creation with `prune` + `branch -D`; do not repair the corpse.

Mission-independent (the file count is per-repo, the trap is not). Verified by construction: the worktree this PR was authored in was created with the new rule applied and came up clean.

## Also: the owed queue row

`m-mission-log-entry-numbering` — the log has **two** entries numbered `## 232` and 230–233 are out of order, so entry numbers are not a usable index. Re-derived in this tree rather than transcribed: heading order reads `225 226 227 228 229 232 231 230 232 233 234` (control `^## 233 — ` = 1). Iteration 234's charter stamp asserted this "is a queue row" while no such row existed; this makes that sentence true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
