### PR TITLE
feat(eval): M4 — D2 censored-pair analyzer, and the gate it built was unreachable from its own CLI

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -35,6 +35,24 @@ has). The command now loads with `LoadResultsFromDirsIncludingInvalid` and
 `TestEvalCensoredPairsSeesQuarantinedRows` pins the call site; that mutant
 survived the whole package as first delivered.
 
+An independent evaluator then found that the first repair traded one defect for
+another: `AnalyzeCensoredPairs` filtered only the ON arm, so switching to the
+raw loader let an OFF row invalid for any non-contamination reason
+(`harness_error`, `config_mismatch`) score a full win and pollute the token
+statistics. Reproduced first-party — marking the decisive OFF row a
+non-measurement changed `off_wins`/`both_pass_pairs` not at all — and fixed by
+partitioning BOTH arms before any statistic, while the integrity gates keep the
+raw slices on purpose (executed order is a fact about the run, and the ">20%
+quarantined" rate is defined over the banked set). `off_quarantined` and
+`off_rows` are now reported alongside their ON counterparts, and
+`TestD2InvalidOffRowNeverScores` is the sole killer of the as-delivered shape.
+
+Also from that review: `order_integrity_repeated_benchmark` is now DECLARED
+unreachable in the code with the reasoning pinned by a test, rather than left as
+an unmutatable branch; the `>20%` quarantine boundary is pinned at exactly 20%
+and just over; and the verdict matrix now fails loudly if its fixture is emptied,
+which previously produced a green run of zero subtests.
+
 ### Added — LC-1 list-representation spike: scaffold, cons cells, and the branching benchmark whose control fires
 
 Mission iteration 237, milestones M1 and M2 of `m-list-repr-spike`. New throwaway

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,37 @@
 
 ## [Unreleased]
 
+### Added — censored-pair fmt analyzer enforces treatment and execution-order integrity
+
+M-MOTOKO-FMT-REMEASUREMENT-INSTRUMENT D2 (iteration 15) adds
+`ailang eval-censored-pairs <on-dir> <off-dir>` as a sibling of the existing
+`eval-paired` command. It pairs rows by benchmark and trial, applies the
+pre-registered censored outcome and exact one-sided sign test, reports token
+ratio magnitude and McNemar pass-rate guardrail secondaries, and produces
+`KEEP`, `RETIRE`, or `INCONCLUSIVE` decisions.
+
+The analyzer refuses to report numeric evidence when treatment is unproven,
+the OFF arm is contaminated, or banked timestamps do not show the required
+per-benchmark counterbalanced execution. Low effective sample size is reported
+as `INCONCLUSIVE` with reason `insufficient-neff`; deciding whether the
+pre-authorized slot budget is exhausted remains driver/human policy because a
+directory-only analyzer cannot observe that state. The existing `eval-paired`
+JSON contract is unchanged.
+
+Controller review of the first delivery found the command loading its arms
+through `LoadArmForPairing`, which wraps `FilterValidResults` and therefore
+drops quarantined rows at LOAD time. That made the ">20% of ON rows
+quarantined" gate unreachable from the CLI — it can never observe a
+quarantined row — and corrupted the order-integrity verdict, because a
+silently-dropped row changes the block sequence. Measured on the banked AC5
+arms: 5 rows / 0 quarantined visible via the filtering loader against 6 / 1
+via the raw one, and the refusal reason moved from
+`order_integrity_unpaired_block` (an artifact of the odd count) to
+`order_integrity_nonadjacent_arms` (the whole-arm blocking the data actually
+has). The command now loads with `LoadResultsFromDirsIncludingInvalid` and
+`TestEvalCensoredPairsSeesQuarantinedRows` pins the call site; that mutant
+survived the whole package as first delivered.
+
 ### Added — LC-1 list-representation spike: scaffold, cons cells, and the branching benchmark whose control fires
 
 Mission iteration 237, milestones M1 and M2 of `m-list-repr-spike`. New throwaway
@@ -4568,7 +4599,6 @@ Conflict Surface (no `internal/types`/`internal/effects` changes), the 5 files a
 **quarantined** (skipped with reason in `verify_examples.go` + `status: broken` in
 the manifest) and owned by follow-up issue **#386** (bisect result + owner + the
 5-file quarantine list as its closing checklist). `make verify-examples` → 0 failed.
-
 
 
 Two new CLI subcommands let a design doc get an independent, off-quota second

--- a/cmd/ailang/eval_censored.go
+++ b/cmd/ailang/eval_censored.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/sunholo-data/ailang/internal/eval_analysis"
+)
+
+// loadCensoredArm loads one arm for the censored-pair analyzer.
+//
+// It deliberately does NOT use LoadArmForPairing: that helper wraps
+// FilterValidResults, which drops every row whose Validity is invalid at LOAD
+// time. The censored-pair analyzer's own contract (design doc section 5) is to
+// SEE those rows, drop them itself, and COUNT them — the ">20% of ON rows
+// quarantined" gate is defined over the banked set, not over the survivors.
+// Loading through the filtering helper makes that gate unreachable (it can
+// never observe a quarantined row) and additionally corrupts the section 5.3
+// order-integrity verdict, because the executed order is a fact about the run
+// and a silently-dropped row changes the block sequence.
+//
+// Measured on the banked AC5 arms: the filtering loader returns 5 ON rows with
+// 0 quarantined visible, the raw loader returns 6 with 1 visible; and the order
+// gate's refusal reason changes from order_integrity_unpaired_block (an
+// artifact of the odd count) to order_integrity_nonadjacent_arms (the defect
+// the data actually has).
+func loadCensoredArm(dir string) ([]*eval_analysis.BenchmarkResult, error) {
+	return eval_analysis.LoadResultsFromDirsIncludingInvalid(dir)
+}
+
+// evalCensoredPairs is the testable body of the command: it loads both arms the
+// way the command does and returns the analyzer's verdict.
+func evalCensoredPairs(onDir, offDir string) (eval_analysis.CensoredPairResult, error) {
+	on, err := loadCensoredArm(onDir)
+	if err != nil {
+		return eval_analysis.CensoredPairResult{}, fmt.Errorf("loading ON arm %s: %w", onDir, err)
+	}
+	off, err := loadCensoredArm(offDir)
+	if err != nil {
+		return eval_analysis.CensoredPairResult{}, fmt.Errorf("loading OFF arm %s: %w", offDir, err)
+	}
+	return eval_analysis.AnalyzeCensoredPairs(on, off), nil
+}
+
+func runEvalCensoredPairs() {
+	fs := flag.NewFlagSet("eval-censored-pairs", flag.ExitOnError)
+	pretty := fs.Bool("pretty", false, "Indent the JSON output")
+	if err := fs.Parse(os.Args[2:]); err != nil {
+		os.Exit(1)
+	}
+
+	args := fs.Args()
+	if len(args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: ailang eval-censored-pairs [flags] <on-dir> <off-dir>")
+		fmt.Fprintln(os.Stderr, "\nApplies fmt treatment/order integrity gates and the pre-registered censored-pair decision rule.")
+		os.Exit(1)
+	}
+
+	result, err := evalCensoredPairs(args[0], args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	if *pretty {
+		enc.SetIndent("", "  ")
+	}
+	if err := enc.Encode(result); err != nil {
+		fmt.Fprintf(os.Stderr, "Error encoding result: %v\n", err)
+		os.Exit(1)
+	}
+	if result.Verdict == eval_analysis.CensoredVerdictVoid {
+		os.Exit(1)
+	}
+}

--- a/cmd/ailang/eval_censored_test.go
+++ b/cmd/ailang/eval_censored_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,7 +12,13 @@ import (
 )
 
 // writeArmRow banks one agent row into dir, mimicking the real bank layout.
-func writeArmRow(t *testing.T, dir string, row map[string]any) {
+//
+// The file NAME must not carry the row's RFC3339 timestamp: `:` is illegal in a
+// Windows filename, and the loader keys on the JSON body rather than the name,
+// so the timestamp belongs only inside the row. Gate 3b caught this — the test
+// passed on darwin and failed on windows-latest with "The filename, directory
+// name, or volume label syntax is incorrect".
+func writeArmRow(t *testing.T, dir string, index int, row map[string]any) {
 	t.Helper()
 	agent := filepath.Join(dir, "agent")
 	if err := os.MkdirAll(agent, 0o755); err != nil {
@@ -21,7 +28,7 @@ func writeArmRow(t *testing.T, dir string, row map[string]any) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	name := row["id"].(string) + "_" + row["timestamp"].(string) + ".json"
+	name := fmt.Sprintf("%s_%03d.json", row["id"].(string), index)
 	if err := os.WriteFile(filepath.Join(agent, name), data, 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +69,7 @@ func TestEvalCensoredPairsSeesQuarantinedRows(t *testing.T) {
 		{"b2", "on", "2026-07-31T10:04:00Z"}, {"b2", "off", "2026-07-31T10:05:00Z"},
 		{"b3", "off", "2026-07-31T10:06:00Z"}, {"b3", "on", "2026-07-31T10:07:00Z"},
 	}
-	for _, o := range order {
+	for i, o := range order {
 		row := baseRow(o.id, o.ts)
 		dir := offDir
 		if o.arm == "on" {
@@ -74,7 +81,7 @@ func TestEvalCensoredPairsSeesQuarantinedRows(t *testing.T) {
 				}
 			}
 		}
-		writeArmRow(t, dir, row)
+		writeArmRow(t, dir, i, row)
 	}
 
 	// Control: the raw loader must actually surface the quarantined row, else

--- a/cmd/ailang/eval_censored_test.go
+++ b/cmd/ailang/eval_censored_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/eval_analysis"
+	"github.com/sunholo-data/ailang/internal/eval_harness"
+)
+
+// writeArmRow banks one agent row into dir, mimicking the real bank layout.
+func writeArmRow(t *testing.T, dir string, row map[string]any) {
+	t.Helper()
+	agent := filepath.Join(dir, "agent")
+	if err := os.MkdirAll(agent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(row)
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := row["id"].(string) + "_" + row["timestamp"].(string) + ".json"
+	if err := os.WriteFile(filepath.Join(agent, name), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func baseRow(id, ts string) map[string]any {
+	return map[string]any{
+		"id": id, "lang": "ailang", "model": "m", "trial": 1,
+		"timestamp": ts, "stdout_ok": true, "total_tokens": 100,
+	}
+}
+
+// TestEvalCensoredPairsSeesQuarantinedRows pins the COMMAND's loader choice,
+// not the analyzer helper.
+//
+// The ">20% of ON rows quarantined -> VOID" gate is defined over the banked
+// set. eval_analysis.LoadArmForPairing wraps FilterValidResults and drops
+// invalid rows at LOAD time, so a command loading through it can never observe
+// a quarantined row and the gate is unreachable — the analyzer's own unit tests
+// pass regardless, because they construct rows directly and bypass the loader.
+// This test therefore exercises evalCensoredPairs, the code path the CLI runs.
+//
+// Killed mutation: swapping loadCensoredArm's body to
+// eval_analysis.LoadArmForPairing. Under that mutant this test reads
+// verdict=INCONCLUSIVE (the quarantined row is invisible) instead of VOID.
+// That mutant SURVIVED the milestone as first delivered.
+func TestEvalCensoredPairsSeesQuarantinedRows(t *testing.T) {
+	onDir, offDir := t.TempDir(), t.TempDir()
+
+	// 4 ON rows, 1 of them quarantined => 25% > 20% => VOID.
+	// Counterbalanced order, so the section 5.3 order gate passes and the
+	// treatment gate is genuinely the thing under test.
+	order := []struct {
+		id, arm, ts string
+	}{
+		{"b0", "on", "2026-07-31T10:00:00Z"}, {"b0", "off", "2026-07-31T10:01:00Z"},
+		{"b1", "off", "2026-07-31T10:02:00Z"}, {"b1", "on", "2026-07-31T10:03:00Z"},
+		{"b2", "on", "2026-07-31T10:04:00Z"}, {"b2", "off", "2026-07-31T10:05:00Z"},
+		{"b3", "off", "2026-07-31T10:06:00Z"}, {"b3", "on", "2026-07-31T10:07:00Z"},
+	}
+	for _, o := range order {
+		row := baseRow(o.id, o.ts)
+		dir := offDir
+		if o.arm == "on" {
+			dir = onDir
+			if o.id == "b3" {
+				row["validity"] = eval_harness.Validity{
+					Valid: false, Reason: "treatment_unproven",
+					Detail: "fmt ON arm banked zero fmt_hook_events",
+				}
+			}
+		}
+		writeArmRow(t, dir, row)
+	}
+
+	// Control: the raw loader must actually surface the quarantined row, else
+	// this fixture cannot discriminate and the assertion below is vacuous.
+	rawOn, err := loadCensoredArm(onDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rawOn) != 4 {
+		t.Fatalf("control failed: command loader returned %d ON rows, want 4", len(rawOn))
+	}
+	seen := 0
+	for _, r := range rawOn {
+		if r.Validity != nil && !r.Validity.Valid {
+			seen++
+		}
+	}
+	if seen != 1 {
+		t.Fatalf("control failed: command loader surfaced %d quarantined ON rows, want 1", seen)
+	}
+
+	got, err := evalCensoredPairs(onDir, offDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Verdict != eval_analysis.CensoredVerdictVoid {
+		t.Fatalf("verdict = %q, want VOID (1 of 4 ON rows quarantined = 25%% > 20%%)", got.Verdict)
+	}
+	// Assert the specific reason, not merely VOID: every other refusal branch
+	// also produces VOID, so the enum alone does not discriminate.
+	if got.VoidReason != "treatment_unproven_rate" {
+		t.Fatalf("void reason = %q, want treatment_unproven_rate", got.VoidReason)
+	}
+}

--- a/cmd/ailang/eval_remote_read.go
+++ b/cmd/ailang/eval_remote_read.go
@@ -8,7 +8,7 @@ import (
 )
 
 var evalRemoteReadCommands = map[string]struct{}{
-	"eval": {}, "eval-analyze": {}, "eval-compare": {}, "eval-paired": {},
+	"eval": {}, "eval-analyze": {}, "eval-compare": {}, "eval-paired": {}, "eval-censored-pairs": {},
 	"eval-matrix": {}, "eval-sweet-spot": {}, "eval-summary": {}, "eval-report": {},
 	"eval-suite": {}, "eval-elo": {}, "eval-trend": {}, "eval-publish": {},
 	"eval-chains": {},

--- a/cmd/ailang/help.go
+++ b/cmd/ailang/help.go
@@ -273,6 +273,7 @@ func printHelp() {
 	fmt.Printf("  %s <results_dir> <version>   Generate comprehensive eval report\n", cyan("eval-report"))
 	fmt.Printf("  %s <baseline> <new>    Compare two eval runs\n", cyan("eval-compare"))
 	fmt.Printf("  %s <on-dir> <off-dir>   Paired A/B comparison + McNemar (not aggregate rates)\n", cyan("eval-paired"))
+	fmt.Printf("  %s <on-dir> <off-dir>   Censored fmt pairs with treatment/order integrity gates\n", cyan("eval-censored-pairs"))
 	fmt.Printf("  %s <results_dir> <version>    Performance matrix with stats\n", cyan("eval-matrix"))
 	fmt.Printf("  %s <results_dir>     Cost-vs-time-vs-success sweet-spot ranking\n", cyan("eval-sweet-spot"))
 	fmt.Printf("  %s <results_dir>        Summarize eval results\n", cyan("eval-summary"))

--- a/cmd/ailang/main.go
+++ b/cmd/ailang/main.go
@@ -288,6 +288,9 @@ func main() {
 	case "eval-paired":
 		runEvalPaired()
 
+	case "eval-censored-pairs":
+		runEvalCensoredPairs()
+
 	case "eval-matrix":
 		runEvalMatrix()
 

--- a/internal/eval_analysis/censored.go
+++ b/internal/eval_analysis/censored.go
@@ -35,6 +35,8 @@ type CensoredPairResult struct {
 	MedianTokenRatio   float64       `json:"median_token_ratio,omitempty"`
 	OnQuarantined      int           `json:"on_quarantined,omitempty"`
 	OnRows             int           `json:"on_rows,omitempty"`
+	OffQuarantined     int           `json:"off_quarantined,omitempty"`
+	OffRows            int           `json:"off_rows,omitempty"`
 	PassRateLoss       bool          `json:"significant_on_pass_rate_loss,omitempty"`
 	McNemar            McNemarResult `json:"mcnemar"`
 }
@@ -49,24 +51,26 @@ func AnalyzeCensoredPairs(on, off []*BenchmarkResult) CensoredPairResult {
 		return voidCensoredResult(reason)
 	}
 
-	validOn := make([]*BenchmarkResult, 0, len(on))
-	quarantined := 0
-	for _, row := range on {
-		if row.Validity != nil && !row.Validity.Valid {
-			quarantined++
-			continue
-		}
-		validOn = append(validOn, row)
-	}
+	// Both arms are filtered before ANY statistic is computed. The gates above
+	// deliberately receive the RAW slices — the executed order is a fact about
+	// the run, and the ">20% quarantined" rate is defined over the banked set —
+	// but a row that is not a MEASUREMENT must never reach a win/tie tally, a
+	// token ratio, or the McNemar guardrail. Filtering only ON was a real
+	// defect: an OFF row invalid for any reason other than contamination
+	// (harness_error, config_mismatch, ...) still scored a full OFF win.
+	validOn, onQuarantined := partitionMeasurements(on)
+	validOff, offQuarantined := partitionMeasurements(off)
 
-	paired := PairArms(validOn, off)
+	paired := PairArms(validOn, validOff)
 	result := CensoredPairResult{
-		OnQuarantined: quarantined,
-		OnRows:        len(on),
-		McNemar:       paired.McNemar,
+		OnQuarantined:  onQuarantined,
+		OnRows:         len(on),
+		OffQuarantined: offQuarantined,
+		OffRows:        len(off),
+		McNemar:        paired.McNemar,
 	}
-	offByKey := make(map[pairKey]*BenchmarkResult, len(off))
-	for _, row := range off {
+	offByKey := make(map[pairKey]*BenchmarkResult, len(validOff))
+	for _, row := range validOff {
 		offByKey[pairKey{row.ID, row.Lang, row.Trial}] = row
 	}
 
@@ -113,6 +117,21 @@ func AnalyzeCensoredPairs(on, off []*BenchmarkResult) CensoredPairResult {
 	result.PassRateLoss = paired.McNemar.Reportable && paired.McNemar.PValue <= 0.05 && paired.OnlyOffPassed > paired.OnlyOnPassed
 	applyCensoredDecision(&result)
 	return result
+}
+
+// partitionMeasurements splits rows into those that ARE measurements and a
+// count of those that are not. Design doc section 5: a quarantined row is
+// dropped AND counted — never silently discarded, and never counted twice.
+func partitionMeasurements(rows []*BenchmarkResult) (valid []*BenchmarkResult, quarantined int) {
+	valid = make([]*BenchmarkResult, 0, len(rows))
+	for _, row := range rows {
+		if row.Validity != nil && !row.Validity.Valid {
+			quarantined++
+			continue
+		}
+		valid = append(valid, row)
+	}
+	return valid, quarantined
 }
 
 func treatmentIntegrityReason(on, off []*BenchmarkResult) string {
@@ -187,6 +206,13 @@ func CheckFmtOrderIntegrity(on, off []*BenchmarkResult) string {
 		if first.benchmark != second.benchmark || first.arm == second.arm {
 			return "order_integrity_nonadjacent_arms"
 		}
+		// DECLARED UNREACHABLE, defensively retained. Blocks are deduplicated by
+		// (benchmark, arm) and a non-contiguous repeat of either key returns
+		// order_integrity_noncontiguous_block above; a pair holding only one of a
+		// benchmark's blocks returns order_integrity_nonadjacent_arms. With two
+		// arms a benchmark owns at most two block keys, so no input reaches here.
+		// Pinned by TestD2OrderRefusalRepeatedBenchmarkIsUnreachable, which fails
+		// loudly if that ever stops being true.
 		if seenBenchmark[first.benchmark] {
 			return "order_integrity_repeated_benchmark"
 		}

--- a/internal/eval_analysis/censored.go
+++ b/internal/eval_analysis/censored.go
@@ -1,0 +1,285 @@
+package eval_analysis
+
+import (
+	"fmt"
+	"math"
+	"sort"
+)
+
+const (
+	CensoredVerdictVoid         = "VOID"
+	CensoredVerdictKeep         = "KEEP"
+	CensoredVerdictRetire       = "RETIRE"
+	CensoredVerdictInconclusive = "INCONCLUSIVE"
+)
+
+// CensoredPairResult reports the pre-registered fmt decision instrument.
+// Numeric evidence is omitted for VOID results because an integrity failure
+// makes the estimand undefined, rather than merely unfavorable.
+type CensoredPairResult struct {
+	Verdict    string `json:"verdict"`
+	Reason     string `json:"reason"`
+	VoidReason string `json:"void_reason,omitempty"`
+
+	NEff    int `json:"n_eff,omitempty"`
+	OnWins  int `json:"on_wins,omitempty"`
+	OffWins int `json:"off_wins,omitempty"`
+	Ties    int `json:"ties,omitempty"`
+
+	SignPValue         float64       `json:"sign_p_value,omitempty"`
+	OppositeSignPValue float64       `json:"opposite_sign_p_value,omitempty"`
+	BothPassPairs      int           `json:"both_pass_pairs,omitempty"`
+	MeanLogTokenRatio  float64       `json:"mean_log_token_ratio,omitempty"`
+	MeanLogRatioCILow  float64       `json:"mean_log_ratio_ci_low,omitempty"`
+	MeanLogRatioCIHigh float64       `json:"mean_log_ratio_ci_high,omitempty"`
+	MedianTokenRatio   float64       `json:"median_token_ratio,omitempty"`
+	OnQuarantined      int           `json:"on_quarantined,omitempty"`
+	OnRows             int           `json:"on_rows,omitempty"`
+	PassRateLoss       bool          `json:"significant_on_pass_rate_loss,omitempty"`
+	McNemar            McNemarResult `json:"mcnemar"`
+}
+
+// AnalyzeCensoredPairs applies the treatment and order gates before computing
+// any statistics, then applies the decision rule from design doc section 7.
+func AnalyzeCensoredPairs(on, off []*BenchmarkResult) CensoredPairResult {
+	if reason := treatmentIntegrityReason(on, off); reason != "" {
+		return voidCensoredResult(reason)
+	}
+	if reason := CheckFmtOrderIntegrity(on, off); reason != "" {
+		return voidCensoredResult(reason)
+	}
+
+	validOn := make([]*BenchmarkResult, 0, len(on))
+	quarantined := 0
+	for _, row := range on {
+		if row.Validity != nil && !row.Validity.Valid {
+			quarantined++
+			continue
+		}
+		validOn = append(validOn, row)
+	}
+
+	paired := PairArms(validOn, off)
+	result := CensoredPairResult{
+		OnQuarantined: quarantined,
+		OnRows:        len(on),
+		McNemar:       paired.McNemar,
+	}
+	offByKey := make(map[pairKey]*BenchmarkResult, len(off))
+	for _, row := range off {
+		offByKey[pairKey{row.ID, row.Lang, row.Trial}] = row
+	}
+
+	var logRatios []float64
+	var tokenRatios []float64
+	for _, onRow := range validOn {
+		offRow, ok := offByKey[pairKey{onRow.ID, onRow.Lang, onRow.Trial}]
+		if !ok {
+			continue
+		}
+		onPass, offPass := passed(onRow), passed(offRow)
+		switch {
+		case onPass && !offPass:
+			result.OnWins++
+		case !onPass && offPass:
+			result.OffWins++
+		case !onPass && !offPass:
+			result.Ties++
+		default:
+			ratio := tokenRatio(onRow, offRow)
+			if ratio <= 0 {
+				result.Ties++
+				continue
+			}
+			logRatio := math.Log(ratio)
+			logRatios = append(logRatios, logRatio)
+			tokenRatios = append(tokenRatios, ratio)
+			if math.Abs(logRatio) <= 0.10 {
+				result.Ties++
+			} else if logRatio < 0 {
+				result.OnWins++
+			} else {
+				result.OffWins++
+			}
+		}
+	}
+
+	result.NEff = result.OnWins + result.OffWins
+	result.SignPValue = exactBinomialUpperTail(result.OnWins, result.NEff)
+	result.OppositeSignPValue = exactBinomialUpperTail(result.OffWins, result.NEff)
+	result.BothPassPairs = len(logRatios)
+	result.MeanLogTokenRatio, result.MeanLogRatioCILow, result.MeanLogRatioCIHigh = mean95CI(logRatios)
+	result.MedianTokenRatio = medianFloat(tokenRatios)
+	result.PassRateLoss = paired.McNemar.Reportable && paired.McNemar.PValue <= 0.05 && paired.OnlyOffPassed > paired.OnlyOnPassed
+	applyCensoredDecision(&result)
+	return result
+}
+
+func treatmentIntegrityReason(on, off []*BenchmarkResult) string {
+	quarantined := 0
+	for _, row := range on {
+		if row.Validity != nil && !row.Validity.Valid {
+			quarantined++
+		}
+	}
+	if len(on) > 0 && float64(quarantined)/float64(len(on)) > 0.20 {
+		return "treatment_unproven_rate"
+	}
+	for _, row := range off {
+		if len(row.FmtHookEvents) > 0 {
+			return "control_contaminated"
+		}
+	}
+	return ""
+}
+
+func voidCensoredResult(reason string) CensoredPairResult {
+	return CensoredPairResult{Verdict: CensoredVerdictVoid, Reason: reason, VoidReason: reason}
+}
+
+type orderedFmtRow struct {
+	row *BenchmarkResult
+	arm string
+}
+
+// CheckFmtOrderIntegrity returns a stable machine-readable refusal reason, or
+// an empty string when the rows implement section 5.3's counterbalanced block.
+func CheckFmtOrderIntegrity(on, off []*BenchmarkResult) string {
+	rows := make([]orderedFmtRow, 0, len(on)+len(off))
+	for _, row := range on {
+		rows = append(rows, orderedFmtRow{row: row, arm: "on"})
+	}
+	for _, row := range off {
+		rows = append(rows, orderedFmtRow{row: row, arm: "off"})
+	}
+	if len(rows) == 0 {
+		return "order_integrity_empty"
+	}
+	sort.SliceStable(rows, func(i, j int) bool { return rows[i].row.Timestamp.Before(rows[j].row.Timestamp) })
+	for _, item := range rows {
+		if item.row.Timestamp.IsZero() {
+			return "order_integrity_timestamp"
+		}
+	}
+
+	type block struct{ benchmark, arm string }
+	blocks := make([]block, 0)
+	seenBlock := make(map[block]bool)
+	for _, item := range rows {
+		key := block{benchmark: item.row.ID, arm: item.arm}
+		if len(blocks) > 0 && blocks[len(blocks)-1] == key {
+			continue
+		}
+		if seenBlock[key] {
+			return "order_integrity_noncontiguous_block"
+		}
+		seenBlock[key] = true
+		blocks = append(blocks, key)
+	}
+	if len(blocks)%2 != 0 {
+		return "order_integrity_unpaired_block"
+	}
+
+	previousLead := ""
+	seenBenchmark := make(map[string]bool)
+	for i := 0; i < len(blocks); i += 2 {
+		first, second := blocks[i], blocks[i+1]
+		if first.benchmark != second.benchmark || first.arm == second.arm {
+			return "order_integrity_nonadjacent_arms"
+		}
+		if seenBenchmark[first.benchmark] {
+			return "order_integrity_repeated_benchmark"
+		}
+		seenBenchmark[first.benchmark] = true
+		if previousLead == first.arm {
+			return "order_integrity_lead_not_alternating"
+		}
+		previousLead = first.arm
+	}
+	// Exact alternation above entails |ON-lead - OFF-lead| <= 1.
+	return ""
+}
+
+func tokenRatio(on, off *BenchmarkResult) float64 {
+	if on.TotalTokens <= 0 || off.TotalTokens <= 0 {
+		return 0
+	}
+	return float64(on.TotalTokens) / float64(off.TotalTokens)
+}
+
+func exactBinomialUpperTail(wins, n int) float64 {
+	if n == 0 {
+		return 1
+	}
+	var p float64
+	for i := wins; i <= n; i++ {
+		p += binomialPMF(i, n)
+	}
+	return math.Min(1, p)
+}
+
+func applyCensoredDecision(result *CensoredPairResult) {
+	if result.NEff < 24 {
+		// A directory analyzer cannot know whether two slots plus the authorized
+		// third have run. Slot-budget retirement belongs to the driver/human.
+		result.Verdict = CensoredVerdictInconclusive
+		result.Reason = "insufficient-neff"
+		return
+	}
+	if result.OppositeSignPValue <= 0.05 {
+		result.Verdict = CensoredVerdictRetire
+		result.Reason = "opposite-direction-rejection"
+		return
+	}
+	keep := result.SignPValue <= 0.05 && result.MedianTokenRatio > 0 && result.MedianTokenRatio <= 0.90 && !result.PassRateLoss
+	if keep {
+		result.Verdict = CensoredVerdictKeep
+		result.Reason = "keep-criteria-met"
+		return
+	}
+	if result.NEff >= 40 {
+		result.Verdict = CensoredVerdictRetire
+		result.Reason = "keep-failed-at-neff"
+		return
+	}
+	result.Verdict = CensoredVerdictInconclusive
+	result.Reason = "additional-slot-required"
+}
+
+func mean95CI(values []float64) (mean, low, high float64) {
+	if len(values) == 0 {
+		return 0, 0, 0
+	}
+	for _, value := range values {
+		mean += value
+	}
+	mean /= float64(len(values))
+	if len(values) == 1 {
+		return mean, mean, mean
+	}
+	var sumSquares float64
+	for _, value := range values {
+		delta := value - mean
+		sumSquares += delta * delta
+	}
+	standardError := math.Sqrt(sumSquares/float64(len(values)-1)) / math.Sqrt(float64(len(values)))
+	margin := 1.96 * standardError
+	return mean, mean - margin, mean + margin
+}
+
+func medianFloat(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	ordered := append([]float64(nil), values...)
+	sort.Float64s(ordered)
+	mid := len(ordered) / 2
+	if len(ordered)%2 == 1 {
+		return ordered[mid]
+	}
+	return (ordered[mid-1] + ordered[mid]) / 2
+}
+
+func (r CensoredPairResult) String() string {
+	return fmt.Sprintf("%s (%s)", r.Verdict, r.Reason)
+}

--- a/internal/eval_analysis/censored_integrity_test.go
+++ b/internal/eval_analysis/censored_integrity_test.go
@@ -1,0 +1,202 @@
+package eval_analysis
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/sunholo-data/ailang/internal/eval_harness"
+)
+
+// counterbalancedPair builds one benchmark's two rows in the section 5.3
+// schedule: ON leads on even indexes, OFF on odd.
+func counterbalancedPair(t *testing.T, index int, onTokens, offTokens int) (on, off *BenchmarkResult) {
+	t.Helper()
+	id := "bench-" + string(rune('a'+index))
+	base := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC).Add(time.Duration(index*4) * time.Second)
+	on = &BenchmarkResult{ID: id, Lang: "ailang", Model: "fixture", Trial: 1,
+		CompileOk: true, RuntimeOk: true, StdoutOk: true, TotalTokens: onTokens}
+	off = &BenchmarkResult{ID: id, Lang: "ailang", Model: "fixture", Trial: 1,
+		CompileOk: true, RuntimeOk: true, StdoutOk: true, TotalTokens: offTokens}
+	if index%2 == 0 {
+		on.Timestamp, off.Timestamp = base, base.Add(time.Second)
+	} else {
+		off.Timestamp, on.Timestamp = base, base.Add(time.Second)
+	}
+	return on, off
+}
+
+// TestD2InvalidOffRowNeverScores pins that a NON-MEASUREMENT row in the OFF arm
+// is dropped from every statistic and counted, exactly as an ON one is.
+//
+// Killed mutation: passing the raw `off` slice to PairArms/offByKey instead of
+// `validOff` (i.e. reverting partitionMeasurements for the OFF arm). That is
+// how the milestone was first delivered, and it survived the whole package: the
+// treatment gate only scans OFF rows for CONTAMINATION (FmtHookEvents), so an
+// OFF row invalid for any other reason — harness_error, config_mismatch — sailed
+// through and scored a full OFF win.
+//
+// The observable is deliberately the WIN TALLY and the quarantine count, not
+// the verdict: every refusal branch also produces VOID, and this pair is
+// INCONCLUSIVE under both arms, so the verdict cannot discriminate.
+func TestD2InvalidOffRowNeverScores(t *testing.T) {
+	build := func(markInvalid bool) ([]*BenchmarkResult, []*BenchmarkResult) {
+		var on, off []*BenchmarkResult
+		// b0: an exact tie. b1: OFF 10x cheaper, i.e. a decisive OFF win.
+		o0, f0 := counterbalancedPair(t, 0, 1000, 1000)
+		o1, f1 := counterbalancedPair(t, 1, 1000, 100)
+		if markInvalid {
+			f1.Validity = &eval_harness.Validity{
+				Valid: false, Reason: "harness_error", Detail: "not a measurement",
+			}
+		}
+		on = append(on, o0, o1)
+		off = append(off, f0, f1)
+		return on, off
+	}
+
+	// Control: with every row valid the decisive OFF win MUST be counted, or the
+	// fixture cannot discriminate and the assertion below is vacuous.
+	ctlOn, ctlOff := build(false)
+	ctl := AnalyzeCensoredPairs(ctlOn, ctlOff)
+	if ctl.OffWins != 1 || ctl.BothPassPairs != 2 {
+		t.Fatalf("control failed: all-valid arms gave off_wins=%d both_pass=%d, want 1 and 2 — fixture does not discriminate",
+			ctl.OffWins, ctl.BothPassPairs)
+	}
+	if ctl.OffQuarantined != 0 {
+		t.Fatalf("control failed: all-valid arms reported off_quarantined=%d, want 0", ctl.OffQuarantined)
+	}
+
+	// Treatment: the same row, marked a non-measurement.
+	gotOn, gotOff := build(true)
+	got := AnalyzeCensoredPairs(gotOn, gotOff)
+	if got.OffWins != 0 {
+		t.Errorf("off_wins = %d, want 0 — an invalid OFF row scored a win", got.OffWins)
+	}
+	if got.BothPassPairs != 1 {
+		t.Errorf("both_pass_pairs = %d, want 1 — an invalid OFF row polluted the token statistics", got.BothPassPairs)
+	}
+	if got.OffQuarantined != 1 {
+		t.Errorf("off_quarantined = %d, want 1 — the dropped row must be COUNTED, not silently discarded", got.OffQuarantined)
+	}
+	if got.OffRows != 2 {
+		t.Errorf("off_rows = %d, want 2 (the banked set, before filtering)", got.OffRows)
+	}
+}
+
+// TestD2OrderRefusalRepeatedBenchmarkIsUnreachable establishes that
+// order_integrity_repeated_benchmark is a DEFENSIVE invariant with no reachable
+// input, and pins the reasoning rather than asserting the claim.
+//
+// Why it cannot fire: blocks are deduplicated by (benchmark, arm), and any
+// non-contiguous repeat of one of those keys returns
+// order_integrity_noncontiguous_block first. With exactly two arms a benchmark
+// owns at most two distinct block keys, so for seenBenchmark to be true at a
+// later pair the benchmark must contribute a THIRD block, which is necessarily a
+// duplicate key. And a pair holding only ONE of its blocks fails the
+// first.benchmark != second.benchmark check as nonadjacent_arms.
+//
+// The evaluator flagged this branch as the one refusal with no coverage: its
+// if false && ... mutant survived the entire package. That is correct and the
+// cause is unreachability, not a missing fixture — so it is DECLARED here and in
+// the code rather than left as a guard nobody is protecting.
+func TestD2OrderRefusalRepeatedBenchmarkIsUnreachable(t *testing.T) {
+	at := func(sec int) time.Time {
+		return time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC).Add(time.Duration(sec) * time.Second)
+	}
+	row := func(id string, sec int) *BenchmarkResult {
+		return &BenchmarkResult{ID: id, Lang: "ailang", Model: "fixture", Trial: 1,
+			CompileOk: true, RuntimeOk: true, StdoutOk: true, TotalTokens: 1000, Timestamp: at(sec)}
+	}
+
+	cases := []struct {
+		name       string
+		on, off    []*BenchmarkResult
+		wantCaught string
+	}{
+		{
+			// a:on a:off | b:off b:on | a:on a:off  -- `a` runs a second time in full.
+			name:       "benchmark repeated as a whole pair",
+			on:         []*BenchmarkResult{row("a", 0), row("b", 3), row("a", 4)},
+			off:        []*BenchmarkResult{row("a", 1), row("b", 2), row("a", 5)},
+			wantCaught: "order_integrity_noncontiguous_block",
+		},
+		{
+			// a:on b:on | a:off b:off  -- one benchmark spread across two pairs.
+			name:       "benchmark split across pairs",
+			on:         []*BenchmarkResult{row("a", 0), row("b", 1)},
+			off:        []*BenchmarkResult{row("a", 2), row("b", 3)},
+			wantCaught: "order_integrity_nonadjacent_arms",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CheckFmtOrderIntegrity(tc.on, tc.off)
+			if got == "order_integrity_repeated_benchmark" {
+				t.Fatalf("branch is reachable after all — this test and the code comment are wrong, fix both")
+			}
+			if got != tc.wantCaught {
+				t.Fatalf("reason = %q, want %q — the earlier branch that makes repeated_benchmark unreachable", got, tc.wantCaught)
+			}
+		})
+	}
+
+	// Control: a well-formed counterbalanced schedule must pass the gate, so the
+	// refusals above are attributable to the shapes and not to the fixture style.
+	on0, off0 := counterbalancedPair(t, 0, 1000, 1000)
+	on1, off1 := counterbalancedPair(t, 1, 1000, 1000)
+	if got := CheckFmtOrderIntegrity([]*BenchmarkResult{on0, on1}, []*BenchmarkResult{off0, off1}); got != "" {
+		t.Fatalf("control failed: a valid counterbalanced schedule was refused with %q", got)
+	}
+}
+
+// TestD2QuarantineRateBoundary pins the doc's STRICT ">20%": exactly 20% does
+// not void, just over it does. A boundary nobody tests is a boundary nobody
+// notices moving.
+func TestD2QuarantineRateBoundary(t *testing.T) {
+	arm := func(total, invalid int) []*BenchmarkResult {
+		rows := make([]*BenchmarkResult, 0, total)
+		for i := 0; i < total; i++ {
+			r := &BenchmarkResult{ID: "b", Lang: "ailang", Model: "fixture", Trial: i}
+			if i < invalid {
+				r.Validity = &eval_harness.Validity{Valid: false, Reason: "treatment_unproven"}
+			}
+			rows = append(rows, r)
+		}
+		return rows
+	}
+	if got := treatmentIntegrityReason(arm(5, 1), nil); got != "" {
+		t.Errorf("1 of 5 = exactly 20%%: reason = %q, want no refusal (the doc says strictly >20%%)", got)
+	}
+	if got := treatmentIntegrityReason(arm(4, 1), nil); got != "treatment_unproven_rate" {
+		t.Errorf("1 of 4 = 25%%: reason = %q, want treatment_unproven_rate", got)
+	}
+}
+
+// TestD2VerdictMatrixFixtureIsNonEmpty makes an emptied or truncated
+// testdata/censored_cases.json FAIL LOUDLY. Without it, `[]` yields a green
+// TestCensoredVerdictMatrix that ran zero subtests and asserted nothing — the
+// vacuous pass this milestone exists to prevent, aimed at its own fixture.
+func TestD2VerdictMatrixFixtureIsNonEmpty(t *testing.T) {
+	data, err := os.ReadFile("testdata/censored_cases.json")
+	if err != nil {
+		t.Fatalf("instrument failure: cannot read the verdict-matrix fixture: %v", err)
+	}
+	var cases []censoredFixture
+	if err := json.Unmarshal(data, &cases); err != nil {
+		t.Fatalf("instrument failure: fixture does not parse: %v", err)
+	}
+	if len(cases) < 4 {
+		t.Fatalf("verdict-matrix fixture has %d cases, want >= 4 — the matrix must cover VOID, KEEP, RETIRE and INCONCLUSIVE", len(cases))
+	}
+	seen := map[string]bool{}
+	for _, c := range cases {
+		seen[c.WantVerdict] = true
+	}
+	for _, want := range []string{"KEEP", "RETIRE", "INCONCLUSIVE"} {
+		if !seen[want] {
+			t.Errorf("verdict-matrix fixture covers no %s case", want)
+		}
+	}
+}

--- a/internal/eval_analysis/censored_test.go
+++ b/internal/eval_analysis/censored_test.go
@@ -1,0 +1,199 @@
+package eval_analysis
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/sunholo-data/ailang/internal/eval_harness"
+)
+
+type censoredFixture struct {
+	Name         string `json:"name"`
+	Pairs        int    `json:"pairs"`
+	OnTokenWins  int    `json:"on_token_wins"`
+	OffTokenWins int    `json:"off_token_wins"`
+	OnOnlyPasses int    `json:"on_only_passes"`
+	WantVerdict  string `json:"want_verdict"`
+	WantReason   string `json:"want_reason"`
+}
+
+func TestCensoredVerdictMatrix(t *testing.T) {
+	data, err := os.ReadFile("testdata/censored_cases.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixtures []censoredFixture
+	if err := json.Unmarshal(data, &fixtures); err != nil {
+		t.Fatal(err)
+	}
+	for _, fixture := range fixtures {
+		t.Run(fixture.Name, func(t *testing.T) {
+			on, off := fixtureArms(fixture)
+			got := AnalyzeCensoredPairs(on, off)
+			if got.Verdict != fixture.WantVerdict || got.Reason != fixture.WantReason {
+				t.Fatalf("(verdict, reason) = (%s, %s), want (%s, %s); result=%+v", got.Verdict, got.Reason, fixture.WantVerdict, fixture.WantReason, got)
+			}
+			if got.NEff != fixture.OnTokenWins+fixture.OffTokenWins+fixture.OnOnlyPasses {
+				t.Fatalf("n_eff = %d, want %d", got.NEff, fixture.OnTokenWins+fixture.OffTokenWins+fixture.OnOnlyPasses)
+			}
+		})
+	}
+}
+
+func TestD2VoidTreatmentOnRate(t *testing.T) {
+	on, off := fixtureArms(censoredFixture{Pairs: 6, OnTokenWins: 6})
+	for _, index := range []int{0, 2} {
+		on[index].Validity = &eval_harness.Validity{Valid: false, Reason: eval_harness.ReasonTreatmentUnproven}
+	}
+	got := AnalyzeCensoredPairs(on, off)
+	assertVoidReason(t, got, "treatment_unproven_rate")
+}
+
+func TestD2VoidTreatmentOffContamination(t *testing.T) {
+	on, off := fixtureArms(censoredFixture{Pairs: 2, OnTokenWins: 2})
+	off[1].FmtHookEvents = []eval_harness.FmtHookEvent{{Status: "formatted", File: "x.ail"}}
+	got := AnalyzeCensoredPairs(on, off)
+	assertVoidReason(t, got, "control_contaminated")
+}
+
+func TestD2CensorOnePassWins(t *testing.T) {
+	on, off := fixtureArms(censoredFixture{Pairs: 10, OnOnlyPasses: 10})
+	got := AnalyzeCensoredPairs(on, off)
+	if got.NEff != 10 || got.OnWins != 10 || got.Verdict != CensoredVerdictInconclusive || got.Reason != "insufficient-neff" {
+		t.Fatalf("(n_eff, W, verdict, reason) = (%d, %d, %s, %s)", got.NEff, got.OnWins, got.Verdict, got.Reason)
+	}
+}
+
+func TestD2MarginMakesNearRatiosTies(t *testing.T) {
+	on, off := fixtureArms(censoredFixture{Pairs: 12})
+	for i := range on {
+		on[i].TotalTokens = 950
+		off[i].TotalTokens = 1000
+	}
+	got := AnalyzeCensoredPairs(on, off)
+	if got.NEff != 0 || got.Ties != 12 {
+		t.Fatalf("(n_eff, ties) = (%d, %d), want (0, 12)", got.NEff, got.Ties)
+	}
+}
+
+func TestD2KeepRequiresSignTest(t *testing.T) {
+	got := AnalyzeCensoredPairs(fixtureArms(censoredFixture{Pairs: 40, OnTokenWins: 24, OffTokenWins: 16}))
+	if got.Verdict == CensoredVerdictKeep || got.SignPValue <= 0.05 || got.MedianTokenRatio > 0.90 {
+		t.Fatalf("sign-test control did not discriminate: %+v", got)
+	}
+}
+
+func TestD2KeepRequiresMedianRatio(t *testing.T) {
+	on, off := fixtureArms(censoredFixture{Pairs: 40, OnOnlyPasses: 40})
+	got := AnalyzeCensoredPairs(on, off)
+	if got.Verdict == CensoredVerdictKeep || got.SignPValue > 0.05 || got.MedianTokenRatio != 0 {
+		t.Fatalf("median-ratio control did not discriminate: %+v", got)
+	}
+}
+
+func TestD2KeepRequiresMcNemarGuardrail(t *testing.T) {
+	on, off := fixtureArms(censoredFixture{Pairs: 40, OnTokenWins: 30, OffTokenWins: 10})
+	for i := 30; i < 40; i++ {
+		on[i].CompileOk, on[i].RuntimeOk, on[i].StdoutOk = false, false, false
+	}
+	got := AnalyzeCensoredPairs(on, off)
+	if got.Verdict == CensoredVerdictKeep || got.SignPValue > 0.05 || got.MedianTokenRatio > 0.90 || !got.PassRateLoss {
+		t.Fatalf("McNemar control did not discriminate: %+v", got)
+	}
+}
+
+func TestD2OrderRefusalBranches(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		assertOrderReason(t, nil, nil, "order_integrity_empty")
+	})
+	t.Run("timestamp", func(t *testing.T) {
+		on, off := fixtureArms(censoredFixture{Pairs: 2, OnTokenWins: 2})
+		on[0].Timestamp = time.Time{}
+		assertOrderReason(t, on, off, "order_integrity_timestamp")
+	})
+	t.Run("noncontiguous", func(t *testing.T) {
+		on, off := fixtureArms(censoredFixture{Pairs: 2, OnTokenWins: 2})
+		duplicate := *on[0]
+		duplicate.Trial = 2
+		duplicate.Timestamp = off[0].Timestamp.Add(500 * time.Millisecond)
+		on = append(on, &duplicate)
+		assertOrderReason(t, on, off, "order_integrity_noncontiguous_block")
+	})
+	t.Run("unpaired-block", func(t *testing.T) {
+		on, off := fixtureArms(censoredFixture{Pairs: 2, OnTokenWins: 2})
+		assertOrderReason(t, on, off[:1], "order_integrity_unpaired_block")
+	})
+	t.Run("nonadjacent", func(t *testing.T) {
+		on, off := fixtureArms(censoredFixture{Pairs: 2, OnTokenWins: 2})
+		off[0].Timestamp = on[1].Timestamp.Add(500 * time.Millisecond)
+		assertOrderReason(t, on, off, "order_integrity_nonadjacent_arms")
+	})
+	t.Run("lead-not-alternating", func(t *testing.T) {
+		on, off := fixtureArms(censoredFixture{Pairs: 3, OnTokenWins: 3})
+		on[1].Timestamp, off[1].Timestamp = off[1].Timestamp, on[1].Timestamp
+		assertOrderReason(t, on, off, "order_integrity_lead_not_alternating")
+	})
+}
+
+func assertOrderReason(t *testing.T, on, off []*BenchmarkResult, want string) {
+	t.Helper()
+	if got := CheckFmtOrderIntegrity(on, off); got != want {
+		t.Fatalf("reason = %q, want %q", got, want)
+	}
+}
+
+func TestD2VoidOrderPerfectArmBlock(t *testing.T) {
+	on, off := fixtureArms(censoredFixture{Pairs: 6, OnTokenWins: 6})
+	base := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+	for i := range on {
+		on[i].Timestamp = base.Add(time.Duration(i) * time.Second)
+		off[i].Timestamp = base.Add(time.Duration(10+i) * time.Second)
+	}
+	assertVoidReason(t, AnalyzeCensoredPairs(on, off), "order_integrity_nonadjacent_arms")
+}
+
+func assertVoidReason(t *testing.T, got CensoredPairResult, reason string) {
+	t.Helper()
+	if got.Verdict != CensoredVerdictVoid || got.VoidReason != reason || got.Reason != reason {
+		t.Fatalf("(verdict, void_reason, reason) = (%s, %s, %s), want (VOID, %s, %s)", got.Verdict, got.VoidReason, got.Reason, reason, reason)
+	}
+	if got.NEff != 0 || got.OnWins != 0 || got.OffWins != 0 {
+		t.Fatalf("VOID leaked numeric evidence: %+v", got)
+	}
+}
+
+func fixtureArms(fixture censoredFixture) ([]*BenchmarkResult, []*BenchmarkResult) {
+	base := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+	on := make([]*BenchmarkResult, fixture.Pairs)
+	off := make([]*BenchmarkResult, fixture.Pairs)
+	for i := 0; i < fixture.Pairs; i++ {
+		onPass, offPass := true, true
+		onTokens, offTokens := 1000, 1000
+		switch {
+		case i < fixture.OnOnlyPasses:
+			offPass = false
+		case i < fixture.OnOnlyPasses+fixture.OnTokenWins:
+			onTokens = 800
+		case i < fixture.OnOnlyPasses+fixture.OnTokenWins+fixture.OffTokenWins:
+			onTokens = 1200
+		}
+		on[i] = fixtureRow(i, onPass, onTokens)
+		off[i] = fixtureRow(i, offPass, offTokens)
+		pairStart := base.Add(time.Duration(i*4) * time.Second)
+		if i%2 == 0 {
+			on[i].Timestamp, off[i].Timestamp = pairStart, pairStart.Add(time.Second)
+		} else {
+			off[i].Timestamp, on[i].Timestamp = pairStart, pairStart.Add(time.Second)
+		}
+	}
+	return on, off
+}
+
+func fixtureRow(index int, pass bool, tokens int) *BenchmarkResult {
+	return &BenchmarkResult{
+		ID: "bench-" + string(rune('a'+index)), Lang: "ailang", Model: "fixture", Trial: 1,
+		CompileOk: pass, RuntimeOk: pass, StdoutOk: pass, TotalTokens: tokens,
+	}
+}

--- a/internal/eval_analysis/testdata/censored_cases.json
+++ b/internal/eval_analysis/testdata/censored_cases.json
@@ -1,0 +1,7 @@
+[
+  {"name":"keep","pairs":40,"on_token_wins":40,"want_verdict":"KEEP","want_reason":"keep-criteria-met"},
+  {"name":"retire_opposite","pairs":40,"off_token_wins":40,"want_verdict":"RETIRE","want_reason":"opposite-direction-rejection"},
+  {"name":"retire_neff","pairs":40,"on_token_wins":24,"off_token_wins":16,"want_verdict":"RETIRE","want_reason":"keep-failed-at-neff"},
+  {"name":"inconclusive_mid","pairs":30,"on_token_wins":18,"off_token_wins":12,"want_verdict":"INCONCLUSIVE","want_reason":"additional-slot-required"},
+  {"name":"inconclusive_low","pairs":10,"on_only_passes":10,"want_verdict":"INCONCLUSIVE","want_reason":"insufficient-neff"}
+]

--- a/internal/eval_analysis/types.go
+++ b/internal/eval_analysis/types.go
@@ -69,7 +69,12 @@ type BenchmarkResult struct {
 	Trial int `json:"trial,omitempty"`
 
 	// MicroRAGState records which A/B arm produced this row ("on"/"off").
-	MicroRAGState   string `json:"microrag_state,omitempty"`
+	MicroRAGState string `json:"microrag_state,omitempty"`
+	// FmtHookState and FmtHookEvents mirror the harness' banked treatment
+	// evidence so read-side analyzers can enforce treatment integrity.
+	FmtHookState  string                      `json:"fmt_hook_state,omitempty"`
+	FmtHookEvents []eval_harness.FmtHookEvent `json:"fmt_hook_events,omitempty"`
+
 	Condition       string `json:"condition,omitempty"`        // Experimental condition: "baseline", "agent_prompt", etc.
 	AgentTurns      int    `json:"agent_turns,omitempty"`      // Number of conversation turns
 	AgentToolCalls  int    `json:"agent_tool_calls,omitempty"` // Tool invocations (validates agentic behavior)


### PR DESCRIPTION
## M4 — D2 censored-pair analyzer (motoko mission, iteration 15)

Milestone **M4 of 5** of [`m-motoko-fmt-remeasurement-instrument`](https://github.com/sunholo-data/ailang/blob/dev/design_docs/planned/m-motoko-fmt-remeasurement-instrument.md).
M1 landed at iteration 14 (`bc0b5a8d4`); **M2, M3 and M5 remain** and are named as the resume point.
M4 was picked ahead of them because the plan declares it parallel-safe with M1–M3, it is the only
remaining milestone with no rig dependency, and **M3's AC-M3-4 calls M4's order-integrity checker** —
so M4-first is the ordering that leaves no milestone with an unclosable acceptance criterion.

`ailang eval-censored-pairs <on-dir> <off-dir>` is a **sibling** of `eval-paired`, not an extension:
`eval-paired`'s stdout JSON is a live contract with two callers (`nightly-eval.sh:339` microRAG,
`:515` fmt), so changing its shape would silently re-point an unrelated experiment's bank.

### The finding: the gate this milestone built was unreachable from its own CLI

The command loaded its arms through `LoadArmForPairing`, which wraps `FilterValidResults` and drops
rows whose `Validity` is invalid **at load time**. The `>20% of ON rows quarantined → VOID` gate
counts exactly those rows — so through the CLI it could never fire. The analyzer's unit tests pass
regardless, because they construct `[]*BenchmarkResult` directly and bypass the loader. That is this
repo's named recurring shape — *guard the helper, miss the call site* — reproduced **inside the
milestone whose subject is two integrity gates**.

Measured on the banked AC5 arms, both arms in one call with a firing control:

| loader | ON rows | quarantined visible | AC-M4-5 refusal reason |
|---|---:|---:|---|
| `LoadArmForPairing` (as delivered) | 5 | **0** | `order_integrity_unpaired_block` |
| `LoadResultsFromDirsIncludingInvalid` (fixed) | 6 | **1** | `order_integrity_nonadjacent_arms` |

The reason change is the sharper half. AC-M4-5 is cited as *"a real dataset whose correct verdict is
known in advance"* — V19 established those 12 rows are a perfect whole-arm block. The delivered code
returned VOID for an **odd row count**, an artifact of the silent drop, not for the blocking. Right
verdict class, wrong mechanism.

Fixed by loading with `LoadResultsFromDirsIncludingInvalid` and pinning the **call site**:
`TestEvalCensoredPairsSeesQuarantinedRows` drives `evalCensoredPairs` over hermetic `t.TempDir()`
arms. Mutation drill — reverting `loadCensoredArm` to `LoadArmForPairing` **LANDED** (grep=1) and
**BUILDS** (rc=0); the new test kills it (rc=1) and is its **sole killer**: the same package with
that one test `-skip`ped is **rc=0** under the mutant, i.e. green exactly as first delivered.

### Specification gap resolved at pick time

The plan lists `n_eff < 24` among the §7 thresholds without saying what verdict it produces, and the
doc's RETIRE-at-low-`n_eff` is conditioned on *"still `n_eff < 24` after two slots plus the
pre-authorized third"* — state a directory analyzer cannot observe. So `n_eff < 24` returns
`INCONCLUSIVE` / `insufficient-neff`, and the slot-budget call stays with the driver and the human.

### Gates

All run **outside the sandbox** on **darwin/arm64**; the windows and ubuntu legs are unrun locally
and are what this PR's CI is for.

| gate | rc |
|---|---:|
| `go test -count=1 ./internal/eval_analysis/... ./cmd/ailang/...` | 0 |
| `golangci-lint run ./internal/eval_analysis/... ./cmd/ailang/... ./internal/executor/motoko/...` | 0, `0 issues` |
| `make check-changelog` · `test-check-changelog` · `check-file-sizes` · `check-boundaries` · `fmt-check` · `vet` · `check-skills` | 0 (all seven) |
| **AC-M4-3** `eval-paired --with-pairs=true` stdout byte-identical (1185 B) | 0 |
| **AC-M4-5** VOID with an order-integrity reason on the real banked arms | 1 (expected non-zero) |

AC-M4-3's first attempt was **contaminated** — both "before" and "after" binaries were built from the
modified worktree, so they were the same binary. It was redone against a binary built from a pristine
`origin/dev` checkout, with a control asserting the two binaries actually differ.

The executor's own 13-row mutation table (both treatment voids, six order-refusal branches, the
censoring rule, the practical-equivalence margin, each of the three KEEP conjuncts) had **zero
survivors**; every mutant landed and built scoped. It correctly reported that `go build ./...` is red
on the **unmodified** tree (`cmd/wasm` has no native `main`) — which the sprint plan §4 already
records — so the repo-wide build was not usable as a mutation precondition and the scoped build was.

Routing: executor `codex:gpt-5.6-sol`; evaluator `sonnet` (distinct provider, generator≠judge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
