### PR TITLE
fix(codegen): array show diverged between run and compile, and five converters swallowed type errors

### DIFF
--- a/internal/gen/golang/codegen.go
+++ b/internal/gen/golang/codegen.go
@@ -554,6 +554,7 @@ func (g *Generator) writePackageHeader() {
 		g.writef("\t\"strings\"\n")
 		g.writef(")\n\n")
 		g.writef("type Tuple []interface{}\n\n")
+		g.writef("type ArrayVal []interface{}\n\n")
 		g.writeRuntimeHelpers()
 	} else if g.needsMathImport || g.needsStrconvImport || g.needsStringsImport || g.needsSortImport {
 		// M-CODEGEN-SUSTAINABILITY: Even when skipping runtime helpers,
@@ -662,6 +663,8 @@ func (g *Generator) GenerateRuntime() ([]byte, error) {
 	g.writef("type List = []interface{}\n\n")
 	g.writef("// Tuple preserves tuple identity for pattern matching and canonical Show output.\n")
 	g.writef("type Tuple []interface{}\n\n")
+	g.writef("// ArrayVal preserves array identity for canonical Show output.\n")
+	g.writef("type ArrayVal []interface{}\n\n")
 
 	// Write the pre-generated helpers (already generated above for import detection)
 	g.buf.WriteString(helpersCode)

--- a/internal/gen/golang/codegen_datastructures_test.go
+++ b/internal/gen/golang/codegen_datastructures_test.go
@@ -42,37 +42,67 @@ func TestGenerateList(t *testing.T) {
 	}
 }
 
+// TestGenerateArrayPreservesRuntimeIdentity pins that an array literal and a list
+// literal compile to DIFFERENT Go values — the whole point of M1.
+//
+// The observable must discriminate. An earlier form of this test asserted only that
+// the strings "type ArrayVal []interface{}", "ArrayVal{" and "case ArrayVal:" appear
+// somewhere in the generated source; all three are unconditional runtime-preamble
+// boilerplate, so it passed for a program containing no array at all. Measured: with
+// core.Array swapped for core.List the old assertions still passed (rc=0), and with a
+// bare int literal too. It was vacuous, which is why the assertion below is written
+// over the emitted LITERAL — text only an array literal can produce — and is checked
+// in both directions against a list-valued twin.
 func TestGenerateArrayPreservesRuntimeIdentity(t *testing.T) {
-	prog := &core.Program{
-		Decls: []core.CoreExpr{
-			&core.Let{
-				Name: "nums",
-				Value: &core.Array{
-					Elements: []core.CoreExpr{
-						&core.Lit{Kind: core.IntLit, Value: int64(1)},
-						&core.Lit{Kind: core.IntLit, Value: int64(2)},
-						&core.Lit{Kind: core.IntLit, Value: int64(3)},
-					},
-				},
-				Body: &core.Var{Name: "nums"},
+	elements := func() []core.CoreExpr {
+		return []core.CoreExpr{
+			&core.Lit{Kind: core.IntLit, Value: int64(1)},
+			&core.Lit{Kind: core.IntLit, Value: int64(2)},
+			&core.Lit{Kind: core.IntLit, Value: int64(3)},
+		}
+	}
+	generate := func(t *testing.T, value core.CoreExpr) string {
+		t.Helper()
+		prog := &core.Program{
+			Decls: []core.CoreExpr{
+				&core.Let{Name: "nums", Value: value, Body: &core.Var{Name: "nums"}},
 			},
-		},
+		}
+		code, err := New("test").Generate(prog)
+		if err != nil {
+			t.Fatalf("Generate failed: %v", err)
+		}
+		return string(code)
 	}
 
-	gen := New("test")
-	code, err := gen.Generate(prog)
-	if err != nil {
-		t.Fatalf("Generate failed: %v", err)
+	const (
+		arrayLiteral = "ArrayVal{int64(1), int64(2), int64(3)}"
+		listLiteral  = "[]interface{}{int64(1), int64(2), int64(3)}"
+	)
+
+	fromArray := generate(t, &core.Array{Elements: elements()})
+	fromList := generate(t, &core.List{Elements: elements()})
+
+	// The array program emits an ArrayVal literal and NOT a bare slice literal.
+	if !strings.Contains(fromArray, arrayLiteral) {
+		t.Errorf("array program: generated source missing %q:\n%s", arrayLiteral, fromArray)
+	}
+	if strings.Contains(fromArray, listLiteral) {
+		t.Errorf("array program: array literal was erased to %q, which is the divergence M1 removes", listLiteral)
 	}
 
-	generated := string(code)
-	for _, want := range []string{
-		"type ArrayVal []interface{}",
-		"ArrayVal{",
-		"case ArrayVal:",
-	} {
-		if !strings.Contains(generated, want) {
-			t.Errorf("generated source missing %q:\n%s", want, generated)
+	// The list program is the negative arm: it must NOT gain array identity.
+	if strings.Contains(fromList, arrayLiteral) {
+		t.Errorf("list program: emitted %q — lists must stay []interface{}", arrayLiteral)
+	}
+	if !strings.Contains(fromList, listLiteral) {
+		t.Errorf("list program: generated source missing %q:\n%s", listLiteral, fromList)
+	}
+
+	// The rendering half: showValue must carry the ArrayVal arm, and the preamble the type.
+	for _, want := range []string{"type ArrayVal []interface{}", "case ArrayVal:"} {
+		if !strings.Contains(fromArray, want) {
+			t.Errorf("generated source missing %q:\n%s", want, fromArray)
 		}
 	}
 }

--- a/internal/gen/golang/codegen_datastructures_test.go
+++ b/internal/gen/golang/codegen_datastructures_test.go
@@ -42,6 +42,41 @@ func TestGenerateList(t *testing.T) {
 	}
 }
 
+func TestGenerateArrayPreservesRuntimeIdentity(t *testing.T) {
+	prog := &core.Program{
+		Decls: []core.CoreExpr{
+			&core.Let{
+				Name: "nums",
+				Value: &core.Array{
+					Elements: []core.CoreExpr{
+						&core.Lit{Kind: core.IntLit, Value: int64(1)},
+						&core.Lit{Kind: core.IntLit, Value: int64(2)},
+						&core.Lit{Kind: core.IntLit, Value: int64(3)},
+					},
+				},
+				Body: &core.Var{Name: "nums"},
+			},
+		},
+	}
+
+	gen := New("test")
+	code, err := gen.Generate(prog)
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	generated := string(code)
+	for _, want := range []string{
+		"type ArrayVal []interface{}",
+		"ArrayVal{",
+		"case ArrayVal:",
+	} {
+		if !strings.Contains(generated, want) {
+			t.Errorf("generated source missing %q:\n%s", want, generated)
+		}
+	}
+}
+
 func TestGenerateRecord(t *testing.T) {
 	// { x: 10, y: 20 }
 	prog := &core.Program{

--- a/internal/gen/golang/codegen_multimodule_test.go
+++ b/internal/gen/golang/codegen_multimodule_test.go
@@ -315,12 +315,17 @@ func TestListPatternMatchGeneratesValidGo(t *testing.T) {
 	}
 
 	output := string(code)
+	matchStart := strings.Index(output, "func checkList_impl")
+	if matchStart == -1 {
+		t.Fatalf("generated source missing checkList_impl:\n%s", output)
+	}
+	matchOutput := output[matchStart:]
 	// Should use if-else path (len check), NOT switch/case
-	if strings.Contains(output, "case []interface{}") {
+	if strings.Contains(matchOutput, "case []interface{}") {
 		t.Errorf("List pattern should use if-else, not switch case. Got:\n%s", output)
 	}
 	// Should contain a length check for empty list
-	if !strings.Contains(output, "ListLen(") && !strings.Contains(output, "len(") {
+	if !strings.Contains(matchOutput, "ListLen(") && !strings.Contains(matchOutput, "len(") {
 		t.Errorf("Expected length check for empty list pattern, got:\n%s", output)
 	}
 }

--- a/internal/gen/golang/codegen_ops.go
+++ b/internal/gen/golang/codegen_ops.go
@@ -353,25 +353,11 @@ func (g *Generator) getListElementType(list *core.List) string {
 	return ""
 }
 
-// generateArray generates a Go slice literal for arrays.
-// M-TYPE1: Arrays use the same Go representation as lists (slices).
+// generateArray generates a distinct Go slice literal for arrays.
+// M-ARRAY-SHOW-DIVERGES-RUN-VS-COMPILE: ArrayVal preserves array identity at runtime.
 func (g *Generator) generateArray(arr *core.Array) error {
-	// M-DX26: In _impl functions, always generate []interface{}
-	inImplFunc := g.expectedReturnType == "interface{}"
-
-	// Try to determine element type from CoreTypeInfo
-	elemType := ""
-	if !inImplFunc {
-		elemType = g.getArrayElementType(arr)
-	}
-
-	if elemType != "" && elemType != "interface{}" {
-		// Generate typed slice (e.g., []int64{1, 2, 3})
-		g.writef("[]%s{", elemType)
-	} else {
-		// Fallback to interface{} slice
-		g.write("[]interface{}{")
-	}
+	// Both formerly dynamic and typed branches must carry the same array identity.
+	g.write("ArrayVal{")
 
 	for i, elem := range arr.Elements {
 		if i > 0 {

--- a/internal/gen/golang/codegen_runtime_collections.go
+++ b/internal/gen/golang/codegen_runtime_collections.go
@@ -135,21 +135,27 @@ func (g *Generator) writeRuntimeListHelpers() {
 // writeArrayRuntimeFunctions generates Go implementations for AILANG array operations.
 // M-TYPE1: These are used when compiling std/array module functions to Go.
 func (g *Generator) writeArrayRuntimeFunctions() {
-	// FromList - creates array from list (both are []interface{} in Go)
+	// FromList - creates an ArrayVal from a list
 	g.writef("// FromList creates an array from a list.\n")
-	g.writef("// In Go, both arrays and lists are []interface{}.\n")
 	g.writef("func FromList(xs interface{}) interface{} {\n")
 	g.indent++
 	g.writef("if xs == nil {\n")
 	g.indent++
-	g.writef("return []interface{}{}\n")
+	g.writef("return ArrayVal{}\n")
+	g.indent--
+	g.writef("}\n")
+	g.writef("if array, ok := xs.(ArrayVal); ok {\n")
+	g.indent++
+	g.writef("result := make(ArrayVal, len(array))\n")
+	g.writef("copy(result, array)\n")
+	g.writef("return result\n")
 	g.indent--
 	g.writef("}\n")
 	g.writef("// Fast path for []interface{}\n")
 	g.writef("if list, ok := xs.([]interface{}); ok {\n")
 	g.indent++
 	g.writef("// Return a copy to preserve immutability\n")
-	g.writef("result := make([]interface{}, len(list))\n")
+	g.writef("result := make(ArrayVal, len(list))\n")
 	g.writef("copy(result, list)\n")
 	g.writef("return result\n")
 	g.indent--
@@ -158,7 +164,7 @@ func (g *Generator) writeArrayRuntimeFunctions() {
 	g.writef("v := reflect.ValueOf(xs)\n")
 	g.writef("if v.Kind() == reflect.Slice {\n")
 	g.indent++
-	g.writef("result := make([]interface{}, v.Len())\n")
+	g.writef("result := make(ArrayVal, v.Len())\n")
 	g.writef("for i := 0; i < v.Len(); i++ {\n")
 	g.indent++
 	g.writef("result[i] = v.Index(i).Interface()\n")
@@ -167,7 +173,7 @@ func (g *Generator) writeArrayRuntimeFunctions() {
 	g.writef("return result\n")
 	g.indent--
 	g.writef("}\n")
-	g.writef("return []interface{}{}\n")
+	g.writef("return ArrayVal{}\n")
 	g.indent--
 	g.writef("}\n\n")
 
@@ -179,6 +185,13 @@ func (g *Generator) writeArrayRuntimeFunctions() {
 	g.writef("if arr == nil {\n")
 	g.indent++
 	g.writef("return []interface{}{}\n")
+	g.indent--
+	g.writef("}\n")
+	g.writef("if slice, ok := arr.(ArrayVal); ok {\n")
+	g.indent++
+	g.writef("result := make([]interface{}, len(slice))\n")
+	g.writef("copy(result, slice)\n")
+	g.writef("return result\n")
 	g.indent--
 	g.writef("}\n")
 	g.writef("// Fast path for []interface{}\n")
@@ -215,6 +228,11 @@ func (g *Generator) writeArrayRuntimeFunctions() {
 	g.writef("return int64(0)\n")
 	g.indent--
 	g.writef("}\n")
+	g.writef("if slice, ok := arr.(ArrayVal); ok {\n")
+	g.indent++
+	g.writef("return int64(len(slice))\n")
+	g.indent--
+	g.writef("}\n")
 	g.writef("// Fast path for []interface{}\n")
 	g.writef("if slice, ok := arr.([]interface{}); ok {\n")
 	g.indent++
@@ -238,6 +256,16 @@ func (g *Generator) writeArrayRuntimeFunctions() {
 	g.writef("func Get(arr interface{}, idx interface{}) interface{} {\n")
 	g.indent++
 	g.writef("i := toInt64(idx)\n")
+	g.writef("if slice, ok := arr.(ArrayVal); ok {\n")
+	g.indent++
+	g.writef("if i < 0 || i >= int64(len(slice)) {\n")
+	g.indent++
+	g.writef("panic(fmt.Sprintf(\"array index out of bounds: %%d (length %%d)\", i, len(slice)))\n")
+	g.indent--
+	g.writef("}\n")
+	g.writef("return slice[i]\n")
+	g.indent--
+	g.writef("}\n")
 	g.writef("// Fast path for []interface{}\n")
 	g.writef("if slice, ok := arr.([]interface{}); ok {\n")
 	g.indent++
@@ -273,6 +301,16 @@ func (g *Generator) writeArrayRuntimeFunctions() {
 	g.writef("if i < 0 {\n")
 	g.indent++
 	g.writef("return makeOptionNone()\n")
+	g.indent--
+	g.writef("}\n")
+	g.writef("if slice, ok := arr.(ArrayVal); ok {\n")
+	g.indent++
+	g.writef("if i >= int64(len(slice)) {\n")
+	g.indent++
+	g.writef("return makeOptionNone()\n")
+	g.indent--
+	g.writef("}\n")
+	g.writef("return makeOptionSome(slice[i])\n")
 	g.indent--
 	g.writef("}\n")
 	g.writef("if slice, ok := arr.([]interface{}); ok {\n")
@@ -321,6 +359,11 @@ func (g *Generator) writeArrayRuntimeFunctions() {
 	g.writef("func UnsafeGet(arr interface{}, idx interface{}) interface{} {\n")
 	g.indent++
 	g.writef("i := toInt64(idx)\n")
+	g.writef("if slice, ok := arr.(ArrayVal); ok {\n")
+	g.indent++
+	g.writef("return slice[i]\n")
+	g.indent--
+	g.writef("}\n")
 	g.writef("if slice, ok := arr.([]interface{}); ok {\n")
 	g.indent++
 	g.writef("return slice[i]\n")
@@ -335,6 +378,19 @@ func (g *Generator) writeArrayRuntimeFunctions() {
 	g.writef("func Set(arr interface{}, idx interface{}, val interface{}) interface{} {\n")
 	g.indent++
 	g.writef("i := toInt64(idx)\n")
+	g.writef("if slice, ok := arr.(ArrayVal); ok {\n")
+	g.indent++
+	g.writef("if i < 0 || i >= int64(len(slice)) {\n")
+	g.indent++
+	g.writef("panic(fmt.Sprintf(\"array index out of bounds: %%d (length %%d)\", i, len(slice)))\n")
+	g.indent--
+	g.writef("}\n")
+	g.writef("result := make(ArrayVal, len(slice))\n")
+	g.writef("copy(result, slice)\n")
+	g.writef("result[i] = val\n")
+	g.writef("return result\n")
+	g.indent--
+	g.writef("}\n")
 	g.writef("if slice, ok := arr.([]interface{}); ok {\n")
 	g.indent++
 	g.writef("if i < 0 || i >= int64(len(slice)) {\n")
@@ -342,7 +398,7 @@ func (g *Generator) writeArrayRuntimeFunctions() {
 	g.writef("panic(fmt.Sprintf(\"array index out of bounds: %%d (length %%d)\", i, len(slice)))\n")
 	g.indent--
 	g.writef("}\n")
-	g.writef("result := make([]interface{}, len(slice))\n")
+	g.writef("result := make(ArrayVal, len(slice))\n")
 	g.writef("copy(result, slice)\n")
 	g.writef("result[i] = val\n")
 	g.writef("return result\n")
@@ -362,7 +418,7 @@ func (g *Generator) writeArrayRuntimeFunctions() {
 	g.writef("n = 0\n")
 	g.indent--
 	g.writef("}\n")
-	g.writef("result := make([]interface{}, n)\n")
+	g.writef("result := make(ArrayVal, n)\n")
 	g.writef("for i := range result {\n")
 	g.indent++
 	g.writef("result[i] = defaultVal\n")

--- a/internal/gen/golang/codegen_runtime_misc.go
+++ b/internal/gen/golang/codegen_runtime_misc.go
@@ -97,6 +97,10 @@ func (g *Generator) writeRuntimeMiscHelpers() {
 	g.indent++
 	g.writef("return \"()\"\n")
 	g.indent--
+	g.writef("case ArrayVal:\n")
+	g.indent++
+	g.writef("return showSequence(reflect.ValueOf(x), depth, \"#[\", \"]\")\n")
+	g.indent--
 	g.writef("case Tuple:\n")
 	g.indent++
 	g.writef("return showSequence(reflect.ValueOf(x), depth, \"(\", \")\")\n")

--- a/internal/gen/golang/codegen_runtime_slices.go
+++ b/internal/gen/golang/codegen_runtime_slices.go
@@ -12,10 +12,19 @@ func (g *Generator) writeRuntimeSliceConverters() {
 	g.writef("return nil\n")
 	g.indent--
 	g.writef("}\n")
-	g.writef("slice, ok := v.([]interface{})\n")
-	g.writef("if !ok {\n")
+	g.writef("var slice []interface{}\n")
+	g.writef("switch x := v.(type) {\n")
+	g.writef("case []interface{}:\n")
 	g.indent++
-	g.writef("return nil\n")
+	g.writef("slice = x\n")
+	g.indent--
+	g.writef("case ArrayVal:\n")
+	g.indent++
+	g.writef("slice = []interface{}(x)\n")
+	g.indent--
+	g.writef("default:\n")
+	g.indent++
+	g.writef("panic(fmt.Sprintf(\"ConvertToInt64Slice: expected list or array slice, got %%T\", v))\n")
 	g.indent--
 	g.writef("}\n")
 	g.writef("result := make([]int64, len(slice))\n")
@@ -36,10 +45,19 @@ func (g *Generator) writeRuntimeSliceConverters() {
 	g.writef("return nil\n")
 	g.indent--
 	g.writef("}\n")
-	g.writef("slice, ok := v.([]interface{})\n")
-	g.writef("if !ok {\n")
+	g.writef("var slice []interface{}\n")
+	g.writef("switch x := v.(type) {\n")
+	g.writef("case []interface{}:\n")
 	g.indent++
-	g.writef("return nil\n")
+	g.writef("slice = x\n")
+	g.indent--
+	g.writef("case ArrayVal:\n")
+	g.indent++
+	g.writef("slice = []interface{}(x)\n")
+	g.indent--
+	g.writef("default:\n")
+	g.indent++
+	g.writef("panic(fmt.Sprintf(\"ConvertToStringSlice: expected list or array slice, got %%T\", v))\n")
 	g.indent--
 	g.writef("}\n")
 	g.writef("result := make([]string, len(slice))\n")
@@ -64,10 +82,19 @@ func (g *Generator) writeRuntimeSliceConverters() {
 	g.writef("return nil\n")
 	g.indent--
 	g.writef("}\n")
-	g.writef("slice, ok := v.([]interface{})\n")
-	g.writef("if !ok {\n")
+	g.writef("var slice []interface{}\n")
+	g.writef("switch x := v.(type) {\n")
+	g.writef("case []interface{}:\n")
 	g.indent++
-	g.writef("return nil\n")
+	g.writef("slice = x\n")
+	g.indent--
+	g.writef("case ArrayVal:\n")
+	g.indent++
+	g.writef("slice = []interface{}(x)\n")
+	g.indent--
+	g.writef("default:\n")
+	g.indent++
+	g.writef("panic(fmt.Sprintf(\"ConvertToRecordSlice: expected list or array slice, got %%T\", v))\n")
 	g.indent--
 	g.writef("}\n")
 	g.writef("result := make([]map[string]interface{}, len(slice))\n")
@@ -99,10 +126,19 @@ func (g *Generator) writeRuntimeSliceConverters() {
 	g.writef("return bs\n")
 	g.indent--
 	g.writef("}\n")
-	g.writef("slice, ok := v.([]interface{})\n")
-	g.writef("if !ok {\n")
+	g.writef("var slice []interface{}\n")
+	g.writef("switch x := v.(type) {\n")
+	g.writef("case []interface{}:\n")
 	g.indent++
-	g.writef("return nil\n")
+	g.writef("slice = x\n")
+	g.indent--
+	g.writef("case ArrayVal:\n")
+	g.indent++
+	g.writef("slice = []interface{}(x)\n")
+	g.indent--
+	g.writef("default:\n")
+	g.indent++
+	g.writef("panic(fmt.Sprintf(\"ConvertToBoolSlice: expected list or array slice, got %%T\", v))\n")
 	g.indent--
 	g.writef("}\n")
 	g.writef("result := make([]bool, len(slice))\n")
@@ -134,10 +170,19 @@ func (g *Generator) writeRuntimeSliceConverters() {
 	g.writef("return fs\n")
 	g.indent--
 	g.writef("}\n")
-	g.writef("slice, ok := v.([]interface{})\n")
-	g.writef("if !ok {\n")
+	g.writef("var slice []interface{}\n")
+	g.writef("switch x := v.(type) {\n")
+	g.writef("case []interface{}:\n")
 	g.indent++
-	g.writef("return nil\n")
+	g.writef("slice = x\n")
+	g.indent--
+	g.writef("case ArrayVal:\n")
+	g.indent++
+	g.writef("slice = []interface{}(x)\n")
+	g.indent--
+	g.writef("default:\n")
+	g.indent++
+	g.writef("panic(fmt.Sprintf(\"ConvertToFloat64Slice: expected list or array slice, got %%T\", v))\n")
 	g.indent--
 	g.writef("}\n")
 	g.writef("result := make([]float64, len(slice))\n")
@@ -216,9 +261,18 @@ func (g *Generator) writeADTSliceConverters() {
 		g.indent--
 		g.writef("}\n")
 
-		// Assert to []interface{}
-		g.writef("src, ok := v.([]interface{})\n")
-		g.writef("if !ok {\n")
+		// Accept list and array dynamic representations.
+		g.writef("var src []interface{}\n")
+		g.writef("switch x := v.(type) {\n")
+		g.writef("case []interface{}:\n")
+		g.indent++
+		g.writef("src = x\n")
+		g.indent--
+		g.writef("case ArrayVal:\n")
+		g.indent++
+		g.writef("src = []interface{}(x)\n")
+		g.indent--
+		g.writef("default:\n")
 		g.indent++
 		g.writef("panic(fmt.Sprintf(\"%s: expected []interface{}, got %%T\", v))\n", funcName)
 		g.indent--
@@ -336,9 +390,18 @@ func (g *Generator) writeRecordSliceConverters() {
 		g.indent--
 		g.writef("}\n")
 
-		// Assert to []interface{}
-		g.writef("src, ok := v.([]interface{})\n")
-		g.writef("if !ok {\n")
+		// Accept list and array dynamic representations.
+		g.writef("var src []interface{}\n")
+		g.writef("switch x := v.(type) {\n")
+		g.writef("case []interface{}:\n")
+		g.indent++
+		g.writef("src = x\n")
+		g.indent--
+		g.writef("case ArrayVal:\n")
+		g.indent++
+		g.writef("src = []interface{}(x)\n")
+		g.indent--
+		g.writef("default:\n")
 		g.indent++
 		g.writef("panic(fmt.Sprintf(\"%s: expected []interface{}, got %%T\", v))\n", funcName)
 		g.indent--

--- a/internal/gen/golang/codegen_runtime_slices_test.go
+++ b/internal/gen/golang/codegen_runtime_slices_test.go
@@ -1,0 +1,101 @@
+package golang
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGeneratedSliceConverters(t *testing.T) {
+	gen := New("runtimefixture")
+	gen.RegisterADTConstructor("UserADT", "One", 0)
+	runtimeCode, err := gen.GenerateRuntime()
+	if err != nil {
+		t.Fatalf("GenerateRuntime failed: %v", err)
+	}
+
+	testCode := `package runtimefixture
+
+import "testing"
+
+func recoveredPanic(f func()) (got interface{}) {
+	defer func() { got = recover() }()
+	f()
+	return nil
+}
+
+func TestLiteralConverterRejectsUnsupportedInput(t *testing.T) {
+	got := recoveredPanic(func() { ConvertToInt64Slice(int64(7)) })
+	want := "ConvertToInt64Slice: expected list or array slice, got int64"
+	if got != want {
+		t.Fatalf("recovered panic = %#v, want %q", got, want)
+	}
+}
+
+// Regression pin: template-loop converters already failed loudly before ArrayVal support.
+func TestTemplateConverterRejectsUnsupportedInput(t *testing.T) {
+	got := recoveredPanic(func() { ConvertToUserADTSlice(int64(7)) })
+	want := "ConvertToUserADTSlice: expected []interface{}, got int64"
+	if got != want {
+		t.Fatalf("recovered panic = %#v, want %q", got, want)
+	}
+}
+
+func TestConvertersAcceptArrayVal(t *testing.T) {
+	ints := ConvertToInt64Slice(ArrayVal{int64(1), int64(2), int64(3)})
+	wantInts := []int64{1, 2, 3}
+	if len(ints) != len(wantInts) {
+		t.Fatalf("int converter length = %d, want %d", len(ints), len(wantInts))
+	}
+	for i := range wantInts {
+		if ints[i] != wantInts[i] {
+			t.Errorf("int converter element %d = %d, want %d", i, ints[i], wantInts[i])
+		}
+	}
+
+	one := &UserADT{Kind: "One"}
+	adts := ConvertToUserADTSlice(ArrayVal{one})
+	if len(adts) != 1 || adts[0] != one {
+		t.Fatalf("ADT converter result = %#v, want [%p]", adts, one)
+	}
+}
+
+// Regression pin: nil is a legitimate input, not a type mismatch.
+func TestLiteralConverterPreservesNil(t *testing.T) {
+	if got := ConvertToInt64Slice(nil); got != nil {
+		t.Fatalf("ConvertToInt64Slice(nil) = %#v, want nil", got)
+	}
+}
+`
+
+	tmp := t.TempDir()
+	files := map[string][]byte{
+		"go.mod":          []byte("module runtimefixture\n\ngo 1.21\n"),
+		"runtime.go":      runtimeCode,
+		"runtime_test.go": []byte(testCode),
+		"user_adt.go":     []byte("package runtimefixture\n\ntype UserADT struct { Kind string }\n"),
+	}
+	for name, contents := range files {
+		if err := os.WriteFile(filepath.Join(tmp, name), contents, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cmd := exec.Command("go", "test", "-count=1", "./...")
+	cmd.Dir = tmp
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("generated runtime tests failed: %v\n%s", err, output)
+	}
+}
+
+func TestSliceConverterEmittersHaveNoSilentTypeFallback(t *testing.T) {
+	source, err := os.ReadFile("codegen_runtime_slices.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(source), "if !ok {\n\t\tg.indent++\n\t\tg.writef(\"return nil") != 0 {
+		t.Fatal("slice converter emitter retains an if !ok { return nil } fallback")
+	}
+}

--- a/tests/golden/codegen/golden_test.go
+++ b/tests/golden/codegen/golden_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-const expectedDifferentialFixtureCount = 5
+const expectedDifferentialFixtureCount = 6
 
 // TestGoldenCompile verifies that each .ail golden test file compiles to Go
 // that passes `go build`. This is the primary acceptance test for the codegen

--- a/tests/golden/codegen/show_differential_array.ail
+++ b/tests/golden/codegen/show_differential_array.ail
@@ -1,5 +1,14 @@
 module test/show_differential_array
+import std/array (fromList, get, set, make, toList)
 
 export func main() -> () ! {IO} {
-  println(show(#[1, 2, 3]))
+  let literal = #[1, 2, 3]
+  let converted = fromList([4, 5, 6])
+  println(show(literal))
+  println(show(converted))
+  println(show(set(literal, 0, 9)))
+  println(show(make(3, 7)))
+  println(show(toList(literal)))
+  println(show(get(literal, 2)))
+  println(show(get(converted, 1)))
 }

--- a/tests/golden/codegen/show_differential_array.ail
+++ b/tests/golden/codegen/show_differential_array.ail
@@ -1,0 +1,5 @@
+module test/show_differential_array
+
+export func main() -> () ! {IO} {
+  println(show(#[1, 2, 3]))
+}


### PR DESCRIPTION
M1 and M2 of `M-ARRAY-SHOW-DIVERGES-RUN-VS-COMPILE` (design doc and sprint plan landed in #824). M3 and M4 are not in this PR.

## The defect

The same well-typed program printed different bytes depending on the backend:

| Backend | `show(#[1,2,3])` | `show([1,2,3])` |
|---|---|---|
| `ailang run` | `#[1, 2, 3]` | `[1, 2, 3]` |
| compiled binary | `[1, 2, 3]` | `[1, 2, 3]` |

The erasure was at **construction, not at `Show`** — an array literal and a list literal generated byte-identical Go, so the emitted `showValue` had no tag to key on. Reproduced first-party at `63952b061`, both arms, `cmp` rc=1.

This is an output-consistency defect in a language whose first stated principle is determinism, plus a hole in the run-vs-compile differential harness — no array fixture could exist because it would fail. It is **not** a soundness bug: `ailang check` still rejects a list where an array is expected.

## What changed

**M1** gives arrays a distinct Go identity, following the in-repo `Tuple` precedent: `type ArrayVal []interface{}` in both runtime preambles, `generateArray` emits `ArrayVal{`, and `showValue` gains `case ArrayVal:` → `#[…]`. The `M-TYPE1` comment at `codegen_ops.go:357` was misattributed — that commit touched only `internal/types/unification.go` — and is rewritten to name the design doc.

**M2** makes array helpers preserve that identity (`FromList`/`Set`/`Make` return `ArrayVal`; `ToList` deliberately does not, and the fixture pins it) and removes the silent fallback from the five literal converters, which each carried `if !ok { return nil }`. They now panic with a converter-specific message, matching the pattern the two template-loop converters have used since M-DX12. The adjacent `if v == nil { return nil }` guards are preserved on purpose: a nil input is not a type error.

The design doc's VL-9 said seven silent sites. It is five — the planner read the template loops' next line and found they already fail loudly.

## Evidence

End to end, both backends now emit identical bytes for the doc's repro (`cmp` rc=0, against rc=1 at base).

Two controller mutations, each asserted **LANDED** (sha256 changed) and **BUILDS** (rc=0) *before* any test result was read, and each a **sole killer**:

| Mutation | Result |
|---|---|
| emitted `showValue` renders `"["` instead of `"#["` | reds exactly `show_differential_array`; other 5 subtests green |
| `ConvertToInt64Slice` restored to a silent nil | reds exactly `TestGeneratedSliceConverters` in the whole package |

Both restored byte-identical afterwards.

The executor's one deviation — narrowing `TestListPatternMatchGeneratesValidGo`'s search region — was adjudicated by measurement, not by its stated reason. Two arms on the identical tree: original assertion rc=1, narrowed rc=0; all five offending `case []interface{}` matches sit inside `ConvertTo*Slice` converters while `checkList_impl` begins ~300 lines later, so the narrowing excludes exactly the converters. Moving the region marker earlier into converter territory lands, builds and reds the test with its original message, so the assertion is live inside its region. Residual named rather than assumed away: the region runs to end-of-file.

## Gates

All run **outside the executor sandbox**, under a binary freshly built from this tree and prepended to `PATH` (`~/go/bin` left untouched — it is shared with concurrent agents on this machine, and it is 60+ commits stale, which reds the golden suite for reasons unrelated to any diff):

`go build ./internal/gen/... ./cmd/ailang` rc=0 · `go test ./tests/golden/codegen/` rc=0 with **6** differential subtests · `go test ./internal/gen/golang/` rc=0 · `go vet ./internal/gen/...` rc=0 · `make check-file-sizes` rc=0 · `gofmt -l` empty. Zero FAIL lines in either suite.

Both milestones are independently committable and the M1 boundary was gated separately before M2 was applied, so the two commits are bisectable.

**darwin/arm64 only** — the linux and windows matrix legs are unrun locally and are exactly what Gate 3b is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
