### PR TITLE
spike(list-repr): LC-1 M3-M5 — the always-copy C2, the measurement programs, and the adjudicator whose rerun path nothing tested

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -53,6 +53,18 @@ an unmutatable branch; the `>20%` quarantine boundary is pinned at exactly 20%
 and just over; and the verdict matrix now fails loudly if its fixture is emptied,
 which previously produced a green run of zero subtests.
 
+### Added — LC-1 list-representation spike: the third candidate, the remaining benchmarks, and the deterministic adjudicator
+
+Mission iteration 238, milestones M3–M5 of `m-list-repr-spike`. C2 (chunked/unrolled
+cons, K in {8, 32}) lands with an **always-copy leading chunk** prepend — no ownership
+tracking, no atomics, no locks — which meets the doc's O(K) = O(1) worst-case bound by
+construction and reverses iteration 237's descope. B3/B4/B5/B-LEN benchmarks, the B6
+retained-heap and B8 GC-shape measurement programs, and the five-fresh-process runner
+with its median-of-paired-ratios adjudicator and predeclared tie/spread rerun rule.
+Still a throwaway spike behind a compiler gate; no production file is touched — the
+whole diff is `tools/internal/spike-listrep/**`. The go/no-go verdict remains OPEN and
+is M6's deliverable.
+
 ### Added — LC-1 list-representation spike: scaffold, cons cells, and the branching benchmark whose control fires
 
 Mission iteration 237, milestones M1 and M2 of `m-list-repr-spike`. New throwaway

--- a/design_docs/planned/m-list-repr-spike-sprint-plan.md
+++ b/design_docs/planned/m-list-repr-spike-sprint-plan.md
@@ -7,7 +7,7 @@ The design doc WINS wherever it and this plan disagree. This plan adds only *how
 
 **Created:** 2026-08-20 (V1 mission iteration 236, sprint-planner stage)
 **Branch / worktree:** `sprint/iter236-list-repr-spike` @ `/Users/voightkampff/dev/sunholo-data/.wt-iter236`
-**Planned at HEAD:** `3ad6a2e46` (design-doc commit); **merge base with `origin/dev`: `8322d22b75adfce7a4aa284eaf3ad99afdd4b570`** — this is the `<merge-base>` literal AC-7 requires.
+**Planned at HEAD:** `3ad6a2e46` (design-doc commit); **merge base with `origin/dev` AT PLANNING TIME: `8322d22b75adfce7a4aa284eaf3ad99afdd4b570`.** ⚠ This is a HISTORICAL record of where planning happened — it is **NOT** the base AC-7 should use, and it was 6 commits stale by iteration 238. AC-7 derives its base with `git merge-base origin/dev HEAD` (see §6 step 7).
 **Milestones:** 6 · **Estimated:** ~1,800 Go LOC + ~450 lines of report markdown · **3.0 days** (top of the doc's 2–3-day box — see §7)
 **Risk level:** MEDIUM · **Planner lane:** opus-required (doc line 10)
 **Target:** v0.34.0
@@ -292,11 +292,32 @@ Implements doc:156-183 exactly. Sequenced here (end of Day 2 / start of Day 3) r
    the instrument is broken and **no verdict may be emitted from it**. Also re-affirm legs 1–2: **all** benchmarks compiled in the external `_test` package, and if any benchmark needed a raw field, clause (e) **fails** (doc:231-235).
 5. **AC-5 verdict:** a per-candidate pass/fail table over (a)–(e) with the arithmetic inline; **≥1 candidate passes all five → GO**, naming the chosen representation (ties broken by (c) then (b)); **zero → STOP**, with a comment posted on **#745** carrying the full matrix and explicitly re-opening D-19. **The verdict may not be "partial go"** (doc:237-240). On STOP the report records the posted comment URL. If AC-2's control leg failed, **no verdict is emitted at all** (AMB-3).
 6. **AC-6:** D3's table reproduced as-built with its per-row `file:line` citations, annotated with anything clause (e) proved infeasible (AMB-6).
-7. **AC-7 anti-goal proof — with the firing control P3 showed is mandatory:**
+7. **AC-7 anti-goal proof — with the firing control P3 showed is mandatory.**
+
+   > **⚠ THE BASE MUST BE *DERIVED*, NEVER TRANSCRIBED — CORRECTED AT ITERATION 238 AFTER THE
+   > HARDCODED LITERAL WENT STALE AND PRODUCED A FALSE AC-7 FAILURE.** This step used to carry
+   > `8322d22b7…` as a literal. Measured at iteration 238: that base is **6 commits** behind
+   > `origin/dev`, and running the step verbatim returns **10** files
+   > (`cmd/ailang/eval_censored*.go`, `internal/eval_analysis/*`) — every one of them from an
+   > unrelated commit (`d5bcfa0c8`, the eval censored-pair analyzer) that landed after the plan
+   > was written. Against the correct base the same command returns **0**, with the unscoped
+   > control returning **15**, so the branch is clean and the *instrument* was what failed.
+   > This is the same trap iteration 237 hit from the other side — its executor directive had to
+   > order the base DERIVED because the plan's literal was already wrong then — and it was fixed
+   > only in that directive, so the plan kept the stale literal for a second iteration. A literal
+   > base goes stale every time `dev` moves; a derived one cannot. Note the failure direction:
+   > it manufactures a **STOP by artifact rather than by measurement**, on a gate that cancels
+   > ~16 person-days.
+
    ```bash
-   git diff --name-only 8322d22b75adfce7a4aa284eaf3ad99afdd4b570..HEAD -- internal/ cmd/ std/ examples/   # MUST be empty
-   git diff --name-only 8322d22b75adfce7a4aa284eaf3ad99afdd4b570..HEAD | head -40                          # MUST list the spike files
+   BASE=$(git merge-base origin/dev HEAD)          # DERIVE it. Never paste a SHA here.
+   echo "AC-7 base: $BASE"                          # record the resolved value in the report
+   git diff --name-only "$BASE"..HEAD -- internal/ cmd/ std/ examples/   # MUST be empty
+   git diff --name-only "$BASE"..HEAD | head -40                          # MUST list the spike files
    ```
+   If the scoped arm is non-empty, **check the base before concluding AC-7 failed**: confirm each
+   named file is reachable from your own branch's commits (`git log --oneline "$BASE"..HEAD --
+   <file>`) rather than inherited from `dev`.
    The scoped command alone is green even if the branch is empty (P3). Both lines go in the report.
 8. **AC-8 final:** `make test` green with the spike included. Plus the three gates the doc's Conflict Surface omits (AMB-7, P4): `make vet` rc=0, `make fmt-check` rc=0, and `go test -timeout 300s ./tools/...` rc=0 as a stand-in for the CI leg's per-package timeout.
 9. **Repo standing rules** (not doc ACs, and outside AC-7's pathspec): a `CHANGELOG.md` entry, and the implemented-doc report filed per the design-doc convention. Note `make test-check-changelog` only self-tests the gate script (`make/test.mk:52-54`) and does not enforce an entry against this diff — the entry is added because the coding standards require it, not because CI would catch its absence.

--- a/design_docs/planned/m-list-repr-spike-sprint-plan.md
+++ b/design_docs/planned/m-list-repr-spike-sprint-plan.md
@@ -257,12 +257,39 @@ Implements doc:156-183 exactly. Sequenced here (end of Day 2 / start of Day 3) r
 1. **Full matrix pass** under M5's runner: all 76 measured points × 5 trials (§5), plus any predeclared reruns. Record the elapsed wall-clock and the before/after `rig.lock` observation (§3) in the report header, alongside `go version` and machine identity (doc:153-154).
 2. **AC-1:** every cell carries **the command and its printed number**. A cell asserted from theory is a red AC (doc:132-133, :320-322).
 3. **AC-2 / AC-3:** the (a)/(b)/(c)/(d) arithmetic, with both operands measured — clause (c) denominated in **B6's measured C0 B/element, never the assumed 16 B derivation** (doc:209-211, :330-331). All raw trials, all paired ratios, sorted order, median arithmetic, and B6's every same-process empty baseline and baseline-adjusted delta.
-4. **AC-4 leg 3:** the grep showing field writes confined to constructor files, **quoted in the report with a firing control**:
+4. **AC-4 leg 3:** the grep showing field writes confined to constructor files, **quoted in the report with a firing control**.
+
+   > **⚠ CORRECTED AT ITERATION 238 — THE REGEX AS ORIGINALLY WRITTEN MATCHED `==`, SO IT
+   > "FIRED" ON COMPARISONS AND THE CLAUSE WOULD HAVE FAILED ON CORRECT CODE.** Measured on the
+   > M3–M5 tree: `\.(…)[[:space:]]*=` returned **3** hits, and all three were `==` comparisons
+   > (`chunklist.go:43`, `:101`, `:106`) — because `=` is a prefix of `==`. All three sit in
+   > `ChunkCons` and `Uncons`, i.e. **outside any constructor**, so the rule as written ("every
+   > hit must be … inside a constructor") **fails on a tree with zero real violations**. Either
+   > the M6 executor reads it literally and emits a spurious clause-(e) STOP on a ~16-person-day
+   > decision, or it waves the three hits through — and a genuine violation lands in the *same
+   > function* and looks identical at a glance (verified: an in-place front-slack slot write in
+   > `ChunkCons` produces a 4th hit indistinguishable in form from the 3 benign ones).
+   >
+   > **Two further facts, both measured, that change how this leg must be read.**
+   > (a) The assignment-only form returns **0** hits on correct code — so for THIS clause an
+   > **empty result is the PASS**, and the "a grep that returns nothing is broken" rule does not
+   > apply to it. The instrument is proved live by a deliberate probe, not by the codebase.
+   > (b) Constructor writes are **composite literals** (`&ChunkList{elems: …}`, `&ConsList{head:
+   > …}`, `&SliceList{value: …}`), which use `:` and are invisible to *both* regex forms — so no
+   > `=`-shaped grep can verify the "inside a constructor" half at all. Check it separately.
+
    ```bash
-   grep -rnE '\.(head|tail|n|elems|count|total)[[:space:]]*=' tools/internal/spike-listrep/*.go   # must be NON-EMPTY (control fires)
-   # and every hit must be inside slicelist.go / conslist.go / chunklist.go, inside a constructor
+   # (i) ASSIGNMENT-ONLY sweep — '=' NOT followed by '='. On correct code this is EMPTY.
+   grep -rnE '\.(head|tail|n|elems|count|total|k)[[:space:]]*=[^=]' tools/internal/spike-listrep/*.go
+   # (ii) PROOF THE INSTRUMENT FIRES — a deliberate probe, since (i) is legitimately empty:
+   printf 'package x\nfunc f(l *T) { l.total = 1 }\n' > /tmp/ac4_probe.go
+   grep -nE '\.(head|tail|n|elems|count|total|k)[[:space:]]*=[^=]' /tmp/ac4_probe.go   # MUST match
+   # (iii) CONSTRUCTOR CHECK — composite literals, which (i) cannot see:
+   grep -nE '&(SliceList|ConsList|ChunkList)\{' tools/internal/spike-listrep/*.go
+   # every hit must be in slicelist.go / conslist.go / chunklist.go, inside that type's constructor
    ```
-   A grep that returns nothing is a broken instrument, not a pass. Also re-affirm legs 1–2: **all** benchmarks compiled in the external `_test` package, and if any benchmark needed a raw field, clause (e) **fails** (doc:231-235).
+   Any hit from (i) outside a constructor body **fails clause (e)**. A missing match in (ii) means
+   the instrument is broken and **no verdict may be emitted from it**. Also re-affirm legs 1–2: **all** benchmarks compiled in the external `_test` package, and if any benchmark needed a raw field, clause (e) **fails** (doc:231-235).
 5. **AC-5 verdict:** a per-candidate pass/fail table over (a)–(e) with the arithmetic inline; **≥1 candidate passes all five → GO**, naming the chosen representation (ties broken by (c) then (b)); **zero → STOP**, with a comment posted on **#745** carrying the full matrix and explicitly re-opening D-19. **The verdict may not be "partial go"** (doc:237-240). On STOP the report records the posted comment URL. If AC-2's control leg failed, **no verdict is emitted at all** (AMB-3).
 6. **AC-6:** D3's table reproduced as-built with its per-row `file:line` citations, annotated with anything clause (e) proved infeasible (AMB-6).
 7. **AC-7 anti-goal proof — with the firing control P3 showed is mandatory:**

--- a/tools/internal/spike-listrep/arms.go
+++ b/tools/internal/spike-listrep/arms.go
@@ -1,0 +1,48 @@
+package spikelistrep
+
+import (
+	"fmt"
+
+	"github.com/sunholo-data/ailang/internal/eval"
+)
+
+// NewArm returns an empty list for a named measurement arm.
+func NewArm(name string) (List, error) {
+	switch name {
+	case "C0":
+		return SliceEmpty(), nil
+	case "C1":
+		return ConsEmpty(), nil
+	case "C2K8":
+		return ChunkEmpty(8), nil
+	case "C2K32":
+		return ChunkEmpty(32), nil
+	default:
+		return nil, fmt.Errorf("unknown arm %q", name)
+	}
+}
+
+// PrependArm prepends to a list from the named measurement arm.
+func PrependArm(name string, value eval.Value, list List) (List, error) {
+	switch name {
+	case "C0":
+		return SliceCons(value, list), nil
+	case "C1":
+		return ConsCons(value, list), nil
+	case "C2K8":
+		return ChunkCons(8, value, list), nil
+	case "C2K32":
+		return ChunkCons(32, value, list), nil
+	default:
+		return nil, fmt.Errorf("unknown arm %q", name)
+	}
+}
+
+// SharedSingletonElements returns n references to the same element.
+func SharedSingletonElements(n int, element eval.Value) []eval.Value {
+	result := make([]eval.Value, n)
+	for i := range result {
+		result[i] = element
+	}
+	return result
+}

--- a/tools/internal/spike-listrep/branching_bench_test.go
+++ b/tools/internal/spike-listrep/branching_bench_test.go
@@ -18,6 +18,8 @@ type benchmarkArm struct {
 var benchmarkArms = []benchmarkArm{
 	{name: "C0", fromSlice: spikelistrep.SliceFromSlice, cons: spikelistrep.SliceCons},
 	{name: "C1", fromSlice: spikelistrep.ConsFromSlice, cons: spikelistrep.ConsCons},
+	{name: "C2K8", fromSlice: func(v []eval.Value) spikelistrep.List { return spikelistrep.ChunkFromSlice(8, v) }, cons: func(v eval.Value, l spikelistrep.List) spikelistrep.List { return spikelistrep.ChunkCons(8, v, l) }},
+	{name: "C2K32", fromSlice: func(v []eval.Value) spikelistrep.List { return spikelistrep.ChunkFromSlice(32, v) }, cons: func(v eval.Value, l spikelistrep.List) spikelistrep.List { return spikelistrep.ChunkCons(32, v, l) }},
 }
 
 func BenchmarkListRep_B1_Branching(b *testing.B) {

--- a/tools/internal/spike-listrep/chunklist.go
+++ b/tools/internal/spike-listrep/chunklist.go
@@ -1,0 +1,130 @@
+package spikelistrep
+
+import (
+	"iter"
+
+	"github.com/sunholo-data/ailang/internal/eval"
+)
+
+// ChunkList is the C2 persistent, unrolled-cons representation. Published
+// chunks are immutable; prepend copies at most the leading K-element chunk.
+type ChunkList struct {
+	elems []eval.Value
+	tail  *ChunkList
+	total int
+	k     int
+}
+
+func ChunkEmpty(k int) List {
+	checkChunkCapacity(k)
+	return newChunkList(nil, nil, 0, k)
+}
+
+func ChunkFromSlice(k int, elements []eval.Value) List {
+	checkChunkCapacity(k)
+	var tail *ChunkList
+	for end := len(elements); end > 0; {
+		start := max(0, end-k)
+		tail = newChunkList(elements[start:end], tail, len(elements)-start, k)
+		end = start
+	}
+	if tail == nil {
+		return newChunkList(nil, nil, 0, k)
+	}
+	return tail
+}
+
+func ChunkCons(k int, head eval.Value, tail List) List {
+	checkChunkCapacity(k)
+	chunkTail, ok := tail.(*ChunkList)
+	if !ok || chunkTail.k != k {
+		return ChunkFromSlice(k, append([]eval.Value{head}, tail.ToSlice()...))
+	}
+	if chunkTail.total == 0 {
+		return newChunkList([]eval.Value{head}, nil, 1, k)
+	}
+	if len(chunkTail.elems) < k {
+		elems := make([]eval.Value, 1, len(chunkTail.elems)+1)
+		elems[0] = head
+		elems = append(elems, chunkTail.elems...)
+		return newChunkList(elems, chunkTail.tail, chunkTail.total+1, k)
+	}
+	return newChunkList([]eval.Value{head}, chunkTail, chunkTail.total+1, k)
+}
+
+func newChunkList(elems []eval.Value, tail *ChunkList, total, k int) *ChunkList {
+	return &ChunkList{elems: append([]eval.Value(nil), elems...), tail: tail, total: total, k: k}
+}
+
+func checkChunkCapacity(k int) {
+	if k <= 0 {
+		panic("spikelistrep: chunk capacity must be positive")
+	}
+}
+
+func (l *ChunkList) Len() int { return l.total }
+
+func (l *ChunkList) At(i int) (eval.Value, bool) {
+	if i < 0 || i >= l.total {
+		return nil, false
+	}
+	for current := l; current != nil; current = current.tail {
+		if i < len(current.elems) {
+			return current.elems[i], true
+		}
+		i -= len(current.elems)
+	}
+	return nil, false
+}
+
+func (l *ChunkList) All() iter.Seq[eval.Value] {
+	return func(yield func(eval.Value) bool) {
+		for current := l; current != nil; current = current.tail {
+			for _, element := range current.elems {
+				if !yield(element) {
+					return
+				}
+			}
+		}
+	}
+}
+
+func (l *ChunkList) ToSlice() []eval.Value {
+	result := make([]eval.Value, 0, l.total)
+	for element := range l.All() {
+		result = append(result, element)
+	}
+	return result
+}
+
+func (l *ChunkList) Uncons() (eval.Value, List, bool) {
+	if l.total == 0 {
+		return nil, l, false
+	}
+	head := l.elems[0]
+	if len(l.elems) == 1 {
+		if l.tail == nil {
+			return head, ChunkEmpty(l.k), true
+		}
+		return head, l.tail, true
+	}
+	return head, newChunkList(l.elems[1:], l.tail, l.total-1, l.k), true
+}
+
+func (l *ChunkList) DropPrefix(count int) List {
+	if count <= 0 {
+		return l
+	}
+	if count >= l.total {
+		return ChunkEmpty(l.k)
+	}
+	current := l
+	for count >= len(current.elems) {
+		count -= len(current.elems)
+		current = current.tail
+	}
+	if count == 0 {
+		return current
+	}
+	return newChunkList(current.elems[count:], current.tail, current.total-count, current.k)
+}

--- a/tools/internal/spike-listrep/cmd/gcshape/main.go
+++ b/tools/internal/spike-listrep/cmd/gcshape/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/sunholo-data/ailang/internal/eval"
+	spikelistrep "github.com/sunholo-data/ailang/tools/internal/spike-listrep"
+)
+
+type report struct {
+	Arm               string `json:"arm"`
+	N                 int    `json:"n"`
+	NumGCDelta        uint32 `json:"num_gc_delta"`
+	PauseTotalNsDelta uint64 `json:"pause_total_ns_delta"`
+	HeapAllocBefore   uint64 `json:"heap_alloc_before"`
+	HeapAllocAfter    uint64 `json:"heap_alloc_after"`
+}
+
+func main() {
+	arm := flag.String("arm", "C0", "C0, C1, C2K8, or C2K32")
+	n := flag.Int("n", 12800, "element count")
+	flag.Parse()
+	list, err := spikelistrep.NewArm(*arm)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	element := &eval.IntValue{Value: 1}
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	for range *n {
+		list, err = spikelistrep.PrependArm(*arm, element, list)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+	}
+	runtime.KeepAlive(list)
+	runtime.ReadMemStats(&after)
+	runtime.KeepAlive(list)
+	_ = json.NewEncoder(os.Stdout).Encode(report{*arm, *n, after.NumGC - before.NumGC, after.PauseTotalNs - before.PauseTotalNs, before.HeapAlloc, after.HeapAlloc})
+}

--- a/tools/internal/spike-listrep/cmd/retained/main.go
+++ b/tools/internal/spike-listrep/cmd/retained/main.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/sunholo-data/ailang/internal/eval"
+	spikelistrep "github.com/sunholo-data/ailang/tools/internal/spike-listrep"
+)
+
+type counters struct {
+	HeapAlloc   uint64 `json:"heap_alloc"`
+	HeapObjects uint64 `json:"heap_objects"`
+}
+type report struct {
+	RawEmptyBaseline     int64    `json:"raw_empty_baseline"`
+	PostWorkloadCounters counters `json:"post_workload_counters"`
+	AdjustedDelta        int64    `json:"adjusted_delta"`
+	BytesPerElement      float64  `json:"bytes_per_element"`
+}
+
+func snapshot() runtime.MemStats {
+	runtime.GC()
+	runtime.GC()
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return m
+}
+
+func main() {
+	arm := flag.String("arm", "C0", "C0, C1, C2K8, or C2K32")
+	n := flag.Int("n", 100000, "element count")
+	flag.Parse()
+	if *n <= 0 {
+		fmt.Fprintln(os.Stderr, "n must be positive")
+		os.Exit(2)
+	}
+	baselineBefore := snapshot()
+	baselineAfter := snapshot()
+	emptyDelta := int64(baselineAfter.HeapAlloc) - int64(baselineBefore.HeapAlloc)
+	before := snapshot()
+	singleton := &eval.IntValue{Value: 1}
+	list, err := spikelistrep.NewArm(*arm)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	for range spikelistrep.SharedSingletonElements(*n, singleton) {
+		list, err = spikelistrep.PrependArm(*arm, singleton, list)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+	}
+	runtime.KeepAlive(list)
+	after := snapshot()
+	runtime.KeepAlive(list)
+	rawDelta := int64(after.HeapAlloc) - int64(before.HeapAlloc)
+	adjusted := rawDelta - emptyDelta
+	_ = json.NewEncoder(os.Stdout).Encode(report{emptyDelta, counters{after.HeapAlloc, after.HeapObjects}, adjusted, float64(adjusted) / float64(*n)})
+}

--- a/tools/internal/spike-listrep/cmd/runner/main.go
+++ b/tools/internal/spike-listrep/cmd/runner/main.go
@@ -1,0 +1,281 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	initialTrials      = 5
+	subprocessDeadline = 12 * time.Minute
+)
+
+type trial struct {
+	Ordinal     int      `json:"ordinal"`
+	Value       float64  `json:"value"`
+	Valid       bool     `json:"valid"`
+	Error       string   `json:"error,omitempty"`
+	Command     []string `json:"command,omitempty"`
+	MaxRSSBytes int64    `json:"max_rss_bytes,omitempty"`
+	RawOutput   string   `json:"raw_output,omitempty"`
+}
+
+type analysis struct {
+	Valid            bool      `json:"valid"`
+	Error            string    `json:"error,omitempty"`
+	Candidate        []trial   `json:"candidate_operands"`
+	Control          []trial   `json:"control_operands"`
+	Ratios           []float64 `json:"paired_ratios,omitempty"`
+	SortedRatios     []float64 `json:"sorted_ratios,omitempty"`
+	Median           float64   `json:"median,omitempty"`
+	MedianArithmetic string    `json:"median_arithmetic,omitempty"`
+	Rerun            bool      `json:"rerun_required"`
+	Pass             bool      `json:"pass"`
+}
+
+func paired(candidate, control []trial, threshold float64, op string, allowRerun bool) analysis {
+	a := analysis{Candidate: candidate, Control: control}
+	if len(candidate) != len(control) || len(candidate) == 0 {
+		a.Error = "operand vectors must have the same non-zero length"
+		return a
+	}
+	for i := range candidate {
+		if !candidate[i].Valid || !control[i].Valid {
+			a.Error = fmt.Sprintf("invalid trial at ordinal %d; sample retained at %d", i+1, len(candidate))
+			return a
+		}
+		if control[i].Value == 0 {
+			a.Error = fmt.Sprintf("zero control operand at ordinal %d", i+1)
+			return a
+		}
+		a.Ratios = append(a.Ratios, candidate[i].Value/control[i].Value)
+	}
+	a.SortedRatios = append([]float64(nil), a.Ratios...)
+	sort.Float64s(a.SortedRatios)
+	a.Median, a.MedianArithmetic = median(a.SortedRatios)
+	a.Valid = true
+	if allowRerun {
+		a.Rerun = a.Median == threshold || touchesBothSides(a.Ratios, threshold)
+	}
+	a.Pass = compare(a.Median, threshold, op) && !a.Rerun
+	return a
+}
+
+func median(sortedValues []float64) (float64, string) {
+	n := len(sortedValues)
+	if n%2 == 1 {
+		m := sortedValues[n/2]
+		return m, fmt.Sprintf("sorted[%d]=%g", n/2, m)
+	}
+	left, right := sortedValues[n/2-1], sortedValues[n/2]
+	return (left + right) / 2, fmt.Sprintf("(%g+%g)/2=%g", left, right, (left+right)/2)
+}
+
+func touchesBothSides(values []float64, threshold float64) bool {
+	low, high := false, false
+	for _, value := range values {
+		low = low || value <= threshold
+		high = high || value >= threshold
+	}
+	return low && high
+}
+
+func compare(value, threshold float64, op string) bool {
+	switch op {
+	case "<=":
+		return value <= threshold
+	case ">=":
+		return value >= threshold
+	default:
+		return false
+	}
+}
+
+func benchmarkCatalog() []string {
+	arms := []string{"C0", "C1", "C2K8", "C2K32"}
+	var cells []string
+	for _, arm := range arms {
+		for _, m := range []int{1024, 4096} {
+			for _, l := range []int{1024, 4096, 16384} {
+				cells = append(cells, fmt.Sprintf("BenchmarkListRep_B1_Branching/arm=%s/m=%d/L=%d", arm, m, l))
+			}
+		}
+		for _, n := range []int{1600, 3200, 6400, 12800} {
+			cells = append(cells, fmt.Sprintf("BenchmarkListRep_B2_LinearBuild/arm=%s/n=%d", arm, n))
+		}
+		for _, n := range []int{4096, 65536} {
+			cells = append(cells, fmt.Sprintf("BenchmarkListRep_B3_Iteration/arm=%s/n=%d", arm, n))
+		}
+		for _, i := range []int{0, 1024, 2048, 4095} {
+			cells = append(cells, fmt.Sprintf("BenchmarkListRep_B4_Nth/arm=%s/n=4096/i=%d", arm, i))
+		}
+		cells = append(cells, fmt.Sprintf("BenchmarkListRep_B5_Materialize/arm=%s/n=4096", arm))
+		for _, n := range []int{4096, 65536} {
+			cells = append(cells, fmt.Sprintf("BenchmarkListRep_BLEN_Length/arm=%s/n=%d", arm, n))
+		}
+	}
+	return cells
+}
+
+func validateCell(pattern string) (string, error) {
+	if !strings.HasPrefix(pattern, "^") || !strings.HasSuffix(pattern, "$") {
+		return "", errors.New("cell regex must be anchored with ^ and $")
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", err
+	}
+	var matches []string
+	for _, cell := range benchmarkCatalog() {
+		if re.MatchString(cell) {
+			matches = append(matches, cell)
+		}
+	}
+	if len(matches) != 1 {
+		return "", fmt.Errorf("cell regex matched %d benchmarks, want exactly 1", len(matches))
+	}
+	return matches[0], nil
+}
+
+type invocation struct{ Kind, Selector, Metric string }
+
+func runTrial(ctx context.Context, ordinal int, in invocation) trial {
+	trialCtx, cancel := context.WithTimeout(ctx, subprocessDeadline)
+	defer cancel()
+	args := []string{"-l", "go"}
+	switch in.Kind {
+	case "benchmark":
+		args = append(args, "test", "./tools/internal/spike-listrep", "-run=^$", "-count=1", "-timeout=10m", "-benchmem", "-benchtime=1s", "-bench="+in.Selector)
+	case "retained", "gcshape":
+		args = append(args, "run", "./tools/internal/spike-listrep/cmd/"+in.Kind, "-arm="+in.Selector)
+	default:
+		return trial{Ordinal: ordinal, Error: "unknown invocation kind"}
+	}
+	cmd := exec.CommandContext(trialCtx, "/usr/bin/time", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	err := cmd.Run()
+	result := trial{Ordinal: ordinal, Command: append([]string{"/usr/bin/time"}, args...)}
+	result.MaxRSSBytes = parseMaxRSS(stderr.String())
+	result.RawOutput = strings.TrimSpace(stdout.String())
+	if trialCtx.Err() == context.DeadlineExceeded {
+		result.Error = "deadline killed subprocess"
+		return result
+	}
+	if err != nil {
+		result.Error = err.Error() + ": " + strings.TrimSpace(stderr.String())
+		return result
+	}
+	value, err := parseMetric(in, stdout.Bytes())
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	result.Value, result.Valid = value, true
+	return result
+}
+
+func parseMaxRSS(stderr string) int64 {
+	re := regexp.MustCompile(`(?m)^\s*(\d+)\s+maximum resident set size`)
+	m := re.FindStringSubmatch(stderr)
+	if len(m) != 2 {
+		return 0
+	}
+	v, _ := strconv.ParseInt(m[1], 10, 64)
+	return v
+}
+
+func parseMetric(in invocation, output []byte) (float64, error) {
+	if in.Kind == "retained" {
+		var r struct {
+			BytesPerElement float64 `json:"bytes_per_element"`
+		}
+		if err := json.Unmarshal(output, &r); err != nil {
+			return 0, err
+		}
+		return r.BytesPerElement, nil
+	}
+	if in.Kind == "gcshape" {
+		var r map[string]float64
+		if err := json.Unmarshal(output, &r); err != nil {
+			return 0, err
+		}
+		v, ok := r[in.Metric]
+		if !ok {
+			return 0, fmt.Errorf("metric %q absent", in.Metric)
+		}
+		return v, nil
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 4 || !strings.HasPrefix(fields[0], strings.TrimSuffix(strings.TrimPrefix(in.Selector, "^"), "$")) {
+			continue
+		}
+		for i := 2; i+1 < len(fields); i++ {
+			if fields[i+1] == in.Metric {
+				return strconv.ParseFloat(fields[i], 64)
+			}
+		}
+	}
+	return 0, fmt.Errorf("metric %q not found", in.Metric)
+}
+
+func collect(ctx context.Context, in invocation, start, count int) []trial {
+	results := make([]trial, 0, count)
+	for i := range count {
+		results = append(results, runTrial(ctx, start+i, in))
+	}
+	return results
+}
+
+func main() {
+	kind := flag.String("kind", "benchmark", "benchmark, retained, or gcshape")
+	cell := flag.String("cell", "", "one anchored benchmark regex, or arm for a main program")
+	control := flag.String("control", "", "anchored control regex, or control arm")
+	metric := flag.String("metric", "ns/op", "reported metric")
+	threshold := flag.Float64("threshold", math.NaN(), "comparison threshold")
+	op := flag.String("op", "<=", "<= or >=")
+	flag.Parse()
+	if *cell == "" || *control == "" || math.IsNaN(*threshold) || (*op != "<=" && *op != ">=") {
+		flag.Usage()
+		os.Exit(2)
+	}
+	if *kind == "benchmark" {
+		if _, err := validateCell(*cell); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+		if _, err := validateCell(*control); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+	}
+	ctx := context.Background()
+	candidateIn, controlIn := invocation{*kind, *cell, *metric}, invocation{*kind, *control, *metric}
+	candidate := collect(ctx, candidateIn, 1, initialTrials)
+	controlTrials := collect(ctx, controlIn, 1, initialTrials)
+	result := paired(candidate, controlTrials, *threshold, *op, true)
+	if result.Valid && result.Rerun {
+		candidate = append(candidate, collect(ctx, candidateIn, 6, 5)...)
+		controlTrials = append(controlTrials, collect(ctx, controlIn, 6, 5)...)
+		result = paired(candidate, controlTrials, *threshold, *op, false)
+	}
+	_ = json.NewEncoder(os.Stdout).Encode(result)
+	if !result.Valid {
+		os.Exit(1)
+	}
+}

--- a/tools/internal/spike-listrep/cmd/runner/main.go
+++ b/tools/internal/spike-listrep/cmd/runner/main.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	initialTrials      = 5
+	rerunTrials        = 5
 	subprocessDeadline = 12 * time.Minute
 )
 
@@ -242,6 +243,29 @@ func collect(ctx context.Context, in invocation, start, count int) []trial {
 	return results
 }
 
+// collector gathers `count` trials for one invocation, numbering them from
+// `start`. Injectable so the rerun ORCHESTRATION below is testable without
+// running any benchmark: iteration 238's evaluator showed that unit-testing
+// paired() alone leaves this function's rerun path entirely unpinned.
+type collector func(ctx context.Context, in invocation, start, count int) []trial
+
+// adjudicate runs the doc's five-trial protocol and, only on the predeclared
+// tie/spread condition, exactly one rerun of `rerunTrials` further fresh
+// trials per arm, numbered contiguously after the first batch. The rerun's
+// own analysis is computed with allowRerun=false, so a rerun can never
+// cascade: the median of all ten is final.
+func adjudicate(ctx context.Context, gather collector, candidateIn, controlIn invocation, threshold float64, op string) analysis {
+	candidate := gather(ctx, candidateIn, 1, initialTrials)
+	controlTrials := gather(ctx, controlIn, 1, initialTrials)
+	result := paired(candidate, controlTrials, threshold, op, true)
+	if result.Valid && result.Rerun {
+		candidate = append(candidate, gather(ctx, candidateIn, initialTrials+1, rerunTrials)...)
+		controlTrials = append(controlTrials, gather(ctx, controlIn, initialTrials+1, rerunTrials)...)
+		result = paired(candidate, controlTrials, threshold, op, false)
+	}
+	return result
+}
+
 func main() {
 	kind := flag.String("kind", "benchmark", "benchmark, retained, or gcshape")
 	cell := flag.String("cell", "", "one anchored benchmark regex, or arm for a main program")
@@ -266,14 +290,7 @@ func main() {
 	}
 	ctx := context.Background()
 	candidateIn, controlIn := invocation{*kind, *cell, *metric}, invocation{*kind, *control, *metric}
-	candidate := collect(ctx, candidateIn, 1, initialTrials)
-	controlTrials := collect(ctx, controlIn, 1, initialTrials)
-	result := paired(candidate, controlTrials, *threshold, *op, true)
-	if result.Valid && result.Rerun {
-		candidate = append(candidate, collect(ctx, candidateIn, 6, 5)...)
-		controlTrials = append(controlTrials, collect(ctx, controlIn, 6, 5)...)
-		result = paired(candidate, controlTrials, *threshold, *op, false)
-	}
+	result := adjudicate(ctx, collect, candidateIn, controlIn, *threshold, *op)
 	_ = json.NewEncoder(os.Stdout).Encode(result)
 	if !result.Valid {
 		os.Exit(1)

--- a/tools/internal/spike-listrep/cmd/runner/main_test.go
+++ b/tools/internal/spike-listrep/cmd/runner/main_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func valid(values ...float64) []trial {
+	result := make([]trial, len(values))
+	for i, value := range values {
+		result[i] = trial{Ordinal: i + 1, Value: value, Valid: true}
+	}
+	return result
+}
+
+func TestAdjudicatorSyntheticVectors(t *testing.T) {
+	ones5 := valid(1, 1, 1, 1, 1)
+	ones10 := valid(1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
+	tests := []struct {
+		name                                       string
+		candidate, control                         []trial
+		threshold                                  float64
+		op                                         string
+		allowRerun, wantValid, wantRerun, wantPass bool
+		wantMedian                                 float64
+	}{
+		{"unsorted odd median", valid(5, 1, 4, 2, 3), ones5, 10, "<=", true, true, false, true, 3},
+		{"median exactly threshold", valid(1, 2, 3, 4, 5), ones5, 3, "<=", true, true, true, false, 3},
+		{"spans threshold", valid(1, 2, 2, 4, 5), ones5, 3, "<=", true, true, true, false, 2},
+		{"equality touches both", valid(1, 1, 1, 1, 2), ones5, 2, "<=", true, true, true, false, 1},
+		{"ten equality passes less", valid(1, 1, 1, 1, 2, 2, 3, 3, 3, 3), ones10, 2, "<=", false, true, false, true, 2},
+		{"ten equality passes greater", valid(1, 1, 1, 1, 2, 2, 3, 3, 3, 3), ones10, 2, ">=", false, true, false, true, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := paired(tt.candidate, tt.control, tt.threshold, tt.op, tt.allowRerun)
+			if got.Valid != tt.wantValid || got.Rerun != tt.wantRerun || got.Pass != tt.wantPass || got.Median != tt.wantMedian {
+				t.Fatalf("got valid=%v rerun=%v pass=%v median=%v; want %v %v %v %v", got.Valid, got.Rerun, got.Pass, got.Median, tt.wantValid, tt.wantRerun, tt.wantPass, tt.wantMedian)
+			}
+		})
+	}
+}
+
+func TestInvalidTrialDoesNotShrinkSample(t *testing.T) {
+	candidate := valid(1, 2, 3, 4, 5)
+	candidate[2] = trial{Ordinal: 3, Error: "deadline killed subprocess"}
+	got := paired(candidate, valid(1, 1, 1, 1, 1), 3, "<=", true)
+	if got.Valid || len(got.Candidate) != 5 || !strings.Contains(got.Error, "invalid trial") {
+		t.Fatalf("invalid trial was not surfaced: %+v", got)
+	}
+}
+
+func TestValidateCellRejectsNonSingletonRegex(t *testing.T) {
+	for _, pattern := range []string{"BenchmarkListRep_B3", "^BenchmarkListRep_B3_Iteration/.*$", "^does-not-exist$"} {
+		if _, err := validateCell(pattern); err == nil {
+			t.Errorf("validateCell(%q) accepted a non-singleton", pattern)
+		}
+	}
+	if _, err := validateCell("^BenchmarkListRep_B3_Iteration/arm=C0/n=4096$"); err != nil {
+		t.Fatalf("exact cell rejected: %v", err)
+	}
+}

--- a/tools/internal/spike-listrep/cmd/runner/main_test.go
+++ b/tools/internal/spike-listrep/cmd/runner/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
@@ -58,5 +59,98 @@ func TestValidateCellRejectsNonSingletonRegex(t *testing.T) {
 	}
 	if _, err := validateCell("^BenchmarkListRep_B3_Iteration/arm=C0/n=4096$"); err != nil {
 		t.Fatalf("exact cell rejected: %v", err)
+	}
+}
+
+// --- iteration 238: rerun-ORCHESTRATION arms ------------------------------
+//
+// The evaluator showed that mutating main()'s rerun batch size (5 -> 4) or
+// re-enabling allowRerun on the second paired() call both SURVIVED the whole
+// suite, because every existing arm calls paired() directly with a hand-built
+// vector and nothing exercised the orchestration. These arms pin it via an
+// injected collector, so no benchmark runs.
+
+type recordedCall struct {
+	selector string
+	start    int
+	count    int
+}
+
+// fakeCollector returns trials whose values are supplied per invocation, and
+// records the (start, count) of every batch it was asked for.
+func fakeCollector(values map[string][]float64, calls *[]recordedCall) collector {
+	return func(_ context.Context, in invocation, start, count int) []trial {
+		*calls = append(*calls, recordedCall{in.Selector, start, count})
+		out := make([]trial, 0, count)
+		for i := range count {
+			ordinal := start + i
+			out = append(out, trial{Ordinal: ordinal, Value: values[in.Selector][ordinal-1], Valid: true})
+		}
+		return out
+	}
+}
+
+func TestAdjudicateNoRerunCollectsFiveTrialsOnly(t *testing.T) {
+	// Ratios all strictly below the threshold: no tie, no spread, no rerun.
+	values := map[string][]float64{
+		"cand": {1.0, 1.0, 1.0, 1.0, 1.0},
+		"ctrl": {1.0, 1.0, 1.0, 1.0, 1.0},
+	}
+	var calls []recordedCall
+	got := adjudicate(context.Background(), fakeCollector(values, &calls),
+		invocation{Selector: "cand"}, invocation{Selector: "ctrl"}, 2.0, "<=")
+
+	if got.Rerun {
+		t.Fatalf("no rerun expected, got Rerun=true")
+	}
+	if len(calls) != 2 {
+		t.Fatalf("want exactly 2 collector batches (one per arm), got %d: %+v", len(calls), calls)
+	}
+	if len(got.Candidate) != initialTrials || len(got.Control) != initialTrials {
+		t.Fatalf("want %d trials per arm, got cand=%d ctrl=%d",
+			initialTrials, len(got.Candidate), len(got.Control))
+	}
+}
+
+func TestAdjudicateRerunCollectsExactlyFiveMoreAndDoesNotCascade(t *testing.T) {
+	// Ratios that TOUCH the threshold on both sides -> rerun is required.
+	// Ten values per arm so the rerun batch has data to draw on.
+	values := map[string][]float64{
+		"cand": {0.5, 1.0, 2.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0},
+		"ctrl": {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0},
+	}
+	var calls []recordedCall
+	got := adjudicate(context.Background(), fakeCollector(values, &calls),
+		invocation{Selector: "cand"}, invocation{Selector: "ctrl"}, 1.0, "<=")
+
+	// 1. The rerun happened: four batches, not two.
+	if len(calls) != 4 {
+		t.Fatalf("want 4 collector batches (2 initial + 2 rerun), got %d: %+v", len(calls), calls)
+	}
+	// 2. The rerun batch is exactly rerunTrials, numbered contiguously.
+	//    Kills the "rerun batch 5 -> 4" mutant.
+	for _, c := range calls[2:] {
+		if c.count != rerunTrials {
+			t.Errorf("rerun batch for %q: want count=%d, got %d", c.selector, rerunTrials, c.count)
+		}
+		if c.start != initialTrials+1 {
+			t.Errorf("rerun batch for %q: want start=%d (contiguous), got %d",
+				c.selector, initialTrials+1, c.start)
+		}
+	}
+	// 3. The median of ALL TEN is final, and the analysis is over ten operands.
+	if len(got.Candidate) != initialTrials+rerunTrials || len(got.Control) != initialTrials+rerunTrials {
+		t.Fatalf("want %d trials per arm after rerun, got cand=%d ctrl=%d",
+			initialTrials+rerunTrials, len(got.Candidate), len(got.Control))
+	}
+	if len(got.Ratios) != initialTrials+rerunTrials {
+		t.Fatalf("want %d paired ratios after rerun, got %d", initialTrials+rerunTrials, len(got.Ratios))
+	}
+	// 4. A rerun may never cascade: the final analysis is computed with
+	//    allowRerun=false, so Rerun must be cleared. Kills the
+	//    "second paired() call allowRerun false -> true" mutant.
+	if got.Rerun {
+		t.Errorf("rerun cascaded: final analysis still reports Rerun=true; " +
+			"the median of all ten must be final")
 	}
 }

--- a/tools/internal/spike-listrep/iter_bench_test.go
+++ b/tools/internal/spike-listrep/iter_bench_test.go
@@ -1,0 +1,34 @@
+package spikelistrep_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/eval"
+)
+
+func BenchmarkListRep_B3_Iteration(b *testing.B) {
+	for _, arm := range benchmarkArms {
+		for _, n := range []int{4096, 65536} {
+			b.Run(fmt.Sprintf("arm=%s/n=%d", arm.name, n), func(b *testing.B) {
+				values := make([]eval.Value, n)
+				for i := range values {
+					values[i] = &eval.IntValue{Value: i}
+				}
+				list := arm.fromSlice(values)
+				b.ReportMetric(0, "ns/element")
+				b.ResetTimer()
+				for range b.N {
+					sum := 0
+					for value := range list.All() {
+						sum += value.(*eval.IntValue).Value
+					}
+					iterationSink = sum
+				}
+				b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*n), "ns/element")
+			})
+		}
+	}
+}
+
+var iterationSink int

--- a/tools/internal/spike-listrep/len_bench_test.go
+++ b/tools/internal/spike-listrep/len_bench_test.go
@@ -1,0 +1,24 @@
+package spikelistrep_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/eval"
+)
+
+func BenchmarkListRep_BLEN_Length(b *testing.B) {
+	for _, arm := range benchmarkArms {
+		for _, n := range []int{4096, 65536} {
+			b.Run(fmt.Sprintf("arm=%s/n=%d", arm.name, n), func(b *testing.B) {
+				list := arm.fromSlice(make([]eval.Value, n))
+				b.ResetTimer()
+				for range b.N {
+					lenSink = list.Len()
+				}
+			})
+		}
+	}
+}
+
+var lenSink int

--- a/tools/internal/spike-listrep/materialize_bench_test.go
+++ b/tools/internal/spike-listrep/materialize_bench_test.go
@@ -1,0 +1,25 @@
+package spikelistrep_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/eval"
+)
+
+func BenchmarkListRep_B5_Materialize(b *testing.B) {
+	const n = 4096
+	for _, arm := range benchmarkArms {
+		b.Run(fmt.Sprintf("arm=%s/n=%d", arm.name, n), func(b *testing.B) {
+			values := make([]eval.Value, n)
+			list := arm.fromSlice(values)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				materializeSink = list.ToSlice()
+			}
+		})
+	}
+}
+
+var materializeSink []eval.Value

--- a/tools/internal/spike-listrep/nth_bench_test.go
+++ b/tools/internal/spike-listrep/nth_bench_test.go
@@ -1,0 +1,29 @@
+package spikelistrep_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/eval"
+)
+
+func BenchmarkListRep_B4_Nth(b *testing.B) {
+	const n = 4096
+	for _, arm := range benchmarkArms {
+		values := make([]eval.Value, n)
+		for i := range values {
+			values[i] = &eval.IntValue{Value: i}
+		}
+		list := arm.fromSlice(values)
+		for _, index := range []int{0, n / 4, n / 2, n - 1} {
+			b.Run(fmt.Sprintf("arm=%s/n=%d/i=%d", arm.name, n, index), func(b *testing.B) {
+				b.ResetTimer()
+				for range b.N {
+					nthSink, _ = list.At(index)
+				}
+			})
+		}
+	}
+}
+
+var nthSink eval.Value

--- a/tools/internal/spike-listrep/retained_test.go
+++ b/tools/internal/spike-listrep/retained_test.go
@@ -1,0 +1,18 @@
+package spikelistrep_test
+
+import (
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/eval"
+	spikelistrep "github.com/sunholo-data/ailang/tools/internal/spike-listrep"
+)
+
+func TestSharedSingletonElements(t *testing.T) {
+	singleton := &eval.IntValue{Value: 1}
+	values := spikelistrep.SharedSingletonElements(100, singleton)
+	for i, value := range values {
+		if value != eval.Value(singleton) {
+			t.Fatalf("element %d is not the shared singleton", i)
+		}
+	}
+}

--- a/tools/internal/spike-listrep/spikelistrep_test.go
+++ b/tools/internal/spike-listrep/spikelistrep_test.go
@@ -1,6 +1,7 @@
 package spikelistrep_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/sunholo-data/ailang/internal/eval"
@@ -13,6 +14,18 @@ func TestSliceListRoundTrip(t *testing.T) {
 
 func TestConsListRoundTrip(t *testing.T) {
 	testRoundTrip(t, spikelistrep.ConsFromSlice, spikelistrep.ConsEmpty, spikelistrep.ConsCons)
+}
+
+func TestChunkListRoundTrip(t *testing.T) {
+	for _, k := range []int{8, 32} {
+		t.Run(fmt.Sprintf("K=%d", k), func(t *testing.T) {
+			testRoundTrip(t,
+				func(v []eval.Value) spikelistrep.List { return spikelistrep.ChunkFromSlice(k, v) },
+				func() spikelistrep.List { return spikelistrep.ChunkEmpty(k) },
+				func(v eval.Value, l spikelistrep.List) spikelistrep.List { return spikelistrep.ChunkCons(k, v, l) },
+			)
+		})
+	}
 }
 
 func testRoundTrip(

--- a/tools/internal/spike-listrep/spikelistrep_test.go
+++ b/tools/internal/spike-listrep/spikelistrep_test.go
@@ -130,3 +130,41 @@ func TestBranchingIndependence(t *testing.T) {
 		})
 	}
 }
+
+// TestFromSliceDefensivelyCopies pins the defensive copy in each arm's
+// constructor. Iteration 238's evaluator landed a mutant that aliased the
+// caller's backing array instead of copying it and the ENTIRE suite stayed
+// green — including TestBranchingIndependence, which only exercises prepends
+// off a shared base and never mutates a caller-owned slice. A persistent
+// structure that aliases its input is not persistent: the caller can rewrite
+// history through a slice it still holds.
+func TestFromSliceDefensivelyCopies(t *testing.T) {
+	arms := map[string]func([]eval.Value) spikelistrep.List{
+		"C0":    spikelistrep.SliceFromSlice,
+		"C1":    spikelistrep.ConsFromSlice,
+		"C2K8":  func(v []eval.Value) spikelistrep.List { return spikelistrep.ChunkFromSlice(8, v) },
+		"C2K32": func(v []eval.Value) spikelistrep.List { return spikelistrep.ChunkFromSlice(32, v) },
+	}
+	for name, fromSlice := range arms {
+		t.Run("arm="+name, func(t *testing.T) {
+			original := &eval.IntValue{Value: 1}
+			tampered := &eval.IntValue{Value: 999}
+			backing := []eval.Value{original, original, original}
+
+			list := fromSlice(backing)
+			backing[0] = tampered // the caller still owns this array
+
+			got, ok := list.At(0)
+			if !ok {
+				t.Fatalf("At(0) not ok")
+			}
+			if got == eval.Value(tampered) {
+				t.Fatalf("constructor ALIASED the caller's slice: mutating backing[0] "+
+					"after construction changed list.At(0) to the tampered value (arm=%s)", name)
+			}
+			if got != eval.Value(original) {
+				t.Fatalf("At(0) = %v, want the original element", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## LC-1 `m-list-repr-spike` — M3, M4, M5 of 6

Mission iteration 238. **M6 (the full matrix run, the kill-criterion arithmetic and the verdict) is deliberately NOT in this PR — the programme's go/no-go remains OPEN.**

### M3 — C2 chunked cons, always-copy, K ∈ {8, 32}
Implements the candidate iteration 237's executor marked infeasible and the controller refuted. Always-copy leading chunk: no ownership tracking, no refcounting, no atomics, no locks. Every prepend copies at most one K-element chunk into a fresh node, so **O(K) = O(1) worst case** — the bound the kill criterion actually measures. The uncontended slot-write is an average-case optimisation the criterion never measures and is deliberately absent. `TestBranchingIndependence` (iteration 237's sole killer) now covers both C2 arms automatically.

### M4 — B3 / B4 / B5 / B-LEN, plus the B6 and B8 measurement programs
`B-LEN` is additive per AMB-2 (AC-3 clause (d) needs a `Len()` observable the doc's matrix has no row for; threshold unchanged). B6/B8 are non-`testing.B` `main` programs on purpose — CI runs `go test ./...` on ubuntu **and** windows, and a memory-measurement `Test*` would produce numbers nobody reads on three platforms. B8 reports **endpoint `HeapAlloc` only, no peak**, which endpoint snapshots cannot establish.

### M5 — deterministic five-trial runner and adjudicator
Fresh process per trial, ordinal pairing, median of paired ratios, and the predeclared tie/spread rerun (median on threshold, or ratios touching both sides, → five more; median of all ten is final, no cascade). Invalid trials are surfaced, never silently dropped. A cell regex matching ≠ 1 benchmark is rejected before anything runs.

---

## Provisional measurements — informative, NOT the verdict

Taken **with M5's own protocol** (five fresh processes, ordinal-paired, `-benchtime=1s`), **darwin/arm64 only**, linux and windows unrun locally. This is not M6's full 76-point matrix and **no clause is adjudicated here.**

| clause | arm | median | threshold | |
|---|---|---|---|---|
| (c) per-element memory | C1 | **1.946×** | ≤ 2.5 | ratios 1.938–1.954 |
| (d) `Len()` n-ratio | C0 / C1 / C2K8 / C2K32 | **1.000 / 0.999 / 0.999 / 1.002** | ≤ 1.2 | all tight |

B6 measured B/element: **C0 16.34–16.50** (doc derivation ≈16), **C1 31.95–32.00** (doc derivation 32), **C2K8 ≈22.0**, **C2K32 ≈17.57** (doc estimate ~16–18).

**This is why the C2 descope had to be reversed.** Clause (c) is where C1 is most at risk, and C2(K=32) sits at ≈1.07× against C1's 1.95×. Descoping C2 before that number existed would have made a STOP reachable by descope rather than by measurement.

⚠ **Clause (d)'s observable sits near the timer floor** (1–4 ns/op). At `-benchtime=100x` C1's ratio swung to **2.26×**; at the protocol's `-benchtime=1s` it is **0.999×**. The protocol's benchtime is load-bearing for clause (d) — anyone re-measuring with a smaller one will see spurious failures.

---

## Evaluator: **PASS 84/100** (sonnet, its own worktree) — three findings fixed *before* merge

1. **`main()`'s rerun orchestration was untested.** Every arm called `paired()` directly with a hand-built ten-vector, so the mechanism AC-5/R6 actually cite was unpinned. Mutating the rerun batch (5→4) and re-enabling `allowRerun` on the second call **both survived the whole suite**. Now pinned by two arms over an injected collector; both mutants die and the new arm is the **sole killer** for each.
2. **`newChunkList`'s defensive copy was uncovered.** A mutant aliasing the caller's backing array kept the entire suite green — `TestBranchingIndependence` only prepends off a shared base and never mutates a caller-owned slice. `TestFromSliceDefensivelyCopies` covers all four arms; sole killer, reds exactly C2K8/C2K32.
3. **AC-7's base SHA was a stale literal** — 6 commits behind `origin/dev`, reporting **10** violations all inherited from an unrelated eval commit, against **0** on the derived base (unscoped control 15). It manufactures a *STOP by artifact rather than by measurement*. The step now **derives** the base via `git merge-base`. Iteration 237 fixed this in its executor directive only, so the plan carried the stale literal for a second iteration.

Every mutation asserted **LANDED** (sha256) and **BUILDS** (`go build` rc=0) *before* any test result was read, and restored from a `cp` backup with byte-identity re-asserted. No `git checkout --` was used.

## Controller-found defect, fixed here

**AC-4 leg 3's gate matched `==`.** Measured: the plan's regex returns **3** hits on correct code, all `==` comparisons, all outside constructors — so the clause, read literally, **fails on a tree with zero violations**. The assignment-only form returns **0** (an empty result is the PASS here, so the "empty grep = broken instrument" rule does not apply), proved live by a deliberate probe instead. Constructor writes are **composite literals**, invisible to both regex forms, so no `=`-shaped grep can verify the "inside a constructor" half at all — it is now a separate check.

## Gates

Derived from `ci.yml`, not recalled: `go build ./tools/...`, `go vet ./tools/...`, `make vet`, `make fmt-check`, `make check-file-sizes`, `make check-boundaries`, `make check-changelog`, `make check-skills`, `go test -timeout 300s ./tools/...` — **all rc=0**. `gofmt -l` over `internal cmd tools std` is empty **with a firing control**. `make test` rc=0, zero failures, run with a **freshly built binary prepended to `PATH`** (the installed `~/go/bin/ailang` is 37 commits stale and reds `TestGoldenCompile` for that reason alone). **All darwin/arm64; linux and windows legs unrun locally and settled by CI.**

AC-7 anti-goal, both arms against the derived base: scoped **0** lines, unscoped control **15**. No production file is touched — the whole diff is `tools/internal/spike-listrep/**` plus the plan and changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
