### PR TITLE
feat(codegen): Array[T] lost its identity at every typed boundary — and the CLI had a second type mapper nobody had enumerated

### DIFF
--- a/cmd/ailang/compile_types.go
+++ b/cmd/ailang/compile_types.go
@@ -318,16 +318,7 @@ func ailangTypeToGo(t ast.Type) string {
 		}
 		return "[]" + elemType
 	case *ast.ArrayType:
-		// M-TYPE1: Arrays use the same Go representation as lists (slices)
-		elemType := ailangTypeToGo(typ.Element)
-		// M-CODEGEN-POINTER-RETURN-TYPES: Same logic as ListType
-		if strings.HasPrefix(elemType, "*") {
-			return "[]" + elemType // []*TypeName
-		}
-		if isUserDefinedGoType(elemType) {
-			return "[]*" + elemType
-		}
-		return "[]" + elemType
+		return "ArrayVal"
 	case *ast.RecordType:
 		return "map[string]interface{}"
 	case *ast.TypeApp:
@@ -394,15 +385,7 @@ func ailangTypeToGoWithValueRecords(t ast.Type, valueRecords map[string]bool) st
 		}
 		return "[]" + elemType
 	case *ast.ArrayType:
-		// M-TYPE1: Arrays use the same Go representation as lists (slices)
-		elemType := ailangTypeToGoWithValueRecords(typ.Element, valueRecords)
-		if strings.HasPrefix(elemType, "*") {
-			return "[]" + elemType
-		}
-		if isUserDefinedGoType(elemType) {
-			return "[]" + elemType
-		}
-		return "[]" + elemType
+		return "ArrayVal"
 	case *ast.RecordType:
 		return "map[string]interface{}"
 	case *ast.TypeApp:

--- a/internal/gen/golang/adt.go
+++ b/internal/gen/golang/adt.go
@@ -380,18 +380,7 @@ func (g *ADTGenerator) mapASTType(t ast.Type) string {
 		return fmt.Sprintf("[]%s", elemType)
 
 	case *ast.ArrayType:
-		elemType := g.mapASTType(typ.Element)
-		// M-DX12: Same as ListType - generate typed slice for ADT elements
-		// M-CODEGEN-VALUE-TYPES: Value records use []Type instead of []*Type
-		if IsUserDefinedType(elemType) {
-			baseType := strings.TrimPrefix(elemType, "*")
-			g.adtSliceTypes[baseType] = true
-			if g.valueRecords[elemType] || strings.HasPrefix(elemType, "*") {
-				return fmt.Sprintf("[]%s", elemType)
-			}
-			return fmt.Sprintf("[]*%s", elemType)
-		}
-		return fmt.Sprintf("[]%s", elemType)
+		return "ArrayVal"
 
 	case *ast.TupleType:
 		return "Tuple"
@@ -442,7 +431,7 @@ func IsUserDefinedType(goType string) bool {
 	// Primitives that don't need interface{} wrapping
 	switch goType {
 	case "int64", "float64", "bool", "string", "interface{}", "struct{}",
-		"map[string]interface{}", "map[string]any", "[]interface{}":
+		"map[string]interface{}", "map[string]any", "[]interface{}", "ArrayVal":
 		return false
 	default:
 		// M-CODEGEN-MULTIMOD: Slice types like []string, []int64, [][]string are NOT

--- a/internal/gen/golang/adt_test.go
+++ b/internal/gen/golang/adt_test.go
@@ -381,6 +381,18 @@ func TestMapASTType_Primitives(t *testing.T) {
 	}
 }
 
+func TestMapASTType_ArrayPreservesIdentityAndListControl(t *testing.T) {
+	gen := NewADTGenerator("test")
+	element := &ast.SimpleType{Name: "int"}
+
+	if got := gen.mapASTType(&ast.ArrayType{Element: element}); got != "ArrayVal" {
+		t.Errorf("mapASTType(Array[int]) = %q, want %q", got, "ArrayVal")
+	}
+	if got := gen.mapASTType(&ast.ListType{Element: element}); got != "[]int64" {
+		t.Errorf("mapASTType([int]) = %q, want %q", got, "[]int64")
+	}
+}
+
 // TestMapASTType_ADTSlices verifies M-DX12: ADT slice fields generate as typed slices
 func TestMapASTType_ADTSlices(t *testing.T) {
 	gen := NewADTGenerator("test")

--- a/internal/gen/golang/codegen_record.go
+++ b/internal/gen/golang/codegen_record.go
@@ -389,7 +389,7 @@ func isPrimitiveGoType(goType string) bool {
 // isRecordValueType returns true if the Go type is a record/struct value type (not a pointer).
 // M-DX13.2: Used to detect when we need to dereference a pointer to get a value.
 func isRecordValueType(goType string) bool {
-	if goType == "" || goType == "interface{}" {
+	if goType == "" || goType == "interface{}" || goType == "ArrayVal" {
 		return false
 	}
 	if isPrimitiveGoType(goType) {

--- a/internal/gen/golang/types.go
+++ b/internal/gen/golang/types.go
@@ -77,11 +77,7 @@ func (tm *TypeMapper) mapTypeWithVisited(t types.Type, visited map[types.Type]bo
 		return GoType(fmt.Sprintf("[]%s", elemType)), nil
 
 	case *types.TArray:
-		elemType, err := tm.mapTypeWithVisited(typ.Element, visited)
-		if err != nil {
-			return "", err
-		}
-		return GoType(fmt.Sprintf("[]%s", elemType)), nil
+		return GoType("ArrayVal"), nil
 
 	case *types.TTuple:
 		return GoType("Tuple"), nil

--- a/internal/gen/golang/types_test.go
+++ b/internal/gen/golang/types_test.go
@@ -90,6 +90,26 @@ func TestTypeMapper_MapType_List(t *testing.T) {
 	}
 }
 
+func TestTypeMapper_MapType_ArrayPreservesIdentityAndListControl(t *testing.T) {
+	tm := NewTypeMapper()
+
+	arrayGot, err := tm.mapTypeWithVisited(&types.TArray{Element: types.TInt}, make(map[types.Type]bool))
+	if err != nil {
+		t.Fatalf("mapTypeWithVisited(TArray[int]) error = %v", err)
+	}
+	if arrayGot != GoType("ArrayVal") {
+		t.Errorf("mapTypeWithVisited(TArray[int]) = %q, want %q", arrayGot, GoType("ArrayVal"))
+	}
+
+	listGot, err := tm.mapTypeWithVisited(&types.TList{Element: types.TInt}, make(map[types.Type]bool))
+	if err != nil {
+		t.Fatalf("mapTypeWithVisited(TList[int]) error = %v", err)
+	}
+	if listGot != GoType("[]int64") {
+		t.Errorf("mapTypeWithVisited(TList[int]) = %q, want %q", listGot, GoType("[]int64"))
+	}
+}
+
 // TestTypeMapper_MapType_Primitives tests basic type mappings
 func TestTypeMapper_MapType_Primitives(t *testing.T) {
 	tm := NewTypeMapper()

--- a/tests/golden/codegen/golden_test.go
+++ b/tests/golden/codegen/golden_test.go
@@ -11,7 +11,55 @@ import (
 	"testing"
 )
 
-const expectedDifferentialFixtureCount = 6
+const expectedDifferentialFixtureCount = 7
+
+func TestTypedAggregateArrayGeneratedOutput(t *testing.T) {
+	outDir := t.TempDir()
+	fixture, err := filepath.Abs("show_differential_array_adt_field.ail")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("ailang", "compile", "--emit-go", "--out", outDir,
+		"--package-name", "golden", "--relax-modules", "--no-verify-go", fixture)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("ailang compile failed: %v\n%s", err, output)
+	}
+
+	goFiles, err := filepath.Glob(filepath.Join(outDir, "golden", "*.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var generated strings.Builder
+	for _, goFile := range goFiles {
+		contents, err := os.ReadFile(goFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		generated.Write(contents)
+	}
+	source := generated.String()
+	for _, want := range []string{
+		"func NewBoxMkBox(v0 ArrayVal)",
+		"Items ArrayVal",
+		"Values []int64",
+		"Values: ConvertToInt64Slice(",
+		"Dirs []*Dir",
+		"Dirs: ConvertToDirSlice(",
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated source missing %q", want)
+		}
+	}
+	for _, unwanted := range []string{
+		"NewBoxMkBox(ConvertToInt64Slice(",
+		"Items: ConvertToInt64Slice(",
+		"NewPlanMkPlan(ConvertToDirSlice(",
+	} {
+		if strings.Contains(source, unwanted) {
+			t.Errorf("generated source unexpectedly contains %q", unwanted)
+		}
+	}
+}
 
 // TestGoldenCompile verifies that each .ail golden test file compiles to Go
 // that passes `go build`. This is the primary acceptance test for the codegen

--- a/tests/golden/codegen/show_differential_array_adt_field.ail
+++ b/tests/golden/codegen/show_differential_array_adt_field.ail
@@ -1,0 +1,35 @@
+module test/show_differential_array_adt_field
+import std/array (fromList)
+
+type Box = MkBox(Array[int])
+
+type Holder = { items: Array[int] }
+
+type ListHolder = { values: [int] }
+
+type Dir = North | South
+
+type Plan = MkPlan(Array[Dir])
+
+type DirListHolder = { dirs: [Dir] }
+
+func boxItems(box: Box) -> Array[int] = match box {
+  MkBox(items) => items
+}
+
+func planDirs(plan: Plan) -> Array[Dir] = match plan {
+  MkPlan(dirs) => dirs
+}
+
+export func main() -> () ! {IO} {
+  let box = MkBox(fromList([1, 2, 3]))
+  let holder: Holder = { items: fromList([4, 5, 6]) }
+  let listHolder: ListHolder = { values: [7, 8] }
+  let plan = MkPlan(fromList([North, South]))
+  let dirListHolder: DirListHolder = { dirs: [North, South] }
+  println(show(boxItems(box)))
+  println(show(holder.items))
+  println(show(listHolder.values))
+  println(show(planDirs(plan)))
+  println(show(dirListHolder.dirs))
+}


### PR DESCRIPTION
## M3 — typed aggregate preservation

Third milestone of `m-array-show-diverges-run-vs-compile`. M1/M2 (PR #826) gave arrays a distinct
Go identity (`ArrayVal`) for **literals and helpers**. Every **typed aggregate boundary** still
erased it: four array cases mapped `Array[T]` to a plain `[]T`, and the generated code then routed
the value through a `ConvertTo*Slice` converter.

### Measured at base `b59255831` — three divergences, all user-visible

| source | interpreted | compiled | generated |
|---|---|---|---|
| `type Box = MkBox(Array[int])` | `#[1, 2, 3]` | `[1, 2, 3]` | `NewBoxMkBox(ConvertToInt64Slice(tmp7))` |
| `type Holder = { items: Array[int] }` | `#[4, 5, 6]` | `[4, 5, 6]` | `&Holder{Items: ConvertToInt64Slice(tmp4)}` |
| `type Plan = MkPlan(Array[Dir])` | `#[North, South]` | `[North, South]` | `NewPlanMkPlan(ConvertToDirSlice(tmp3))` |

All three now emit a bare `tmp.(ArrayVal)` assertion and agree byte-for-byte across backends.

### Lists are untouched, and that is pinned rather than assumed

One generated line carries both halves:

```go
return &Both{Arr: tmp8.(ArrayVal), Lst: ConvertToInt64Slice(tmp9)}
```

No converter call site was hand-edited — `getSliceConversion` returns `""` for `"ArrayVal"` by
construction. The generated-output test asserts that, *and* asserts a list field still emits its
converter, so "no converter calls" cannot be satisfied by breaking conversion outright.

### The plan's edit-site list was incomplete, and it is a real finding

`cmd/ailang/compile_types.go` holds a **second, duplicate AST-to-Go type mapper** with two more
array cases — outside `internal/gen/golang/`, which the design doc declared the sprint
"self-contained" to. The executor found it and said so. Adjudicated by measurement rather than by
its stated reason: reverting that file alone — mutant landed (sha256) and building (`go build`
rc=0) — reds `TestTypedAggregateArrayGeneratedOutput` and the `show_differential_array_adt_field`
subtest, while the delivered tree is rc=0. Two type mappers for one language is the underlying
defect; filed as its own backlog row rather than widened into this sprint.

### Controller mutants (each landed + building asserted *before* any test result was read)

| mutant | expected | result |
|---|---|---|
| `TList` also maps to `ArrayVal` ("everything is an array") | the new mapper test's **in-test list control** reds | reds `TestTypeMapper_MapType_ArrayPreservesIdentityAndListControl` |
| `getSliceConversion` neutered to `""` | M3.4's **non-vacuity control** reds | reds with exactly `missing "Values: ConvertToInt64Slice("` / `missing "Dirs: ConvertToDirSlice("` |

Both restored byte-identical (sha256).

### Gates — re-run by the controller OUTSIDE the executor sandbox

Under a binary freshly built from this tree and prepended to `PATH`; `~/go/bin` left untouched for
concurrent agents (the golden suite shells out to a bare `ailang`, so a stale PATH copy produces a
red that looks exactly like a code defect).

`go build ./internal/gen/... ./cmd/ailang` · `go vet ./internal/gen/...` ·
`go test ./internal/gen/golang/` · `go test ./tests/golden/codegen/` (**31** `--- PASS`, **0** FAIL,
**7/7** differential subtests) · `make check-file-sizes` · `make check-boundaries` ·
`make check-changelog` · `gofmt -l` empty · `make verify-examples` **211 passed, 0 failed, 6 skipped**
— all rc=0.

**darwin/arm64 only**; the linux and windows legs run in CI and are unrun locally.

Differential fixture count **6 → 7** — the sprint plan's progressive schedule, which the design
doc's M4 text predates.

Executor `codex:gpt-5.6-sol`; evaluator `sonnet` (generator≠judge holds — different provider).
Mission iteration 250. M4 (changelog, doc move, adjacent-defect rows) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
