### PR TITLE
fix(testing): ailang test could not run a function-less module's test blocks against delegated stdlib builtins

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,14 @@
 
 ## [Unreleased]
 
+### Fixed — function-less named tests resolve delegated stdlib builtins
+
+`ailang test` now supplies its `ModeEval` pipelines with a builtin-backed global
+resolver. Function-less modules can therefore run named test blocks that call
+stdlib exports such as `std/list.length` and `std/list.reverse`, instead of
+failing with `EVA002: module not compiled: $builtin`. A Go runner regression
+test and a function-less stdlib suite pin the load-bearing module shape.
+
 ### Changed — `std/list.reverse` delegates to the iterative builtin
 
 `std/list.reverse` now delegates to `_list_reverse`, replacing the recursive

--- a/internal/testing/executor.go
+++ b/internal/testing/executor.go
@@ -16,21 +16,27 @@ import (
 
 // Executor handles evaluation of test expressions through the AILANG pipeline.
 type Executor struct {
-	modulePath  string
-	sourceFile  *ast.File // Full source file for context
-	enableDebug bool
-	modules     map[string]*loader.LoadedModule // Cached modules from last pipeline run
-	lastMeta    map[string]*core.DeclMeta       // Cached Core.Meta from last pipeline run (lowered contracts)
+	modulePath string
+	sourceFile *ast.File // Full source file for context
+	// ModeEval evaluates Core.Decls[0] through link.Resolver, which only gains a
+	// $builtin lookup when the caller supplies a GlobalResolver.
+	globalResolver eval.GlobalResolver
+	enableDebug    bool
+	modules        map[string]*loader.LoadedModule // Cached modules from last pipeline run
+	lastMeta       map[string]*core.DeclMeta       // Cached Core.Meta from last pipeline run (lowered contracts)
 }
 
 // NewExecutor creates a new test executor.
 func NewExecutor(modulePath string) *Executor {
+	evaluator := eval.NewCoreEvaluator()
+	builtins := runtime.NewBuiltinRegistry(evaluator)
 	return &Executor{
-		modulePath:  modulePath,
-		sourceFile:  nil,
-		enableDebug: false,
-		modules:     make(map[string]*loader.LoadedModule),
-		lastMeta:    nil,
+		modulePath:     modulePath,
+		sourceFile:     nil,
+		globalResolver: runtime.NewBuiltinOnlyResolver(builtins),
+		enableDebug:    false,
+		modules:        make(map[string]*loader.LoadedModule),
+		lastMeta:       nil,
 	}
 }
 
@@ -93,7 +99,8 @@ func (e *Executor) EvaluateExpression(expr ast.Expr) (eval.Value, error) {
 
 	// Use pipeline with ModeEval (non-module evaluation)
 	cfg := pipeline.Config{
-		Mode: pipeline.ModeEval,
+		Mode:           pipeline.ModeEval,
+		GlobalResolver: e.globalResolver,
 	}
 	src := pipeline.Source{
 		Code:     source,
@@ -286,9 +293,10 @@ func (e *Executor) EvaluateNamedTestBodyExprs(bodyExprs []ast.Expr) (eval.Value,
 	}
 
 	cfg := pipeline.Config{
-		Mode:         pipeline.ModeEval,
-		RelaxModules: true,
-		PackageDir:   pkgDir,
+		Mode:           pipeline.ModeEval,
+		RelaxModules:   true,
+		PackageDir:     pkgDir,
+		GlobalResolver: e.globalResolver,
 	}
 	pipelineSrc := pipeline.Source{
 		Code:     combinedSource,
@@ -466,8 +474,9 @@ func (e *Executor) ExtractFunctionBinding(functionName string, sourceFile *ast.F
 		pipelineFilename = tmpFile
 	}
 	cfg := pipeline.Config{
-		Mode:         pipeline.ModeEval,
-		RelaxModules: true,
+		Mode:           pipeline.ModeEval,
+		RelaxModules:   true,
+		GlobalResolver: e.globalResolver,
 	}
 	src := pipeline.Source{
 		Code:     strippedSource,
@@ -643,7 +652,8 @@ func (e *Executor) ExtractPureClusterForFunction(
 	}
 
 	cfg := pipeline.Config{
-		Mode: pipeline.ModeEval,
+		Mode:           pipeline.ModeEval,
+		GlobalResolver: e.globalResolver,
 	}
 	src := pipeline.Source{
 		// With a filename, the module pipeline reloads source from disk

--- a/internal/testing/executor_builtin_resolution_test.go
+++ b/internal/testing/executor_builtin_resolution_test.go
@@ -1,0 +1,43 @@
+package testing
+
+import "testing"
+
+// TestFunctionlessNamedTestsResolveStdlibBuiltins pins the ailang test path for
+// modules whose first Core declaration is a named-test body rather than a function.
+func TestFunctionlessNamedTestsResolveStdlibBuiltins(t *testing.T) {
+	const source = `module test_builtin_resolution
+
+import std/list (any, length)
+
+test "delegating export" { length([1, 2, 3]) == 3 }
+test "non-delegating control" { any(\x. x == 2, [1, 2, 3]) }
+test "intentional failure control" { false }
+`
+
+	result := runInlineTestsOnSource(t, source)
+	if len(result.Tests) == 0 {
+		t.Fatal("instrument failure")
+	}
+	if len(result.Tests) != 3 {
+		t.Fatalf("expected 3 test results, got %d", len(result.Tests))
+	}
+
+	want := map[string]TestStatus{
+		"delegating export":           StatusPass,
+		"non-delegating control":      StatusPass,
+		"intentional failure control": StatusFail,
+	}
+	for _, got := range result.Tests {
+		status, ok := want[got.Name]
+		if !ok {
+			t.Fatalf("unexpected test result %q", got.Name)
+		}
+		if got.Status != status {
+			t.Errorf("%s: expected %s, got %s: %s", got.Name, status, got.Status, got.Error)
+		}
+		delete(want, got.Name)
+	}
+	if len(want) != 0 {
+		t.Fatalf("instrument failure: missing test results: %v", want)
+	}
+}

--- a/tests/stdlib/functionless_builtin_resolution_test.ail
+++ b/tests/stdlib/functionless_builtin_resolution_test.ail
@@ -1,0 +1,12 @@
+module tests/stdlib/functionless_builtin_resolution_test
+import std/list (length, reverse)
+
+-- This function-less shape is load-bearing for the builtin-resolution defect;
+-- do not "fix" it by adding a helper function.
+test "delegating length resolves" {
+  assert length([1, 2, 3, 4]) == 4
+}
+
+test "multiple delegating exports resolve" {
+  assert length(reverse([1, 2, 3])) == 3
+}


### PR DESCRIPTION
## What

`ailang test` could not run a `test { }` block that called any `std/` export delegating to a `$builtin.*` global, when the module under test declared no functions of its own. It failed with `EVA002: module not compiled: $builtin`.

This supplies the test executor's `ModeEval` pipelines with a builtin-backed global resolver, and pins the shape at two layers.

## The defect is not what it was filed as

The originating report (iteration 242's evaluator) characterised it as requiring a **`let`-bound** call inside the test block. Measured here on a freshly built binary at `adac647c2`, that is false in both directions — it fails with and without a `let`, and passes with and without one. The real variable is **whether the module declares at least one function of its own**:

| shape | rc |
|---|---|
| imports + `test { }` calling a delegating export (`length`/`reverse`/`map`) | **1**, `EVA002` |
| the same, plus any function — even an unused `pure func unusedHelper` | 0 |
| function-less, calling a *non*-delegating export (`any`) | 0 |
| the same delegating call under `ailang run` | 0 |

## Mechanism

`pipeline.Run` wires the `$builtin` lookup hook only under `cfg.GlobalResolver != nil` (`internal/pipeline/pipeline_module.go:442`), and in `ModeEval` it evaluates `Core.Decls[0]` through that resolver, returning immediately on error (`:494-501`). The elaborator emits function/let declarations *before* the trailing bare test-body block — so with no functions, `Decls[0]` **is** the test body, and it reaches `$builtin` through a resolver that has no builtin lookup. Any function absorbs `Decls[0]`, the pipeline returns normally, and the executor's own second pass (correctly wired to a `CombinedResolver`) runs the real body and succeeds. That is the whole of the shape-dependence.

`ailang run` was never affected because `cmd/ailang/main_run_exec.go:198,243` already supplies exactly this resolver.

## Scope (Principle 3)

All four `pipeline.Config` sites in `internal/testing/executor.go` omitted `GlobalResolver`, and all four use `ModeEval`. The resolver is now constructed once per `Executor` and passed to all four — one unified fix rather than a per-site patch. `NewExecutor` is the only construction path (audited: the sole `&Executor{` literal in the package is inside it), so the fix cannot be bypassed.

Only the `EvaluateNamedTestBodyExprs` site has a reproducing arm at this commit. The `property`/`forall` path, which routes through `EvaluateExpression`, fails **earlier** with `PAR_UNEXPECTED_TOKEN ... at _test.ail` — the source-synthesis defect `internal/testing/runner.go:267,307,312` already names in comments. Measured, and left untouched. Sites 95/468/645 are changed for consistency and are stated as having no reproducing arm rather than claimed as covered.

## The arms

- `internal/testing/executor_builtin_resolution_test.go` — inline function-less source, three arms (delegating must pass · non-delegating must pass · intentional failure must **fail**, so the harness is shown able to report failure), exact result-count assertion, and a `t.Fatal("instrument failure")` floor on an empty result set.
- `tests/stdlib/functionless_builtin_resolution_test.ail` — function-less by design, calls two different delegating exports, wired into `make test-stdlib-ail` (required CI job). The target glob-enumerates `tests/stdlib/*_test.ail`; the enumerated suite count **moves 2 → 3** and the new file is named in the output, so it is genuinely enumerated rather than merely present.

## Mutation drill (controller-run, outside the sandbox)

Mutant: remove `GlobalResolver` from the named-test-body site only (neutered, not deleted — every import stays used). Asserted **landed** (sha256 `4d1b6432…` → `ce36392d…`) and **building** (`go build ./internal/... ./cmd/ailang` rc=0) *before* any test result was read.

- Go arm: package reds **exactly one** test, `TestFunctionlessNamedTestsResolveStdlibBuiltins`; inverse run `-skip`-ing it is **rc=0** with 0 FAILs → **sole killer**.
- `.ail` arm: the make target short-circuits on first failure, so the three suites were run **individually** rather than inheriting the aggregate — `bounded_take_parity` rc=0, `list_reverse` rc=0, `functionless_builtin_resolution` rc=1 → **sole killer**.

Restored from the pre-mutation copy (not `git checkout --`, which would have deleted uncommitted executor output) and verified byte-identical by sha256.

## Gates

All run by the controller **outside** the codex sandbox, on darwin/arm64, each rc captured without a pipe; the linux and windows legs are unrun locally and are left to CI:

`build` · `test-stdlib-ail` · `check-file-sizes` · `check-boundaries` · `check-changelog` · `test-check-changelog` · `test-check-autoclose` · `check-skills` · `check-golden-drift` · `fmt-check` · `vet` · `test-regression-guards` · `verify-no-shim` — **all rc=0**.

`go test ./internal/testing/... ./internal/builtins/...` rc=0 under a **freshly built binary prepended to `PATH`** (the shared `~/go/bin/ailang` is ~54 commits stale and produces false reds in tests that shell out to `ailang`; `~/go/bin` was deliberately left untouched for concurrent agents).

## Why now

The queued `m-stdlib-list-delegation-sweep` row moves 13 more `std/list` exports onto builtin delegation. Every one of them becomes untestable in the natural test-module shape at the moment it is delegated. Current breakage is zero — the two existing `tests/stdlib` fixtures both happen to declare helper functions, which is luck rather than design — so this is a prospective constraint being removed before the sweep needs it, not a live CI red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
