### PR TITLE
ci(guard): refuse issue-closing phrases in records that ship no code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,28 @@ jobs:
     - name: Changelog index gate self-test
       run: make test-check-changelog
 
+    # Squash merges turn the PR title and body into the merge commit message, so
+    # PR text is the primary record. Pushes scan the exact delivered commit range.
+    - name: Check accidental issue auto-closure
+      shell: bash
+      run: |
+        case "$GITHUB_EVENT_NAME" in
+          pull_request)
+            jq -r '.pull_request.title // "", .pull_request.body // ""' "$GITHUB_EVENT_PATH" > "$RUNNER_TEMP/autoclose-pr-text"
+            git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" > "$RUNNER_TEMP/autoclose-pr-files"
+            make check-autoclose AUTOCLOSE_ARGS="--text-file $RUNNER_TEMP/autoclose-pr-text --files-from $RUNNER_TEMP/autoclose-pr-files"
+            ;;
+          push)
+            make check-autoclose AUTOCLOSE_ARGS="--commits ${{ github.event.before }}..${{ github.sha }}"
+            ;;
+          *)
+            make check-autoclose AUTOCLOSE_ARGS="--commits HEAD^..HEAD"
+            ;;
+        esac
+
+    - name: Issue autoclose gate self-test
+      run: make test-check-autoclose
+
     - name: Check skill frontmatter
       run: make check-skills
 

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -12,7 +12,7 @@ is refused; code-shipping records remain valid. An issue-specific `Autoclose-OK:
 the explicit escape hatch for a genuine documentation issue.
 
 The discriminator is pinned to the measured corpus since 2026-06-01: 24 keyword-hit commits were
-reported, with 20 code-shipping commits (all legitimate) and 5 docs-only hazard commits. Recording
+reported, with 19 code-shipping commits (all legitimate) and 5 docs-only hazard commits. Recording
 those first-party counts here makes any future broadening or narrowing of the rule reviewable
 against the evidence that selected it.
 

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,18 @@
 
 ## [Unreleased]
 
+### Added — CI refuses accidental issue auto-closure from docs-only records
+
+`make check-autoclose` now scans commit messages and squash-merge PR title/body text for GitHub
+closing keywords followed by issue references. A matching record that changes only documentation
+is refused; code-shipping records remain valid. An issue-specific `Autoclose-OK: #N` trailer is
+the explicit escape hatch for a genuine documentation issue.
+
+The discriminator is pinned to the measured corpus since 2026-06-01: 24 keyword-hit commits were
+reported, with 20 code-shipping commits (all legitimate) and 5 docs-only hazard commits. Recording
+those first-party counts here makes any future broadening or narrowing of the rule reviewable
+against the evidence that selected it.
+
 ### Documented — `::` is O(n), so prepend-built lists are quadratic; recursion caps at 10,000 frames
 
 LC-0 of the cons-cell programme: the representation fix is 15.5-21.5 person-days and has not

--- a/docs/docs/guides/development-workflow.md
+++ b/docs/docs/guides/development-workflow.md
@@ -247,6 +247,19 @@ Fixes #17
 Fixes #42"
 ```
 
+### Accidental Auto-Close Guard
+
+GitHub treats a closing keyword immediately followed by an issue reference in a commit message,
+PR title, or PR body as an instruction to close that issue. Because this repository squash-merges,
+the PR title and body become the merge commit message. CI therefore runs `make check-autoclose`
+against PR text and its changed-file list (or against the delivered commit range on pushes).
+
+The gate refuses phrases such as `fixes #676` when the record ships documentation only. Describe
+the relationship without putting the keyword before the number: `#676 is fixed by ...`, `the
+defect in #676`, or `reported at #676`. If a docs-only change genuinely closes a documentation
+issue, add the issue-specific trailer `Autoclose-OK: #676`. A bare `Autoclose-OK:` is an instrument
+error, and a trailer for one issue never suppresses another.
+
 ## Best Practices
 
 ### Realistic Estimates

--- a/make/code-health.mk
+++ b/make/code-health.mk
@@ -142,6 +142,10 @@ check-boundaries: ## Check architecture layer boundaries (CI gate)
 check-changelog: ## Check root CHANGELOG.md stays an index, not a changelog (CI gate)
 	@bash scripts/check_changelog.sh
 
+AUTOCLOSE_ARGS ?= --commits origin/dev..HEAD
+check-autoclose: ## Refuse issue-closing phrases in docs-only commit/PR records (CI gate)
+	@bash scripts/check_autoclose.sh $(AUTOCLOSE_ARGS)
+
 check-skills: ## Check .claude/skills/*/SKILL.md have name+description frontmatter (CI gate)
 	@bash scripts/check_skills.sh
 

--- a/make/test.mk
+++ b/make/test.mk
@@ -7,7 +7,7 @@
 .PHONY: test-operator-assertions test-regression-guards test-builtin-consistency
 .PHONY: test-stdlib-canaries test-row-properties test-golden-types test-repl-smoke
 .PHONY: test-sim-stub test-stdlib-freeze verify-no-shim verify-lowering
-.PHONY: test-nightly-classifier test-launchd-drivers test-check-changelog
+.PHONY: test-nightly-classifier test-launchd-drivers test-check-changelog test-check-autoclose
 
 # Core tests. Depends on build so integration tests that shell out to the
 # ailang binary never see a stale bin/ailang — a stale binary caused phantom
@@ -52,6 +52,10 @@ test-launchd-drivers: ## Run launchd driver tests (pin-root + routing + notices 
 test-check-changelog: ## Run the changelog-index gate's own self-test (bash 3.2)
 	@/bin/bash scripts/test_check_changelog.sh
 	@/bin/bash -n scripts/check_changelog.sh
+
+test-check-autoclose: ## Run the issue-autoclose gate's own self-test (bash 3.2)
+	@/bin/bash scripts/test_check_autoclose.sh
+	@/bin/bash -n scripts/check_autoclose.sh
 
 test-parser: ## Run parser tests only
 	@echo "Testing parser..."

--- a/scripts/check_autoclose.sh
+++ b/scripts/check_autoclose.sh
@@ -141,7 +141,7 @@ if [ "$INSTRUMENT_ERROR" -eq 0 ] && [ -n "$COMMITS_RANGE" ]; then
 			[ -z "$_sha" ] && continue
 			_message="$TMPDIR_AUTOCLOSE/message.$_sha"
 			_files="$TMPDIR_AUTOCLOSE/files.$_sha"
-			if ! git show -s --format=%B "$_sha" > "$_message" || ! git diff-tree --no-commit-id --name-only -r --root "$_sha" > "$_files"; then
+			if ! git show -s --format=%B "$_sha" > "$_message" || ! git diff-tree --no-commit-id --name-only -r -m --root "$_sha" > "$_files"; then
 				record_error "INSTRUMENT FAILURE: cannot read commit $_sha"
 				break
 			fi
@@ -155,8 +155,6 @@ if [ "$INSTRUMENT_ERROR" -eq 0 ] && [ -n "$TEXT_FILE" ]; then
 		record_error "INSTRUMENT FAILURE: text file not found: $TEXT_FILE"
 	elif [ ! -f "$FILES_FROM" ]; then
 		record_error "INSTRUMENT FAILURE: changed-file list not found: $FILES_FROM"
-	elif [ ! -s "$FILES_FROM" ]; then
-		record_error "INSTRUMENT FAILURE: no changed files enumerated from $FILES_FROM"
 	else
 		scan_record "PR title/body" "$TEXT_FILE" "$FILES_FROM"
 	fi

--- a/scripts/check_autoclose.sh
+++ b/scripts/check_autoclose.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Refuse GitHub auto-close phrases in records that ship documentation only.
+# GitHub interprets commit messages and squash-merge PR title/body text, but not
+# repository file contents. Keep this script compatible with bash 3.2.
+set -eu
+
+KEYWORD_PATTERN='(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]*:?[[:space:]]*#[0-9]+'
+
+COMMITS_RANGE=""
+TEXT_FILE=""
+FILES_FROM=""
+INSTRUMENT_ERROR=0
+ERROR_MESSAGE=""
+RECORDS_SCANNED=0
+VIOLATIONS=0
+
+# Refusal branch R0: without private scratch space the enumerator cannot run.
+if ! TMPDIR_AUTOCLOSE=$(mktemp -d "${TMPDIR:-/tmp}/check-autoclose.XXXXXX"); then
+	echo "INSTRUMENT FAILURE: cannot create temporary workspace" >&2
+	exit 2
+fi
+trap 'rm -rf "$TMPDIR_AUTOCLOSE"' EXIT HUP INT TERM
+
+record_error() {
+	if [ "$INSTRUMENT_ERROR" -eq 0 ]; then
+		ERROR_MESSAGE="$1"
+	fi
+	INSTRUMENT_ERROR=1
+}
+
+usage_error() {
+	record_error "$1
+usage: scripts/check_autoclose.sh [--commits <git-range>] [--text-file <f> --files-from <g>]"
+}
+
+is_docs_path() {
+	case "$1" in
+		docs/*|design_docs/*|changelogs/*|CHANGELOG|CHANGELOG.*|README|README.*|.claude/*|.agents/*)
+			return 0
+			;;
+		*)
+			case "$1" in
+				*/*) return 1 ;;
+				*.md) return 0 ;;
+				*) return 1 ;;
+			esac
+			;;
+	esac
+}
+
+ships_code() {
+	_files="$1"
+	while IFS= read -r _path || [ -n "$_path" ]; do
+		[ -z "$_path" ] && continue
+		if ! is_docs_path "$_path"; then
+			return 0
+		fi
+	done < "$_files"
+	return 1
+}
+
+trailer_allows() {
+	_text="$1"
+	_issue="$2"
+	grep -Eiq "^[[:space:]]*Autoclose-OK:[[:space:]]*#${_issue}([[:space:]]*)$" "$_text"
+}
+
+scan_record() {
+	_label="$1"
+	_text="$2"
+	_files="$3"
+	RECORDS_SCANNED=$((RECORDS_SCANNED + 1))
+
+	if grep -Eq '^[[:space:]]*Autoclose-OK:[[:space:]]*$' "$_text"; then
+		record_error "ERROR: $_label has malformed trailer 'Autoclose-OK:'; name an issue as Autoclose-OK: #N"
+		return
+	fi
+
+	_hits="$TMPDIR_AUTOCLOSE/hits.$RECORDS_SCANNED"
+	if ! grep -Ein "$KEYWORD_PATTERN" "$_text" > "$_hits"; then
+		return
+	fi
+	if ships_code "$_files"; then
+		return
+	fi
+
+	while IFS= read -r _hit || [ -n "$_hit" ]; do
+		_phrases="$TMPDIR_AUTOCLOSE/phrases.$RECORDS_SCANNED"
+		printf '%s\n' "$_hit" | grep -Eio "$KEYWORD_PATTERN" > "$_phrases"
+		while IFS= read -r _phrase || [ -n "$_phrase" ]; do
+			_issue=$(printf '%s\n' "$_phrase" | grep -Eo '#[0-9]+' | head -1 | tr -d '#')
+			if trailer_allows "$_text" "$_issue"; then
+				continue
+			fi
+			VIOLATIONS=$((VIOLATIONS + 1))
+			printf 'VIOLATION: %s: issue #%s\n' "$_label" "$_issue"
+			printf '  context: %s\n' "$_hit"
+			printf '  matched: %s\n' "$_phrase"
+		done < "$_phrases"
+	done < "$_hits"
+}
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--commits)
+			if [ "$#" -lt 2 ]; then usage_error "ERROR: --commits requires a git range"; break; fi
+			if [ -n "$COMMITS_RANGE" ]; then usage_error "ERROR: --commits may be specified only once"; break; fi
+			COMMITS_RANGE="$2"
+			shift 2
+			;;
+		--text-file)
+			if [ "$#" -lt 2 ]; then usage_error "ERROR: --text-file requires a path"; break; fi
+			TEXT_FILE="$2"
+			shift 2
+			;;
+		--files-from)
+			if [ "$#" -lt 2 ]; then usage_error "ERROR: --files-from requires a path"; break; fi
+			FILES_FROM="$2"
+			shift 2
+			;;
+		*)
+			usage_error "ERROR: unknown argument: $1"
+			break
+			;;
+	esac
+done
+
+if [ -z "$COMMITS_RANGE" ] && [ -z "$TEXT_FILE" ] && [ -z "$FILES_FROM" ]; then
+	usage_error "ERROR: select --commits and/or --text-file with --files-from"
+fi
+if { [ -n "$TEXT_FILE" ] && [ -z "$FILES_FROM" ]; } || { [ -z "$TEXT_FILE" ] && [ -n "$FILES_FROM" ]; }; then
+	usage_error "ERROR: --text-file and --files-from must be provided together"
+fi
+
+if [ "$INSTRUMENT_ERROR" -eq 0 ] && [ -n "$COMMITS_RANGE" ]; then
+	_commits="$TMPDIR_AUTOCLOSE/commits"
+	if ! git rev-list "$COMMITS_RANGE" > "$_commits" 2> "$TMPDIR_AUTOCLOSE/git-error"; then
+		record_error "INSTRUMENT FAILURE: cannot enumerate commit range '$COMMITS_RANGE': $(sed -n '1p' "$TMPDIR_AUTOCLOSE/git-error")"
+	else
+		while IFS= read -r _sha || [ -n "$_sha" ]; do
+			[ -z "$_sha" ] && continue
+			_message="$TMPDIR_AUTOCLOSE/message.$_sha"
+			_files="$TMPDIR_AUTOCLOSE/files.$_sha"
+			if ! git show -s --format=%B "$_sha" > "$_message" || ! git diff-tree --no-commit-id --name-only -r --root "$_sha" > "$_files"; then
+				record_error "INSTRUMENT FAILURE: cannot read commit $_sha"
+				break
+			fi
+			scan_record "$_sha" "$_message" "$_files"
+		done < "$_commits"
+	fi
+fi
+
+if [ "$INSTRUMENT_ERROR" -eq 0 ] && [ -n "$TEXT_FILE" ]; then
+	if [ ! -f "$TEXT_FILE" ]; then
+		record_error "INSTRUMENT FAILURE: text file not found: $TEXT_FILE"
+	elif [ ! -f "$FILES_FROM" ]; then
+		record_error "INSTRUMENT FAILURE: changed-file list not found: $FILES_FROM"
+	elif [ ! -s "$FILES_FROM" ]; then
+		record_error "INSTRUMENT FAILURE: no changed files enumerated from $FILES_FROM"
+	else
+		scan_record "PR title/body" "$TEXT_FILE" "$FILES_FROM"
+	fi
+fi
+
+# Refusal branch R2: malformed input, enumeration/read failure, or usage error.
+if [ "$INSTRUMENT_ERROR" -ne 0 ]; then
+	printf '%s\n' "$ERROR_MESSAGE" >&2
+	exit 2
+fi
+
+# Refusal branch R3: an empty commit range must never certify itself green.
+if [ "$RECORDS_SCANNED" -eq 0 ]; then
+	echo "INSTRUMENT FAILURE: no records enumerated" >&2
+	exit 2
+fi
+
+# Refusal branch R1: docs-only text that GitHub would interpret as issue closure.
+if [ "$VIOLATIONS" -ne 0 ]; then
+	cat <<'EOF'
+
+Remedy:
+  - rephrase so the keyword does not precede the number:
+      "fixes #676"  ->  "#676 is fixed by ..."  /  "the defect in #676"  /  "reported at #676"
+  - or, if this docs commit really does close the issue, add a trailer:  Autoclose-OK: #676
+EOF
+	printf '✗ check-autoclose: %s records scanned, %s violations\n' "$RECORDS_SCANNED" "$VIOLATIONS"
+	exit 1
+fi
+
+printf '✓ check-autoclose: %s records scanned, 0 violations\n' "$RECORDS_SCANNED"

--- a/scripts/test_check_autoclose.sh
+++ b/scripts/test_check_autoclose.sh
@@ -9,7 +9,7 @@ trap 'rm -rf "$WORK"' EXIT HUP INT TERM
 
 FAILED=0
 FIXTURES_RUN=0
-FIXTURES_EXPECTED=10
+FIXTURES_EXPECTED=16
 OUT=""
 RC=0
 
@@ -91,6 +91,72 @@ expect_rc 'VACUITY empty commit range' 2 'INSTRUMENT FAILURE: no records enumera
 OUT=$(TMPDIR="$WORK/no-such-parent/child" "$GATE" --commits HEAD..HEAD 2>&1)
 RC=$?
 expect_rc 'TEMPFAIL unavailable scratch directory' 2 'INSTRUMENT FAILURE: cannot create temporary workspace'
+
+# --- Instrument-integrity arms (iteration 241 evaluator, BLOCKING findings) ---------------
+# The guards below all EXISTED, but no fixture killed them: neutering the text-file-exists
+# check left the whole self-test green while a missing text file passed rc=0 CLEAN. In CI the
+# text file is written by jq from the event payload, so a silent pass there is exactly the
+# vacuous-pass class this gate exists to prevent. A guard is not a gate until something reds.
+
+OUT=$("$GATE" --text-file "$WORK/definitely-absent-text" --files-from "$WORK/definitely-absent-files" 2>&1)
+RC=$?
+expect_rc 'MISSINGTEXT absent text file' 2 'INSTRUMENT FAILURE: text file not found'
+
+mkdir -p "$WORK/missingfiles"
+printf '%s\n' 'a record with no issue references' > "$WORK/missingfiles/text"
+OUT=$("$GATE" --text-file "$WORK/missingfiles/text" --files-from "$WORK/definitely-absent-files" 2>&1)
+RC=$?
+expect_rc 'MISSINGFILES absent changed-file list' 2 'INSTRUMENT FAILURE: changed-file list not found'
+
+OUT=$(cd "$EMPTY_REPO" && "$GATE" --commits HEAD..HEAD --not-a-real-flag 2>&1)
+RC=$?
+expect_rc 'UNKNOWNARG unrecognised argument' 2 'unknown argument'
+
+# An EXISTING but empty changed-file list is not an instrument failure: it is a record that
+# ships no code, which is precisely the hazard condition. It must be SCANNED, not errored --
+# otherwise an empty-diff PR whose body closes an issue escapes through an rc=2 that reads
+# like a broken instrument.
+mkdir -p "$WORK/emptyfiles"
+printf '%s\n' 'this closes #4242 with no code at all' > "$WORK/emptyfiles/text"
+: > "$WORK/emptyfiles/files"
+OUT=$("$GATE" --text-file "$WORK/emptyfiles/text" --files-from "$WORK/emptyfiles/files" 2>&1)
+RC=$?
+expect_rc 'EMPTYFILES no-code record is scanned, not errored' 1 'issue #4242'
+
+printf '%s\n' 'a rebase-only PR that references nothing' > "$WORK/emptyfiles/text2"
+OUT=$("$GATE" --text-file "$WORK/emptyfiles/text2" --files-from "$WORK/emptyfiles/files" 2>&1)
+RC=$?
+expect_rc 'EMPTYFILES clean no-code record passes' 0 '1 records scanned, 0 violations'
+
+# A real 2-parent merge commit. `git diff-tree --root` without `-m` reports ZERO files for a
+# merge, so a merge whose own message carries a closing keyword would be misread as shipping no
+# code and refused. Measured on origin/dev: 60 merge commits exist, and the as-written form saw
+# 0 files where `-m` saw 5. This arm pins the `-m`.
+MERGE_REPO="$WORK/merge-repo"
+mkdir -p "$MERGE_REPO"
+(
+	cd "$MERGE_REPO" || exit 1
+	git init -q
+	git config user.email test@example.invalid
+	git config user.name 'Autoclose Gate Test'
+	git symbolic-ref HEAD refs/heads/main
+	mkdir -p internal/foo
+	printf '%s\n' 'package foo' > internal/foo/bar.go
+	git add internal/foo/bar.go
+	git commit -q -m base
+	git checkout -q -b side
+	printf '%s\n' 'package foo // side' > internal/foo/bar.go
+	git commit -q -am side-change
+	git checkout -q main
+	printf '%s\n' 'main note' > MAINLINE.txt
+	git add MAINLINE.txt
+	git commit -q -m main-change
+	git merge --no-ff -q -m 'merge side: fixes #4321' side 2>/dev/null || \
+		git merge --no-ff -q --strategy-option=theirs -m 'merge side: fixes #4321' side
+)
+OUT=$(cd "$MERGE_REPO" && "$GATE" --commits 'HEAD^..HEAD' 2>&1)
+RC=$?
+expect_rc 'MERGECOMMIT ships code via -m, not misread as docs-only' 0 '0 violations'
 
 if [ "$FIXTURES_RUN" -ne "$FIXTURES_EXPECTED" ]; then
 	echo "  FAIL — $FIXTURES_RUN of $FIXTURES_EXPECTED fixtures ran; refusing vacuous green"

--- a/scripts/test_check_autoclose.sh
+++ b/scripts/test_check_autoclose.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Self-test for every observable refusal in check_autoclose.sh. Bash 3.2 only.
+set -u
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+GATE="$REPO_ROOT/scripts/check_autoclose.sh"
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/test-check-autoclose.XXXXXX") || exit 1
+trap 'rm -rf "$WORK"' EXIT HUP INT TERM
+
+FAILED=0
+FIXTURES_RUN=0
+FIXTURES_EXPECTED=10
+OUT=""
+RC=0
+
+pass() { echo "  ok   — $1"; FIXTURES_RUN=$((FIXTURES_RUN + 1)); }
+fail() { echo "  FAIL — $1"; FAILED=1; FIXTURES_RUN=$((FIXTURES_RUN + 1)); }
+
+run_text() {
+	_name="$1"
+	_text="$2"
+	_file="$3"
+	_dir="$WORK/$_name"
+	mkdir -p "$_dir"
+	printf '%s\n' "$_text" > "$_dir/text"
+	printf '%s\n' "$_file" > "$_dir/files"
+	OUT=$("$GATE" --text-file "$_dir/text" --files-from "$_dir/files" 2>&1)
+	RC=$?
+}
+
+expect_rc() {
+	_name="$1"
+	_want="$2"
+	_fragment="$3"
+	if [ "$RC" -ne "$_want" ]; then
+		fail "$_name — expected rc=$_want, got rc=$RC"
+	elif ! printf '%s\n' "$OUT" | grep -qF "$_fragment"; then
+		fail "$_name — rc=$RC came from the wrong path (missing: $_fragment)"
+	else
+		pass "$_name (rc=$RC)"
+	fi
+}
+
+echo "autoclose gate:"
+
+run_text bad1 'the arena fixes #676 completely' 'design_docs/record.md'
+expect_rc 'BAD-1 docs-only arena phrase' 1 'issue #676'
+
+run_text bad2 'a "Fixes #612" would wrongly auto-close the follow-up' 'docs/record.md'
+expect_rc 'BAD-2 self-referential warning' 1 'issue #612'
+
+run_text bad3 'Fix #2 (gpt5-6-sol): new bounded-execution section' 'changelogs/v0.18-current.md'
+expect_rc 'BAD-3 ordinal-looking issue phrase' 1 'issue #2'
+
+run_text good1 'Fixes #694' 'internal/foo/bar.go'
+expect_rc 'GOOD-1 code-shipping record' 0 '1 records scanned, 0 violations'
+
+run_text good2 '#598 closed as a duplicate of #602' 'design_docs/record.md'
+expect_rc 'GOOD-2 inverted closure wording' 0 '1 records scanned, 0 violations'
+
+run_text good3 'reported at #676 and filed as #612' 'README.md'
+expect_rc 'GOOD-3 neutral references' 0 '1 records scanned, 0 violations'
+
+run_text good4 'fixes #676
+
+Autoclose-OK: #676' 'docs/record.md'
+expect_rc 'GOOD-4 numbered escape trailer' 0 '1 records scanned, 0 violations'
+
+# This directly pins refusal R2 (instrument/usage failure), including its rc=2 contract.
+run_text malformed 'Autoclose-OK:' 'docs/record.md'
+expect_rc 'MALFORMED bare escape trailer' 2 'malformed trailer'
+
+# A valid git repository with a deliberately empty range pins refusal R3. This is
+# not a missing-repository error: enumeration succeeds and produces zero records.
+EMPTY_REPO="$WORK/empty-range"
+mkdir -p "$EMPTY_REPO"
+(
+	cd "$EMPTY_REPO" || exit 1
+	git init -q
+	git config user.email test@example.invalid
+	git config user.name 'Autoclose Gate Test'
+	printf '%s\n' seed > seed.txt
+	git add seed.txt
+	git commit -q -m seed
+)
+OUT=$(cd "$EMPTY_REPO" && "$GATE" --commits HEAD..HEAD 2>&1)
+RC=$?
+expect_rc 'VACUITY empty commit range' 2 'INSTRUMENT FAILURE: no records enumerated'
+
+# A nonexistent TMPDIR deterministically pins refusal R0 before enumeration starts.
+OUT=$(TMPDIR="$WORK/no-such-parent/child" "$GATE" --commits HEAD..HEAD 2>&1)
+RC=$?
+expect_rc 'TEMPFAIL unavailable scratch directory' 2 'INSTRUMENT FAILURE: cannot create temporary workspace'
+
+if [ "$FIXTURES_RUN" -ne "$FIXTURES_EXPECTED" ]; then
+	echo "  FAIL — $FIXTURES_RUN of $FIXTURES_EXPECTED fixtures ran; refusing vacuous green"
+	FAILED=1
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+	echo "autoclose gate: FAILED ($FIXTURES_RUN fixtures)"
+	exit 1
+fi
+
+echo "autoclose gate: OK ($FIXTURES_RUN fixtures)"


### PR DESCRIPTION
## What

A repo gate that refuses issue-closing phrases in records that ship no code.

GitHub auto-closes an issue when a `fix|close|resolve` keyword sits adjacent to
`#N` in a **commit message, PR title, or PR body** — it does not read the
sentence around it. The mission loop writes long record commits that discuss
issues by number, so the practice manufactures the keyword.

Two records have already closed issues that were never done:

| record | files | ships code | phrase | issue |
|---|---:|---|---|---|
| `dedf3b91f` | 7 | no | `the arena ... #676 completely` | live user-reported OOM |
| `7c7e5e58a` | 1 | no | `a "..." would wrongly auto-close ...` | AST-analyzer follow-up |

Both issues were reopened and are now regression fixtures. The second is
self-referential: the sentence *warning* about the hazard is what triggered it.

## The discriminator, measured

Over `origin/dev` since 2026-06-01 — 1,913 commits, 24 carrying a closing
keyword:

- **19 ship code** → all legitimate (`fix(...)`, `feat(...)`, `test(ci)`)
- **5 are docs-only** → the hazard class

The gate reproduces that split exactly: **5 red / 19 pass, zero false
positives** across the 19 legitimate commits. A docs-only record cannot
legitimately fix a code issue.

## What landed

- `scripts/check_autoclose.sh` — commit-range and PR-title/body modes,
  docs-path discrimination, an `Autoclose-OK: #N` escape trailer for a genuine
  docs-only closure, and an **anti-vacuity floor**: an empty enumeration exits
  2, never a checkmark. `rc 0` clean / `1` violation / `2` instrument failure.
- `make check-autoclose` + a CI step in the `test` job. Squash merges turn the
  PR title and body into the merge commit message, so **PR text is the primary
  record scanned**, not just branch commits.
- `make test-check-autoclose` — 10 fixtures under **bash 3.2.57**, including
  both real offending phrases, the ordinal-looking `Fix` + number shape, the
  inverted non-triggering wording the loop must still be able to write, and an
  empty-range vacuity arm.

## Verification (all outside the executor sandbox)

| check | result |
|---|---|
| `make test-check-autoclose` | rc=0, 10/10 fixtures |
| corpus regression (24 commits) | 5 red / 19 pass, **0 mismatches** |
| `make check-changelog` / `test-check-changelog` | rc=0 / rc=0 |
| `make check-file-sizes` / `check-skills` | rc=0 / rc=0 |
| empty PR body + code / + docs | rc=0, rc=0 (no false vacuity) |
| degenerate `000...` push range | rc=2, named instrument failure |

**Mutation drill** — 4 refusal branches, each neutered with `if false && ...`,
each mutant asserted LANDED (sha256 differs) and PARSING (`bash -n`) before any
test result was read, each restored byte-identical from a `cp` backup:

| branch | blast radius (measured, not predicted) |
|---|---|
| R1 violation refusal | BAD-1, BAD-2, BAD-3 |
| R3 vacuity floor | VACUITY alone (sole killer) |
| R2 instrument/usage | MALFORMED alone |
| R0 scratch-dir failure | TEMPFAIL |

CI hazards checked: `push` is `[main, dev]` only (no first-push `000...` case),
`fetch-depth: 0` so the PR base sha resolves locally, and `jq` is explicitly
installed in the same `test` job before the step uses it.

The gate was dogfooded on this PR's own commit message and caught a real
adjacency in it, which was rephrased before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Round 2 — evaluator findings (sonnet, 83/100 PASS), fixed before merge

Both BLOCKING findings reproduced first-party before acting. The
text-file-exists and unknown-argument guards **existed and fired correctly**,
but no fixture killed them: neutering either left the self-test fully green,
and a missing text file passed **rc=0 CLEAN**. In CI that file is written by
`jq` from the event payload, so a silent pass there is precisely the class this
gate exists to prevent — a guard is not a gate until something reds.

- **Fixtures 10 → 16**: MISSINGTEXT, MISSINGFILES, UNKNOWNARG, two EMPTYFILES
  arms, MERGECOMMIT. All three previously-surviving mutants now red. Two of the
  three are caught by the **message fragment**, not the exit code — rc=2 is
  over-subscribed across four branches, so a bare rc assertion would have
  missed them (`rc=2 came from the wrong path`).
- **Merge commits were invisible**: `git diff-tree --root` without `-m` reports
  zero files for a 2-parent merge. 60 merge commits exist on `origin/dev`;
  as-written saw 0 files where `-m` saw 5. Non-merge and root commits unchanged
  under `-m` (7=7, 3=3), and the new MERGECOMMIT arm pins it.
- **Empty-but-present changed-file list** is no longer an instrument failure. It
  means "ships no code" — the hazard condition — so it is scanned. An
  empty-diff PR whose body closes an issue previously escaped behind an rc=2
  that read like a broken instrument. A **missing** list stays rc=2.
- Changelog arithmetic corrected: 19 code-shipping, not 20 (19+5=24).

Corpus regression unchanged after every edit: **5 red / 19 pass, 0 mismatches**.

Non-blocking and not taken: nothing further outstanding from the evaluation.
