### PR TITLE
fix(ci): the stdlib .ail suite gate could not see a fixture that moved or was renamed

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -14,9 +14,22 @@ deleting a fixture was equally invisible while at least one remained. Both loops
 recursively via sorted `find`, and both assert an exact count pinned in
 `STDLIB_AIL_SUITES_EXPECTED` / `STDLIB_AIL_FIXTURES_EXPECTED`, so adding, moving, renaming or
 removing a fixture becomes a deliberate, reviewable one-line change; a mismatch reports expected
-vs actual with the full file list. Eight mutants — nested suite, nested fixture, nested *failing*
-suite, nested orphan `.expected`, rename-out, delete-one, delete-two, delete-all — now all red,
-where six of them were previously green.
+vs actual with the full file list.
+
+Enumeration uses `find -L`, so a **symlinked** fixture is a real fixture: with a bare `-type f` a
+committed symlink is type `l` and invisible to both the run and the count, which let a symlinked
+suite asserting `1 == 2` sit one directory down at rc=0. A *dangling* symlink is still type `l`
+under `-L`, so it is rejected explicitly rather than skipped. The file list is read from a temp
+file rather than word-split out of `$(...)`, so a path containing a space stays one path, and a
+missing `tests/stdlib` reports its own instrument failure instead of leaking `find`'s stderr.
+
+Eleven mutants now red where most were previously green: nested suite; nested `.ail`/`.expected`
+pair; nested *failing* suite; **symlinked** failing suite; **symlinked** `.expected`; **dangling**
+symlink; path containing a **space**; nested orphan `.expected`; rename-out; remove-one-fixture;
+delete-all. The nested and symlinked failing suites red because they *actually run* — the log
+shows the suite path and then `assertion 1 failed` — not merely because a count moved. Known
+residual, declared in the target's own comment: name matching stays case-sensitive, so `*_TEST.ail`
+and `*.EXPECTED` remain invisible.
 
 ### Fixed — function-less named tests resolve delegated stdlib builtins
 

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,20 @@
 
 ## [Unreleased]
 
+### Fixed — the stdlib `.ail` suite gate could not see a fixture that moved or was renamed
+
+`make test-stdlib-ail` (a required CI gate) enumerated `tests/stdlib/*_test.ail` and
+`tests/stdlib/*.expected` with non-recursive globs and floored at `-ge 1` rather than an exact
+count. A suite placed one directory down was invisible — including one that *cannot pass*: a
+nested `assert 1 == 2` left the gate at rc=0 printing "3 .ail test suite(s) passed". Renaming or
+deleting a fixture was equally invisible while at least one remained. Both loops now enumerate
+recursively via sorted `find`, and both assert an exact count pinned in
+`STDLIB_AIL_SUITES_EXPECTED` / `STDLIB_AIL_FIXTURES_EXPECTED`, so adding, moving, renaming or
+removing a fixture becomes a deliberate, reviewable one-line change; a mismatch reports expected
+vs actual with the full file list. Eight mutants — nested suite, nested fixture, nested *failing*
+suite, nested orphan `.expected`, rename-out, delete-one, delete-two, delete-all — now all red,
+where six of them were previously green.
+
 ### Fixed — function-less named tests resolve delegated stdlib builtins
 
 `ailang test` now supplies its `ModeEval` pipelines with a builtin-backed global

--- a/make/test.mk
+++ b/make/test.mk
@@ -255,27 +255,31 @@ test-parity: build ## Test REPL/file parity for imports (interactive)
 # over any .ail suite. M-TAKE-FLATMAP-PEAK-MEMORY M2's entire behavioural pin (the fused
 # delegation instrument and the parity suite) lived there, so it would have shipped as
 # decoration: a guard is not a gate until something reds when you remove it.
-# Both loops carry an ANTI-VACUITY FLOOR — an empty glob must FAIL LOUDLY, never pass silently,
-# because "no suites found" and "all suites green" are otherwise the same exit code.
+# Both loops carry an EXACT COUNT PIN — adding, removing, renaming, or moving a test must be a
+# deliberate, reviewable change rather than silently shrinking or growing the gate.
 # The .expected files are captured from the product's OWN stdout and diffed against a verbatim
 # re-run, rather than reconstructed by the gate — a reconstruction verifies our arithmetic, not
 # the artifact.
+STDLIB_AIL_SUITES_EXPECTED := 3
+STDLIB_AIL_FIXTURES_EXPECTED := 4
+
 test-stdlib-ail: build ## Run the .ail test suites + run-fixtures under tests/stdlib/
 	@echo "Running stdlib .ail test suites..."
-	@suites=0; \
-	for f in tests/stdlib/*_test.ail; do \
-	  [ -e "$$f" ] || continue; \
+	@suites=0; suite_files=`find tests/stdlib -type f -name '*_test.ail' | sort`; \
+	for f in $$suite_files; do \
 	  suites=$$((suites+1)); \
 	  echo "  test: $$f"; \
 	  ./bin/ailang test --no-color "$$f" > /tmp/ailang_stdlib_test.$$$$ 2>&1 || \
 	    { echo "FAIL: $$f"; cat /tmp/ailang_stdlib_test.$$$$; rm -f /tmp/ailang_stdlib_test.$$$$; exit 1; }; \
 	  rm -f /tmp/ailang_stdlib_test.$$$$; \
 	done; \
-	[ "$$suites" -ge 1 ] || { echo "instrument failure: no tests/stdlib/*_test.ail suites found"; exit 1; }; \
+	[ "$$suites" -eq "$(STDLIB_AIL_SUITES_EXPECTED)" ] || \
+	  { echo "instrument failure: expected $(STDLIB_AIL_SUITES_EXPECTED) stdlib .ail test suite(s), actual $$suites"; \
+	    echo "actual files:"; printf '  %s\n' $$suite_files; \
+	    echo "If this change was intentional, update STDLIB_AIL_SUITES_EXPECTED in make/test.mk."; exit 1; }; \
 	echo "  $$suites .ail test suite(s) passed"
-	@fixtures=0; \
-	for e in tests/stdlib/*.expected; do \
-	  [ -e "$$e" ] || continue; \
+	@fixtures=0; fixture_files=`find tests/stdlib -type f -name '*.expected' | sort`; \
+	for e in $$fixture_files; do \
 	  f=`echo "$$e" | sed 's/\.expected$$/.ail/'`; \
 	  [ -e "$$f" ] || { echo "instrument failure: $$e has no matching $$f"; exit 1; }; \
 	  fixtures=$$((fixtures+1)); \
@@ -288,6 +292,9 @@ test-stdlib-ail: build ## Run the .ail test suites + run-fixtures under tests/st
 	  rm -f /tmp/ailang_stdlib_err.$$$$; \
 	  rm -f /tmp/ailang_stdlib_run.$$$$; \
 	done; \
-	[ "$$fixtures" -ge 1 ] || { echo "instrument failure: no tests/stdlib/*.expected fixtures found"; exit 1; }; \
+	[ "$$fixtures" -eq "$(STDLIB_AIL_FIXTURES_EXPECTED)" ] || \
+	  { echo "instrument failure: expected $(STDLIB_AIL_FIXTURES_EXPECTED) stdlib run-fixture(s), actual $$fixtures"; \
+	    echo "actual files:"; printf '  %s\n' $$fixture_files; \
+	    echo "If this change was intentional, update STDLIB_AIL_FIXTURES_EXPECTED in make/test.mk."; exit 1; }; \
 	echo "  $$fixtures run-fixture(s) matched expected stdout"
 	@echo "$(GREEN)✓ stdlib .ail suites and run-fixtures pass$(NC)"

--- a/make/test.mk
+++ b/make/test.mk
@@ -257,6 +257,13 @@ test-parity: build ## Test REPL/file parity for imports (interactive)
 # decoration: a guard is not a gate until something reds when you remove it.
 # Both loops carry an EXACT COUNT PIN — adding, removing, renaming, or moving a test must be a
 # deliberate, reviewable change rather than silently shrinking or growing the gate.
+# Enumeration is `find -L` (symlinks FOLLOWED, so a symlinked fixture is a real fixture: with a
+# bare `-type f` a committed symlink is type `l`, invisible to both the run and the count, and a
+# suite that cannot pass sat one directory down at rc=0). A DANGLING symlink is still type `l`
+# under -L, so it is rejected explicitly rather than silently skipped. The file list is read from
+# a temp file, not word-split from `$(...)`, so a path containing a space stays one path.
+# Known residual, declared rather than assumed: name matching is case-SENSITIVE, so `*_TEST.ail`
+# and `*.EXPECTED` are still invisible, and a real suite not ending `_test.ail` is not enumerated.
 # The .expected files are captured from the product's OWN stdout and diffed against a verbatim
 # re-run, rather than reconstructed by the gate — a reconstruction verifies our arithmetic, not
 # the artifact.
@@ -265,21 +272,33 @@ STDLIB_AIL_FIXTURES_EXPECTED := 4
 
 test-stdlib-ail: build ## Run the .ail test suites + run-fixtures under tests/stdlib/
 	@echo "Running stdlib .ail test suites..."
-	@suites=0; suite_files=`find tests/stdlib -type f -name '*_test.ail' | sort`; \
-	for f in $$suite_files; do \
+	@test -d tests/stdlib || { echo "instrument failure: tests/stdlib does not exist"; exit 1; }; \
+	find -L tests/stdlib -type l -name '*_test.ail' > /tmp/ailang_stdlib_dangling.$$$$; \
+	if [ -s /tmp/ailang_stdlib_dangling.$$$$ ]; then \
+	  echo "instrument failure: broken symlink(s) matching *_test.ail — a suite that cannot be read is not a suite:"; \
+	  sed 's/^/  /' /tmp/ailang_stdlib_dangling.$$$$; rm -f /tmp/ailang_stdlib_dangling.$$$$; exit 1; \
+	fi; rm -f /tmp/ailang_stdlib_dangling.$$$$; \
+	suites=0; find -L tests/stdlib -type f -name '*_test.ail' | sort > /tmp/ailang_stdlib_suites.$$$$; \
+	while IFS= read -r f; do \
 	  suites=$$((suites+1)); \
 	  echo "  test: $$f"; \
 	  ./bin/ailang test --no-color "$$f" > /tmp/ailang_stdlib_test.$$$$ 2>&1 || \
 	    { echo "FAIL: $$f"; cat /tmp/ailang_stdlib_test.$$$$; rm -f /tmp/ailang_stdlib_test.$$$$; exit 1; }; \
 	  rm -f /tmp/ailang_stdlib_test.$$$$; \
-	done; \
+	done < /tmp/ailang_stdlib_suites.$$$$; \
 	[ "$$suites" -eq "$(STDLIB_AIL_SUITES_EXPECTED)" ] || \
 	  { echo "instrument failure: expected $(STDLIB_AIL_SUITES_EXPECTED) stdlib .ail test suite(s), actual $$suites"; \
-	    echo "actual files:"; printf '  %s\n' $$suite_files; \
+	    echo "actual files:"; sed 's/^/  /' /tmp/ailang_stdlib_suites.$$$$; rm -f /tmp/ailang_stdlib_suites.$$$$; \
 	    echo "If this change was intentional, update STDLIB_AIL_SUITES_EXPECTED in make/test.mk."; exit 1; }; \
+	rm -f /tmp/ailang_stdlib_suites.$$$$; \
 	echo "  $$suites .ail test suite(s) passed"
-	@fixtures=0; fixture_files=`find tests/stdlib -type f -name '*.expected' | sort`; \
-	for e in $$fixture_files; do \
+	@find -L tests/stdlib -type l -name '*.expected' > /tmp/ailang_stdlib_dangling.$$$$; \
+	if [ -s /tmp/ailang_stdlib_dangling.$$$$ ]; then \
+	  echo "instrument failure: broken symlink(s) matching *.expected:"; \
+	  sed 's/^/  /' /tmp/ailang_stdlib_dangling.$$$$; rm -f /tmp/ailang_stdlib_dangling.$$$$; exit 1; \
+	fi; rm -f /tmp/ailang_stdlib_dangling.$$$$; \
+	fixtures=0; find -L tests/stdlib -type f -name '*.expected' | sort > /tmp/ailang_stdlib_fixtures.$$$$; \
+	while IFS= read -r e; do \
 	  f=`echo "$$e" | sed 's/\.expected$$/.ail/'`; \
 	  [ -e "$$f" ] || { echo "instrument failure: $$e has no matching $$f"; exit 1; }; \
 	  fixtures=$$((fixtures+1)); \
@@ -291,10 +310,11 @@ test-stdlib-ail: build ## Run the .ail test suites + run-fixtures under tests/st
 	      rm -f /tmp/ailang_stdlib_run.$$$$ /tmp/ailang_stdlib_err.$$$$; exit 1; }; \
 	  rm -f /tmp/ailang_stdlib_err.$$$$; \
 	  rm -f /tmp/ailang_stdlib_run.$$$$; \
-	done; \
+	done < /tmp/ailang_stdlib_fixtures.$$$$; \
 	[ "$$fixtures" -eq "$(STDLIB_AIL_FIXTURES_EXPECTED)" ] || \
 	  { echo "instrument failure: expected $(STDLIB_AIL_FIXTURES_EXPECTED) stdlib run-fixture(s), actual $$fixtures"; \
-	    echo "actual files:"; printf '  %s\n' $$fixture_files; \
+	    echo "actual files:"; sed 's/^/  /' /tmp/ailang_stdlib_fixtures.$$$$; rm -f /tmp/ailang_stdlib_fixtures.$$$$; \
 	    echo "If this change was intentional, update STDLIB_AIL_FIXTURES_EXPECTED in make/test.mk."; exit 1; }; \
+	rm -f /tmp/ailang_stdlib_fixtures.$$$$; \
 	echo "  $$fixtures run-fixture(s) matched expected stdout"
 	@echo "$(GREEN)✓ stdlib .ail suites and run-fixtures pass$(NC)"


### PR DESCRIPTION
## The defect

`make test-stdlib-ail` is a **required CI gate** (`.github/workflows/ci.yml:127`). Both of its
loops enumerated with a **non-recursive glob** and floored at `-ge 1` instead of an exact count,
so the gate was blind in **both** directions.

Measured on the pristine tree at `1e5d842be`, exit codes captured without a pipe, tree restored
byte-identical after each mutant:

| Mutant | What | rc | gate printed | truth |
|---|---|---|---|---|
| base | pristine | 0 | 3 suites / 4 fixtures | 3 / 4 |
| MUT-A | +1 suite in `tests/stdlib/<subdir>/` | 0 | 3 suites | 4 existed |
| MUT-B | +1 `.ail`/`.expected` pair in a subdir | 0 | 4 fixtures | 5 existed |
| MUT-C | +1 subdir suite asserting `1 == 2` | 0 | "3 .ail test suite(s) passed" | a **failing** suite was invisible |
| MUT-D | rename one suite out of the glob | 0 | 2 suites | silently dropped |
| MUT-E | delete 2 of 3 suites | 0 | 1 suite | floor satisfied at 1 |
| MUT-F | delete **all** suites (positive control) | 2 | instrument failure | floor CAN fire |

**MUT-C** is the sharp one: a suite that *cannot pass*, one directory down, left a required gate
green. **MUT-F** is the control showing the gate was not simply inert.

## The change

Both loops now enumerate recursively with a **sorted** `find` (deterministic across the macOS and
Linux runners), and both assert an **exact count** pinned in `STDLIB_AIL_SUITES_EXPECTED` /
`STDLIB_AIL_FIXTURES_EXPECTED`. A mismatch reports expected vs actual **with the full file list**
and says to update the pin if the change was intentional. The `.expected` → sibling `.ail` pairing
check is retained and resolves correctly under recursion.

The pin is deliberately a **literal a human wrote**, not a value derived from the same `find` — a
derived expectation cannot detect a fixture disappearing, which would reproduce the defect one
level up.

## Verification

Eight mutants re-drilled **independently by the controller** after the change (the executor's own
table was not banked):

`base=0` · `MUT-A=2` · `MUT-B=2` · `MUT-B'` (nested fixture, no nested suite) `=2` · `MUT-C=2` ·
`MUT-D=2` · `MUT-F=2` · `MUT-G` (nested orphan `.expected`) `=2` · `MUT-H` (remove one fixture) `=2`
· `final=0`

MUT-C reds because the nested suite **actually runs** — the log shows
`test: tests/stdlib/<subdir>/broken_test.ail` followed by `assertion 1 failed` — not merely
because a count moved. That distinction is what proves recursion rather than counting.

Local gates, **darwin/arm64 only** (ubuntu and windows legs unrun locally): `test-stdlib-ail`,
`check-changelog`, `test-check-changelog`, `check-file-sizes`, `check-boundaries`, `check-skills`,
`check-autoclose` all rc=0, under a binary built in-worktree whose `--version` equals
`git describe`.

## Why now

The queue row beneath this one (`m-stdlib-list-delegation-sweep`) adds ~13 more fixtures of exactly
this shape. Each one's protection would otherwise be contingent on its filename never drifting and
nobody ever moving it into a subdirectory.

Reported at the `m-stdlib-ail-suite-enumerator-blind` charter row (filed by iteration 243's judge);
pre-existing, not introduced by that iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
