### PR TITLE
perf(stdlib): drop delegates to the iterative builtin, and 11 of the 13 'delegation candidates' have no interpreter to delegate to

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,19 @@
 
 ## [Unreleased]
 
+### Changed — `std/list.drop` delegates and list exemptions are typed
+
+`std/list.drop` now delegates to the iterative `_list_drop` runtime builtin, preserving
+negative, zero, in-range and out-of-range behavior while avoiding evaluator recursion-depth
+failures on large inputs. Unit and stdlib fixtures pin those boundary semantics.
+
+The live-registry delegation gate now distinguishes runtime-backed builtins from codegen-only
+helpers with typed categories. Its audit corrected the prior blanket “delegation candidate”
+label: 11 recursive `std/list` functions cannot delegate in the interpreter because their
+names have only generated-Go helpers and no interpreter implementation. The gate validates
+those claims against the runtime registry, and addition/removal mutants prove that both new
+unexplained names and false runtime classifications fail by builtin name.
+
 ### Fixed — the stdlib `.ail` suite gate could not see a fixture that moved or was renamed
 
 `make test-stdlib-ail` (a required CI gate) enumerated `tests/stdlib/*_test.ail` and

--- a/internal/builtins/list_test.go
+++ b/internal/builtins/list_test.go
@@ -83,6 +83,38 @@ func TestListCons(t *testing.T) {
 	}
 }
 
+func TestListDropImplMatchesRecursiveSemantics(t *testing.T) {
+	ctx := testctx.NewMockEffContext()
+	xs := []eval.Value{testctx.MakeInt(1), testctx.MakeInt(2), testctx.MakeInt(3), testctx.MakeInt(4)}
+	tests := []struct {
+		name string
+		n    int
+		xs   []eval.Value
+		want []eval.Value
+	}{
+		{"negative", -1, xs, xs},
+		{"zero", 0, xs, xs},
+		{"one", 1, xs, xs[1:]},
+		{"len minus one", len(xs) - 1, xs, xs[len(xs)-1:]},
+		{"len", len(xs), xs, []eval.Value{}},
+		{"greater than len", len(xs) + 1, xs, []eval.Value{}},
+		{"empty negative", -1, []eval.Value{}, []eval.Value{}},
+		{"empty zero", 0, []eval.Value{}, []eval.Value{}},
+		{"empty positive", 1, []eval.Value{}, []eval.Value{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := listDropImpl(ctx.EffContext, []eval.Value{
+				testctx.MakeInt(tt.n),
+				&eval.ListValue{Elements: tt.xs},
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, testctx.GetList(got))
+		})
+	}
+}
+
 // TestListConsTypeMismatch tests error handling for wrong types
 func TestListConsTypeMismatch(t *testing.T) {
 	ctx := testctx.NewMockEffContext()

--- a/internal/builtins/stdlib_delegation_test.go
+++ b/internal/builtins/stdlib_delegation_test.go
@@ -55,8 +55,12 @@ var listDelegationExemptions = map[string]listDelegationExemption{
 	"_list_mapE":      {NoRuntimeImpl, false, "codegen-only: the interpreter has no implementation to which std/list.mapE can delegate"},
 	"_list_sortBy":    {NoRuntimeImpl, false, "codegen-only: the interpreter has no implementation to which std/list.sortBy can delegate"},
 	"_list_tail":      {NotNeeded, false, "codegen-only helper is unnecessary in the interpreter because std/list.tail is O(1) pattern matching"},
-	"_list_take":      {DelegableNow, true, "runtime-backed, but delegation is deferred because the builtin writes a materialization note to stderr"},
-	"_list_zip":       {NoRuntimeImpl, false, "codegen-only: the interpreter has no implementation to which std/list.zip can delegate"},
+	"_list_take": {DelegableNow, true, "runtime-backed, and std/list.take STILL FAILS RT_REC_003 on large n — " +
+		"the same crash std/list.drop had, measured at take(12000, <16384-element list>). Delegation is " +
+		"deferred, NOT because the problem is absent, but because _list_take is the only list builtin that " +
+		"writes to stderr (a materialization note), so delegating would make a pure stdlib function emit " +
+		"output on the common take(small_n, big_list) call. Needs its own fix, not just a delegation"},
+	"_list_zip": {NoRuntimeImpl, false, "codegen-only: the interpreter has no implementation to which std/list.zip can delegate"},
 }
 
 // registeredListBuiltins reads the LIVE registries rather than parsing source.

--- a/internal/builtins/stdlib_delegation_test.go
+++ b/internal/builtins/stdlib_delegation_test.go
@@ -14,36 +14,49 @@ import (
 const stdlibSourceDir = "../../std"
 
 // listDelegationExemptions records, for every registered _list_* builtin with no
-// call site in std/*.ail, WHY that is acceptable. Two categories only:
+// call site in std/*.ail, WHY that is acceptable. Runtime and codegen registries
+// describe different execution paths: a codegen helper is not callable by the
+// interpreter. Categories are therefore machine-checked against AllNames(), the
+// runtime registry, rather than trusted as prose.
 //
-//	DELEGATION-CANDIDATE — a std/list export shadows this builtin with a recursive
-//	                       AILANG implementation that is asymptotically worse.
-//	                       Delegating each one needs its own semantic-equivalence
-//	                       verification; tracked as m-stdlib-list-delegation-sweep.
-//	NOT-NEEDED           — there is nothing to delegate, or the std/list form is
-//	                       already as cheap as the builtin.
+// In particular, 11 entries previously described as "delegation candidates" are
+// blocked on a MISSING INTERPRETER IMPLEMENTATION, not on their std/list forms
+// being recursive. Their codegen helpers run only in generated Go programs.
 //
 // _list_reverse is deliberately ABSENT: std/list.reverse delegates to it, and that
 // absence is the fixture proving this gate is live.
-var listDelegationExemptions = map[string]string{
-	"_list_any":       "DELEGATION-CANDIDATE: std/list.any is recursive; see m-stdlib-list-delegation-sweep",
-	"_list_contains":  "NOT-NEEDED: std/list exposes membership as member, which delegates to _list_member; both builtins use the same structural valuesEqual, so contains has no std/list counterpart to serve",
-	"_list_drop":      "DELEGATION-CANDIDATE: std/list.drop is recursive; see m-stdlib-list-delegation-sweep",
-	"_list_extract":   "NOT-NEEDED: std/list exposes no extract operation to delegate",
-	"_list_filterE":   "DELEGATION-CANDIDATE: std/list.filterE is recursive; see m-stdlib-list-delegation-sweep",
-	"_list_findIndex": "DELEGATION-CANDIDATE: std/list.findIndex recurses through findIndexHelper; see m-stdlib-list-delegation-sweep",
-	"_list_flatMap":   "DELEGATION-CANDIDATE: std/list.flatMap is recursive and concatenates per element; see m-stdlib-list-delegation-sweep",
-	"_list_flatMapE":  "DELEGATION-CANDIDATE: std/list.flatMapE is recursive and concatenates per element; see m-stdlib-list-delegation-sweep",
-	"_list_foldlE":    "DELEGATION-CANDIDATE: std/list.foldlE is recursive; see m-stdlib-list-delegation-sweep",
-	"_list_foldr":     "DELEGATION-CANDIDATE: std/list.foldr is recursive; see m-stdlib-list-delegation-sweep",
-	"_list_forEachE":  "DELEGATION-CANDIDATE: std/list.forEachE is recursive; see m-stdlib-list-delegation-sweep",
-	"_list_head":      "NOT-NEEDED: std/list.head is already O(1) through list pattern matching",
-	"_list_last":      "NOT-NEEDED: std/list.last already composes the delegated _list_length and _list_nth",
-	"_list_mapE":      "DELEGATION-CANDIDATE: std/list.mapE is recursive and appends per element; see m-stdlib-list-delegation-sweep",
-	"_list_sortBy":    "DELEGATION-CANDIDATE: std/list.sortBy is recursive and builds on the recursive take/drop/mergeBy; see m-stdlib-list-delegation-sweep",
-	"_list_tail":      "NOT-NEEDED: std/list.tail is already O(1) through list pattern matching",
-	"_list_take":      "DELEGATION-CANDIDATE: std/list.take is recursive and appends per element; see m-stdlib-list-delegation-sweep",
-	"_list_zip":       "DELEGATION-CANDIDATE: std/list.zip is recursive and appends per element; see m-stdlib-list-delegation-sweep",
+type listDelegationCategory uint8
+
+const (
+	DelegableNow listDelegationCategory = iota
+	NoRuntimeImpl
+	NotNeeded
+)
+
+type listDelegationExemption struct {
+	category      listDelegationCategory
+	runtimeBacked bool
+	reason        string
+}
+
+var listDelegationExemptions = map[string]listDelegationExemption{
+	"_list_any":       {NoRuntimeImpl, false, "codegen-only: the interpreter has no implementation to which std/list.any can delegate"},
+	"_list_contains":  {NotNeeded, true, "std/list exposes membership as member, which delegates to _list_member; contains has no std/list counterpart to serve"},
+	"_list_extract":   {NotNeeded, true, "std/list exposes no extract operation to delegate"},
+	"_list_filterE":   {NoRuntimeImpl, false, "codegen-only: the interpreter has no implementation to which std/list.filterE can delegate"},
+	"_list_findIndex": {NoRuntimeImpl, false, "codegen-only: the interpreter has no implementation to which std/list.findIndex can delegate"},
+	"_list_flatMap":   {NoRuntimeImpl, false, "codegen-only: the interpreter has no implementation to which std/list.flatMap can delegate"},
+	"_list_flatMapE":  {NoRuntimeImpl, false, "codegen-only: the interpreter has no implementation to which std/list.flatMapE can delegate"},
+	"_list_foldlE":    {NoRuntimeImpl, false, "codegen-only: the interpreter has no implementation to which std/list.foldlE can delegate"},
+	"_list_foldr":     {NoRuntimeImpl, false, "codegen-only: the interpreter has no implementation to which std/list.foldr can delegate"},
+	"_list_forEachE":  {NoRuntimeImpl, false, "codegen-only: the interpreter has no implementation to which std/list.forEachE can delegate"},
+	"_list_head":      {NotNeeded, true, "std/list.head is already O(1) through list pattern matching"},
+	"_list_last":      {NotNeeded, false, "codegen-only helper is unnecessary in the interpreter because std/list.last composes _list_length and _list_nth"},
+	"_list_mapE":      {NoRuntimeImpl, false, "codegen-only: the interpreter has no implementation to which std/list.mapE can delegate"},
+	"_list_sortBy":    {NoRuntimeImpl, false, "codegen-only: the interpreter has no implementation to which std/list.sortBy can delegate"},
+	"_list_tail":      {NotNeeded, false, "codegen-only helper is unnecessary in the interpreter because std/list.tail is O(1) pattern matching"},
+	"_list_take":      {DelegableNow, true, "runtime-backed, but delegation is deferred because the builtin writes a materialization note to stderr"},
+	"_list_zip":       {NoRuntimeImpl, false, "codegen-only: the interpreter has no implementation to which std/list.zip can delegate"},
 }
 
 // registeredListBuiltins reads the LIVE registries rather than parsing source.
@@ -113,6 +126,17 @@ func stdlibListCallSites(t *testing.T, names []string) map[string]int {
 
 func TestEveryListBuiltinIsDelegatedOrExplained(t *testing.T) {
 	names := registeredListBuiltins()
+	runtimeNames := map[string]struct{}{}
+	runtimeListCount := 0
+	for _, name := range AllNames() {
+		if strings.HasPrefix(name, "_list_") {
+			runtimeNames[name] = struct{}{}
+			runtimeListCount++
+		}
+	}
+	if runtimeListCount < 15 {
+		t.Fatalf("instrument failure: found only %d runtime _list_* builtins; want at least 15", runtimeListCount)
+	}
 
 	// Anti-vacuity floor: an enumeration that finds (almost) nothing must fail
 	// loudly, never pass. "no builtins found" and "every builtin delegates"
@@ -136,6 +160,44 @@ func TestEveryListBuiltinIsDelegatedOrExplained(t *testing.T) {
 		t.Fatal("instrument failure: known-positive control _list_map has zero call sites")
 	}
 
+	categorized := make(map[string]struct{}, len(listDelegationExemptions))
+	for name, exemption := range listDelegationExemptions {
+		if exemption.reason == "" {
+			t.Errorf("exemption %s has an empty reason", name)
+		}
+		_, hasRuntimeImpl := runtimeNames[name]
+		switch exemption.category {
+		case NoRuntimeImpl:
+			categorized[name] = struct{}{}
+			if hasRuntimeImpl {
+				t.Errorf("%s is categorized NoRuntimeImpl but is present in the runtime registry", name)
+			}
+		case DelegableNow:
+			categorized[name] = struct{}{}
+			if !exemption.runtimeBacked {
+				t.Errorf("%s is DelegableNow but does not claim a runtime implementation", name)
+			}
+			if !hasRuntimeImpl {
+				t.Errorf("%s is categorized DelegableNow but is absent from the runtime registry", name)
+			}
+		case NotNeeded:
+			categorized[name] = struct{}{}
+			if exemption.runtimeBacked && !hasRuntimeImpl {
+				t.Errorf("%s claims a runtime implementation but is absent from the runtime registry", name)
+			}
+		default:
+			t.Errorf("%s has unknown delegation category %d", name, exemption.category)
+		}
+	}
+	if len(categorized) != len(listDelegationExemptions) {
+		t.Fatalf("instrument failure: %d categorized names != %d exempted names", len(categorized), len(listDelegationExemptions))
+	}
+	for name := range listDelegationExemptions {
+		if _, ok := categorized[name]; !ok {
+			t.Errorf("exempted name %s is not categorized", name)
+		}
+	}
+
 	for name := range listDelegationExemptions {
 		if counts[name] > 0 {
 			t.Errorf("stale exemption %s: it now has %d call site(s) in std/*.ail — delete the exemption", name, counts[name])
@@ -153,14 +215,14 @@ func TestEveryListBuiltinIsDelegatedOrExplained(t *testing.T) {
 
 	var unexplained []string
 	for _, name := range names {
-		if counts[name] == 0 && listDelegationExemptions[name] == "" {
+		if _, exempted := listDelegationExemptions[name]; counts[name] == 0 && !exempted {
 			unexplained = append(unexplained, name)
 		}
 	}
 	sort.Strings(unexplained)
 	for _, name := range unexplained {
 		t.Errorf("%s has zero exact call sites in std/*.ail and no delegation exemption "+
-			"(delegate it from std/, or add a DELEGATION-CANDIDATE / NOT-NEEDED reason)", name)
+			"(delegate it from std/, or add a categorized reason)", name)
 	}
 
 	t.Logf("scan summary: %d registered _list_* builtins, %d exact std/ call sites, %d exemptions",

--- a/make/test.mk
+++ b/make/test.mk
@@ -267,7 +267,7 @@ test-parity: build ## Test REPL/file parity for imports (interactive)
 # The .expected files are captured from the product's OWN stdout and diffed against a verbatim
 # re-run, rather than reconstructed by the gate — a reconstruction verifies our arithmetic, not
 # the artifact.
-STDLIB_AIL_SUITES_EXPECTED := 3
+STDLIB_AIL_SUITES_EXPECTED := 4
 STDLIB_AIL_FIXTURES_EXPECTED := 4
 
 test-stdlib-ail: build ## Run the .ail test suites + run-fixtures under tests/stdlib/

--- a/std/list.ail
+++ b/std/list.ail
@@ -101,13 +101,8 @@ export pure func take[a](n: int, xs: [a]) -> [a] {
 }
 
 -- drop: Drop first n elements
-export pure func drop[a](n: int, xs: [a]) -> [a] {
-  if n <= 0 then xs
-  else match xs {
-    [] => [],
-    [_, ...rest] => drop(n - 1, rest)
-  }
-}
+-- Delegates to the iterative builtin to avoid recursion-depth failures on large n.
+export pure func drop[a](n: int, xs: [a]) -> [a] = _list_drop(n, xs)
 
 -- ============================================================================
 -- Index Access (v0.6.5) - Element access by index

--- a/tests/stdlib/list_drop_test.ail
+++ b/tests/stdlib/list_drop_test.ail
@@ -1,0 +1,47 @@
+module tests/stdlib/list_drop_test
+import std/list (concat, drop, length)
+
+pure func intsEqual(xs: [int], ys: [int]) -> bool = match xs {
+  [] => match ys {
+    [] => true,
+    _ => false
+  },
+  [x, ...xr] => match ys {
+    [] => false,
+    [y, ...yr] => x == y && intsEqual(xr, yr)
+  }
+}
+
+pure func bigList() -> [int] {
+  let seed = [1, 2, 3, 4, 5, 6, 7, 8]
+  let x16 = concat(seed, seed)
+  let x32 = concat(x16, x16)
+  let x64 = concat(x32, x32)
+  let x128 = concat(x64, x64)
+  let x256 = concat(x128, x128)
+  let x512 = concat(x256, x256)
+  let x1024 = concat(x512, x512)
+  let x2048 = concat(x1024, x1024)
+  let x4096 = concat(x2048, x2048)
+  let x8192 = concat(x4096, x4096)
+  concat(x8192, x8192)
+}
+
+test "drop boundary semantics" {
+  assert intsEqual(drop(-1, [1, 2, 3, 4]), [1, 2, 3, 4])
+  assert intsEqual(drop(0, [1, 2, 3, 4]), [1, 2, 3, 4])
+  assert intsEqual(drop(1, [1, 2, 3, 4]), [2, 3, 4])
+  assert intsEqual(drop(3, [1, 2, 3, 4]), [4])
+  assert intsEqual(drop(4, [1, 2, 3, 4]), [])
+  assert intsEqual(drop(5, [1, 2, 3, 4]), [])
+}
+
+test "drop empty semantics" {
+  assert intsEqual(drop(-1, []), [])
+  assert intsEqual(drop(0, []), [])
+  assert intsEqual(drop(1, []), [])
+}
+
+test "drop avoids recursive depth cap" {
+  assert length(drop(12000, bigList())) == 4384
+}


### PR DESCRIPTION
## What this is

Iteration 245 picked `m-stdlib-list-delegation-sweep`, whose queue row scoped **13 delegation
candidates, ~2–3 days**. Measuring the row before routing showed **11 of the 13 cannot be delegated
at all** — so most of this PR is correcting the record, and the code change is the one delegation
that was actually available.

## The finding

The gate enumerates `_list_*` builtins from the union of two live registries. Those registries
describe **different execution paths**, and the exemption table did not distinguish them:

- `AllNames()` — the interpreter's spec registry — holds **18** `_list_*` names.
- `GetBuiltinNames()` — codegen metadata — holds **26**. Union: **31**.

Of the 13 names classified `DELEGATION-CANDIDATE`, only **`_list_take` and `_list_drop`** are in the
**runtime** registry. The other eleven (`any`, `zip`, `foldr`, `findIndex`, `flatMap`, `sortBy`,
`mapE`, `filterE`, `foldlE`, `flatMapE`, `forEachE`) are **codegen-only** — they exist for generated
Go and the interpreter has no implementation. Delegating any of them would not make `std/list`
faster, it would break it.

Three-arm probe, `ailang run --caps IO`, fresh binary, exit codes captured without a pipe:

| call | rc | output |
|---|---|---|
| `_list_drop(1, [1,2,3])` | 0 | `[2, 3]` |
| `_list_reverse([1,2,3])` (control, already delegated) | 0 | `[3, 2, 1]` |
| `_list_zip([1,2], [3,4])` | 1 | `type error … undefined variable: _list_zip` |

So the blocker was never "the `std/list` form is recursive". It is a missing interpreter
implementation, which is materially larger work than a delegation.

## Changes

**M1 — `std/list.drop` delegates to `_list_drop`.** The recursive form recursed `n` deep:
`drop(12000, xs)` on a 16,384-element list died `RT_REC_003: max recursion depth 10000 exceeded`.
Equivalence verified at `n<0, 0, 1, len-1, len, >len` and on the empty list. Pinned by
`tests/stdlib/list_drop_test.ail`, which builds that same 16,384-element list and asserts
`length(drop(12000, big)) == 4384` — the exact program that failed before.
`STDLIB_AIL_SUITES_EXPECTED` moves 3 → 4 because that count is an equality, not a floor.

**M2 — the classification is machine-checked instead of prose.** Each exemption now carries a
category (`DelegableNow` / `NoRuntimeImpl` / `NotNeeded`) and a runtime-backed flag, asserted
against `AllNames()`: `NoRuntimeImpl` names must be ABSENT from the runtime registry, runtime-backed
names PRESENT, and the categorised set must equal the exempted set. A wrong classification now reds
rather than reading as documentation — which is how the previous one stayed wrong.

**M3 — changelog** (in `changelogs/`, not the root index).

## Mutation drill — 4 mutants, each LANDED (sha256) + BUILDS asserted before any test result

| mutant | gate | names | `-skip` gate |
|---|---|---|---|
| misclassify `_list_zip` as `DelegableNow` | RED | `_list_zip` | rc=0 |
| register a new codegen-only `_list_mutantProbe` | RED, count 31 → 32 | `_list_mutantProbe` | rc=0 |
| revert the `drop` delegation | RED | `_list_drop` | rc=0 |
| stale-exemption arm (`_list_drop` left exempted) | RED | `_list_drop` | — |

Each is a **sole killer**. A removal proves the check fires; only the **addition** proves it looks.
Restores verified byte-identical by sha256, from `cp` backups (never `git checkout --`, which would
have deleted uncommitted sprint work).

## Deliberately NOT done

`std/list.take` is **not** delegated, though `_list_take` is runtime-backed. It is the only list
builtin that writes to stderr (control: exactly 1 `Fprintf` in `internal/builtins/list.go`).
Measured: `_list_take(100, <16384-element list>)` emits a two-line `note:` about materialization.
Because `_list_take` has no `std/` call site today, that note is dormant; delegating would activate
it and make a `pure` stdlib function write to stderr on the common `take(small_n, big_list)` call.
That needs a decision, not a controller's improvisation, so it is filed as its own queue row and the
exemption records it verbatim.

## Gates — all controller-run OUTSIDE the executor sandbox, on darwin/arm64

`go build ./internal/builtins/...` · `go build ./cmd/ailang` · `go test ./internal/builtins/...` ·
`go test ./internal/eval/...` · `make test-stdlib-ail` (4 suites, 4 run-fixtures) ·
`check-changelog` · `check-file-sizes` · `check-boundaries` · `check-skills` · `gofmt -l internal/`
— **all rc=0**, under a binary built in-worktree. ubuntu and windows legs unrun locally.

Note `go build ./...` is **not** in that list: it is rc=1 on untouched `dev` (`cmd/wasm` and
`gen/main` have no native `main`). The executor refused to assert mutant-buildability against it and
was right to; the criterion was corrected mid-sprint rather than the code.

The executor also reformatted the whole of `std/list.ail` (type-signature and semicolon churn
unrelated to `drop`). That was reverted — `std/list.ail` is now base + the delegation only, 2
insertions / 7 deletions.

Commits are per-milestone; M1 alone is red on the stale exemption that M2 deletes, which squash-merge
makes moot for `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
