### PR TITLE
fix(codegen): stdlib calls resolved by a flat name index, so compiled programs ran a different module's implementation

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -12,7 +12,12 @@ module-less references resolve only when exactly one registered spec claims the
 bare name. This prevents collisions such as `std/option.map` selecting the list
 helper and `std/list.length` selecting the string helper. A source-scanning gate
 checks all exported functions under `std/`, rejects duplicate qualified claims,
-and pins the deliberate cross-family mappings.
+and pins the deliberate cross-family mappings. `$`-prefixed pseudo-modules remain
+direct builtin identities rather than qualified stdlib modules, restoring
+compiled boolean negation (`$builtin.not_Bool`) without weakening fail-closed
+resolution for genuine modules. The gate also rejects exemption rows that do not
+correspond to a real source export; its remaining semantic-substitution blind
+spot is documented alongside the test.
 
 ### Changed — `std/list.drop` delegates and list exemptions are typed
 

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,16 @@
 
 ## [Unreleased]
 
+### Fixed — Go codegen resolves stdlib functions by module and name
+
+The builtin codegen registry now indexes stdlib exports by their qualified
+`module + name` pair. Qualified references fail closed on module mismatch, and
+module-less references resolve only when exactly one registered spec claims the
+bare name. This prevents collisions such as `std/option.map` selecting the list
+helper and `std/list.length` selecting the string helper. A source-scanning gate
+checks all exported functions under `std/`, rejects duplicate qualified claims,
+and pins the deliberate cross-family mappings.
+
 ### Changed — `std/list.drop` delegates and list exemptions are typed
 
 `std/list.drop` now delegates to the iterative `_list_drop` runtime builtin, preserving

--- a/internal/builtins/registry.go
+++ b/internal/builtins/registry.go
@@ -39,6 +39,11 @@ type GoCodegenSpec struct {
 	// Used by the codegen to resolve VarGlobal references from stdlib imports.
 	StdlibName string
 
+	// StdlibModule is the AILANG module whose exported StdlibName this spec
+	// implements (for example, "std/string"). Qualified lookup never matches
+	// specs that omit this field.
+	StdlibModule string
+
 	// RequiresADT specifies which ADT must be registered for this helper to be emitted.
 	// Values: "Json", "Option", "Result", or "" (always emit).
 	// Helpers with RequiresADT are eagerly emitted when their ADT is registered,
@@ -66,11 +71,19 @@ type GoHelperSpec struct {
 // This is a simple data structure with no dependencies on eval or runtime
 var Registry = make(map[string]*BuiltinMeta)
 
-// StdlibIndex maps stdlib function names (e.g., "trim", "map") to their
-// internal builtin names (e.g., "_str_trim", "_list_map").
+type StdlibKey struct {
+	Module string
+	Name   string
+}
+
+// StdlibIndex maps qualified stdlib exports to internal builtin names.
 // M-CODEGEN-SUSTAINABILITY: Built automatically from GoCodegenSpec.StdlibName fields.
 // The codegen queries this to resolve VarGlobal references from stdlib imports.
-var StdlibIndex = make(map[string]string)
+var StdlibIndex = make(map[StdlibKey]string)
+
+// unambiguousStdlibNameIndex supports module-less references. A name is
+// present only when exactly one codegen spec claims it across the registry.
+var unambiguousStdlibNameIndex = make(map[string]string)
 
 func init() {
 	registerArithmeticMeta()
@@ -115,10 +128,22 @@ func GetCodegenSpec(name string) *GoCodegenSpec {
 	return meta.GoCodegen
 }
 
-// GetCodegenSpecByStdlibName looks up a codegen spec by stdlib function name.
-// Example: GetCodegenSpecByStdlibName("trim") returns the spec for _str_trim.
-func GetCodegenSpecByStdlibName(stdlibName string) *GoCodegenSpec {
-	builtinName, ok := StdlibIndex[stdlibName]
+// GetCodegenSpecByStdlibName looks up a codegen spec by qualified stdlib export.
+func GetCodegenSpecByStdlibName(module, stdlibName string) *GoCodegenSpec {
+	if module == "" {
+		return nil
+	}
+	builtinName, ok := StdlibIndex[StdlibKey{Module: module, Name: stdlibName}]
+	if !ok {
+		return nil
+	}
+	return GetCodegenSpec(builtinName)
+}
+
+// GetCodegenSpecByUnambiguousStdlibName looks up a module-less stdlib name.
+// Ambiguous names are deliberately absent rather than resolved by map order.
+func GetCodegenSpecByUnambiguousStdlibName(stdlibName string) *GoCodegenSpec {
+	builtinName, ok := unambiguousStdlibNameIndex[stdlibName]
 	if !ok {
 		return nil
 	}
@@ -140,9 +165,22 @@ func GetHelpersRequiringADT(adtName string) []*GoCodegenSpec {
 // RebuildStdlibIndex populates StdlibIndex from all registered builtins.
 // Called after all builtins are registered.
 func RebuildStdlibIndex() {
+	clear(StdlibIndex)
+	clear(unambiguousStdlibNameIndex)
+	counts := make(map[string]int)
 	for name, meta := range Registry {
 		if meta.GoCodegen != nil && meta.GoCodegen.StdlibName != "" {
-			StdlibIndex[meta.GoCodegen.StdlibName] = name
+			spec := meta.GoCodegen
+			counts[spec.StdlibName]++
+			if spec.StdlibModule != "" {
+				StdlibIndex[StdlibKey{Module: spec.StdlibModule, Name: spec.StdlibName}] = name
+			}
+			unambiguousStdlibNameIndex[spec.StdlibName] = name
+		}
+	}
+	for stdlibName, count := range counts {
+		if count != 1 {
+			delete(unambiguousStdlibNameIndex, stdlibName)
 		}
 	}
 }

--- a/internal/builtins/registry_codegen_effects.go
+++ b/internal/builtins/registry_codegen_effects.go
@@ -167,15 +167,15 @@ func registerEffectCodegenSpecs() {
 
 	// Math helpers
 	mathHelpers := []struct {
-		name, stdlib, funcName, body string
+		name, module, stdlib, funcName, body string
 	}{
-		{"_math_maximumInt", "maximumInt", "MaximumInt", `a := toInt64(args[0]); b := toInt64(args[1]); if a > b { return a }; return b`},
-		{"_math_minimumInt", "minimumInt", "MinimumInt", `a := toInt64(args[0]); b := toInt64(args[1]); if a < b { return a }; return b`},
-		{"_math_maximumFloat", "maximumFloat", "MaximumFloat", `a := args[0].(float64); b := args[1].(float64); if a > b { return a }; return b`},
-		{"_math_minimumFloat", "minimumFloat", "MinimumFloat", `a := args[0].(float64); b := args[1].(float64); if a < b { return a }; return b`},
-		{"_math_absInt", "absInt", "AbsInt", `v := toInt64(args[0]); if v < 0 { return -v }; return v`},
-		{"_math_maximumString", "maximumString", "MaximumString", `a := args[0].(string); b := args[1].(string); if a > b { return a }; return b`},
-		{"_math_minimumString", "minimumString", "MinimumString", `a := args[0].(string); b := args[1].(string); if a < b { return a }; return b`},
+		{"_math_maximumInt", "std/list", "maximumInt", "MaximumInt", `a := toInt64(args[0]); b := toInt64(args[1]); if a > b { return a }; return b`},
+		{"_math_minimumInt", "std/list", "minimumInt", "MinimumInt", `a := toInt64(args[0]); b := toInt64(args[1]); if a < b { return a }; return b`},
+		{"_math_maximumFloat", "std/list", "maximumFloat", "MaximumFloat", `a := args[0].(float64); b := args[1].(float64); if a > b { return a }; return b`},
+		{"_math_minimumFloat", "std/list", "minimumFloat", "MinimumFloat", `a := args[0].(float64); b := args[1].(float64); if a < b { return a }; return b`},
+		{"_math_absInt", "", "", "AbsInt", `v := toInt64(args[0]); if v < 0 { return -v }; return v`},
+		{"_math_maximumString", "std/list", "maximumString", "MaximumString", `a := args[0].(string); b := args[1].(string); if a > b { return a }; return b`},
+		{"_math_minimumString", "std/list", "minimumString", "MinimumString", `a := args[0].(string); b := args[1].(string); if a < b { return a }; return b`},
 	}
 	for _, spec := range mathHelpers {
 		registerIfMissing(spec.name, 2, true, &GoCodegenSpec{
@@ -185,7 +185,7 @@ func registerEffectCodegenSpecs() {
 				Body:      spec.body,
 			},
 			StdlibName:   spec.stdlib,
-			StdlibModule: "std/list",
+			StdlibModule: spec.module,
 		})
 	}
 

--- a/internal/builtins/registry_codegen_effects.go
+++ b/internal/builtins/registry_codegen_effects.go
@@ -28,7 +28,8 @@ func registerEffectCodegenSpecs() {
 				Signature: "func " + funcName + "(args ...interface{}) interface{}",
 				Body:      `panic("` + funcName + `: XML operations not yet available in compiled mode")`,
 			},
-			StdlibName: spec.stdlib,
+			StdlibName:   spec.stdlib,
+			StdlibModule: "std/xml",
 		})
 	}
 
@@ -39,7 +40,8 @@ func registerEffectCodegenSpecs() {
 			Signature: "func ParseElements(args ...interface{}) interface{}",
 			Body:      `panic("ParseElements: XML streaming not available in compiled mode - provide an XML handler")`,
 		},
-		StdlibName: "parseElements",
+		StdlibName:   "parseElements",
+		StdlibModule: "std/xml",
 	})
 
 	// JSON helpers for DocParse
@@ -57,8 +59,9 @@ func registerEffectCodegenSpecs() {
 	if result == nil { result = []interface{}{} }
 	return result`,
 		},
-		StdlibName:  "filterStrings",
-		RequiresADT: "Json",
+		StdlibName:   "filterStrings",
+		StdlibModule: "std/json",
+		RequiresADT:  "Json",
 	})
 	registerIfMissing("_json_getObject", 2, true, &GoCodegenSpec{
 		Helper: &GoHelperSpec{
@@ -68,8 +71,9 @@ func registerEffectCodegenSpecs() {
 	if IsNone(opt).(bool) { return NewOptionNone() }
 	return AsObject(OptionGetOrElse(opt, nil))`,
 		},
-		StdlibName:  "getObject",
-		RequiresADT: "Json",
+		StdlibName:   "getObject",
+		StdlibModule: "std/json",
+		RequiresADT:  "Json",
 	})
 
 	// NotBool helper — registered as not_Bool to match Core IR VarGlobal name
@@ -88,7 +92,8 @@ func registerEffectCodegenSpecs() {
 			Signature: "func Check(label interface{}, value interface{}) interface{}",
 			Body:      `return value`,
 		},
-		StdlibName: "check",
+		StdlibName:   "check",
+		StdlibModule: "std/debug",
 	})
 
 	// Effectful list combinators — panic stubs for compiled mode
@@ -108,7 +113,8 @@ func registerEffectCodegenSpecs() {
 				Signature: "func " + funcName + "(args ...interface{}) interface{}",
 				Body:      `panic("` + funcName + `: effectful list operation not available in compiled mode - provide a handler")`,
 			},
-			StdlibName: spec.stdlib,
+			StdlibName:   spec.stdlib,
+			StdlibModule: "std/list",
 		})
 	}
 
@@ -133,8 +139,9 @@ func registerEffectCodegenSpecs() {
 				Signature: "func " + funcName + "(args ...interface{}) interface{}",
 				Body:      `panic("` + funcName + `: JSON helper not yet available in compiled mode")`,
 			},
-			StdlibName:  spec.stdlib,
-			RequiresADT: "Json",
+			StdlibName:   spec.stdlib,
+			StdlibModule: "std/json",
+			RequiresADT:  "Json",
 		})
 	}
 
@@ -145,7 +152,8 @@ func registerEffectCodegenSpecs() {
 			Signature: "func ToString(v interface{}) interface{}",
 			Body:      `return Show(v)`,
 		},
-		StdlibName: "toString",
+		StdlibName:   "toString",
+		StdlibModule: "std/bytes",
 	})
 	registerIfMissing("_str_fromString", 1, true, &GoCodegenSpec{
 		Helper: &GoHelperSpec{
@@ -153,7 +161,8 @@ func registerEffectCodegenSpecs() {
 			Signature: "func FromString(s interface{}) interface{}",
 			Body:      `return s`,
 		},
-		StdlibName: "fromString",
+		StdlibName:   "fromString",
+		StdlibModule: "std/bytes",
 	})
 
 	// Math helpers
@@ -175,26 +184,27 @@ func registerEffectCodegenSpecs() {
 				Signature: "func " + spec.funcName + "(args ...interface{}) interface{}",
 				Body:      spec.body,
 			},
-			StdlibName: spec.stdlib,
+			StdlibName:   spec.stdlib,
+			StdlibModule: "std/list",
 		})
 	}
 
 	// Process/IO effect stubs
 	ioEffectFuncs := []struct {
-		name, stdlib, funcName string
-		numArgs                int
+		name, module, stdlib, funcName string
+		numArgs                        int
 	}{
-		{"_process_spawn", "spawnProcess", "SpawnProcess", 1},
-		{"_process_exec", "exec", "Exec", 1},
-		{"_process_asyncExec", "asyncExecProcess", "AsyncExecProcess", 1},
-		{"_process_writeStdin", "writeProcessStdin", "WriteProcessStdin", 2},
-		{"_process_closeStdin", "closeProcessStdin", "CloseProcessStdin", 1},
-		{"_process_asyncReadStdinLines", "asyncReadStdinLines", "AsyncReadStdinLines", 1},
-		{"_io_listDir", "listDir", "ListDir", 1},
-		{"_clock_now", "now", "Now", 0},
-		{"_net_httpGet", "httpGet", "HttpGet", 1},
-		{"_net_httpRequest", "httpRequest", "HttpRequest", 1},
-		{"_net_httpRequestBytes", "httpRequestBytes", "HttpRequestBytes", 1},
+		{"_process_spawn", "std/process", "spawnProcess", "SpawnProcess", 1},
+		{"_process_exec", "std/process", "exec", "Exec", 1},
+		{"_process_asyncExec", "std/stream", "asyncExecProcess", "AsyncExecProcess", 1},
+		{"_process_writeStdin", "std/process", "writeProcessStdin", "WriteProcessStdin", 2},
+		{"_process_closeStdin", "std/process", "closeProcessStdin", "CloseProcessStdin", 1},
+		{"_process_asyncReadStdinLines", "std/stream", "asyncReadStdinLines", "AsyncReadStdinLines", 1},
+		{"_io_listDir", "std/fs", "listDir", "ListDir", 1},
+		{"_clock_now", "std/clock", "now", "Now", 0},
+		{"_net_httpGet", "std/net", "httpGet", "HttpGet", 1},
+		{"_net_httpRequest", "std/net", "httpRequest", "HttpRequest", 1},
+		{"_net_httpRequestBytes", "std/net", "httpRequestBytes", "HttpRequestBytes", 1},
 	}
 	for _, spec := range ioEffectFuncs {
 		funcName := spec.funcName
@@ -204,7 +214,8 @@ func registerEffectCodegenSpecs() {
 				Signature: "func " + funcName + "(args ...interface{}) interface{}",
 				Body:      `panic("` + funcName + `: effect not available in compiled mode - provide a handler")`,
 			},
-			StdlibName: spec.stdlib,
+			StdlibName:   spec.stdlib,
+			StdlibModule: spec.module,
 		})
 	}
 
@@ -215,7 +226,8 @@ func registerEffectCodegenSpecs() {
 			Signature: "func Head(xs interface{}) interface{}",
 			Body:      `return ListHead(xs)`,
 		},
-		StdlibName: "head",
+		StdlibName:   "head",
+		StdlibModule: "std/list",
 	})
 	registerIfMissing("_list_tail", 1, true, &GoCodegenSpec{
 		Helper: &GoHelperSpec{
@@ -223,7 +235,8 @@ func registerEffectCodegenSpecs() {
 			Signature: "func Tail(xs interface{}) interface{}",
 			Body:      `return ListTail(xs)`,
 		},
-		StdlibName: "tail",
+		StdlibName:   "tail",
+		StdlibModule: "std/list",
 	})
 	registerIfMissing("_list_member", 2, true, &GoCodegenSpec{
 		Helper: &GoHelperSpec{
@@ -235,7 +248,8 @@ func registerEffectCodegenSpecs() {
 	}
 	return false`,
 		},
-		StdlibName: "member",
+		StdlibName:   "member",
+		StdlibModule: "std/list",
 	})
 	registerIfMissing("_list_difference", 2, true, &GoCodegenSpec{
 		Helper: &GoHelperSpec{
@@ -252,6 +266,7 @@ func registerEffectCodegenSpecs() {
 	if result == nil { result = []interface{}{} }
 	return result`,
 		},
-		StdlibName: "difference",
+		StdlibName:   "difference",
+		StdlibModule: "std/list",
 	})
 }

--- a/internal/builtins/registry_codegen_io.go
+++ b/internal/builtins/registry_codegen_io.go
@@ -11,8 +11,9 @@ func registerIOCodegenSpecs() {
 			Body: `fmt.Println(Show(v))
 	return struct{}{}`,
 		},
-		Imports:    []string{"fmt"},
-		StdlibName: "println",
+		Imports:      []string{"fmt"},
+		StdlibName:   "println",
+		StdlibModule: "std/io",
 	})
 	setSpec("_io_print", &GoCodegenSpec{
 		Helper: &GoHelperSpec{
@@ -20,34 +21,35 @@ func registerIOCodegenSpecs() {
 			Body: `fmt.Print(Show(v))
 	return struct{}{}`,
 		},
-		Imports:    []string{"fmt"},
-		StdlibName: "print",
+		Imports:      []string{"fmt"},
+		StdlibName:   "print",
+		StdlibModule: "std/io",
 	})
 
 	// Effect stubs — these panic with clear messages
 	for _, spec := range []struct {
-		name, stdlib, funcName, msg string
-		numArgs                     int
+		name, module, stdlib, funcName, msg string
+		numArgs                             int
 	}{
-		{"_fs_readFile", "readFile", "ReadFile", "FS", 1},
-		{"_fs_writeFile", "writeFile", "WriteFile", "FS", 2},
-		{"_fs_exists", "fileExists", "FileExists", "FS", 1},
-		{"_fs_readFileBytes", "readFileBytes", "ReadFileBytes", "FS", 1},
-		{"_fs_mkdir", "mkdir", "Mkdir", "FS", 1},
-		{"_fs_mkdirAll", "mkdirAll", "MkdirAll", "FS", 1},
-		{"_fs_isDir", "isDir", "IsDir", "FS", 1},
-		{"_fs_isFile", "isFile", "IsFile", "FS", 1},
-		{"_fs_removeFile", "removeFile", "RemoveFile", "FS", 1},
-		{"_zip_readEntry", "readEntry", "ReadEntry", "zip", 0},
-		{"_zip_readEntryBytes", "readEntryBytes", "ReadEntryBytes", "zip", 0},
-		{"_zip_listEntries", "listEntries", "ListEntries", "zip", 0},
-		{"_zip_createArchive", "createArchive", "CreateArchive", "zip", 0},
-		{"_env_getEnvOr", "getEnvOr", "GetEnvOr", "Env", 2},
-		{"_env_getArgs", "getArgs", "GetArgs", "Env", 0},
-		{"_env_getEnv", "getEnv", "GetEnv", "Env", 1},
-		{"_ai_call", "call", "Call", "AI", 0},
-		{"_ai_callJson", "callJson", "CallJson", "AI", 0},
-		{"_ai_callJsonSimple", "callJsonSimple", "CallJsonSimple", "AI", 0},
+		{"_fs_readFile", "std/fs", "readFile", "ReadFile", "FS", 1},
+		{"_fs_writeFile", "std/fs", "writeFile", "WriteFile", "FS", 2},
+		{"_fs_exists", "std/fs", "fileExists", "FileExists", "FS", 1},
+		{"_fs_readFileBytes", "std/fs", "readFileBytes", "ReadFileBytes", "FS", 1},
+		{"_fs_mkdir", "std/fs", "mkdir", "Mkdir", "FS", 1},
+		{"_fs_mkdirAll", "std/fs", "mkdirAll", "MkdirAll", "FS", 1},
+		{"_fs_isDir", "std/fs", "isDir", "IsDir", "FS", 1},
+		{"_fs_isFile", "std/fs", "isFile", "IsFile", "FS", 1},
+		{"_fs_removeFile", "std/fs", "removeFile", "RemoveFile", "FS", 1},
+		{"_zip_readEntry", "std/zip", "readEntry", "ReadEntry", "zip", 0},
+		{"_zip_readEntryBytes", "std/zip", "readEntryBytes", "ReadEntryBytes", "zip", 0},
+		{"_zip_listEntries", "std/zip", "listEntries", "ListEntries", "zip", 0},
+		{"_zip_createArchive", "std/zip", "createArchive", "CreateArchive", "zip", 0},
+		{"_env_getEnvOr", "std/env", "getEnvOr", "GetEnvOr", "Env", 2},
+		{"_env_getArgs", "std/env", "getArgs", "GetArgs", "Env", 0},
+		{"_env_getEnv", "std/env", "getEnv", "GetEnv", "Env", 1},
+		{"_ai_call", "std/ai", "call", "Call", "AI", 0},
+		{"_ai_callJson", "std/ai", "callJson", "CallJson", "AI", 0},
+		{"_ai_callJsonSimple", "std/ai", "callJsonSimple", "CallJsonSimple", "AI", 0},
 	} {
 		funcName := spec.funcName
 		msg := spec.msg
@@ -57,7 +59,8 @@ func registerIOCodegenSpecs() {
 				Signature: "func " + funcName + "(args ...interface{}) interface{}",
 				Body:      `panic("` + funcName + `: ` + msg + ` effect not available in compiled mode - provide a handler")`,
 			},
-			StdlibName: spec.stdlib,
+			StdlibName:   spec.stdlib,
+			StdlibModule: spec.module,
 		})
 	}
 }

--- a/internal/builtins/registry_codegen_json.go
+++ b/internal/builtins/registry_codegen_json.go
@@ -10,16 +10,18 @@ func registerJSONCodegenSpecs() {
 			FuncName: "Decode", Signature: "func Decode(s interface{}) interface{}",
 			Body: `return NewResultErr("JSON decode not yet available in compiled Go mode")`,
 		},
-		StdlibName:  "decode",
-		RequiresADT: "Json",
+		StdlibName:   "decode",
+		StdlibModule: "std/json",
+		RequiresADT:  "Json",
 	})
 	setSpec("_json_encode", &GoCodegenSpec{
 		Helper: &GoHelperSpec{
 			FuncName: "Encode", Signature: "func Encode(obj interface{}) interface{}",
 			Body: `return "{}"`,
 		},
-		StdlibName:  "encode",
-		RequiresADT: "Json",
+		StdlibName:   "encode",
+		StdlibModule: "std/json",
+		RequiresADT:  "Json",
 	})
 
 	// JSON constructor and accessor helpers
@@ -165,9 +167,10 @@ func registerJSONCodegenSpecs() {
 		}, "Json"},
 	} {
 		registerIfMissing(spec.name, spec.numArgs, true, &GoCodegenSpec{
-			Helper:      spec.helper,
-			StdlibName:  spec.stdlib,
-			RequiresADT: spec.requiresADT,
+			Helper:       spec.helper,
+			StdlibName:   spec.stdlib,
+			StdlibModule: "std/json",
+			RequiresADT:  spec.requiresADT,
 		})
 	}
 
@@ -202,9 +205,10 @@ func registerJSONCodegenSpecs() {
 		}, "Result"},
 	} {
 		registerIfMissing(spec.name, spec.numArgs, true, &GoCodegenSpec{
-			Helper:      spec.helper,
-			StdlibName:  spec.stdlib,
-			RequiresADT: spec.requiresADT,
+			Helper:       spec.helper,
+			StdlibName:   spec.stdlib,
+			StdlibModule: map[string]string{"Option": "std/option", "Result": "std/result"}[spec.requiresADT],
+			RequiresADT:  spec.requiresADT,
 		})
 	}
 }

--- a/internal/builtins/registry_codegen_list.go
+++ b/internal/builtins/registry_codegen_list.go
@@ -14,7 +14,8 @@ func registerListCodegenSpecs() {
 			Signature: "func Concat(a, b interface{}) interface{}",
 			Body:      `return ConcatList(a, b)`,
 		},
-		StdlibName: "concat",
+		StdlibName:   "concat",
+		StdlibModule: "std/list",
 	})
 
 	registerIfMissing("_list_map", 2, true, &GoCodegenSpec{
@@ -28,7 +29,8 @@ func registerListCodegenSpecs() {
 	}
 	return result`,
 		},
-		StdlibName: "map",
+		StdlibName:   "map",
+		StdlibModule: "std/list",
 	})
 	registerIfMissing("_list_filter", 2, true, &GoCodegenSpec{
 		Helper: &GoHelperSpec{
@@ -44,7 +46,8 @@ func registerListCodegenSpecs() {
 	if result == nil { result = []interface{}{} }
 	return result`,
 		},
-		StdlibName: "filter",
+		StdlibName:   "filter",
+		StdlibModule: "std/list",
 	})
 	registerIfMissing("_list_foldl", 3, true, &GoCodegenSpec{
 		Helper: &GoHelperSpec{
@@ -57,7 +60,8 @@ func registerListCodegenSpecs() {
 	}
 	return result`,
 		},
-		StdlibName: "foldl",
+		StdlibName:   "foldl",
+		StdlibModule: "std/list",
 	})
 	registerIfMissing("_list_foldr", 3, true, &GoCodegenSpec{
 		Helper: &GoHelperSpec{
@@ -70,7 +74,8 @@ func registerListCodegenSpecs() {
 	}
 	return result`,
 		},
-		StdlibName: "foldr",
+		StdlibName:   "foldr",
+		StdlibModule: "std/list",
 	})
 	registerIfMissing("_list_dedup", 1, true, &GoCodegenSpec{
 		Helper: &GoHelperSpec{
@@ -88,7 +93,8 @@ func registerListCodegenSpecs() {
 	if result == nil { result = []interface{}{} }
 	return result`,
 		},
-		StdlibName: "dedup",
+		StdlibName:   "dedup",
+		StdlibModule: "std/list",
 	})
 
 	// M-CODEGEN-LETBIND-FIX: Set operations (intersect, union) used by DocParse
@@ -111,7 +117,8 @@ func registerListCodegenSpecs() {
 	if result == nil { result = []interface{}{} }
 	return result`,
 		},
-		StdlibName: "intersect",
+		StdlibName:   "intersect",
+		StdlibModule: "std/list",
 	})
 	registerIfMissing("_list_union", 2, true, &GoCodegenSpec{
 		Helper: &GoHelperSpec{
@@ -136,7 +143,8 @@ func registerListCodegenSpecs() {
 	if result == nil { result = []interface{}{} }
 	return result`,
 		},
-		StdlibName: "union",
+		StdlibName:   "union",
+		StdlibModule: "std/list",
 	})
 
 	// Additional list helpers used by stdlib but not as builtins
@@ -216,8 +224,9 @@ func registerListCodegenSpecs() {
 		}},
 	} {
 		registerIfMissing(spec.name, spec.numArgs, true, &GoCodegenSpec{
-			Helper:     spec.helper,
-			StdlibName: spec.stdlib,
+			Helper:       spec.helper,
+			StdlibName:   spec.stdlib,
+			StdlibModule: "std/list",
 		})
 	}
 
@@ -230,7 +239,8 @@ func registerListCodegenSpecs() {
 	if i < 0 || i >= len(list) { return NewOptionNone() }
 	return NewOptionSome(list[i])`,
 		},
-		StdlibName: "nth",
+		StdlibName:   "nth",
+		StdlibModule: "std/list",
 	})
 	registerIfMissing("_list_last", 1, true, &GoCodegenSpec{
 		Helper: &GoHelperSpec{
@@ -239,7 +249,8 @@ func registerListCodegenSpecs() {
 	if len(list) == 0 { return NewOptionNone() }
 	return NewOptionSome(list[len(list)-1])`,
 		},
-		StdlibName: "last",
+		StdlibName:   "last",
+		StdlibModule: "std/list",
 	})
 	registerIfMissing("_list_findIndex", 2, true, &GoCodegenSpec{
 		Helper: &GoHelperSpec{
@@ -252,14 +263,16 @@ func registerListCodegenSpecs() {
 	}
 	return NewOptionNone()`,
 		},
-		StdlibName: "findIndex",
+		StdlibName:   "findIndex",
+		StdlibModule: "std/list",
 	})
 	registerIfMissing("_list_mapE", 2, false, &GoCodegenSpec{
 		Helper: &GoHelperSpec{
 			FuncName: "MapE", Signature: "func MapE(f, xs interface{}) interface{}",
 			Body: `return Map(f, xs)`,
 		},
-		StdlibName: "mapE",
+		StdlibName:   "mapE",
+		StdlibModule: "std/list",
 	})
 	registerIfMissing("_list_forEachE", 2, false, &GoCodegenSpec{
 		Helper: &GoHelperSpec{
@@ -270,6 +283,7 @@ func registerListCodegenSpecs() {
 	}
 	return struct{}{}`,
 		},
-		StdlibName: "forEachE",
+		StdlibName:   "forEachE",
+		StdlibModule: "std/list",
 	})
 }

--- a/internal/builtins/registry_codegen_math.go
+++ b/internal/builtins/registry_codegen_math.go
@@ -30,30 +30,35 @@ func registerMathCodegenSpecs() {
 			numArgs = 2
 		}
 		registerIfMissing(name, numArgs, true, &GoCodegenSpec{
-			Inline:     spec.goExpr,
-			Imports:    []string{"math"},
-			StdlibName: spec.stdlibName,
+			Inline:       spec.goExpr,
+			Imports:      []string{"math"},
+			StdlibName:   spec.stdlibName,
+			StdlibModule: "std/math",
 		})
 	}
 	// Math constants
 	registerIfMissing("_math_PI", 0, true, &GoCodegenSpec{
-		Inline:     `math.Pi`,
-		Imports:    []string{"math"},
-		StdlibName: "PI",
+		Inline:       `math.Pi`,
+		Imports:      []string{"math"},
+		StdlibName:   "PI",
+		StdlibModule: "std/math",
 	})
 	registerIfMissing("_math_E", 0, true, &GoCodegenSpec{
-		Inline:     `math.E`,
-		Imports:    []string{"math"},
-		StdlibName: "E",
+		Inline:       `math.E`,
+		Imports:      []string{"math"},
+		StdlibName:   "E",
+		StdlibModule: "std/math",
 	})
 	// Conversion builtins used by math
 	registerIfMissing("_int_to_float", 1, true, &GoCodegenSpec{
-		Inline:     `float64(toInt64({{arg0}}))`,
-		StdlibName: "intToFloat",
+		Inline:       `float64(toInt64({{arg0}}))`,
+		StdlibName:   "intToFloat",
+		StdlibModule: "std/math",
 	})
 	registerIfMissing("_float_to_int", 1, true, &GoCodegenSpec{
-		Inline:     `int64({{arg0}}.(float64))`,
-		StdlibName: "floatToInt",
+		Inline:       `int64({{arg0}}.(float64))`,
+		StdlibName:   "floatToInt",
+		StdlibModule: "std/math",
 	})
 }
 
@@ -63,11 +68,9 @@ func registerMathCodegenSpecs() {
 
 func registerConversionCodegenSpecs() {
 	setSpec("intToFloat", &GoCodegenSpec{
-		Inline:     `float64(toInt64({{arg0}}))`,
-		StdlibName: "intToFloat",
+		Inline: `float64(toInt64({{arg0}}))`,
 	})
 	setSpec("floatToInt", &GoCodegenSpec{
-		Inline:     `int64({{arg0}}.(float64))`,
-		StdlibName: "floatToInt",
+		Inline: `int64({{arg0}}.(float64))`,
 	})
 }

--- a/internal/builtins/registry_codegen_string.go
+++ b/internal/builtins/registry_codegen_string.go
@@ -13,27 +13,27 @@ func registerStringCodegenSpecs() {
 			Body:      `return strings.TrimSpace(s.(string))`,
 		},
 		Imports:    []string{"strings"},
-		StdlibName: "trim",
+		StdlibName: "trim", StdlibModule: "std/string",
 	})
 	setSpec("_str_upper", &GoCodegenSpec{
 		Inline:     `strings.ToUpper({{arg0}}.(string))`,
 		Imports:    []string{"strings"},
-		StdlibName: "toUpper",
+		StdlibName: "toUpper", StdlibModule: "std/string",
 	})
 	setSpec("_str_lower", &GoCodegenSpec{
 		Inline:     `strings.ToLower({{arg0}}.(string))`,
 		Imports:    []string{"strings"},
-		StdlibName: "toLower",
+		StdlibName: "toLower", StdlibModule: "std/string",
 	})
 	setSpec("_str_len", &GoCodegenSpec{
 		Inline:     `int64(utf8.RuneCountInString({{arg0}}.(string)))`,
 		Imports:    []string{"unicode/utf8"},
-		StdlibName: "length",
+		StdlibName: "length", StdlibModule: "std/string",
 	})
 	setSpec("_str_compare", &GoCodegenSpec{
 		Inline:     `int64(strings.Compare({{arg0}}.(string), {{arg1}}.(string)))`,
 		Imports:    []string{"strings"},
-		StdlibName: "compare",
+		StdlibName: "compare", StdlibModule: "std/string",
 	})
 	setSpec("_str_find", &GoCodegenSpec{
 		Helper: &GoHelperSpec{
@@ -45,7 +45,7 @@ func registerStringCodegenSpecs() {
 	return int64(utf8.RuneCountInString(str[:byteIdx]))`,
 		},
 		Imports:    []string{"strings", "unicode/utf8"},
-		StdlibName: "find",
+		StdlibName: "find", StdlibModule: "std/string",
 	})
 	setSpec("_str_eq", &GoCodegenSpec{
 		Inline: `{{arg0}}.(string) == {{arg1}}.(string)`,
@@ -63,7 +63,7 @@ func registerStringCodegenSpecs() {
 	if st > en { return "" }
 	return string(runes[st:en])`,
 		},
-		StdlibName: "substring",
+		StdlibName: "substring", StdlibModule: "std/string",
 	})
 
 	// String builtins not in registry.go but referenced by stdlib
@@ -79,17 +79,17 @@ func registerStringCodegenSpecs() {
 	return result`,
 		},
 		Imports:    []string{"strings"},
-		StdlibName: "split",
+		StdlibName: "split", StdlibModule: "std/string",
 	})
 	registerIfMissing("_str_startsWith", 2, true, &GoCodegenSpec{
 		Inline:     `strings.HasPrefix({{arg0}}.(string), {{arg1}}.(string))`,
 		Imports:    []string{"strings"},
-		StdlibName: "startsWith",
+		StdlibName: "startsWith", StdlibModule: "std/string",
 	})
 	registerIfMissing("_str_endsWith", 2, true, &GoCodegenSpec{
 		Inline:     `strings.HasSuffix({{arg0}}.(string), {{arg1}}.(string))`,
 		Imports:    []string{"strings"},
-		StdlibName: "endsWith",
+		StdlibName: "endsWith", StdlibModule: "std/string",
 	})
 	registerIfMissing("_str_chars", 1, true, &GoCodegenSpec{
 		Helper: &GoHelperSpec{
@@ -102,7 +102,7 @@ func registerStringCodegenSpecs() {
 	}
 	return result`,
 		},
-		StdlibName: "chars",
+		StdlibName: "chars", StdlibModule: "std/string",
 	})
 	registerIfMissing("_str_words", 1, true, &GoCodegenSpec{
 		Helper: &GoHelperSpec{
@@ -116,7 +116,7 @@ func registerStringCodegenSpecs() {
 	return result`,
 		},
 		Imports:    []string{"strings"},
-		StdlibName: "words",
+		StdlibName: "words", StdlibModule: "std/string",
 	})
 	registerIfMissing("_str_join", 2, true, &GoCodegenSpec{
 		Helper: &GoHelperSpec{
@@ -130,7 +130,7 @@ func registerStringCodegenSpecs() {
 	return strings.Join(strs, delimiter.(string))`,
 		},
 		Imports:    []string{"strings"},
-		StdlibName: "join",
+		StdlibName: "join", StdlibModule: "std/string",
 	})
 	registerIfMissing("_str_splitAny", 2, true, &GoCodegenSpec{
 		Helper: &GoHelperSpec{
@@ -152,17 +152,17 @@ func registerStringCodegenSpecs() {
 	return result`,
 		},
 		Imports:    []string{"strings"},
-		StdlibName: "splitAny",
+		StdlibName: "splitAny", StdlibModule: "std/string",
 	})
 	registerIfMissing("_str_contains", 2, true, &GoCodegenSpec{
 		Inline:     `strings.Contains({{arg0}}.(string), {{arg1}}.(string))`,
 		Imports:    []string{"strings"},
-		StdlibName: "contains",
+		StdlibName: "contains", StdlibModule: "std/string",
 	})
 	registerIfMissing("_str_replace", 3, true, &GoCodegenSpec{
 		Inline:     `strings.ReplaceAll({{arg0}}.(string), {{arg1}}.(string), {{arg2}}.(string))`,
 		Imports:    []string{"strings"},
-		StdlibName: "replace",
+		StdlibName: "replace", StdlibModule: "std/string",
 	})
 	registerIfMissing("_str_repeat", 2, true, &GoCodegenSpec{
 		Helper: &GoHelperSpec{
@@ -171,7 +171,7 @@ func registerStringCodegenSpecs() {
 			Body:      `return strings.Repeat(s.(string), int(toInt64(n)))`,
 		},
 		Imports:    []string{"strings"},
-		StdlibName: "repeat",
+		StdlibName: "repeat", StdlibModule: "std/string",
 	})
 	// charAt indexes by RUNE, matching both interpreter tiers. The former body
 	// indexed by BYTE (`str[i]`, bounds-checked against `len(str)`), so a
@@ -203,7 +203,7 @@ func registerStringCodegenSpecs() {
 	}
 	panic(fmt.Sprintf("charAt: index %d out of bounds for string of length %d", i, n))`,
 		},
-		StdlibName: "charAt",
+		StdlibName: "charAt", StdlibModule: "std/string",
 	})
 	// charCode had NO codegen spec at all, so any compiled program using it
 	// failed with "undefined: CharCode" (ailang#688). Same import constraint as
@@ -224,7 +224,7 @@ func registerStringCodegenSpecs() {
 	}
 	return int64(first)`,
 		},
-		StdlibName: "charCode",
+		StdlibName: "charCode", StdlibModule: "std/string",
 	})
 	registerIfMissing("_str_foldChars", 3, true, &GoCodegenSpec{
 		Helper: &GoHelperSpec{
@@ -237,7 +237,7 @@ func registerStringCodegenSpecs() {
 	}
 	return result`,
 		},
-		StdlibName: "foldChars",
+		StdlibName: "foldChars", StdlibModule: "std/string",
 	})
 	registerIfMissing("_stringToInt", 1, true, &GoCodegenSpec{
 		Helper: &GoHelperSpec{
@@ -249,7 +249,7 @@ func registerStringCodegenSpecs() {
 	return NewOptionSome(n)`,
 		},
 		Imports:    []string{"strings", "strconv"},
-		StdlibName: "stringToInt",
+		StdlibName: "stringToInt", StdlibModule: "std/string",
 	})
 	registerIfMissing("_stringToFloat", 1, true, &GoCodegenSpec{
 		Helper: &GoHelperSpec{
@@ -263,16 +263,16 @@ func registerStringCodegenSpecs() {
 	return NewOptionSome(f)`,
 		},
 		Imports:    []string{"strings", "strconv"},
-		StdlibName: "stringToFloat",
+		StdlibName: "stringToFloat", StdlibModule: "std/string",
 	})
 	registerIfMissing("_string_intToStr", 1, true, &GoCodegenSpec{
 		Inline:     `fmt.Sprintf("%d", toInt64({{arg0}}))`,
 		Imports:    []string{"fmt"},
-		StdlibName: "intToStr",
+		StdlibName: "intToStr", StdlibModule: "std/string",
 	})
 	registerIfMissing("_string_floatToStr", 1, true, &GoCodegenSpec{
 		Inline:     `fmt.Sprintf("%g", {{arg0}}.(float64))`,
 		Imports:    []string{"fmt"},
-		StdlibName: "floatToStr",
+		StdlibName: "floatToStr", StdlibModule: "std/string",
 	})
 }

--- a/internal/builtins/registry_codegen_test.go
+++ b/internal/builtins/registry_codegen_test.go
@@ -16,7 +16,7 @@ func TestCodegenSpecDirectLookup(t *testing.T) {
 }
 
 func TestCodegenSpecStdlibLookup(t *testing.T) {
-	spec := GetCodegenSpecByStdlibName("trim")
+	spec := GetCodegenSpecByStdlibName("std/string", "trim")
 	if spec == nil {
 		t.Fatal("stdlib 'trim' should resolve to a GoCodegenSpec")
 	}
@@ -26,7 +26,7 @@ func TestCodegenSpecStdlibLookup(t *testing.T) {
 }
 
 func TestCodegenSpecHelperLookup(t *testing.T) {
-	spec := GetCodegenSpecByStdlibName("map")
+	spec := GetCodegenSpecByStdlibName("std/list", "map")
 	if spec == nil {
 		t.Fatal("stdlib 'map' should resolve to a GoCodegenSpec")
 	}
@@ -35,6 +35,30 @@ func TestCodegenSpecHelperLookup(t *testing.T) {
 	}
 	if spec.Helper.FuncName != "Map" {
 		t.Errorf("'map' Helper.FuncName = %q, want 'Map'", spec.Helper.FuncName)
+	}
+}
+
+func TestQualifiedStdlibResolutionRejectsMeasuredCrossModuleCollisions(t *testing.T) {
+	if spec := GetCodegenSpecByStdlibName("std/option", "map"); spec != nil {
+		t.Fatalf("std/option.map resolved to codegen spec %+v; must not resolve to _list_map", spec)
+	}
+	if spec := GetCodegenSpecByStdlibName("std/list", "length"); spec != nil {
+		t.Fatalf("std/list.length resolved to codegen spec %+v; must not resolve to _str_len", spec)
+	}
+
+	controls := []struct {
+		module, name, builtin string
+	}{
+		{"std/string", "trim", "_str_trim"},
+		{"std/list", "map", "_list_map"},
+	}
+	for _, control := range controls {
+		key := StdlibKey{Module: control.module, Name: control.name}
+		if spec := GetCodegenSpecByStdlibName(control.module, control.name); spec == nil {
+			t.Errorf("positive control %s.%s did not resolve", control.module, control.name)
+		} else if got := StdlibIndex[key]; got != control.builtin {
+			t.Errorf("positive control %s.%s resolved to %q, want %q", control.module, control.name, got, control.builtin)
+		}
 	}
 }
 
@@ -56,18 +80,18 @@ func TestCodegenSpecCoverage(t *testing.T) {
 
 func TestStdlibIndexCompleteness(t *testing.T) {
 	// Verify key stdlib functions are indexed
-	required := []string{
-		"trim", "split", "substring", "toUpper", "toLower",
-		"map", "filter", "foldl", "reverse", "any",
-		"sin", "cos", "sqrt", "pow",
-		"println", "readFile", "writeFile",
-		"decode", "encode", "get", "getString",
-		"isNone", "isSome", "getOrElse",
-		"parse", "findAll", "getText",
+	required := []StdlibKey{
+		{"std/string", "trim"}, {"std/string", "split"}, {"std/string", "substring"}, {"std/string", "toUpper"}, {"std/string", "toLower"},
+		{"std/list", "map"}, {"std/list", "filter"}, {"std/list", "foldl"}, {"std/list", "reverse"}, {"std/list", "any"},
+		{"std/math", "sin"}, {"std/math", "cos"}, {"std/math", "sqrt"}, {"std/math", "pow"},
+		{"std/io", "println"}, {"std/fs", "readFile"}, {"std/fs", "writeFile"},
+		{"std/json", "decode"}, {"std/json", "encode"}, {"std/json", "get"}, {"std/json", "getString"},
+		{"std/option", "isNone"}, {"std/option", "isSome"}, {"std/option", "getOrElse"},
+		{"std/xml", "parse"}, {"std/xml", "findAll"}, {"std/xml", "getText"},
 	}
-	for _, name := range required {
-		if _, ok := StdlibIndex[name]; !ok {
-			t.Errorf("StdlibIndex missing required entry: %q", name)
+	for _, key := range required {
+		if _, ok := StdlibIndex[key]; !ok {
+			t.Errorf("StdlibIndex missing required entry: %s.%s", key.Module, key.Name)
 		}
 	}
 }

--- a/internal/builtins/stdlib_codegen_resolution_test.go
+++ b/internal/builtins/stdlib_codegen_resolution_test.go
@@ -51,7 +51,6 @@ var crossModuleCodegenExemptions = map[StdlibKey]crossModuleCodegenExemption{
 	{"std/bytes", "fromString"}:           {"_str_fromString", "bytes conversion is implemented by the shared string/bytes bridge"},
 	{"std/bytes", "toString"}:             {"_str_toString", "bytes conversion is implemented by the shared string/bytes bridge"},
 	{"std/fs", "listDir"}:                 {"_io_listDir", "directory listing uses the shared IO effect helper"},
-	{"std/list", "absInt"}:                {"_math_absInt", "integer absolute value delegates to the math helper"},
 	{"std/list", "concat"}:                {"concat_List", "list concatenation uses the polymorphic core concatenation helper"},
 	{"std/list", "maximumFloat"}:          {"_math_maximumFloat", "list reduction delegates pairwise comparison to the math helper"},
 	{"std/list", "maximumInt"}:            {"_math_maximumInt", "list reduction delegates pairwise comparison to the math helper"},
@@ -70,6 +69,13 @@ var crossModuleCodegenExemptions = map[StdlibKey]crossModuleCodegenExemption{
 }
 
 func TestStdlibCodegenResolutionIsModuleQualified(t *testing.T) {
+	// Blind spot (declared, not closed by this structural gate): a codegen spec
+	// can claim a genuine export of its own module, use that module's expected
+	// builtin-family prefix, and still implement the wrong semantics. For example,
+	// a fabricated _list_evilZipWith spec claiming std/list.zipWith and returning
+	// xs passes every check below, while interpreted zipWith(+, [1,2,3],
+	// [10,20,30]) produces [11,22,33] and compiled code produces [1,2,3]. Closing
+	// this requires a source-level delegation/substitution invariant.
 	paths, err := filepath.Glob(filepath.Join(stdlibSourceDir, "*.ail"))
 	if err != nil {
 		t.Fatalf("instrument failure: enumerate stdlib sources: %v", err)
@@ -124,6 +130,7 @@ func TestStdlibCodegenResolutionIsModuleQualified(t *testing.T) {
 	}
 
 	exportCount := 0
+	exported := make(map[StdlibKey]bool)
 	for _, path := range paths {
 		body, err := os.ReadFile(path)
 		if err != nil {
@@ -138,6 +145,7 @@ func TestStdlibCodegenResolutionIsModuleQualified(t *testing.T) {
 		for _, match := range stdlibExportedFunction.FindAllSubmatch(body, -1) {
 			exportCount++
 			name := string(match[1])
+			exported[StdlibKey{Module: module, Name: name}] = true
 			spec := GetCodegenSpecByStdlibName(module, name)
 			if spec == nil {
 				continue // Missing codegen is allowed and fails loudly during compilation.
@@ -149,6 +157,9 @@ func TestStdlibCodegenResolutionIsModuleQualified(t *testing.T) {
 	}
 
 	for key, exemption := range crossModuleCodegenExemptions {
+		if !exported[key] {
+			t.Errorf("cross-module exemption %s.%s has no corresponding stdlib export", key.Module, key.Name)
+		}
 		if exemption.reason == "" {
 			t.Errorf("cross-module exemption %s.%s has no reason", key.Module, key.Name)
 		}

--- a/internal/builtins/stdlib_codegen_resolution_test.go
+++ b/internal/builtins/stdlib_codegen_resolution_test.go
@@ -1,0 +1,161 @@
+package builtins
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+var (
+	stdlibModuleDeclaration = regexp.MustCompile(`(?m)^module\s+(std/[A-Za-z0-9_]+)\s*$`)
+	stdlibExportedFunction  = regexp.MustCompile(`(?m)^export\s+(?:pure\s+)?func\s+([A-Za-z_][A-Za-z0-9_]*)`)
+)
+
+type crossModuleCodegenExemption struct {
+	builtin string
+	reason  string
+}
+
+// stdlibBuiltinFamilyPrefix independently ties each exporting module to the
+// builtin family that implements it. These spellings come from the registered
+// builtin names (not from mechanically transforming the module name); notably,
+// std/string is implemented by the _str_ family.
+var stdlibBuiltinFamilyPrefix = map[string]string{
+	"std/ai":      "_ai_",
+	"std/bytes":   "_bytes_",
+	"std/clock":   "_clock_",
+	"std/debug":   "_debug_",
+	"std/env":     "_env_",
+	"std/fs":      "_fs_",
+	"std/io":      "_io_",
+	"std/json":    "_json_",
+	"std/list":    "_list_",
+	"std/math":    "_math_",
+	"std/net":     "_net_",
+	"std/option":  "_option_",
+	"std/process": "_process_",
+	"std/result":  "_result_",
+	"std/stream":  "_stream_",
+	"std/string":  "_str_",
+	"std/xml":     "_xml_",
+	"std/zip":     "_zip_",
+}
+
+// These exports deliberately use an implementation whose builtin family name
+// differs from the exporting module. The qualified claim remains the exporting
+// module; this table pins the exceptional implementation identity and rationale.
+var crossModuleCodegenExemptions = map[StdlibKey]crossModuleCodegenExemption{
+	{"std/bytes", "fromString"}:           {"_str_fromString", "bytes conversion is implemented by the shared string/bytes bridge"},
+	{"std/bytes", "toString"}:             {"_str_toString", "bytes conversion is implemented by the shared string/bytes bridge"},
+	{"std/fs", "listDir"}:                 {"_io_listDir", "directory listing uses the shared IO effect helper"},
+	{"std/list", "absInt"}:                {"_math_absInt", "integer absolute value delegates to the math helper"},
+	{"std/list", "concat"}:                {"concat_List", "list concatenation uses the polymorphic core concatenation helper"},
+	{"std/list", "maximumFloat"}:          {"_math_maximumFloat", "list reduction delegates pairwise comparison to the math helper"},
+	{"std/list", "maximumInt"}:            {"_math_maximumInt", "list reduction delegates pairwise comparison to the math helper"},
+	{"std/list", "maximumString"}:         {"_math_maximumString", "list reduction delegates pairwise comparison to the comparison helper"},
+	{"std/list", "minimumFloat"}:          {"_math_minimumFloat", "list reduction delegates pairwise comparison to the math helper"},
+	{"std/list", "minimumInt"}:            {"_math_minimumInt", "list reduction delegates pairwise comparison to the math helper"},
+	{"std/list", "minimumString"}:         {"_math_minimumString", "list reduction delegates pairwise comparison to the comparison helper"},
+	{"std/math", "floatToInt"}:            {"_float_to_int", "numeric conversion uses the conversion builtin family"},
+	{"std/math", "intToFloat"}:            {"_int_to_float", "numeric conversion uses the conversion builtin family"},
+	{"std/stream", "asyncExecProcess"}:    {"_process_asyncExec", "stream source creation is implemented by the process bridge"},
+	{"std/stream", "asyncReadStdinLines"}: {"_process_asyncReadStdinLines", "stdin streaming is implemented by the process bridge"},
+	{"std/string", "floatToStr"}:          {"_string_floatToStr", "legacy numeric formatting builtin predates the canonical string family spelling"},
+	{"std/string", "intToStr"}:            {"_string_intToStr", "legacy numeric formatting builtin predates the canonical string family spelling"},
+	{"std/string", "stringToFloat"}:       {"_stringToFloat", "legacy numeric parsing builtin predates the canonical string family spelling"},
+	{"std/string", "stringToInt"}:         {"_stringToInt", "legacy numeric parsing builtin predates the canonical string family spelling"},
+}
+
+func TestStdlibCodegenResolutionIsModuleQualified(t *testing.T) {
+	paths, err := filepath.Glob(filepath.Join(stdlibSourceDir, "*.ail"))
+	if err != nil {
+		t.Fatalf("instrument failure: enumerate stdlib sources: %v", err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("instrument failure")
+	}
+	if len(StdlibIndex) == 0 {
+		t.Fatal("instrument failure")
+	}
+	if len(stdlibBuiltinFamilyPrefix) == 0 {
+		t.Fatal("instrument failure")
+	}
+
+	claims := make(map[StdlibKey][]string)
+	for builtinName, meta := range Registry {
+		if meta.GoCodegen == nil || meta.GoCodegen.StdlibName == "" {
+			continue
+		}
+		spec := meta.GoCodegen
+		key := StdlibKey{Module: spec.StdlibModule, Name: spec.StdlibName}
+		claims[key] = append(claims[key], builtinName)
+	}
+	for key, names := range claims {
+		if key.Module == "" {
+			t.Errorf("qualified claim %q has an empty StdlibModule", key.Name)
+		}
+		if len(names) > 1 {
+			sort.Strings(names)
+			t.Errorf("duplicate qualified claim %s.%s: %v", key.Module, key.Name, names)
+		}
+	}
+
+	qualifiedEntriesChecked := 0
+	for key, builtinName := range StdlibIndex {
+		prefix, ok := stdlibBuiltinFamilyPrefix[key.Module]
+		if !ok || prefix == "" {
+			t.Errorf("qualified claim %s.%s uses builtin %q but module has no builtin family prefix", key.Module, key.Name, builtinName)
+			continue
+		}
+		qualifiedEntriesChecked++
+		if strings.HasPrefix(builtinName, prefix) {
+			continue
+		}
+		exemption, exempt := crossModuleCodegenExemptions[key]
+		if !exempt || exemption.builtin != builtinName || exemption.reason == "" {
+			t.Errorf("qualified claim %s.%s uses builtin %q outside expected family %q without a matching cross-module exemption", key.Module, key.Name, builtinName, prefix)
+		}
+	}
+	if qualifiedEntriesChecked == 0 {
+		t.Fatal("instrument failure")
+	}
+
+	exportCount := 0
+	for _, path := range paths {
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		moduleMatch := stdlibModuleDeclaration.FindSubmatch(body)
+		if moduleMatch == nil {
+			t.Errorf("%s has no module declaration", path)
+			continue
+		}
+		module := string(moduleMatch[1])
+		for _, match := range stdlibExportedFunction.FindAllSubmatch(body, -1) {
+			exportCount++
+			name := string(match[1])
+			spec := GetCodegenSpecByStdlibName(module, name)
+			if spec == nil {
+				continue // Missing codegen is allowed and fails loudly during compilation.
+			}
+		}
+	}
+	if exportCount == 0 {
+		t.Fatal("instrument failure")
+	}
+
+	for key, exemption := range crossModuleCodegenExemptions {
+		if exemption.reason == "" {
+			t.Errorf("cross-module exemption %s.%s has no reason", key.Module, key.Name)
+		}
+		if got := StdlibIndex[key]; got != exemption.builtin {
+			t.Errorf("cross-module exemption %s.%s resolved to %q, want %q", key.Module, key.Name, got, exemption.builtin)
+		}
+	}
+
+	t.Logf("scan summary: %d stdlib files, %d exported functions, %d qualified index entries", len(paths), exportCount, len(StdlibIndex))
+}

--- a/internal/gen/golang/codegen_expr_simple.go
+++ b/internal/gen/golang/codegen_expr_simple.go
@@ -84,7 +84,7 @@ func (g *Generator) generateVar(v *core.Var) error {
 		// This handles cases like `println` being passed as a first-class function
 		// argument — the Core IR binds it as a Var, but we need to resolve it
 		// to our helper function name (e.g., Println) to avoid shadowing Go built-ins.
-		if resolved := g.resolveBuiltinViaRegistry(v.Name); resolved != "" {
+		if resolved := g.resolveBuiltinViaRegistry("", v.Name); resolved != "" {
 			g.write(resolved)
 		} else {
 			g.write(ToGoVarName(v.Name))
@@ -139,7 +139,7 @@ func (g *Generator) generateVarGlobal(e *core.VarGlobal) error {
 
 	// M-CODEGEN-SUSTAINABILITY: Query the builtin registry for Go codegen specs.
 	// This replaces mapPureMathBuiltin, mapPureListBuiltin, and mapStdlibBuiltin.
-	if resolved := g.resolveBuiltinViaRegistry(e.Ref.Name); resolved != "" {
+	if resolved := g.resolveBuiltinViaRegistry(e.Ref.Module, e.Ref.Name); resolved != "" {
 		g.write(resolved)
 		return nil
 	}

--- a/internal/gen/golang/codegen_math_test.go
+++ b/internal/gen/golang/codegen_math_test.go
@@ -69,7 +69,7 @@ func TestMathStdlibNameResolution(t *testing.T) {
 	for _, name := range constantNames {
 		t.Run(name+"_varglobal", func(t *testing.T) {
 			g := New("test")
-			result := g.resolveBuiltinViaRegistry(name)
+			result := g.resolveBuiltinViaRegistry("std/math", name)
 			if result == "" {
 				t.Errorf("resolveBuiltinViaRegistry(%q) returned empty — not in registry", name)
 			}
@@ -82,7 +82,7 @@ func TestMathStdlibNameResolution(t *testing.T) {
 	for _, name := range funcNames {
 		t.Run(name+"_inline", func(t *testing.T) {
 			g := New("test")
-			result := g.resolveInlineBuiltin(name, []string{"x"})
+			result := g.resolveInlineBuiltin("std/math", name, []string{"x"})
 			if result == "" {
 				t.Errorf("resolveInlineBuiltin(%q) returned empty — not in registry", name)
 			}
@@ -197,7 +197,7 @@ func TestMathFunctionCall(t *testing.T) {
 // TestMathNonBuiltin tests that non-math builtins don't resolve via registry.
 func TestMathNonBuiltin(t *testing.T) {
 	g := New("test")
-	result := g.resolveBuiltinViaRegistry("some_random_func")
+	result := g.resolveBuiltinViaRegistry("", "some_random_func")
 	if result != "" {
 		t.Errorf("resolveBuiltinViaRegistry should return empty for non-math builtin, got %q", result)
 	}

--- a/internal/gen/golang/codegen_registry.go
+++ b/internal/gen/golang/codegen_registry.go
@@ -15,13 +15,18 @@ import (
 //
 // Returns the Go expression/name to emit, or empty string if not found.
 // Also registers any needed runtime helpers and tracks imports.
-func (g *Generator) resolveBuiltinViaRegistry(name string) string {
-	// Try direct lookup first (internal builtin names like _str_trim)
-	spec := builtins.GetCodegenSpec(name)
-
-	// Then try stdlib name lookup (exported names like trim, map, split)
-	if spec == nil {
-		spec = builtins.GetCodegenSpecByStdlibName(name)
+func (g *Generator) resolveBuiltinViaRegistry(module, name string) string {
+	var spec *builtins.GoCodegenSpec
+	if module != "" {
+		// A qualified reference must never fall back to either a direct or bare
+		// name match: its module is authoritative.
+		spec = builtins.GetCodegenSpecByStdlibName(module, name)
+	} else {
+		// Module-less internal builtin names resolve directly first.
+		spec = builtins.GetCodegenSpec(name)
+		if spec == nil {
+			spec = builtins.GetCodegenSpecByUnambiguousStdlibName(name)
+		}
 	}
 
 	if spec == nil {
@@ -197,9 +202,10 @@ func sortStrings(s []string) {
 // Returns the complete Go expression or empty string if not an inline builtin.
 func (g *Generator) tryResolveInlineApp(app *core.App) string {
 	// Extract the function name from the App
-	var name string
+	var module, name string
 	switch f := app.Func.(type) {
 	case *core.VarGlobal:
+		module = f.Ref.Module
 		name = f.Ref.Name
 	case *core.Var:
 		name = f.Name
@@ -222,17 +228,22 @@ func (g *Generator) tryResolveInlineApp(app *core.App) string {
 		_ = buf // suppress unused
 	}
 
-	return g.resolveInlineBuiltin(name, argExprs)
+	return g.resolveInlineBuiltin(module, name, argExprs)
 }
 
 // resolveInlineBuiltin checks if a VarGlobal + App combination can use an Inline spec.
 // M-CODEGEN-SUSTAINABILITY: For builtins with Inline specs like "strings.TrimSpace({{arg0}}.(string))",
 // this substitutes the actual argument expressions and returns the final Go expression.
 // Returns empty string if not an Inline builtin.
-func (g *Generator) resolveInlineBuiltin(name string, argExprs []string) string {
-	spec := builtins.GetCodegenSpec(name)
-	if spec == nil {
-		spec = builtins.GetCodegenSpecByStdlibName(name)
+func (g *Generator) resolveInlineBuiltin(module, name string, argExprs []string) string {
+	var spec *builtins.GoCodegenSpec
+	if module != "" {
+		spec = builtins.GetCodegenSpecByStdlibName(module, name)
+	} else {
+		spec = builtins.GetCodegenSpec(name)
+		if spec == nil {
+			spec = builtins.GetCodegenSpecByUnambiguousStdlibName(name)
+		}
 	}
 	if spec == nil || spec.Inline == "" {
 		return ""

--- a/internal/gen/golang/codegen_registry.go
+++ b/internal/gen/golang/codegen_registry.go
@@ -17,12 +17,13 @@ import (
 // Also registers any needed runtime helpers and tracks imports.
 func (g *Generator) resolveBuiltinViaRegistry(module, name string) string {
 	var spec *builtins.GoCodegenSpec
-	if module != "" {
+	if module != "" && !strings.HasPrefix(module, "$") {
 		// A qualified reference must never fall back to either a direct or bare
 		// name match: its module is authoritative.
 		spec = builtins.GetCodegenSpecByStdlibName(module, name)
 	} else {
-		// Module-less internal builtin names resolve directly first.
+		// Module-less names and $-prefixed pseudo-module references are internal
+		// builtin identities, so resolve them directly first.
 		spec = builtins.GetCodegenSpec(name)
 		if spec == nil {
 			spec = builtins.GetCodegenSpecByUnambiguousStdlibName(name)
@@ -237,7 +238,7 @@ func (g *Generator) tryResolveInlineApp(app *core.App) string {
 // Returns empty string if not an Inline builtin.
 func (g *Generator) resolveInlineBuiltin(module, name string, argExprs []string) string {
 	var spec *builtins.GoCodegenSpec
-	if module != "" {
+	if module != "" && !strings.HasPrefix(module, "$") {
 		spec = builtins.GetCodegenSpecByStdlibName(module, name)
 	} else {
 		spec = builtins.GetCodegenSpec(name)

--- a/internal/gen/golang/codegen_registry_pseudomodule_test.go
+++ b/internal/gen/golang/codegen_registry_pseudomodule_test.go
@@ -1,0 +1,42 @@
+package golang
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/core"
+)
+
+func TestPseudoModuleBuiltinEmitsReferencedHelper(t *testing.T) {
+	prog := &core.Program{Decls: []core.CoreExpr{
+		&core.Let{
+			Name: "negate",
+			Value: &core.Lambda{Params: []string{"x"}, Body: &core.App{
+				Func: &core.VarGlobal{Ref: core.GlobalRef{Module: "$builtin", Name: "not_Bool"}},
+				Args: []core.CoreExpr{&core.Var{Name: "x"}},
+			}},
+			Body: &core.Var{Name: "negate"},
+		},
+	}}
+
+	code, err := New("pseudomodule_not").Generate(prog)
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	generated := string(code)
+	if !strings.Contains(generated, "NotBool(") {
+		t.Fatalf("generated code does not reference NotBool helper:\n%s", generated)
+	}
+	if !strings.Contains(generated, "func NotBool(v interface{}) interface{}") {
+		t.Fatalf("generated code references NotBool without emitting its helper:\n%s", generated)
+	}
+}
+
+func TestPseudoModuleInlineBuiltinResolvesDirectly(t *testing.T) {
+	got := New("pseudomodule_inline").resolveInlineBuiltin(
+		"$builtin", "_str_eq", []string{`"left"`, `"right"`},
+	)
+	if got != `"left" == "right"` {
+		t.Fatalf("pseudo-module inline lookup = %q, want direct _str_eq expansion", got)
+	}
+}


### PR DESCRIPTION
## What

The Go code generator resolved every stdlib call through `StdlibIndex`, a **single flat namespace
keyed on the bare exported name** (161 entries across 20 builtin families). A compiled program
could therefore be lowered to an implementation belonging to a **different module** while the
interpreter stayed correct.

Two cases, measured end-to-end at `8040dfd41` (interpreter arm vs compiled-and-run arm):

| call | `ailang run` | compiled, before |
|---|---|---|
| `std/option.map(\x. x + 1, Some(41))` | `42`, rc=0 | emits the **LIST** `Map` helper, builds, **PANICS** — `interface conversion: interface {} is []interface {}, not *Option`, rc=2 |
| `std/list.length(...)` | correct | `int64(utf8.RuneCountInString(x.(string)))` — the **string** builtin; generated Go does not compile (`undefined: utf8`) and would type-assert a slice to `string` |

`StdlibName: "length"` is claimed only by `_str_len` (`registry_codegen_string.go:31`), and
`_list_length` carries no codegen spec at all — so the flat index handed list calls to the string
implementation.

## Change

- `GoCodegenSpec` gains `StdlibModule`; `StdlibIndex` is re-keyed on `(module, name)`.
- `GetCodegenSpecByStdlibName(module, name)` returns nil on mismatch and **never** falls back.
  A spec with no `StdlibModule` is unreachable by qualified lookup (fail-closed).
- Module-less references (a builtin passed as a first-class value) use a separate lookup that
  resolves only names exactly one spec claims; an ambiguous bare name returns nil rather than guessing.
- Principle 3: all three consult sites fixed together — `generateVar`, `generateVarGlobal`, and
  `resolveInlineBuiltin` (the third found by the executor's own audit, not named in the directive).

Refusing a wrong match turns a silent wrong answer into a **loud compile error** — `std/option.map`
now fails `codegen: undefined: Map`, the same way any stdlib function with no codegen spec already
does (`std/list.zipWith` → `undefined: ZipWith`, measured at base). `std/list.length` now resolves
to the list `Length` helper and the compiled arm **agrees with the interpreter** (both print `2`).

## Gate, and why round 1's version did not count

`TestStdlibCodegenResolutionIsModuleQualified` scans all 45 `std/*.ail` (423 exported functions),
maps 18 modules to their real builtin-family prefixes (`std/string` → `_str_`, not `_string_`), and
requires every cross-family claim to be an explicit exemption row with a reason. Four anti-vacuity
floors `t.Fatal` rather than pass on an empty enumeration.

Round 1's gate was **green on a tree that reintroduced the original defect**: its module check read
the `StdlibModule` of a spec fetched *by that same* `StdlibModule`, so the branch was unreachable
by construction. Controller-measured, mutant asserted LANDED (sha `279bddf2…` → `98258986…`) and
BUILDS before any test result was read:

| mutant | before | after |
|---|---|---|
| `_str_len` re-annotated to `std/list` (the original bug, exactly) | gate **rc=0** | gate **rc=1** — `qualified claim std/list.length uses builtin "_str_len" outside expected family "_list_" without a matching cross-module exemption` |
| delete the `std/list.concat` exemption row | — | rc=1 |
| add a spec with a `StdlibName` and no `StdlibModule` | — | rc=1 |
| unmutated control | rc=0 | rc=0 |

Every mutant restored from a `cp` backup and re-verified byte-identical by sha256.

## Gates

All run by the controller **outside** the executor sandbox, on darwin/arm64, under a binary built
fresh into a scratch dir and prepended to `PATH` (`tests/golden/codegen` shells out to `ailang` from
`PATH`; measured on pristine dev: fresh `rc=0`, stale `rc=1`):

`make test` (**0 FAIL lines**, 14126 pass/ok lines) · `make test-stdlib-ail` · `check-file-sizes` ·
`check-boundaries` · `check-changelog` · `check-skills` · `fmt-check` · `vet` · `go build ./cmd/ailang` ·
`go build ./internal/gen/... ./internal/builtins/...` · `go vet` · `go test ./internal/builtins/` ·
`go test ./internal/gen/golang/` · `go test ./tests/golden/codegen/` — **all rc=0**.

Linux and Windows legs unrun locally; settled by CI.

## Scope, stated honestly

This closes the *dispatch* half. The 13 codegen-only `_list_*` builtins still have no interpreter
implementation, so `std/list`'s recursive AILANG definitions and the Go helpers remain two
implementations of the same function with no differential harness comparing them — that stays
open as `m-list-builtins-codegen-only`. `show` also renders lists differently between the two
modes (`[1, 2, 3]` vs `[1 2 3]`) and tuples not at all under the interpreter
(`<*eval.TupleValue>`); measured this iteration, filed separately, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
