### PR TITLE
docs(limitations): LC-0 — `::` is O(n), so prepend-built lists are quadratic, and recursion stops at 10,000 frames

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,26 @@
 
 ## [Unreleased]
 
+### Documented — `::` is O(n), so prepend-built lists are quadratic; recursion caps at 10,000 frames
+
+LC-0 of the cons-cell programme: the representation fix is 15.5-21.5 person-days and has not
+shipped, so the limitation is now stated honestly instead of being rediscovered. Full entry in
+`docs/docs/reference/limitations.md` (the canonical page), summary row in `docs/LIMITATIONS.md`.
+
+`eval.ListValue` is a flat Go slice (`internal/eval/value.go:84-86`) and `listConsImpl` copies the
+whole tail on every `::` (`internal/builtins/list.go:87`), so one prepend is O(len(tail)) and a
+prepend-built list is O(n^2). Scale, cited as dated LC-1 measurements (2026-08-20): the heaviest
+control cell (m=4096 prepends onto a retained L=16384 tail) ran 54.8 ms/op against 73 us/op for
+cons cells, with a median 417 GC cycles at n=12800.
+
+Separately, `ailang run` caps evaluator recursion at 10,000 frames (`RT_REC_003`) and there is no
+tail-call elimination, so deep right-recursion hits a wall rather than flattening.
+
+Workarounds are verified against the Go builtins rather than assumed: `map` and `takeMap` allocate
+the result once and never cons; `foldl` is iterative but is a workaround ONLY for scalar/record
+accumulation — growing a list accumulator with `++` is quadratic exactly as `::` is, since
+`listConcatImpl` copies both operands, and `++` is the idiom the prompt teaches. Reported at #676.
+
 ### Added — LC-1 list-representation spike reaches its kill criterion: GO
 
 M6 of `m-list-repr-spike` runs the full 76-point measurement matrix (5 fresh-process

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -28,6 +28,7 @@ workarounds. Verified open at v0.33.1 (2026-08-17):
 | **Raw-mode single keypress / mid-call `std/ai.step()` abort** | Narrow input gaps | line input (`readLine`, `asyncReadStdinLines`) works; raw keypress is out-of-core by design. |
 | **Regex backreferences / lookaround** | Design constraint (RE2 linear-time guarantee) | `std/regex` wraps Go's RE2 engine → **no backreferences, no lookahead/lookbehind**. `regex.compile("(a)\\1")` / `compile("(?=x)")` return `Err(message)` (never panic). This is the deliberate price of the linear-time, no-catastrophic-backtracking guarantee. |
 | **Strict `take` after `flatMap` / allocating `map` bounds results, not peak memory** | Design constraint (strict evaluation) | Use `takeFlatMap(n, f, xs)` or, when `f` allocates, `takeMap(n, f, xs)`; [canonical entry](docs/docs/reference/limitations.md#strict-evaluation-taken-flatmapf-xs-bounds-the-result-not-the-peak) has the v0.33.0 repro and remaining bounds. |
+| **Quadratic `::` prepend / 10,000-frame evaluator recursion cap** | Runtime limitations (representation fix in progress) | Flat-slice `ListValue` makes every cons copy its tail; deep recursion returns `RT_REC_003`. Prefer builtin-backed `map` / `takeMap`, or `foldl` for non-list aggregation; `--max-recursion-depth N` raises only the depth wall, not the cons memory cost. See the [canonical entry](docs/docs/reference/limitations.md#prepending-with--is-quadratic-evaluator-recursion-is-capped-at-10000-frames). |
 
 ### If-Else Branches Require Explicit Braces {#if-else-branches-require-explicit-braces}
 

--- a/docs/docs/reference/limitations.md
+++ b/docs/docs/reference/limitations.md
@@ -247,6 +247,67 @@ Single-expression branches don't need braces.
 
 ## Language Feature Gaps
 
+### Prepending with `::` is quadratic; evaluator recursion is capped at 10,000 frames
+
+**Status**: Known runtime limitations; the list fix is a multi-week representation change now in progress, not yet shipped
+**Verified at**: v0.33.1-171-gc62e64878 (2026-08-21)
+
+These are two separate limits that often meet in hand-written recursive list builders:
+
+#### 1. Quadratic list construction by prepending (`::` / cons)
+
+The evaluator does not currently represent a list as cons cells. `eval.ListValue` stores a flat Go
+slice (`internal/eval/value.go:84-86`), and every `::` allocates a new slice and appends every element
+of the tail (`internal/builtins/list.go:87,98-103`). One prepend is therefore O(length of tail), and a
+list built by repeatedly prepending is O(n²) in copied element references and allocation volume.
+
+The LC-1 representation spike measured this same current-slice control on 2026-08-20: its heaviest
+branching-prepend cell (4,096 prepends onto a retained 16,384-element tail) took **54.8 ms/op**,
+versus **73 µs/op** for the candidate cons-cell representation. The n=12,800 current-slice workload
+also produced a median **417 Go GC cycles** across five trials. Those are dated spike measurements,
+not estimates; see
+[`m-list-repr-spike-M6-report.md`](https://github.com/sunholo-data/ailang/blob/dev/design_docs/implemented/v0_34_0/m-list-repr-spike-M6-report.md).
+
+**Workarounds**:
+
+1. Prefer the iterative builtin-backed `std/list.map` when transforming an entire existing list,
+   or `std/list.takeMap` when only a prefix is required. Their Go implementations allocate the
+   result slice directly and fill it in one pass (`internal/builtins/list_iterative.go:68-89` and
+   `internal/builtins/list_bounded.go:78-113`); neither invokes `::` per result.
+2. Use builtin-backed `std/list.foldl` for scalar or record aggregation instead of hand-written
+   recursion (`internal/builtins/list_iterative.go:202-223`). Do **not** grow a *list* accumulator
+   inside the fold: the fold itself is iterative, but its callback still pays the per-call copy.
+   This applies to **`++` exactly as much as to `::`** — `listConcatImpl`
+   (`internal/builtins/list.go:161`) allocates a fresh slice and copies both operands, so
+   `acc ++ [x]` is O(len(`acc`)) per step and `foldl(\acc. \x. acc ++ [x], [], xs)` is quadratic
+   in the same way `x :: acc` is. `++` is the idiom the AILANG prompt teaches for list
+   concatenation, so it is the likelier of the two mistakes, not the safer one. `foldl` is a
+   workaround only when the accumulator is a **scalar or record**.
+
+The permanent fix changes the evaluator's list representation and its consumers. That is a
+multi-week programme currently in progress; the representation spike returned GO, but no runtime
+representation fix has shipped yet.
+
+#### 2. Evaluator recursion depth cap (`RT_REC_003`)
+
+`ailang run` caps evaluator recursion at **10,000 frames** by default
+(`cmd/ailang/main_run.go:35`; the evaluator defaults are also set at
+`internal/eval/eval_evaluator.go:148,160`). Exceeding the cap returns `RT_REC_003`, as pinned by
+`internal/eval/recursion_test.go:265,301-302`. The evaluator has no tail-call elimination, so even
+tail-position or deep right-recursive code reaches this wall instead of becoming an iterative
+loop. A same-scope scan on 2026-08-21 found the positive `recursionDepth` guard in two files under
+`internal/eval/` and no tail-call implementation there; the sole tail-call match is a test that
+explicitly verifies the evaluator does not advertise nonexistent tail-call elimination.
+
+The executable remedy test at v0.33.1-171-gc62e64878 (2026-08-21) measured a right-recursive
+`sum(300)`: it raises `RT_REC_003` with a 100-frame ceiling and completes after the ceiling is raised
+to 10,000 (`internal/eval/rt_rec_003_message_test.go:31-112`).
+
+**Workaround**: pass `--max-recursion-depth N` to raise the evaluator's depth ceiling. Prefer the
+iterative `map`, `foldl`, and `takeMap` paths above where they express the operation. Raising the
+depth ceiling does **not** add tail-call elimination and does **not** fix the memory amplification
+from `::`; allowing a quadratic recursive builder to run longer can increase its memory use.
+
 ### Strict evaluation: `take(n, flatMap(f, xs))` bounds the result, not the peak
 
 **Status**: Design constraint (strict evaluation)


### PR DESCRIPTION
## LC-0 `m-list-interim-communication` — the honest-communication piece

`design_docs/planned/m-list-cons-cells-decomposition.md` §LC-0 (0.5 d, quorum-cleared over two
rounds + carve-out). Docs-only: **2 files, +56 lines, no code**.

The representation programme (LC-1…LC-5) is 15.5–21.5 person-days. LC-1's spike returned **GO** on
2026-08-20, but no runtime change has shipped, and the defect reported at #676 is live. LC-0 says so
in the docs now, with workarounds that were verified rather than assumed.

### What landed

- **`docs/docs/reference/limitations.md`** (the canonical page) — a full entry covering two separate
  limits: quadratic construction by prepending (`::`), and the 10,000-frame recursion cap
  (`RT_REC_003`, no tail-call elimination).
- **`docs/LIMITATIONS.md`** — one summary row, matching the existing table's three columns.

**Adjudicated deviation from the AC's letter:** the design doc's AC names only `docs/LIMITATIONS.md`.
At HEAD that file declares itself a *"pointer + short summary"* and names the website copy canonical
(*"authoritative and carries per-entry repro transcripts + verified-at dates"*). Writing the entry
only into the root file would satisfy the AC while violating that file's own stated policy, so the
full entry is in the canonical page and the root gets the summary row.

### Controller verification, outside the sandbox

| Check | Result | Control |
|---|---|---|
| `file:line` citations resolve to the claimed symbol | **9/9** | negative control correctly unresolved |
| root → canonical anchors resolve (github-slugger, as Docusaurus uses) | **2/2** | pre-existing anchor resolves |
| `m`/`L` semantics vs `branching_bench_test.go` | m = prepend count, L = retained base length — doc's plain-English rendering is faithful | benchmark body read directly |
| `make check-changelog` · `test-check-changelog` · `check-file-sizes` · `check-skills` | all **rc=0** | freshly built binary prepended to `PATH` |

Numbers are cited as **dated** LC-1 measurements (2026-08-20), not re-measured here — 54.8 ms/op vs
73 µs/op at m=4096/L=16384, median 417 GC cycles at n=12800. The inherited pprof/RSS figures from the
#676 triage were deliberately **not** used, because they were not re-derived.

Workarounds are each backed by reading the Go builtin: `map`/`takeMap` allocate once and never cons;
`foldl` is iterative but is recommended only for scalar aggregation, since consing into a list
accumulator keeps the quadratic cost.

Green on darwin/arm64; linux and windows legs unrun locally and settled by CI.

### Evaluator round 1: **FAIL** → fixed before merge

The sonnet evaluator (its own worktree) scored 74/100 and failed it on one blocking finding, which I
reproduced first-party before acting: **the `foldl` carve-out named `::` only.** `++` has the
identical cost shape — `listConcatImpl` (`internal/builtins/list.go:161`) allocates a fresh slice and
copies both operands — so `foldl(\acc. \x. acc ++ [x], [], xs)` is quadratic exactly as `x :: acc`
is (judge measured ~4× per doubling). `++` is what `prompts/v0.16.1.md:170` teaches for list concat,
so it is the **likelier** mistake, not the safer one. A docs page whose workaround walks the reader
back into the defect it documents is worse than no page.

Fixed: the carve-out now names both operators, cites `listConcatImpl`, and restricts `foldl` to
scalar/record accumulators. The judge's second finding (no changelog entry) is also addressed. The
same correction was posted to #676, where the original wording had already gone out.

**Third finding, recorded rather than inherited:** the evaluator reported
`TestGoldenCompile/string_charat` failing on `undefined: CharCode` as a pre-existing codegen defect.
Two arms on the identical tree: stale PATH binary **rc=1**, freshly built binary **rc=0**. It is the
stale-binary instrument trap, not the code — the conclusion (unrelated to LC-0) was right, the
characterisation was not.

Reported at #676, which stays open until a runtime fix ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
