### PR TITLE
fix(show): compiled programs printed heap addresses, and the interpreter printed Go type names

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,18 @@
 
 ## [Unreleased]
 
+### Fixed — `show` is deterministic and agrees across runtimes
+
+Interpreter `show` now deliberately renders every live `eval.Value` implementation,
+including tuples, maps, arrays, bytes, callable values, and recursive indirections. A
+source-derived exhaustiveness test fails whenever a new value implementation lacks a case.
+
+Generated Go now emits canonical AILANG syntax for lists, tuples, sorted records, ADTs,
+units, functions, and floats instead of falling through to Go formatting, which could expose
+live heap addresses for ADTs. A non-vacuous golden differential executes a pinned fixture in
+the interpreter and as a compiled binary and requires byte-identical stdout across lists,
+nested lists, records, ADTs, tuples, and floats.
+
 ### Fixed — Go codegen resolves stdlib functions by module and name
 
 The builtin codegen registry now indexes stdlib exports by their qualified

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -10,11 +10,14 @@ Interpreter `show` now deliberately renders every live `eval.Value` implementati
 including tuples, maps, arrays, bytes, callable values, and recursive indirections. A
 source-derived exhaustiveness test fails whenever a new value implementation lacks a case.
 
-Generated Go now emits canonical AILANG syntax for lists, tuples, sorted records, ADTs,
-units, functions, and floats instead of falling through to Go formatting, which could expose
+Generated Go now emits stable AILANG-style syntax for lists, tuples, records sorted by field
+name, ADTs, units, functions, and floats instead of falling through to Go formatting, which
+could expose
 live heap addresses for ADTs. A non-vacuous golden differential executes a pinned fixture in
 the interpreter and as a compiled binary and requires byte-identical stdout across lists,
-nested lists, records, ADTs, tuples, and floats.
+nested lists, named and inline records, ADTs, tuples, floats, depth limiting, and width
+elision. The `Map{...}` spelling is deliberate debug notation rather than round-trippable
+AILANG surface syntax because the language has no map literal.
 
 ### Fixed — Go codegen resolves stdlib functions by module and name
 

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -19,6 +19,10 @@ nested lists, named and inline records, ADTs, tuples, floats, depth limiting, an
 elision. The `Map{...}` spelling is deliberate debug notation rather than round-trippable
 AILANG surface syntax because the language has no map literal.
 
+Generated float rendering now also matches the interpreter for non-finite values and extreme
+magnitudes: `NaN`, `Inf`, and `-Inf` retain their canonical spellings, while finite values use
+fixed-point formatting rather than switching to scientific notation.
+
 ### Fixed — Go codegen resolves stdlib functions by module and name
 
 The builtin codegen registry now indexes stdlib exports by their qualified

--- a/internal/builtins/show.go
+++ b/internal/builtins/show.go
@@ -120,15 +120,26 @@ func showValue(v eval.Value, depth int) string {
 		return val.Value
 
 	case *eval.ListValue:
-		if len(val.Elements) == 0 {
-			return "[]"
+		return showSequence(val.Elements, depth, "[", "]")
+
+	case *eval.ArrayValue:
+		return showSequence(val.Elements, depth, "#[", "]")
+
+	case *eval.TupleValue:
+		return showSequence(val.Elements, depth, "(", ")")
+
+	case *eval.MapValue:
+		keys := make([]string, 0, len(val.Entries))
+		for key := range val.Entries {
+			keys = append(keys, key)
 		}
-		var parts []string
-		for _, elem := range val.Elements {
-			parts = append(parts, showValue(elem, depth+1))
+		sort.Strings(keys)
+		parts := make([]string, 0, len(keys))
+		for _, key := range keys {
+			entry := val.Entries[key]
+			parts = append(parts, showValue(entry.Key, depth+1)+": "+showValue(entry.Value, depth+1))
 		}
-		result := "[" + strings.Join(parts, ", ") + "]"
-		return truncateIfNeeded(result)
+		return truncateIfNeeded("Map{" + strings.Join(parts, ", ") + "}")
 
 	case *eval.RecordValue:
 		if len(val.Fields) == 0 {
@@ -165,13 +176,35 @@ func showValue(v eval.Value, depth int) string {
 	case *eval.FunctionValue:
 		return "<function>"
 
+	case *eval.BuiltinFunction:
+		return "<function>"
+
+	case *eval.ConstructorClosure:
+		return "<function>"
+
+	case *eval.BytesValue:
+		return val.String()
+
+	case *eval.IndirectValue:
+		if val.Cell == nil || !val.Cell.Init || val.Cell.Val == nil {
+			return "<uninitialized>"
+		}
+		return showValue(val.Cell.Val, depth)
+
 	case *eval.ErrorValue:
 		return fmt.Sprintf("Error: %s", val.Message)
 
 	default:
-		// Fallback for unknown types
-		return fmt.Sprintf("<%T>", val)
+		return "<unknown>"
 	}
+}
+
+func showSequence(elements []eval.Value, depth int, open, close string) string {
+	parts := make([]string, 0, len(elements))
+	for _, elem := range elements {
+		parts = append(parts, showValue(elem, depth+1))
+	}
+	return truncateIfNeeded(open + strings.Join(parts, ", ") + close)
 }
 
 // truncateIfNeeded elides the middle of long strings to keep under maxWidth

--- a/internal/builtins/show.go
+++ b/internal/builtins/show.go
@@ -129,6 +129,8 @@ func showValue(v eval.Value, depth int) string {
 		return showSequence(val.Elements, depth, "(", ")")
 
 	case *eval.MapValue:
+		// Map{...} is deliberate debug notation: AILANG has no map literal, so
+		// this rendering is not round-trippable surface syntax.
 		keys := make([]string, 0, len(val.Entries))
 		for key := range val.Entries {
 			keys = append(keys, key)

--- a/internal/builtins/show_test.go
+++ b/internal/builtins/show_test.go
@@ -1,7 +1,13 @@
 package builtins
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"math"
+	"path/filepath"
+	"runtime"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,6 +15,95 @@ import (
 	"github.com/sunholo-data/ailang/internal/effects/testctx"
 	"github.com/sunholo-data/ailang/internal/eval"
 )
+
+func TestShow_AllEvalValueImplementationsHandled(t *testing.T) {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	builtinsDir := filepath.Dir(thisFile)
+
+	valueTypes := evalValueImplementations(t, filepath.Join(builtinsDir, "..", "eval"))
+	handledTypes := showValueCases(t, filepath.Join(builtinsDir, "show.go"))
+
+	var unhandled []string
+	for _, name := range valueTypes {
+		if !handledTypes[name] {
+			unhandled = append(unhandled, name)
+		}
+	}
+	require.Empty(t, unhandled, "showValue must explicitly handle every eval.Value implementation")
+}
+
+func evalValueImplementations(t *testing.T, evalDir string) []string {
+	t.Helper()
+	methods := make(map[string]map[string]bool)
+	fset := token.NewFileSet()
+	files, err := filepath.Glob(filepath.Join(evalDir, "*.go"))
+	require.NoError(t, err)
+	require.NotEmpty(t, files)
+	for _, filename := range files {
+		if filepath.Ext(filename) != ".go" || len(filename) >= 8 && filename[len(filename)-8:] == "_test.go" {
+			continue
+		}
+		file, parseErr := parser.ParseFile(fset, filename, nil, 0)
+		require.NoError(t, parseErr)
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv == nil || len(fn.Recv.List) != 1 || fn.Name == nil {
+				continue
+			}
+			star, ok := fn.Recv.List[0].Type.(*ast.StarExpr)
+			if !ok {
+				continue
+			}
+			ident, ok := star.X.(*ast.Ident)
+			if !ok {
+				continue
+			}
+			if methods[ident.Name] == nil {
+				methods[ident.Name] = make(map[string]bool)
+			}
+			methods[ident.Name][fn.Name.Name] = true
+		}
+	}
+	var implementations []string
+	for name, names := range methods {
+		if names["Type"] && names["String"] {
+			implementations = append(implementations, name)
+		}
+	}
+	sort.Strings(implementations)
+	return implementations
+}
+
+func showValueCases(t *testing.T, filename string) map[string]bool {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filename, nil, 0)
+	require.NoError(t, err)
+	handled := make(map[string]bool)
+	ast.Inspect(file, func(node ast.Node) bool {
+		typeSwitch, ok := node.(*ast.TypeSwitchStmt)
+		if !ok {
+			return true
+		}
+		for _, statement := range typeSwitch.Body.List {
+			clause := statement.(*ast.CaseClause)
+			for _, expr := range clause.List {
+				star, ok := expr.(*ast.StarExpr)
+				if !ok {
+					continue
+				}
+				selector, ok := star.X.(*ast.SelectorExpr)
+				if ok {
+					handled[selector.Sel.Name] = true
+				}
+			}
+		}
+		return false
+	})
+	return handled
+}
 
 func TestShow_Primitives(t *testing.T) {
 	ctx := testctx.NewMockEffContext()
@@ -294,6 +389,34 @@ func TestShow_FunctionValue(t *testing.T) {
 	result, err := showImpl(ctx.EffContext, []eval.Value{funcVal})
 	require.NoError(t, err)
 	assert.Equal(t, "<function>", testctx.GetString(result))
+}
+
+func TestShow_RemainingValueForms(t *testing.T) {
+	initialized := &eval.IndirectValue{Cell: &eval.RefCell{Val: &eval.TupleValue{
+		Elements: []eval.Value{testctx.MakeInt(1), testctx.MakeString("a")},
+	}, Init: true}}
+	tests := []struct {
+		name     string
+		value    eval.Value
+		expected string
+	}{
+		{"tuple", &eval.TupleValue{Elements: []eval.Value{testctx.MakeInt(1), testctx.MakeString("a")}}, "(1, a)"},
+		{"array", &eval.ArrayValue{Elements: []eval.Value{testctx.MakeInt(1), testctx.MakeInt(2)}}, "#[1, 2]"},
+		{"map", &eval.MapValue{Entries: map[string]*eval.MapEntry{
+			"s:b": {Key: testctx.MakeString("b"), Value: testctx.MakeInt(2)},
+			"s:a": {Key: testctx.MakeString("a"), Value: testctx.MakeInt(1)},
+		}}, "Map{a: 1, b: 2}"},
+		{"bytes", &eval.BytesValue{Value: []byte{0x01, 0xab}}, "<bytes:01ab>"},
+		{"builtin", &eval.BuiltinFunction{Name: "example"}, "<function>"},
+		{"constructor closure", &eval.ConstructorClosure{CtorName: "Some", Arity: 1}, "<function>"},
+		{"indirect", initialized, "(1, a)"},
+		{"uninitialized indirect", &eval.IndirectValue{Cell: &eval.RefCell{}}, "<uninitialized>"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, showValue(tt.value, 0))
+		})
+	}
 }
 
 func TestShow_ErrorValue(t *testing.T) {

--- a/internal/builtins/show_test.go
+++ b/internal/builtins/show_test.go
@@ -82,7 +82,16 @@ func showValueCases(t *testing.T, filename string) map[string]bool {
 	file, err := parser.ParseFile(fset, filename, nil, 0)
 	require.NoError(t, err)
 	handled := make(map[string]bool)
-	ast.Inspect(file, func(node ast.Node) bool {
+	var showValue *ast.FuncDecl
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Name.Name == "showValue" {
+			showValue = fn
+			break
+		}
+	}
+	require.NotNil(t, showValue, "showValue declaration not found")
+	ast.Inspect(showValue.Body, func(node ast.Node) bool {
 		typeSwitch, ok := node.(*ast.TypeSwitchStmt)
 		if !ok {
 			return true

--- a/internal/gen/golang/adt.go
+++ b/internal/gen/golang/adt.go
@@ -394,8 +394,7 @@ func (g *ADTGenerator) mapASTType(t ast.Type) string {
 		return fmt.Sprintf("[]%s", elemType)
 
 	case *ast.TupleType:
-		// Tuples become slices of interface{} for simplicity
-		return "[]interface{}"
+		return "Tuple"
 
 	case *ast.RecordType:
 		// Inline records become map[string]interface{} for simplicity

--- a/internal/gen/golang/codegen.go
+++ b/internal/gen/golang/codegen.go
@@ -547,14 +547,10 @@ func (g *Generator) writePackageHeader() {
 		// M-CODEGEN-STDLIB-STRING: strconv needed when using string conversion functions
 		g.writef("import (\n")
 		g.writef("\t\"fmt\"\n")
-		if g.needsMathImport {
-			g.writef("\t\"math\"\n")
-		}
+		g.writef("\t\"math\"\n")
 		g.writef("\t\"reflect\"\n")
 		g.writef("\t\"sort\"\n")
-		if g.needsStrconvImport {
-			g.writef("\t\"strconv\"\n")
-		}
+		g.writef("\t\"strconv\"\n")
 		g.writef("\t\"strings\"\n")
 		g.writef(")\n\n")
 		g.writef("type Tuple []interface{}\n\n")
@@ -645,6 +641,9 @@ func (g *Generator) GenerateRuntime() ([]byte, error) {
 
 	g.writef("import (\n")
 	g.writef("\t\"fmt\"\n")
+	if strings.Contains(helpersCode, "math.") || g.needsMathImport {
+		g.writef("\t\"math\"\n")
+	}
 	g.writef("\t\"reflect\"\n")
 	if strings.Contains(helpersCode, "sort.") || g.needsSortImport {
 		g.writef("\t\"sort\"\n")
@@ -654,9 +653,6 @@ func (g *Generator) GenerateRuntime() ([]byte, error) {
 	}
 	if strings.Contains(helpersCode, "strings.") || g.needsStringsImport {
 		g.writef("\t\"strings\"\n")
-	}
-	if g.needsMathImport {
-		g.writef("\t\"math\"\n")
 	}
 	g.writef(")\n\n")
 

--- a/internal/gen/golang/codegen.go
+++ b/internal/gen/golang/codegen.go
@@ -551,11 +551,13 @@ func (g *Generator) writePackageHeader() {
 			g.writef("\t\"math\"\n")
 		}
 		g.writef("\t\"reflect\"\n")
+		g.writef("\t\"sort\"\n")
 		if g.needsStrconvImport {
 			g.writef("\t\"strconv\"\n")
 		}
 		g.writef("\t\"strings\"\n")
 		g.writef(")\n\n")
+		g.writef("type Tuple []interface{}\n\n")
 		g.writeRuntimeHelpers()
 	} else if g.needsMathImport || g.needsStrconvImport || g.needsStringsImport || g.needsSortImport {
 		// M-CODEGEN-SUSTAINABILITY: Even when skipping runtime helpers,
@@ -662,6 +664,8 @@ func (g *Generator) GenerateRuntime() ([]byte, error) {
 	// maps to []interface{} in Go. Needed when functions have unparameterized List return types.
 	g.writef("// List is the AILANG list type (unparameterized).\n")
 	g.writef("type List = []interface{}\n\n")
+	g.writef("// Tuple preserves tuple identity for pattern matching and canonical Show output.\n")
+	g.writef("type Tuple []interface{}\n\n")
 
 	// Write the pre-generated helpers (already generated above for import detection)
 	g.buf.WriteString(helpersCode)

--- a/internal/gen/golang/codegen_match_patterns.go
+++ b/internal/gen/golang/codegen_match_patterns.go
@@ -153,16 +153,15 @@ func (g *Generator) generatePatternCondition(p core.CorePattern, scrutinee strin
 		return "true", nil, nil
 
 	case *core.TuplePattern:
-		// M-CODEGEN-TUPLE: Tuple patterns extract elements from []interface{}
-		// In _impl functions, tuples are represented as []interface{} slices
-		cond := fmt.Sprintf("len(%s.([]interface{})) == %d", scrutinee, len(pat.Elements))
+		// M-CODEGEN-TUPLE: Tuple has a distinct runtime type so Show can preserve syntax.
+		cond := fmt.Sprintf("len(%s.(Tuple)) == %d", scrutinee, len(pat.Elements))
 
 		// Generate bindings for each element
 		for i, elem := range pat.Elements {
 			switch elemPat := elem.(type) {
 			case *core.VarPattern:
 				if elemPat.Name != "_" {
-					binding := fmt.Sprintf("%s := %s.([]interface{})[%d]",
+					binding := fmt.Sprintf("%s := %s.(Tuple)[%d]",
 						ToGoVarName(elemPat.Name), scrutinee, i)
 					bindings = append(bindings, binding)
 					if s := suppressUnusedStr(ToGoVarName(elemPat.Name)); s != "" {
@@ -174,7 +173,7 @@ func (g *Generator) generatePatternCondition(p core.CorePattern, scrutinee strin
 			case *core.TuplePattern:
 				// Nested tuple - generate temp var and recurse
 				tempVar := fmt.Sprintf("_tuple%d", i)
-				binding := fmt.Sprintf("%s := %s.([]interface{})[%d]", tempVar, scrutinee, i)
+				binding := fmt.Sprintf("%s := %s.(Tuple)[%d]", tempVar, scrutinee, i)
 				bindings = append(bindings, binding)
 				if s := suppressUnusedStr(tempVar); s != "" {
 					bindings = append(bindings, s)
@@ -188,7 +187,7 @@ func (g *Generator) generatePatternCondition(p core.CorePattern, scrutinee strin
 			default:
 				// Other pattern types in tuple - generate temp and recurse
 				tempVar := fmt.Sprintf("_elem%d", i)
-				binding := fmt.Sprintf("%s := %s.([]interface{})[%d]", tempVar, scrutinee, i)
+				binding := fmt.Sprintf("%s := %s.(Tuple)[%d]", tempVar, scrutinee, i)
 				bindings = append(bindings, binding)
 				_, nestedBindings, err := g.generatePatternCondition(elem, tempVar)
 				if err != nil {

--- a/internal/gen/golang/codegen_math_test.go
+++ b/internal/gen/golang/codegen_math_test.go
@@ -125,8 +125,9 @@ func TestMathImportGeneration(t *testing.T) {
 	}
 }
 
-// TestNoMathImportWhenNotNeeded tests that math import is not added when not needed.
-func TestNoMathImportWhenNotNeeded(t *testing.T) {
+// TestRuntimeShowRequiresMathImport tests that the generated Show helper brings
+// in math even when the source program does not otherwise use std/math.
+func TestRuntimeShowRequiresMathImport(t *testing.T) {
 	g := New("test")
 
 	// Create a simple program without math functions
@@ -147,9 +148,8 @@ func TestNoMathImportWhenNotNeeded(t *testing.T) {
 
 	codeStr := string(code)
 
-	// Check that math import is NOT present
-	if strings.Contains(codeStr, `"math"`) {
-		t.Error("Generated code should NOT contain math import when not needed")
+	if !strings.Contains(codeStr, `"math"`) {
+		t.Error("Generated code should contain math import for runtime Show")
 	}
 }
 

--- a/internal/gen/golang/codegen_ops.go
+++ b/internal/gen/golang/codegen_ops.go
@@ -417,9 +417,9 @@ func (g *Generator) getArrayElementType(arr *core.Array) string {
 	return ""
 }
 
-// generateTuple generates a Go struct for tuple.
+// generateTuple preserves tuple identity for canonical rendering and matching.
 func (g *Generator) generateTuple(tuple *core.Tuple) error {
-	g.write("[]interface{}{")
+	g.write("Tuple{")
 	for i, elem := range tuple.Elements {
 		if i > 0 {
 			g.write(", ")

--- a/internal/gen/golang/codegen_runtime_misc.go
+++ b/internal/gen/golang/codegen_runtime_misc.go
@@ -46,8 +46,8 @@ func (g *Generator) writeRuntimeMiscHelpers() {
 	g.indent--
 	g.writef("}\n\n")
 
-	// Show helper for converting values to strings
-	g.writef("// Show converts any value to its string representation.\n")
+	// Show helper for converting values to canonical AILANG surface syntax.
+	g.writef("// Show converts any value to canonical AILANG surface syntax.\n")
 	g.writef("func Show(v interface{}) string {\n")
 	g.indent++
 	g.writef("switch x := v.(type) {\n")
@@ -65,7 +65,9 @@ func (g *Generator) writeRuntimeMiscHelpers() {
 	g.indent--
 	g.writef("case float64:\n")
 	g.indent++
-	g.writef("return fmt.Sprintf(\"%%g\", x)\n")
+	g.writef("s := fmt.Sprintf(\"%%g\", x)\n")
+	g.writef("if !strings.ContainsAny(s, \".eE\") { s += \".0\" }\n")
+	g.writef("return s\n")
 	g.indent--
 	g.writef("case bool:\n")
 	g.indent++
@@ -76,11 +78,119 @@ func (g *Generator) writeRuntimeMiscHelpers() {
 	g.indent++
 	g.writef("return \"()\"\n")
 	g.indent--
+	g.writef("case Tuple:\n")
+	g.indent++
+	g.writef("return showSequence(reflect.ValueOf(x), \"(\", \")\")\n")
+	g.indent--
 	g.writef("default:\n")
 	g.indent++
-	g.writef("return fmt.Sprintf(\"%%v\", x)\n")
+	g.writef("return showReflect(reflect.ValueOf(x))\n")
 	g.indent--
 	g.writef("}\n")
+	g.indent--
+	g.writef("}\n\n")
+
+	g.writef("func showReflect(v reflect.Value) string {\n")
+	g.indent++
+	g.writef("if !v.IsValid() { return \"()\" }\n")
+	g.writef("if v.Kind() == reflect.Interface {\n")
+	g.indent++
+	g.writef("if v.IsNil() { return \"()\" }\n")
+	g.writef("return Show(v.Elem().Interface())\n")
+	g.indent--
+	g.writef("}\n")
+	g.writef("switch v.Kind() {\n")
+	g.writef("case reflect.Ptr:\n")
+	g.indent++
+	g.writef("if v.IsNil() { return \"()\" }\n")
+	g.writef("return showReflect(v.Elem())\n")
+	g.indent--
+	g.writef("case reflect.Slice, reflect.Array:\n")
+	g.indent++
+	g.writef("return showSequence(v, \"[\", \"]\")\n")
+	g.indent--
+	g.writef("case reflect.Map:\n")
+	g.indent++
+	g.writef("return showMap(v)\n")
+	g.indent--
+	g.writef("case reflect.Struct:\n")
+	g.indent++
+	g.writef("return showStruct(v)\n")
+	g.indent--
+	g.writef("case reflect.Func:\n")
+	g.indent++
+	g.writef("return \"<function>\"\n")
+	g.indent--
+	g.writef("}\n")
+	g.writef("return \"<unknown>\"\n")
+	g.indent--
+	g.writef("}\n\n")
+
+	g.writef("func showSequence(v reflect.Value, open, close string) string {\n")
+	g.indent++
+	g.writef("parts := make([]string, v.Len())\n")
+	g.writef("for i := 0; i < v.Len(); i++ { parts[i] = Show(v.Index(i).Interface()) }\n")
+	g.writef("return open + strings.Join(parts, \", \") + close\n")
+	g.indent--
+	g.writef("}\n\n")
+
+	g.writef("func showMap(v reflect.Value) string {\n")
+	g.indent++
+	g.writef("if v.Type().Key().Kind() != reflect.String { return \"<map>\" }\n")
+	g.writef("tag := v.MapIndex(reflect.ValueOf(\"_tag\"))\n")
+	g.writef("if tag.IsValid() {\n")
+	g.indent++
+	g.writef("ctor, ok := tag.Interface().(string)\n")
+	g.writef("if !ok { return \"<unknown>\" }\n")
+	g.writef("keys := make([]string, 0, v.Len()-1)\n")
+	g.writef("for _, key := range v.MapKeys() { if key.String() != \"_tag\" { keys = append(keys, key.String()) } }\n")
+	g.writef("sort.Strings(keys)\n")
+	g.writef("if len(keys) == 0 { return ctor }\n")
+	g.writef("parts := make([]string, len(keys))\n")
+	g.writef("for i, key := range keys { parts[i] = Show(v.MapIndex(reflect.ValueOf(key)).Interface()) }\n")
+	g.writef("return ctor + \"(\" + strings.Join(parts, \", \") + \")\"\n")
+	g.indent--
+	g.writef("}\n")
+	g.writef("keys := make([]string, 0, v.Len())\n")
+	g.writef("for _, key := range v.MapKeys() { keys = append(keys, key.String()) }\n")
+	g.writef("sort.Strings(keys)\n")
+	g.writef("parts := make([]string, len(keys))\n")
+	g.writef("for i, key := range keys { parts[i] = key + \": \" + Show(v.MapIndex(reflect.ValueOf(key)).Interface()) }\n")
+	g.writef("return \"{\" + strings.Join(parts, \", \") + \"}\"\n")
+	g.indent--
+	g.writef("}\n\n")
+
+	g.writef("func showStruct(v reflect.Value) string {\n")
+	g.indent++
+	g.writef("if v.NumField() == 0 { return \"()\" }\n")
+	g.writef("if kind := v.FieldByName(\"Kind\"); kind.IsValid() {\n")
+	g.indent++
+	g.writef("for i := 0; i < v.NumField(); i++ {\n")
+	g.indent++
+	g.writef("fieldInfo := v.Type().Field(i)\n")
+	g.writef("field := v.Field(i)\n")
+	g.writef("if fieldInfo.Name == \"Kind\" || field.Kind() != reflect.Ptr || field.IsNil() { continue }\n")
+	g.writef("variant := field.Elem()\n")
+	g.writef("parts := make([]string, variant.NumField())\n")
+	g.writef("for j := 0; j < variant.NumField(); j++ { parts[j] = Show(variant.Field(j).Interface()) }\n")
+	g.writef("if len(parts) == 0 { return fieldInfo.Name }\n")
+	g.writef("return fieldInfo.Name + \"(\" + strings.Join(parts, \", \") + \")\"\n")
+	g.indent--
+	g.writef("}\n")
+	g.writef("return \"<unknown>\"\n")
+	g.indent--
+	g.writef("}\n")
+	g.writef("parts := make([]string, 0, v.NumField())\n")
+	g.writef("for i := 0; i < v.NumField(); i++ {\n")
+	g.indent++
+	g.writef("fieldInfo := v.Type().Field(i)\n")
+	g.writef("if fieldInfo.PkgPath != \"\" { continue }\n")
+	g.writef("name := strings.ToLower(fieldInfo.Name[:1]) + fieldInfo.Name[1:]\n")
+	g.writef("parts = append(parts, name + \": \" + Show(v.Field(i).Interface()))\n")
+	g.indent--
+	g.writef("}\n")
+	g.writef("sort.Strings(parts)\n")
+	g.writef("return \"{\" + strings.Join(parts, \", \") + \"}\"\n")
 	g.indent--
 	g.writef("}\n\n")
 

--- a/internal/gen/golang/codegen_runtime_misc.go
+++ b/internal/gen/golang/codegen_runtime_misc.go
@@ -81,8 +81,11 @@ func (g *Generator) writeRuntimeMiscHelpers() {
 	g.indent--
 	g.writef("case float64:\n")
 	g.indent++
-	g.writef("s := fmt.Sprintf(\"%%g\", x)\n")
-	g.writef("if !strings.ContainsAny(s, \".eE\") { s += \".0\" }\n")
+	g.writef("if math.IsNaN(x) { return \"NaN\" }\n")
+	g.writef("if math.IsInf(x, 1) { return \"Inf\" }\n")
+	g.writef("if math.IsInf(x, -1) { return \"-Inf\" }\n")
+	g.writef("s := strconv.FormatFloat(x, 'f', -1, 64)\n")
+	g.writef("if !strings.Contains(s, \".\") { s += \".0\" }\n")
 	g.writef("return s\n")
 	g.indent--
 	g.writef("case bool:\n")

--- a/internal/gen/golang/codegen_runtime_misc.go
+++ b/internal/gen/golang/codegen_runtime_misc.go
@@ -50,6 +50,22 @@ func (g *Generator) writeRuntimeMiscHelpers() {
 	g.writef("// Show converts any value to canonical AILANG surface syntax.\n")
 	g.writef("func Show(v interface{}) string {\n")
 	g.indent++
+	g.writef("return showValue(v, 0)\n")
+	g.indent--
+	g.writef("}\n\n")
+
+	g.writef("const (\n")
+	g.indent++
+	g.writef("showMaxDepth = 3\n")
+	g.writef("showMaxWidth = 80\n")
+	g.writef("showElisionPrefix = 20\n")
+	g.writef("showElisionSuffix = 20\n")
+	g.indent--
+	g.writef(")\n\n")
+
+	g.writef("func showValue(v interface{}, depth int) string {\n")
+	g.indent++
+	g.writef("if depth > showMaxDepth { return \"...\" }\n")
 	g.writef("switch x := v.(type) {\n")
 	g.writef("case string:\n")
 	g.indent++
@@ -80,42 +96,43 @@ func (g *Generator) writeRuntimeMiscHelpers() {
 	g.indent--
 	g.writef("case Tuple:\n")
 	g.indent++
-	g.writef("return showSequence(reflect.ValueOf(x), \"(\", \")\")\n")
+	g.writef("return showSequence(reflect.ValueOf(x), depth, \"(\", \")\")\n")
 	g.indent--
 	g.writef("default:\n")
 	g.indent++
-	g.writef("return showReflect(reflect.ValueOf(x))\n")
+	g.writef("return showReflect(reflect.ValueOf(x), depth)\n")
 	g.indent--
 	g.writef("}\n")
 	g.indent--
 	g.writef("}\n\n")
 
-	g.writef("func showReflect(v reflect.Value) string {\n")
+	g.writef("func showReflect(v reflect.Value, depth int) string {\n")
 	g.indent++
+	g.writef("if depth > showMaxDepth { return \"...\" }\n")
 	g.writef("if !v.IsValid() { return \"()\" }\n")
 	g.writef("if v.Kind() == reflect.Interface {\n")
 	g.indent++
 	g.writef("if v.IsNil() { return \"()\" }\n")
-	g.writef("return Show(v.Elem().Interface())\n")
+	g.writef("return showValue(v.Elem().Interface(), depth)\n")
 	g.indent--
 	g.writef("}\n")
 	g.writef("switch v.Kind() {\n")
 	g.writef("case reflect.Ptr:\n")
 	g.indent++
 	g.writef("if v.IsNil() { return \"()\" }\n")
-	g.writef("return showReflect(v.Elem())\n")
+	g.writef("return showReflect(v.Elem(), depth)\n")
 	g.indent--
 	g.writef("case reflect.Slice, reflect.Array:\n")
 	g.indent++
-	g.writef("return showSequence(v, \"[\", \"]\")\n")
+	g.writef("return showSequence(v, depth, \"[\", \"]\")\n")
 	g.indent--
 	g.writef("case reflect.Map:\n")
 	g.indent++
-	g.writef("return showMap(v)\n")
+	g.writef("return showMap(v, depth)\n")
 	g.indent--
 	g.writef("case reflect.Struct:\n")
 	g.indent++
-	g.writef("return showStruct(v)\n")
+	g.writef("return showStruct(v, depth)\n")
 	g.indent--
 	g.writef("case reflect.Func:\n")
 	g.indent++
@@ -126,15 +143,15 @@ func (g *Generator) writeRuntimeMiscHelpers() {
 	g.indent--
 	g.writef("}\n\n")
 
-	g.writef("func showSequence(v reflect.Value, open, close string) string {\n")
+	g.writef("func showSequence(v reflect.Value, depth int, open, close string) string {\n")
 	g.indent++
 	g.writef("parts := make([]string, v.Len())\n")
-	g.writef("for i := 0; i < v.Len(); i++ { parts[i] = Show(v.Index(i).Interface()) }\n")
-	g.writef("return open + strings.Join(parts, \", \") + close\n")
+	g.writef("for i := 0; i < v.Len(); i++ { parts[i] = showValue(v.Index(i).Interface(), depth+1) }\n")
+	g.writef("return truncateShow(open + strings.Join(parts, \", \") + close)\n")
 	g.indent--
 	g.writef("}\n\n")
 
-	g.writef("func showMap(v reflect.Value) string {\n")
+	g.writef("func showMap(v reflect.Value, depth int) string {\n")
 	g.indent++
 	g.writef("if v.Type().Key().Kind() != reflect.String { return \"<map>\" }\n")
 	g.writef("tag := v.MapIndex(reflect.ValueOf(\"_tag\"))\n")
@@ -147,20 +164,22 @@ func (g *Generator) writeRuntimeMiscHelpers() {
 	g.writef("sort.Strings(keys)\n")
 	g.writef("if len(keys) == 0 { return ctor }\n")
 	g.writef("parts := make([]string, len(keys))\n")
-	g.writef("for i, key := range keys { parts[i] = Show(v.MapIndex(reflect.ValueOf(key)).Interface()) }\n")
+	g.writef("for i, key := range keys { parts[i] = showValue(v.MapIndex(reflect.ValueOf(key)).Interface(), depth+1) }\n")
 	g.writef("return ctor + \"(\" + strings.Join(parts, \", \") + \")\"\n")
 	g.indent--
 	g.writef("}\n")
+	g.writef("// Go maps also back inline records. Map{...} is deliberate non-round-trippable debug notation;\n")
+	g.writef("// this shared representation must retain record syntax here.\n")
 	g.writef("keys := make([]string, 0, v.Len())\n")
 	g.writef("for _, key := range v.MapKeys() { keys = append(keys, key.String()) }\n")
 	g.writef("sort.Strings(keys)\n")
 	g.writef("parts := make([]string, len(keys))\n")
-	g.writef("for i, key := range keys { parts[i] = key + \": \" + Show(v.MapIndex(reflect.ValueOf(key)).Interface()) }\n")
-	g.writef("return \"{\" + strings.Join(parts, \", \") + \"}\"\n")
+	g.writef("for i, key := range keys { parts[i] = key + \": \" + showValue(v.MapIndex(reflect.ValueOf(key)).Interface(), depth+1) }\n")
+	g.writef("return truncateShow(\"{\" + strings.Join(parts, \", \") + \"}\")\n")
 	g.indent--
 	g.writef("}\n\n")
 
-	g.writef("func showStruct(v reflect.Value) string {\n")
+	g.writef("func showStruct(v reflect.Value, depth int) string {\n")
 	g.indent++
 	g.writef("if v.NumField() == 0 { return \"()\" }\n")
 	g.writef("if kind := v.FieldByName(\"Kind\"); kind.IsValid() {\n")
@@ -172,7 +191,7 @@ func (g *Generator) writeRuntimeMiscHelpers() {
 	g.writef("if fieldInfo.Name == \"Kind\" || field.Kind() != reflect.Ptr || field.IsNil() { continue }\n")
 	g.writef("variant := field.Elem()\n")
 	g.writef("parts := make([]string, variant.NumField())\n")
-	g.writef("for j := 0; j < variant.NumField(); j++ { parts[j] = Show(variant.Field(j).Interface()) }\n")
+	g.writef("for j := 0; j < variant.NumField(); j++ { parts[j] = showValue(variant.Field(j).Interface(), depth+1) }\n")
 	g.writef("if len(parts) == 0 { return fieldInfo.Name }\n")
 	g.writef("return fieldInfo.Name + \"(\" + strings.Join(parts, \", \") + \")\"\n")
 	g.indent--
@@ -180,17 +199,29 @@ func (g *Generator) writeRuntimeMiscHelpers() {
 	g.writef("return \"<unknown>\"\n")
 	g.indent--
 	g.writef("}\n")
-	g.writef("parts := make([]string, 0, v.NumField())\n")
+	g.writef("fields := make(map[string]reflect.Value, v.NumField())\n")
+	g.writef("keys := make([]string, 0, v.NumField())\n")
 	g.writef("for i := 0; i < v.NumField(); i++ {\n")
 	g.indent++
 	g.writef("fieldInfo := v.Type().Field(i)\n")
 	g.writef("if fieldInfo.PkgPath != \"\" { continue }\n")
 	g.writef("name := strings.ToLower(fieldInfo.Name[:1]) + fieldInfo.Name[1:]\n")
-	g.writef("parts = append(parts, name + \": \" + Show(v.Field(i).Interface()))\n")
+	g.writef("keys = append(keys, name)\n")
+	g.writef("fields[name] = v.Field(i)\n")
 	g.indent--
 	g.writef("}\n")
-	g.writef("sort.Strings(parts)\n")
-	g.writef("return \"{\" + strings.Join(parts, \", \") + \"}\"\n")
+	g.writef("sort.Strings(keys)\n")
+	g.writef("parts := make([]string, len(keys))\n")
+	g.writef("for i, key := range keys { parts[i] = key + \": \" + showValue(fields[key].Interface(), depth+1) }\n")
+	g.writef("return truncateShow(\"{\" + strings.Join(parts, \", \") + \"}\")\n")
+	g.indent--
+	g.writef("}\n\n")
+
+	g.writef("func truncateShow(s string) string {\n")
+	g.indent++
+	g.writef("if len(s) <= showMaxWidth { return s }\n")
+	g.writef("if showElisionPrefix+showElisionSuffix+3 >= len(s) { return s }\n")
+	g.writef("return s[:showElisionPrefix] + \"...\" + s[len(s)-showElisionSuffix:]\n")
 	g.indent--
 	g.writef("}\n\n")
 

--- a/internal/gen/golang/codegen_string_test.go
+++ b/internal/gen/golang/codegen_string_test.go
@@ -145,8 +145,9 @@ func TestIntToStrGeneration(t *testing.T) {
 	}
 }
 
-// TestNoStrconvImportWhenNotNeeded tests that strconv import is not added when not needed.
-func TestNoStrconvImportWhenNotNeeded(t *testing.T) {
+// TestRuntimeShowRequiresStrconvImport tests that the generated Show helper brings
+// in strconv even when the source program does not use conversion builtins.
+func TestRuntimeShowRequiresStrconvImport(t *testing.T) {
 	g := New("test")
 
 	// Create a simple program without string conversion functions
@@ -167,10 +168,8 @@ func TestNoStrconvImportWhenNotNeeded(t *testing.T) {
 
 	codeStr := string(code)
 
-	// Check that strconv import is NOT present
-	if strings.Contains(codeStr, `"strconv"`) {
-		t.Error("Generated code should NOT contain strconv import when not needed")
-		t.Logf("Generated code:\n%s", codeStr)
+	if !strings.Contains(codeStr, `"strconv"`) {
+		t.Error("Generated code should contain strconv import for runtime Show")
 	}
 }
 

--- a/internal/gen/golang/types.go
+++ b/internal/gen/golang/types.go
@@ -84,9 +84,7 @@ func (tm *TypeMapper) mapTypeWithVisited(t types.Type, visited map[types.Type]bo
 		return GoType(fmt.Sprintf("[]%s", elemType)), nil
 
 	case *types.TTuple:
-		// Go doesn't have tuples, generate a struct type name
-		// For now, return a placeholder
-		return GoType("struct{}"), nil
+		return GoType("Tuple"), nil
 
 	case *types.TRecord:
 		// M-CROSS-MODULE: First check if TypeName is set (preserves nominal type identity)

--- a/tests/golden/codegen/golden_test.go
+++ b/tests/golden/codegen/golden_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-const expectedDifferentialFixtureCount = 4
+const expectedDifferentialFixtureCount = 5
 
 // TestGoldenCompile verifies that each .ail golden test file compiles to Go
 // that passes `go build`. This is the primary acceptance test for the codegen

--- a/tests/golden/codegen/golden_test.go
+++ b/tests/golden/codegen/golden_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -118,7 +119,12 @@ func TestInterpreterCompiledDifferential(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(outDir, "go.mod"), []byte("module differential\n\ngo 1.21\n"), 0644); err != nil {
 				t.Fatal(err)
 			}
-			binary := filepath.Join(outDir, "fixture-bin")
+			// Windows requires the .exe suffix or exec cannot find the file it just built.
+			binaryName := "fixture-bin"
+			if runtime.GOOS == "windows" {
+				binaryName += ".exe"
+			}
+			binary := filepath.Join(outDir, binaryName)
 			build := exec.Command("go", "build", "-o", binary, "./main/")
 			build.Dir = outDir
 			if output, err := build.CombinedOutput(); err != nil {

--- a/tests/golden/codegen/golden_test.go
+++ b/tests/golden/codegen/golden_test.go
@@ -1,12 +1,16 @@
 package codegen_golden_test
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+const expectedDifferentialFixtureCount = 1
 
 // TestGoldenCompile verifies that each .ail golden test file compiles to Go
 // that passes `go build`. This is the primary acceptance test for the codegen
@@ -65,6 +69,68 @@ func TestGoldenCompile(t *testing.T) {
 			vetOut, err := vetCmd.CombinedOutput()
 			if err != nil {
 				t.Fatalf("go vet failed for %s:\n%s", ailFile, string(vetOut))
+			}
+		})
+	}
+}
+
+// TestInterpreterCompiledDifferential executes the same fixtures through both
+// runtimes. This catches semantic drift that compile-only golden tests cannot.
+func TestInterpreterCompiledDifferential(t *testing.T) {
+	fixtures, err := filepath.Glob("show_differential*.ail")
+	if err != nil {
+		t.Fatalf("failed to glob differential fixtures: %v", err)
+	}
+	if len(fixtures) == 0 {
+		t.Fatal("no run-vs-compiled differential fixtures found")
+	}
+	if len(fixtures) != expectedDifferentialFixtureCount {
+		t.Fatalf("differential fixture count = %d, want exactly %d; update the literal deliberately when changing coverage",
+			len(fixtures), expectedDifferentialFixtureCount)
+	}
+
+	for _, fixture := range fixtures {
+		fixture := fixture
+		name := strings.TrimSuffix(filepath.Base(fixture), ".ail")
+		t.Run(name, func(t *testing.T) {
+			absFixture, err := filepath.Abs(fixture)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			interpreted := exec.Command("ailang", "run", "--quiet", "--caps", "IO", "--relax-modules", absFixture)
+			interpretedOut, err := interpreted.Output()
+			if err != nil {
+				t.Fatalf("ailang run failed for %s: %v", fixture, err)
+			}
+
+			outDir := t.TempDir()
+			compile := exec.Command("ailang", "compile", "--emit-go", "--out", outDir,
+				"--package-name", "main", "--relax-modules", "--no-verify-go", absFixture)
+			if output, err := compile.CombinedOutput(); err != nil {
+				t.Fatalf("ailang compile failed for %s: %v\n%s", fixture, err, output)
+			}
+			pkgDir := filepath.Join(outDir, "main")
+			driver := fmt.Sprintf("package main\n\nfunc main() { %s__Main() }\n", name)
+			if err := os.WriteFile(filepath.Join(pkgDir, "driver.go"), []byte(driver), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(outDir, "go.mod"), []byte("module differential\n\ngo 1.21\n"), 0644); err != nil {
+				t.Fatal(err)
+			}
+			binary := filepath.Join(outDir, "fixture-bin")
+			build := exec.Command("go", "build", "-o", binary, "./main/")
+			build.Dir = outDir
+			if output, err := build.CombinedOutput(); err != nil {
+				t.Fatalf("go build failed for %s: %v\n%s", fixture, err, output)
+			}
+			compiledOut, err := exec.Command(binary).Output()
+			if err != nil {
+				t.Fatalf("compiled fixture failed for %s: %v", fixture, err)
+			}
+			if !bytes.Equal(interpretedOut, compiledOut) {
+				t.Fatalf("interpreter/compiled stdout differs for %s\ninterpreter:\n%s\ncompiled:\n%s",
+					fixture, interpretedOut, compiledOut)
 			}
 		})
 	}

--- a/tests/golden/codegen/golden_test.go
+++ b/tests/golden/codegen/golden_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-const expectedDifferentialFixtureCount = 1
+const expectedDifferentialFixtureCount = 4
 
 // TestGoldenCompile verifies that each .ail golden test file compiles to Go
 // that passes `go build`. This is the primary acceptance test for the codegen

--- a/tests/golden/codegen/show_differential.ail
+++ b/tests/golden/codegen/show_differential.ail
@@ -1,0 +1,12 @@
+module test/show_differential
+
+type Option[a] = Some(a) | None
+
+export func main() -> () ! {IO} {
+  println(show([1, 2, 3]))
+  println(show([[1, 2], [3]]))
+  println(show({ x: 5, y: 10 }))
+  println(show(Some(42)))
+  println(show((1, "a")))
+  println(show(3.5))
+}

--- a/tests/golden/codegen/show_differential_depth.ail
+++ b/tests/golden/codegen/show_differential_depth.ail
@@ -1,0 +1,5 @@
+module test/show_differential_depth
+
+export func main() -> () ! {IO} {
+  println(show([[[[[42]]]]]))
+}

--- a/tests/golden/codegen/show_differential_float.ail
+++ b/tests/golden/codegen/show_differential_float.ail
@@ -1,0 +1,9 @@
+module test/show_differential_float
+
+export func main() -> () ! {IO} {
+  println(show(1.0 / 0.0))
+  println(show(-1.0 / 0.0))
+  println(show(0.0 / 0.0))
+  println(show(1e+21))
+  println(show(1e-07))
+}

--- a/tests/golden/codegen/show_differential_named_record.ail
+++ b/tests/golden/codegen/show_differential_named_record.ail
@@ -1,0 +1,8 @@
+module test/show_differential_named_record
+
+type Config = { a: int, a1: int }
+
+export func main() -> () ! {IO} {
+  let config: Config = {a: 2, a1: 1};
+  println(show(config))
+}

--- a/tests/golden/codegen/show_differential_width.ail
+++ b/tests/golden/codegen/show_differential_width.ail
@@ -1,0 +1,5 @@
+module test/show_differential_width
+
+export func main() -> () ! {IO} {
+  println(show([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]))
+}


### PR DESCRIPTION
## `show` meant two different things, and one of them printed a heap address

`show` has two implementations — the interpreter's `showValue` and a `Show` helper the Go
backend emits — and nothing anywhere checked that they agree. They did not.

The worst of it is a determinism defect. The generated `Show` fell through to `fmt.Sprintf("%v", x)`,
and an ADT is a pointer to a struct, so a compiled AILANG binary printed its own heap addresses:

```
show(Some(42))  ->  &{0 0x29de23be2150 <nil>}
```

Three consecutive runs of one unchanged binary gave three different strings, `cmp` differing on
every pair, while a list-only control program was byte-identical across runs. A compiled program
was non-deterministic in its output.

On the interpreter side, `showValue` switched over 10 of the 17 live `eval.Value` implementations
and sent the rest to `fmt.Sprintf("<%T>", val)` — a Go type name, to the user. Three of the seven
are one line of ordinary code away:

```
show(zip([1,2,3],[4,5,6]))     ->  [<*eval.TupleValue>, <*eval.TupleValue>, ...]
show(insert(empty(), "a", 1))  ->  <*eval.MapValue>
show(fromList([1,2,3]))        ->  <*eval.ArrayValue>
```

## What changed

Both implementations now render the same AILANG surface syntax — `[a, b]`, `{k: v}` with sorted
keys, `Ctor(args)`, `(a, b)`, `#[a, b]` (the language's own array literal). All 17 value types are
handled, and exhaustiveness is machine-checked against the live source: adding an unhandled
`eval.Value` implementation reds the test.

And `tests/golden/codegen` now **runs** what it compiles. It previously stopped at `go build` and
`go vet`, which is exactly how two implementations diverged with every check green. The new
differential executes each fixture under `ailang run` and as a compiled binary and requires
byte-equal stdout.

## Three review rounds, three divergences the fixtures did not cover

Rounds 2 and 3 exist because an independent evaluator found real defects, each reproduced
first-party before being acted on:

- **Named records sorted wrongly.** The generated code sorted the rendered `"key: value"` strings
  rather than the keys, comparing `' '` against `'1'`, so `type Config = {a, a1}` printed
  `{a1: 1, a: 2}` compiled against `{a: 2, a1: 1}` interpreted. A named record compiles to a Go
  struct; an inline one compiles to a map and was already correct. Round 1's single fixture used
  an inline record.
- **No depth or width caps.** The interpreter truncates at depth 3 and width 80 with 20/20 elision;
  the generated `Show` did neither, so the arms diverged on any deep or wide value.
- **Floats.** `%g` plus an unconditional `.0` produced `+Inf.0`, `NaN.0`, `1e+21` and `1e-07`
  where the interpreter gives `Inf`, `NaN`, `1000000000000000000000.0` and `0.0000001`.

Each round widened the fixture set as well as fixing the code — the count literal went 1 → 4 → 5 —
because a fix without a fixture leaves the next member of the class exactly as invisible. The float
case is the clearest illustration: `TestShow_FloatSpecialValues` already pinned the interpreter's
`NaN`/`Inf` strings, but it only ever calls `showImpl`, so it could not see the other implementation.

## Verification

Every claim below was re-derived by the controller outside any sandbox, on darwin/arm64, with a
worktree-built binary first on PATH (`~/go/bin` untouched — it is shared with other agents).
The linux and windows CI legs are unrun locally.

- interpreted stdout == compiled stdout, byte-identical, for records, named records, ADTs, tuples,
  floats, non-finite floats, nested lists, and values past both caps
- compiled binary byte-identical across three runs; zero `0x` in stdout (the pre-sprint arm differs)
- **465** `.ail` files under `examples/` and `tests/` compile to the same exit code before and after —
  run twice, after round 1 and after round 3, **0 divergences** each time. This is what adjudicates
  the executor's one deviation from the plan: it introduced a distinct generated `Tuple` type,
  touching typing and pattern matching, which is wider than the directive asked for.
- controller mutation drill, each mutant asserted LANDED by sha256 **and** BUILDS rc=0 before any
  test result was read, each restored byte-identically: interpreter tuple delimiters → differential
  red, sole killer; generated `Show` restored to `%v` → differential red, sole killer
- gates rc=0: `go build ./internal/builtins/... ./internal/gen/golang/...`;
  `go test ./internal/builtins/ ./internal/gen/golang/ ./tests/golden/codegen/`;
  `make check-file-sizes` / `check-boundaries` / `check-changelog`; `gofmt -l` clean.
  (`go build ./...` is rc=1 on untouched dev — `cmd/wasm`, `gen/main` — and is not a signal.)

Evaluator: sonnet, in its own worktree, three rounds — 78/100, 80/100, and a final pass.
Executor: codex `gpt-5.6-sol`, five milestones, no git writes; commits reconstructed by the
controller from cumulative snapshots and proven faithful by sha256 manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
