### PR TITLE
motoko row 6c: the probe's self-test ran nowhere, and two of its refusals could not refuse

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -8142,6 +8142,15 @@ Patch release on top of v0.18.0's M-MOTOKO-EXECUTOR-ADAPTER. Local smoke testing
 **LOC tally:** ~80 LOC AILANG-side (parser fallback, HealthCheck enhancement, env-var emit), ~250 LOC motoko-side (TS profile mirror, --headless/--version flags, sanitizer, cost env override, AILANG resolve_profile_dir + env_int). 11 new tests across both repos (3 parser fallback, 6 session-logger sanitization, 2 budget passthrough). One new design doc captures the v0.19.0 follow-up: M-FS-SANDBOX-DIAGNOSTICS for the silent-false `fileExists` issue.
 # Nightly evaluation
 
+### Fixed — motoko connection probe refuses vacuous routing verdicts
+
+The load-bearing motoko/OpenRouter connection probe is now exercised by the CI launchd-driver
+gate, retains both lanes' driver and raw `lsof` diagnostics beside its JSON artifact on success
+and refusal, propagates process-tree discovery failures out of command substitution, and rejects
+empty or malformed PID scopes before invoking `lsof`. Its Bash 3.2 hermetic self-test covers the
+live platform, dependency, DNS, timeout, artifact-write, retention, and usage refusal paths without
+starting an eval or making a network request.
+
 - Split run-level unmeasured categories from per-benchmark infrastructure taint,
   so suite-wide non-agentic and provider/budget outages invalidate a night without
   suppressing individual model-outcome filings. Invalid-run notifications now name

--- a/make/test.mk
+++ b/make/test.mk
@@ -35,13 +35,18 @@ test-nightly-classifier: ## Run nightly variance-guard contract and replay tests
 # The launchd drivers carried ZERO automated coverage until #558's second recurrence — a large
 # part of why two silent-staleness bugs shipped unnoticed. /bin/bash explicitly, not $$SHELL:
 # the rig runs 3.2.57, so a suite that only passes under a newer bash proves nothing about it.
+# The motoko connection probe's routing verdict is load-bearing; run its self-test here so CI
+# refuses when the instrument can no longer prove both treatment absence and control visibility.
 test-launchd-drivers: ## Run launchd driver tests (pin-root + routing + notices + hook stdout, bash 3.2)
 	@/bin/bash tools/launchd/test_pin_root.sh
 	@/bin/bash tools/launchd/test_driver_notify.sh
 	@/bin/bash tools/launchd/test_mission_routing.sh
 	@/bin/bash tools/launchd/test_hook_stdout.sh
 	@/bin/bash tools/launchd/test_fmt_ab_schedule.sh
+	@/bin/bash tools/eval/test_motoko_connection_probe.sh
 	@for f in tools/launchd/*.sh tools/launchd/lib/*.sh; do /bin/bash -n "$$f" || exit 1; done
+	@/bin/bash -n tools/eval/motoko_connection_probe.sh
+	@/bin/bash -n tools/eval/test_motoko_connection_probe.sh
 	@/bin/bash -n scripts/mission_decisions.sh
 	@echo "launchd drivers: tests + bash 3.2 syntax OK"
 

--- a/tools/eval/motoko_connection_probe.sh
+++ b/tools/eval/motoko_connection_probe.sh
@@ -138,7 +138,36 @@ else
 fi
 
 tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/motoko-connection-probe.XXXXXX") || instrument_failure "could not create temporary directory"
-trap 'rm -rf "$tmp_dir"' EXIT
+treatment_driver_log="$tmp_dir/treatment.driver.log"
+treatment_lsof="$tmp_dir/treatment.lsof"
+control_driver_log="$tmp_dir/control.driver.log"
+control_lsof="$tmp_dir/control.lsof"
+
+retain_diagnostics() {
+  local failed=0 src dest
+  for src in "$treatment_driver_log" "$treatment_lsof" "$control_driver_log" "$control_lsof"; do
+    [[ -e "$src" ]] || continue
+    dest="$artifact.${src##*/}"
+    if cp "$src" "$dest"; then
+      echo "retained connection probe diagnostic: $dest" >&2
+    else
+      echo "INSTRUMENT FAILURE: could not retain diagnostic: $dest" >&2
+      failed=1
+    fi
+  done
+  return "$failed"
+}
+
+cleanup() {
+  local original_rc=$? retention_rc=0
+  retain_diagnostics || retention_rc=$?
+  rm -rf "$tmp_dir"
+  if (( retention_rc != 0 )); then
+    exit 1
+  fi
+  exit "$original_rc"
+}
+trap cleanup EXIT
 or_file="$tmp_dir/or_ips"
 { dig +short +time=5 +tries=2 A openrouter.ai; dig +short +time=5 +tries=2 AAAA openrouter.ai; } |
   awk '/^([0-9]{1,3}\.){3}[0-9]{1,3}$/ || /:/' | LC_ALL=C sort -u > "$or_file"
@@ -147,8 +176,15 @@ or_file="$tmp_dir/or_ips"
 descendant_pids() {
   local root=$1 deadline=$2 current child
   local -a queue=("$root") result=()
+  if [[ "${PROBE_TEST_DESCENDANT_FAILURE:-0}" == 1 ]]; then
+    echo "process-tree discovery deadline expired" >&2
+    return 1
+  fi
   while ((${#queue[@]} > 0)); do
-    (( $(date +%s) <= deadline )) || instrument_failure "process-tree discovery deadline expired"
+    if (( $(date +%s) > deadline )); then
+      echo "process-tree discovery deadline expired" >&2
+      return 1
+    fi
     current=${queue[0]}
     queue=("${queue[@]:1}")
     result+=("$current")
@@ -160,9 +196,21 @@ descendant_pids() {
   printf '%s\n' "${result[*]}"
 }
 
+assert_pid_scope() {
+  local pids=$1
+  [[ "$pids" =~ ^[0-9]+(,[0-9]+)*$ ]] || instrument_failure "invalid empty or malformed pid scope: ${pids:-<empty>}"
+}
+
 sample_tree() {
   local root=$1 raw_file=$2 deadline=$3 pids
-  pids=$(descendant_pids "$root" "$deadline")
+  if [[ -n "${PROBE_TEST_PID_SCOPE+x}" ]]; then
+    pids=$PROBE_TEST_PID_SCOPE
+  else
+    if ! pids=$(descendant_pids "$root" "$deadline"); then
+      instrument_failure "process-tree discovery failed"
+    fi
+  fi
+  assert_pid_scope "$pids"
   lsof -nP -iTCP -sTCP:ESTABLISHED -a -p "$pids" 2>/dev/null >> "$raw_file" || true
 }
 
@@ -205,11 +253,11 @@ run_lane() {
 probe_start=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 treatment_peers="$tmp_dir/treatment.peers"
 control_peers="$tmp_dir/control.peers"
-run_lane "$treatment_lane" "$treatment_peers" "$tmp_dir/treatment.lsof" "$tmp_dir/treatment.driver.log"
+run_lane "$treatment_lane" "$treatment_peers" "$treatment_lsof" "$treatment_driver_log"
 treatment_start=$lane_start
 treatment_end=$lane_end
 treatment_rc=$lane_rc
-run_lane "$control_lane" "$control_peers" "$tmp_dir/control.lsof" "$tmp_dir/control.driver.log"
+run_lane "$control_lane" "$control_peers" "$control_lsof" "$control_driver_log"
 control_start=$lane_start
 control_end=$lane_end
 control_rc=$lane_rc

--- a/tools/eval/test_motoko_connection_probe.sh
+++ b/tools/eval/test_motoko_connection_probe.sh
@@ -2,7 +2,7 @@
 set -uo pipefail
 
 script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
-probe="$script_dir/motoko_connection_probe.sh"
+probe=${PROBE_UNDER_TEST:-$script_dir/motoko_connection_probe.sh}
 tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/test-motoko-connection-probe.XXXXXX") || exit 1
 trap 'rm -rf "$tmp_dir"' EXIT
 arms=0
@@ -93,6 +93,134 @@ expect_failure "control must demonstrate OpenRouter visibility" "treatment verdi
 printf '%s\n' '127.0.0.1:11434' '[2001:db8::8]:443' > "$tmp_dir/leaky-v6.peers"
 expect_failure "treatment rejects an OpenRouter peer reached over IPv6" "contains OpenRouter endpoint" \
   "$probe" --assert-treatment "$tmp_dir/leaky-v6.peers" "$tmp_dir/or_ips"
+
+# Build a hermetic live-path toolchain. The driver is a stub: no eval, GPU, Ollama,
+# or network access occurs. lsof derives the lane from the sampled driver's PID.
+live_bin="$tmp_dir/live-bin"
+mkdir -p "$live_bin"
+for tool in awk bash cat cp cut date grep kill mkdir mktemp rm sleep sort; do
+  tool_path=$(command -v "$tool") || exit 1
+  ln -s "$tool_path" "$live_bin/$tool"
+done
+ln -s "$(command -v jq)" "$live_bin/jq"
+cat > "$live_bin/uname" <<'EOF'
+#!/bin/bash
+echo "${PROBE_TEST_UNAME:-Darwin arm64}"
+EOF
+cat > "$live_bin/dig" <<'EOF'
+#!/bin/bash
+[[ "${PROBE_TEST_DIG_EMPTY:-0}" == 1 ]] || echo 203.0.113.8
+EOF
+cat > "$live_bin/pgrep" <<'EOF'
+#!/bin/bash
+if [[ "${PROBE_TEST_PGREP_LOOP:-0}" == 1 ]]; then
+  while [[ $# -gt 1 ]]; do shift; done
+  echo "$1"
+fi
+exit 0
+EOF
+cat > "$live_bin/lsof" <<'EOF'
+#!/bin/bash
+pid=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == -p ]]; then pid=$2; break; fi
+  shift
+done
+lane_file="${PROBE_STUB_STATE}.${pid}"
+[[ -f "$lane_file" ]] || exit 1
+lane=$(cat "$lane_file")
+echo "COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME"
+if [[ "$lane" == treatment ]]; then
+  echo "stub $pid user 1u IPv4 0 0t0 TCP 127.0.0.1:51000->127.0.0.1:11434 (ESTABLISHED)"
+else
+  echo "stub $pid user 1u IPv4 0 0t0 TCP 192.0.2.1:51000->203.0.113.8:443 (ESTABLISHED)"
+fi
+EOF
+cat > "$live_bin/ailang-stub" <<'EOF'
+#!/bin/bash
+lane=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == --models ]]; then lane=$2; break; fi
+  shift
+done
+echo "$lane" > "${PROBE_STUB_STATE}.$$"
+echo "stub driver lane=$lane"
+if [[ "${PROBE_TEST_IGNORE_TERM:-0}" == 1 ]]; then trap '' TERM; fi
+sleep "${PROBE_TEST_DRIVER_SLEEP:-2}"
+rm -f "${PROBE_STUB_STATE}.$$"
+EOF
+chmod +x "$live_bin/uname" "$live_bin/dig" "$live_bin/pgrep" "$live_bin/lsof" "$live_bin/ailang-stub"
+
+run_live() {
+  env PATH="$live_bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=4 \
+    PROBE_STUB_STATE="$tmp_dir/lane" "$@" /bin/bash "$probe" treatment control "$tmp_dir/live.json"
+}
+
+expect_failure "live usage rejects wrong arity" "usage:" /bin/bash "$probe"
+expect_failure "classify usage rejects wrong arity" "usage:" /bin/bash "$probe" --classify-fixture
+expect_failure "nonempty usage rejects wrong arity" "usage:" /bin/bash "$probe" --assert-nonempty
+expect_failure "treatment usage rejects wrong arity" "usage:" /bin/bash "$probe" --assert-treatment
+expect_failure "control usage rejects wrong arity" "usage:" /bin/bash "$probe" --assert-control
+expect_failure "timeout rejects non-positive values" "positive integer" \
+  env PROBE_TIMEOUT_SECS=0 /bin/bash "$probe" treatment control "$tmp_dir/reject.json"
+expect_failure "timeout rejects non-integer values" "positive integer" \
+  env PROBE_TIMEOUT_SECS=no /bin/bash "$probe" treatment control "$tmp_dir/reject.json"
+expect_failure "platform gate rejects non-darwin arm64" "requires darwin/arm64" \
+  run_live PROBE_TEST_UNAME='Linux x86_64'
+
+make_dependency_path() {
+  local omitted=$1 dep_dir="$tmp_dir/dep-$1" name
+  mkdir -p "$dep_dir"
+  for name in "$live_bin"/*; do
+    [[ "${name##*/}" == "$omitted" ]] || ln -s "$name" "$dep_dir/${name##*/}"
+  done
+  printf '%s\n' "$dep_dir"
+}
+for dependency in dig lsof pgrep jq ailang-stub; do
+  dependency_path=$(make_dependency_path "$dependency")
+  expected_dependency=$dependency
+  [[ "$dependency" == ailang-stub ]] && expected_dependency=AILANG_BIN
+  expect_failure "dependency gate rejects missing $dependency" "$expected_dependency" \
+    env PATH="$dependency_path" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=2 \
+      PROBE_STUB_STATE="$tmp_dir/lane" /bin/bash "$probe" treatment control "$tmp_dir/dep.json"
+done
+expect_failure "empty dig result refuses the live verdict" "dig returned no addresses" \
+  run_live PROBE_TEST_DIG_EMPTY=1
+expect_failure "temporary-directory creation failure refuses" "could not create temporary directory" \
+  run_live TMPDIR="$tmp_dir/missing/parent"
+expect_failure "empty pid scope fails loudly instead of widening lsof" "invalid empty or malformed pid scope" \
+  run_live PROBE_TEST_PID_SCOPE=
+expect_failure "descendant discovery deadline refuses at the caller" "process-tree discovery failed" \
+  run_live PROBE_TEST_DESCENDANT_FAILURE=1
+expect_failure "lane sampling deadline refuses" "exceeded 1s sampling deadline" \
+  run_live PROBE_TEST_DRIVER_SLEEP=10 PROBE_TIMEOUT_SECS=1
+expect_failure "bounded termination deadline refuses" "bounded termination deadline" \
+  run_live PROBE_TEST_DRIVER_SLEEP=20 PROBE_TEST_IGNORE_TERM=1 PROBE_TIMEOUT_SECS=1
+
+success_artifact="$tmp_dir/success/probe.json"
+mkdir -p "$tmp_dir/success"
+expect_success "hermetic live success retains both lanes diagnostics" \
+  env PATH="$live_bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=4 \
+    PROBE_STUB_STATE="$tmp_dir/lane-success" /bin/bash "$probe" treatment control "$success_artifact"
+for retained in treatment.driver.log treatment.lsof control.driver.log control.lsof; do
+  [[ -s "$success_artifact.$retained" ]] || { echo "not ok - missing retained $retained" >&2; exit 1; }
+done
+
+refusal_artifact="$tmp_dir/refusal/probe.json"
+mkdir -p "$tmp_dir/refusal"
+expect_failure "refusing live path still retains both lanes diagnostics" "treatment verdict is void" \
+  env PATH="$live_bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=4 \
+    PROBE_STUB_STATE="$tmp_dir/lane-refusal" PROBE_TEST_FORCE_TREATMENT=1 \
+    /bin/bash "$probe" treatment treatment "$refusal_artifact"
+for retained in treatment.driver.log treatment.lsof control.driver.log control.lsof; do
+  [[ -s "$refusal_artifact.$retained" ]] || { echo "not ok - refusal lost $retained" >&2; exit 1; }
+done
+
+unwritable="$tmp_dir/not-a-directory"
+: > "$unwritable"
+expect_failure "JSON artifact write failure refuses" "could not write JSON artifact" \
+  env PATH="$live_bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=4 \
+    PROBE_STUB_STATE="$tmp_dir/lane-write" /bin/bash "$probe" treatment control "$unwritable/probe.json"
 
 if [[ $(uname -s) == Darwin ]] && command -v nc >/dev/null && command -v lsof >/dev/null; then
   port=$((42000 + ($$ % 10000)))

--- a/tools/eval/test_motoko_connection_probe.sh
+++ b/tools/eval/test_motoko_connection_probe.sh
@@ -214,7 +214,7 @@ refusal_artifact="$tmp_dir/refusal/probe.json"
 mkdir -p "$tmp_dir/refusal"
 expect_failure "refusing live path refuses with the control-void message" "treatment verdict is void" \
   env PATH="$live_bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=4 \
-    PROBE_STUB_STATE="$tmp_dir/lane-refusal" PROBE_TEST_FORCE_TREATMENT=1 \
+    PROBE_STUB_STATE="$tmp_dir/lane-refusal" \
     /bin/bash "$probe" treatment treatment "$refusal_artifact"
 for retained in treatment.driver.log treatment.lsof control.driver.log control.lsof; do
   [[ -s "$refusal_artifact.$retained" ]] || { echo "not ok - refusal lost $retained" >&2; exit 1; }
@@ -265,6 +265,36 @@ if [[ $(uname -s) == Darwin ]] && command -v nc >/dev/null && command -v lsof >/
 else
   echo "UNINFORMATIVE UNDER SANDBOX: live synthetic socket arm requires darwin nc+lsof; fixture arm remains authoritative"
 fi
+
+# The REAL wall-clock deadline inside descendant_pids, not the PROBE_TEST_DESCENDANT_FAILURE
+# short-circuit. The pgrep stub above returns its own argument under PROBE_TEST_PGREP_LOOP, which
+# makes the process tree self-referential and never empties the queue — the only way to reach the
+# in-loop `date` check. The stub was written for this and no invocation used it, so the branch
+# that actually bounds the walk was unexercised while an arm claimed the deadline was pinned.
+expect_failure "descendant discovery refuses on the real wall-clock deadline" "process-tree discovery failed" \
+  env PATH="$live_bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=1 PROBE_TEST_PGREP_LOOP=1 \
+    PROBE_STUB_STATE="$tmp_dir/lane-pgreploop" /bin/bash "$probe" treatment control "$tmp_dir/pgreploop.json"
+
+# Refusal-branch drift gate. Every arm above proves a branch that EXISTS goes red when neutered —
+# a removal proves the check FIRES; only an addition proves it LOOKS. Adding a new refusal to the
+# probe passes the whole suite byte-identically, so the coverage claim is a one-time manual count
+# that silently rots on the next edit. Count the branches and refuse when the number moves.
+expected_refusal_branches=23
+actual_instrument_failures=$(grep -c 'instrument_failure "' "$probe")
+actual_usage_refusals=$(grep -cE '\|\| usage$' "$probe")
+# Anti-vacuity: a counter that returns zero is a broken instrument, not a clean result.
+if (( actual_instrument_failures == 0 || actual_usage_refusals == 0 )); then
+  echo "not ok - refusal-branch counter matched nothing; instrument failure, not a verdict" >&2
+  exit 1
+fi
+actual_refusal_branches=$(( actual_instrument_failures + actual_usage_refusals ))
+if (( actual_refusal_branches != expected_refusal_branches )); then
+  echo "not ok - refusal-branch drift: probe has $actual_refusal_branches refusal branches," >&2
+  echo "         this suite is written for $expected_refusal_branches. Add an arm for the new" >&2
+  echo "         branch (or delete a stale one), then update expected_refusal_branches." >&2
+  exit 1
+fi
+pass_arm "refusal-branch count still matches the set this suite covers ($actual_refusal_branches)"
 
 if (( arms == 0 )); then
   echo "not ok - zero test arms ran" >&2

--- a/tools/eval/test_motoko_connection_probe.sh
+++ b/tools/eval/test_motoko_connection_probe.sh
@@ -178,8 +178,8 @@ make_dependency_path() {
 }
 for dependency in dig lsof pgrep jq ailang-stub; do
   dependency_path=$(make_dependency_path "$dependency")
-  expected_dependency=$dependency
-  [[ "$dependency" == ailang-stub ]] && expected_dependency=AILANG_BIN
+  expected_dependency="$dependency is required"
+  [[ "$dependency" == ailang-stub ]] && expected_dependency="AILANG_BIN is not executable"
   expect_failure "dependency gate rejects missing $dependency" "$expected_dependency" \
     env PATH="$dependency_path" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=2 \
       PROBE_STUB_STATE="$tmp_dir/lane" /bin/bash "$probe" treatment control "$tmp_dir/dep.json"

--- a/tools/eval/test_motoko_connection_probe.sh
+++ b/tools/eval/test_motoko_connection_probe.sh
@@ -199,22 +199,29 @@ expect_failure "bounded termination deadline refuses" "bounded termination deadl
 
 success_artifact="$tmp_dir/success/probe.json"
 mkdir -p "$tmp_dir/success"
-expect_success "hermetic live success retains both lanes diagnostics" \
+expect_success "hermetic live success path completes" \
   env PATH="$live_bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=4 \
     PROBE_STUB_STATE="$tmp_dir/lane-success" /bin/bash "$probe" treatment control "$success_artifact"
 for retained in treatment.driver.log treatment.lsof control.driver.log control.lsof; do
   [[ -s "$success_artifact.$retained" ]] || { echo "not ok - missing retained $retained" >&2; exit 1; }
 done
+# Its own arm: the expect_success above only proves the probe exited 0. An "ok" line whose label
+# claims retention, while the retention check sits outside the arm, is an assertion that cannot
+# fail for the reason it names.
+pass_arm "success path retains both lanes driver logs and lsof captures"
 
 refusal_artifact="$tmp_dir/refusal/probe.json"
 mkdir -p "$tmp_dir/refusal"
-expect_failure "refusing live path still retains both lanes diagnostics" "treatment verdict is void" \
+expect_failure "refusing live path refuses with the control-void message" "treatment verdict is void" \
   env PATH="$live_bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=4 \
     PROBE_STUB_STATE="$tmp_dir/lane-refusal" PROBE_TEST_FORCE_TREATMENT=1 \
     /bin/bash "$probe" treatment treatment "$refusal_artifact"
 for retained in treatment.driver.log treatment.lsof control.driver.log control.lsof; do
   [[ -s "$refusal_artifact.$retained" ]] || { echo "not ok - refusal lost $retained" >&2; exit 1; }
 done
+# Same reason as above, and this is the load-bearing half: a lane that REFUSES is exactly the case
+# the retained log exists for.
+pass_arm "refusal path retains both lanes driver logs and lsof captures"
 
 unwritable="$tmp_dir/not-a-directory"
 : > "$unwritable"


### PR DESCRIPTION
Queue row **6c** of the motoko mission: the connection probe's self-test covered its four
`assert_*` front doors and nothing in its live path. Verifying that row first-party turned up a
larger finding, and then a soundness defect in the instrument itself.

### The self-test was not a weak gate — it was not a gate

Measured on `origin/dev` with a same-scope firing control:

| query | result |
|---|---|
| `grep -rl test_motoko_connection_probe make/ .github/workflows/` | **0** files |
| `grep -rl test_fmt_ab_schedule make/ .github/workflows/` (control) | 1 (`make/test.mk:43`) |
| repo-wide over `*.mk` / `*.yml` / `Makefile` | **0** |

It is now wired into `test-launchd-drivers`, the target `ci.yml:507` runs, under an explicit
`/bin/bash` (the rig's is 3.2.57). Proven by making the self-test exit 1 and watching the target
go red, then restoring byte-identically.

### Two refusal branches that could not refuse

Both measured with the arms' exit codes captured without a pipe and printed side by side:

- `instrument_failure` does `exit 1`; called inside a command substitution it exits only the
  **subshell** — repro rc=**0**, control (same call outside `$( )`) rc=**1**. `descendant_pids`'s
  process-tree deadline was exactly that shape, so `pids` became `""` and the probe carried on.
- `lsof -nP -iTCP -sTCP:ESTABLISHED -a -p ""` returns **75** lines, rc=0, empty stderr — the same
  count as the fully unscoped query (**75**). Control: the same shape with a real pid holding no
  established TCP returns **0** lines, rc=1. An empty pid list does not narrow the scope, it
  removes it.

Chained, an instrument whose entire job is to certify *no OpenRouter connections* would sample
every established connection on the machine and could then pass on another process's loopback peer
or fail on another process's OpenRouter one — silently, behind `2>/dev/null || true`. False
certification in both directions. Audit of the whole script for the same shape: **0** remaining.

### Keep the driver logs

The `trap … EXIT` deleted both lanes' driver logs and lsof captures. For a lane that exits
non-zero that log is the entire diagnostic — losing it is why the last VOID verdict cost a GPU
re-run to diagnose. Retention now runs from the EXIT trap, so it fires on the **refusing** path
too, and a failed copy is itself an instrument failure.

### Coverage

Re-derived: 17 `instrument_failure` call sites + 6 `usage` refusals = **23** refusal branches, of
which the self-test reached **4**. The evaluator's demonstration reproduced first-party — neutering
the darwin/arm64 gate left stdout **byte-identical** at `PASS: 8`, rc=0 both arms. Now **32** arms,
every new one mutation-proven (mutant LANDED by sha256, VALID by `bash -n`, arm reds, restore
byte-identical from a `cp` backup).

Three dependency arms the executor **self-reported as not honestly proven** were re-proven by the
controller sequentially (its batch had been contaminated by concurrency): `dig` / `lsof` / `jq`
each rc 0 → 1 with its own named message, plus a `pgrep` control that also reds.

### What this does NOT do

**V38 is not isolated.** The mechanism by which the probe as shipped breaks the runs it observes
still lies in the deadline-carrying `descendant_pids` or the two-lanes-in-one-process sequencing,
and isolating it needs the rig. What changes is that the next rig run will have the driver logs it
needs — which was this row's own named next step. The live path is exercised only hermetically
here: no eval run, GPU, ollama or network call.

### Gates

`bash -n` ×2 · `/bin/bash` self-test (`PASS: 32`) · `shellcheck -S warning` ·
`make test-launchd-drivers` · `check-file-sizes` · `check-changelog` · `check-skills` ·
`test-check-changelog` — all **rc=0**, run outside the executor sandbox, each one baselined on
untouched `dev` first. `go build ./...` deliberately excluded: it is red at base
(`cmd/wasm` has no native `main`). darwin/arm64 only; the windows and ubuntu legs are unrun locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
