### PR TITLE
driver: report a HELD pin whose source clone has drifted, once per doubling

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,26 @@
 
 ## [Unreleased]
 
+### Fixed — a HELD driver pin no longer hides an ever-staler source clone
+
+`tools/launchd/lib/pin-root.sh` re-execs each launchd mission driver out of a worktree pinned to
+`origin/dev`, which moves the driver, the skill and the charter together. It leaves the SOURCE
+CLONE behind, and `mission-control.sh` posted to the human channel only when the pin FAILED — so a
+clone drifting further behind on every fire was reported nowhere but the driver log. Measured on
+the rig: one mission's source clone reached 170 commits behind with a `SKILL.md` 1,063 lines short
+of `origin/dev`, its drift logged as 119 → 132 → 144 → 159 → 170 across five fires and never
+surfaced. That drift is harmless to the driver, whose pin holds, and not harmless to an
+interactive session started in that clone, which resolves ITS `.claude/skills/` and `design_docs/`.
+
+The driver now posts once when the drift crosses `AILANG_DRIVER_DRIFT_WARN` (default 25) and
+thereafter only when the drift DOUBLES, persisted in a per-mission state file that is removed
+again below the threshold so the notice re-arms after a reconcile. A non-positive threshold is
+floored rather than obeyed, because a threshold of zero would make the notice fire on every fire —
+the outcome the doubling rule exists to prevent, reached through its own knob. The notice names
+the source clone from `AILANG_DRIVER_SRC`, never `$REPO`, which on the pinned pass is the
+throwaway worktree whose drift is zero by construction.
+
+
 ### Added — auditable Motoko provider-connection probe
 
 The eval tooling now includes a bounded, darwin/arm64 connection probe for a caller-named

--- a/tools/launchd/mission-control.sh
+++ b/tools/launchd/mission-control.sh
@@ -373,12 +373,25 @@ if [ "$PIN_STATUS" = "STALE" ]; then
 else
   log "driver pin: $PIN_NOTE"
   if [ "$PIN_STATUS" = "pinned" ]; then
+    # Normalise once: `set -u` is in force and every reference below is bare. pin-root.sh sets
+    # PIN_DRIFT on the line after PIN_STATUS, so an unset value is unreachable today — pinned
+    # so the invariant is enforced rather than assumed.
+    PIN_DRIFT="${PIN_DRIFT:-}"
     case "$PIN_DRIFT" in
       ''|*[!0-9]*)
         log "driver pin drift: unknown ($PIN_DRIFT); notice suppressed"
         ;;
       *)
         _pin_drift_warn="${AILANG_DRIVER_DRIFT_WARN:-25}"
+        # A threshold of 0 persists a previous of 0, and `-ge $((0 * 2))` is then true on
+        # every fire — the notice-every-90-minutes outcome this whole block exists to avoid,
+        # arriving through its own knob. A default is an instrument too: floor it, loudly.
+        case "$_pin_drift_warn" in
+          ''|*[!0-9]*|0)
+            log "driver pin drift: AILANG_DRIVER_DRIFT_WARN='$_pin_drift_warn' is not a positive integer; using 25"
+            _pin_drift_warn=25
+            ;;
+        esac
         if [ "$PIN_DRIFT" -lt "$_pin_drift_warn" ]; then
           rm -f "$PIN_DRIFT_FILE"
           log "driver pin drift: $PIN_DRIFT below warning threshold $_pin_drift_warn; notice re-armed"

--- a/tools/launchd/mission-control.sh
+++ b/tools/launchd/mission-control.sh
@@ -67,6 +67,7 @@ if [ "$MISSION_NAME" = "v1" ]; then
   EXEC_ONCE_FILE="$STATE_DIR/mission-executor-model-once"
   GH_ISSUE_FILE="$STATE_DIR/mission-gh-issue"
   BLOCKED_FILE="$STATE_DIR/mission-control.blocked"
+  PIN_DRIFT_FILE="$STATE_DIR/mission-control.pin-drift"
   MSG_FROM="mission-control"
 else
   LOG="/tmp/ailang-mission-${MISSION_NAME}.log"
@@ -77,6 +78,7 @@ else
   EXEC_ONCE_FILE="$STATE_DIR/mission-${MISSION_NAME}-executor-model-once"
   GH_ISSUE_FILE="$STATE_DIR/mission-${MISSION_NAME}-gh-issue"
   BLOCKED_FILE="$STATE_DIR/mission-${MISSION_NAME}.blocked"
+  PIN_DRIFT_FILE="$STATE_DIR/mission-${MISSION_NAME}.pin-drift"
   MSG_FROM="mission-${MISSION_NAME}"
 fi
 # -----------------------------------------------------------------------------
@@ -359,7 +361,9 @@ else
   PIN_DRIFT="?"
   PIN_NOTE="$REPO/tools/launchd/lib/pin-root.sh is absent — this clone predates the driver pin (#558)"
 fi
+# --- DRIVER PIN DECISION START ---
 _pin_degraded=""
+_pin_drift_degraded=""
 if [ "$PIN_STATUS" = "STALE" ]; then
   # Deliberately NOT fatal: aborting would make network/git availability a hard dependency of
   # every fire, trading rare silent staleness for common loud outage. Loud instead of fatal.
@@ -368,7 +372,44 @@ if [ "$PIN_STATUS" = "STALE" ]; then
 - driver pin: **FAILED** — \`$PIN_NOTE\`. This fire ran \`$REPO\` at \`$(git -C "$REPO" rev-parse --short HEAD 2>/dev/null)\` ($(git -C "$REPO" rev-list --count HEAD..origin/dev 2>/dev/null || echo '?') behind \`origin/dev\`), so any landed driver/skill/charter fix newer than that commit was NOT in effect."
 else
   log "driver pin: $PIN_NOTE"
+  if [ "$PIN_STATUS" = "pinned" ]; then
+    case "$PIN_DRIFT" in
+      ''|*[!0-9]*)
+        log "driver pin drift: unknown ($PIN_DRIFT); notice suppressed"
+        ;;
+      *)
+        _pin_drift_warn="${AILANG_DRIVER_DRIFT_WARN:-25}"
+        if [ "$PIN_DRIFT" -lt "$_pin_drift_warn" ]; then
+          rm -f "$PIN_DRIFT_FILE"
+          log "driver pin drift: $PIN_DRIFT below warning threshold $_pin_drift_warn; notice re-armed"
+        else
+          _pin_drift_previous=""
+          [ -r "$PIN_DRIFT_FILE" ] && _pin_drift_previous="$(head -1 "$PIN_DRIFT_FILE" 2>/dev/null)"
+          case "$_pin_drift_previous" in
+            ''|*[!0-9]*) _pin_drift_emit=1 ;;
+            *)
+              if [ "$PIN_DRIFT" -ge $((_pin_drift_previous * 2)) ]; then
+                _pin_drift_emit=1
+              else
+                _pin_drift_emit=0
+              fi
+              ;;
+          esac
+          if [ "$_pin_drift_emit" -eq 1 ]; then
+            _pin_drift_degraded="$PIN_DRIFT"
+            printf '%s\n' "$PIN_DRIFT" > "$PIN_DRIFT_FILE"
+            log "driver pin drift: $PIN_DRIFT at/above threshold $_pin_drift_warn; notice armed (previous=${_pin_drift_previous:-none})"
+          else
+            log "driver pin drift: $PIN_DRIFT at/above threshold $_pin_drift_warn; deduped until doubling from $_pin_drift_previous"
+          fi
+        fi
+        ;;
+    esac
+  else
+    log "driver pin drift: skipped (status=$PIN_STATUS)"
+  fi
 fi
+# --- DRIVER PIN DECISION END ---
 
 # designer default is the claude-CLI lane (claude:<full-id>), NOT the bare "fable" alias: the
 # Agent tool pins only sonnet|opus|haiku (F1, iteration 31), so under an opus-first controller a
@@ -670,9 +711,9 @@ fi
 
 # DRIVER-PIN NOTICE — same site and same reasoning as the lane notice above: after every early
 # exit, so a fire that does not run cannot post. Emitted only when the pin actually FAILED, i.e.
-# only when stale code really did run. The shared clone being behind is not itself reportable —
-# once drivers pin, that drift is harmless, and posting it every 90 minutes would train the
-# channel to be ignored, which is how the original silent fallback survived twelve commits.
+# only when stale code really did run. Source-clone drift is reported separately below because it
+# is hazardous to interactive sessions; a persisted doubling threshold replaces posting it every
+# 90 minutes, which would train the channel to be ignored.
 if [ -n "$_pin_degraded" ]; then
   _pin_body="**Driver ran UNPINNED on this fire** — recorded before the iteration ran.
 ${_pin_degraded}
@@ -682,6 +723,21 @@ unknown. Fix: reconcile that clone with \`origin/dev\`, or find why the fetch fa
 every fire silently runs whatever that working tree happens to hold — the class \`#558\` tracks,
 measured twice (2026-08-03 \`#556\`, 2026-08-12 \`564cc4640\`)."
   _mc_notify "Mission ${MISSION_NAME}: driver ran UNPINNED (code provenance unknown)" "$_pin_body" "driver-pin"
+fi
+
+if [ -n "$_pin_drift_degraded" ]; then
+  _pin_drift_body="**Pinned driver held, but the source clone drifted** — this fire ran correctly pinned.
+
+Source clone: \`${AILANG_DRIVER_SRC:-$REPO}\`. Drift: **${_pin_drift_degraded} commits behind** \`origin/dev\`.
+The hazard is an interactive session started in that clone: it resolves that clone's own
+\`.claude/skills/\` and \`design_docs/\`, not the pinned driver's copies. Fix: reconcile
+\`${AILANG_DRIVER_SRC:-$REPO}\` with \`origin/dev\`. This notice repeats only when the measured
+drift doubles.
+
+\`\$REPO\` is NOT the path to reconcile: pin-root.sh exports MISSION_WORKDIR=<pin worktree> before
+re-execing, and REPO is derived from it, so on the pinned pass REPO names the throwaway worktree —
+whose drift is 0 by construction. AILANG_DRIVER_SRC is the source clone."
+  _mc_notify "Mission ${MISSION_NAME}: pinned source clone drifted (${_pin_drift_degraded} behind)" "$_pin_drift_body" "pin-drift"
 fi
 
 log "=== mission iteration starting (controller=$CONTROLLER_ID via ${MODEL_WHY}, timeout=${HARD_TIMEOUT}s | bg-wait-ceiling=${CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS}ms | roles: designer=$MISSION_DESIGNER_MODEL planner=$MISSION_PLANNER_MODEL executor=$MISSION_EXECUTOR_MODEL evaluator=$MISSION_EVALUATOR_MODEL) ==="

--- a/tools/launchd/test_driver_notify.sh
+++ b/tools/launchd/test_driver_notify.sh
@@ -9,13 +9,15 @@ DRV="$REPO_ROOT/tools/launchd/mission-control.sh"
 LAB="${TMPDIR:-/tmp}/emitlab.$$"; rm -rf "$LAB"; mkdir -p "$LAB"
 
 awk '/^_mc_notify\(\) \{/,/^\}/' "$DRV"                        > "$LAB/notify.sh"
+awk '/^# --- DRIVER PIN DECISION START ---/,/^# --- DRIVER PIN DECISION END ---/' "$DRV" > "$LAB/pin_decision.sh"
 awk '/^if \[ -n "\$_pin_degraded" \]; then/,/^fi$/' "$DRV"     > "$LAB/pin_block.sh"
+awk '/^if \[ -n "\$_pin_drift_degraded" \]; then/,/^fi$/' "$DRV" > "$LAB/pin_drift_block.sh"
 awk '/^if \[ -n "\$_lane_degraded" \]; then/,/^fi$/' "$DRV"    > "$LAB/lane_block.sh"
 
-for f in notify pin_block lane_block; do
+for f in notify pin_decision pin_block pin_drift_block lane_block; do
   if [ ! -s "$LAB/$f.sh" ]; then echo "FATAL: extraction of $f produced nothing"; exit 1; fi
 done
-echo "extracted: notify=$(wc -l < "$LAB/notify.sh") pin=$(wc -l < "$LAB/pin_block.sh") lane=$(wc -l < "$LAB/lane_block.sh") lines"
+echo "extracted: notify=$(wc -l < "$LAB/notify.sh") pin-decision=$(wc -l < "$LAB/pin_decision.sh") pin=$(wc -l < "$LAB/pin_block.sh") pin-drift=$(wc -l < "$LAB/pin_drift_block.sh") lane=$(wc -l < "$LAB/lane_block.sh") lines"
 
 PASS=0; FAIL=0
 ok(){ PASS=$((PASS+1)); echo "  PASS: $1"; }
@@ -47,6 +49,52 @@ GH:$*"; return ${GH_RC:-0}; }
 RC:$?"
   ' _ "$LAB/notify.sh" "$LAB/$block.sh" \
     "$( [ "$block" = pin_block ] && echo _pin_degraded || echo _lane_degraded )" "$val" 2>&1
+}
+
+run_drift() { # $1=status $2=drift $3=threshold $4=state-value (absent for no file)
+  local state_dir="$LAB/state.$$.${RUN_SEQ:-0}"
+  RUN_SEQ=$((${RUN_SEQ:-0}+1))
+  rm -rf "$state_dir"; mkdir -p "$state_dir"
+  if [ "$4" != absent ]; then printf '%s\n' "$4" > "$state_dir/pin-drift"; fi
+  /bin/bash -c '
+    set -uo pipefail
+    TRACE=""
+    log() { TRACE="$TRACE
+LOG:$*"; }
+    ailang() { TRACE="$TRACE
+AILANG:$*"; return 0; }
+    gh()     { TRACE="$TRACE
+GH:$*"; return 0; }
+    MISSION_NAME=motoko; MISSION_REPO=sunholo-data/ailang; MSG_FROM=mission-motoko
+    MISSION_GH_ISSUE=635; LOG=/tmp/x.log; REPO=/pinned/driver-worktree
+    AILANG_DRIVER_SRC=/source/ailang-motoko
+    PIN_STATUS="$1"; PIN_DRIFT="$2"; AILANG_DRIVER_DRIFT_WARN="$3"
+    PIN_DRIFT_FILE="$4/pin-drift"; PIN_NOTE="pinned test note"
+    _pin_degraded=""; _pin_drift_degraded=""
+    . "$5"
+    . "$6"
+    echo "DECISION_RC:$?"
+    . "$7"
+    . "$8"
+    if [ -f "$PIN_DRIFT_FILE" ]; then
+      echo "STATE:$(cat "$PIN_DRIFT_FILE")"
+    else
+      echo "STATE:absent"
+    fi
+    printf "%s" "$TRACE"
+  ' _ "$1" "$2" "$3" "$state_dir" "$LAB/notify.sh" "$LAB/pin_decision.sh" "$LAB/pin_drift_block.sh" "$LAB/pin_block.sh" 2>&1
+  rm -rf "$state_dir"
+}
+
+arm_ok() { # $1=name $2=trace $3=required substring; remaining args are forbidden substrings
+  local name="$1" trace="$2" required="$3" forbidden
+  shift 3
+  case "$trace" in *"DECISION_RC:0"*) ;; *) bad "$name" "$(printf '%s' "$trace"|tr '\n' '|')"; return;; esac
+  case "$trace" in *"$required"*) ;; *) bad "$name" "$(printf '%s' "$trace"|tr '\n' '|')"; return;; esac
+  for forbidden in "$@"; do
+    case "$trace" in *"$forbidden"*) bad "$name" "$(printf '%s' "$trace"|tr '\n' '|')"; return;; esac
+  done
+  ok "$name"
 }
 
 echo "== pin notice =="
@@ -82,6 +130,30 @@ check "lane keeps its own title"            "$T" "executor/planner lane degraded
 check "lane logs its summary"               "$T" "LOG:LANE DEGRADED this fire"
 T=$(run lane_block "")
 checkno "lane SILENT when healthy"          "$T" "AILANG:"
+
+echo "== held pin source-clone drift =="
+T=$(run_drift pinned 170 25 absent)
+case "$T" in *"DECISION_RC:0"*"AILANG:messages send controlplane"*"GH:issue comment 635"*"/source/ailang-motoko"*"170"*) ok "drift-a: first threshold notice reaches both channels with path/count";; *) bad "drift-a: first threshold notice reaches both channels with path/count" "$(printf '%s' "$T"|tr '\n' '|')";; esac
+T=$(run_drift pinned 170 25 170)
+arm_ok "drift-b: equal state dedupes" "$T" "STATE:170" "AILANG:" "GH:"
+T=$(run_drift pinned 340 25 170)
+arm_ok "drift-c: doubling notifies" "$T" "AILANG:messages send controlplane" "STATE:170"
+T=$(run_drift pinned 3 25 170)
+arm_ok "drift-d: below threshold is silent and re-arms" "$T" "STATE:absent" "AILANG:" "GH:"
+T=$(run_drift disabled 170 25 absent)
+arm_ok "drift-e: disabled pin is silent" "$T" "STATE:absent" "AILANG:" "GH:"
+T=$(run_drift pinned '?' 25 absent)
+arm_ok "drift-f: unknown drift is log-only" "$T" "LOG:driver pin drift: unknown" "AILANG:" "GH:"
+T=$(run_drift STALE 170 25 absent)
+case "$T" in *"DECISION_RC:0"*"driver ran UNPINNED"*) case "$T" in *"source clone drifted"*) bad "drift-g: STALE keeps original notice only" "$(printf '%s' "$T"|tr '\n' '|')";; *) ok "drift-g: STALE keeps original notice only";; esac;; *) bad "drift-g: STALE keeps original notice only" "$(printf '%s' "$T"|tr '\n' '|')";; esac
+
+# drift-h: the body must name the SOURCE CLONE, never $REPO. On the pinned pass pin-root.sh has
+# already exported MISSION_WORKDIR=<pin worktree>, and REPO is derived from it — so a body built
+# from $REPO tells the human to reconcile a detached throwaway whose drift is 0 by construction.
+# Measured live 2026-08-23: MISSION_WORKDIR=/Users/.../.ailang-driver-pin/motoko while
+# AILANG_DRIVER_SRC=/Users/.../dev/sunholo-data/ailang-motoko at 170 behind.
+T=$(run_drift pinned 170 25 absent)
+arm_ok "drift-h: notice names the source clone, not the pin worktree" "$T" "/source/ailang-motoko" "/pinned/driver-worktree"
 
 echo ""
 echo "==== $PASS passed, $FAIL failed ===="

--- a/tools/launchd/test_driver_notify.sh
+++ b/tools/launchd/test_driver_notify.sh
@@ -155,6 +155,38 @@ case "$T" in *"DECISION_RC:0"*"driver ran UNPINNED"*) case "$T" in *"source clon
 T=$(run_drift pinned 170 25 absent)
 arm_ok "drift-h: notice names the source clone, not the pin worktree" "$T" "/source/ailang-motoko" "/pinned/driver-worktree"
 
+# drift-i: a threshold of 0 persists a previous of 0, after which `-ge $((0 * 2))` is TRUE on every
+# fire — the post-every-90-minutes outcome the doubling rule exists to prevent, reached through the
+# block's own config knob. The floor coerces it to 25, so a drift of 3 is BELOW threshold and stays
+# silent. Remove the floor and this arm reds, because 3 -ge 0 notifies.
+T=$(run_drift pinned 3 0 absent)
+arm_ok "drift-i: a non-positive threshold is floored, not obeyed" "$T" "using 25" "AILANG:" "GH:"
+
+# drift-j: PIN_DRIFT unset under `set -u` must be handled, not abort. Unreachable through
+# pin-root.sh today (it sets PIN_STATUS and PIN_DRIFT on consecutive lines) — pinned here so the
+# invariant is enforced rather than assumed, per the evaluator's finding 4.
+T=$(/bin/bash -c '
+    set -uo pipefail
+    TRACE=""
+    log() { TRACE="$TRACE
+LOG:$*"; }
+    ailang() { TRACE="$TRACE
+AILANG:$*"; return 0; }
+    gh()     { TRACE="$TRACE
+GH:$*"; return 0; }
+    MISSION_NAME=motoko; MISSION_REPO=sunholo-data/ailang; MSG_FROM=mission-motoko
+    MISSION_GH_ISSUE=635; LOG=/tmp/x.log; REPO=/pinned/driver-worktree
+    AILANG_DRIVER_SRC=/source/ailang-motoko
+    PIN_STATUS=pinned; PIN_DRIFT_FILE=/tmp/nonexistent.$$/pin-drift; PIN_NOTE=n
+    _pin_degraded=""; _pin_drift_degraded=""
+    . "$1"
+    . "$2"
+    echo "DECISION_RC:$?"
+    . "$3"
+    printf "%s" "$TRACE"
+  ' _ "$LAB/notify.sh" "$LAB/pin_decision.sh" "$LAB/pin_drift_block.sh" 2>&1)
+arm_ok "drift-j: unset PIN_DRIFT is log-only, not a set -u abort" "$T" "LOG:driver pin drift: unknown" "AILANG:" "GH:"
+
 echo ""
 echo "==== $PASS passed, $FAIL failed ===="
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## The measured defect

`tools/launchd/lib/pin-root.sh` (issue 558) re-execs each launchd mission driver out of a worktree
pinned to `origin/dev`, so the driver, the skill and the charter move together. It leaves the
**source clone** behind, and `mission-control.sh` posted its human-channel pin notice only when
`PIN_STATUS=STALE`. The comment above that emit block stated why:

> "The shared clone being behind is not itself reportable — once drivers pin, that drift is
> harmless, and posting it every 90 minutes would train the channel to be ignored"

Half of that is true and is preserved. The other half is measured false.

Measured on the rig 2026-08-23, mission `motoko`:

| | |
|---|---|
| source clone `~/dev/sunholo-data/ailang-motoko` | **170 commits behind** `origin/dev`, 7 uncommitted files dated 2026-08-15 |
| its `.claude/skills/mission-control/SKILL.md` | **2594 lines** vs `origin/dev`'s **3657** |
| driver log, five consecutive fires | 119 → 132 → 144 → 159 → 170, success path, log only |

Drift is harmless to the **driver**, whose pin holds. It is not harmless to a **human session**:
the mission charter names that clone as the working checkout, and a session started there resolves
ITS `.claude/skills/` and `design_docs/` — a rulebook missing every rule added since 2026-08-15.
A diverged rulebook that nothing executes is indistinguishable from one that does, until someone
runs there.

## What this changes

- Notify once when the drift crosses `AILANG_DRIVER_DRIFT_WARN` (default 25), then only when it
  **doubles**, persisted in a per-mission state file (`mission-<name>.pin-drift`; the v1 legacy
  block gets `mission-control.pin-drift`). Below threshold the file is removed, so the notice
  re-arms after a reconcile. At most one post per doubling is what keeps the channel credible.
- A non-positive or non-numeric threshold is **floored to 25 and logged**, not obeyed: a threshold
  of 0 persists a previous of 0, after which `-ge $((0 * 2))` is true on every fire — the exact
  outcome the doubling rule prevents, reached through its own knob.
- The notice names `AILANG_DRIVER_SRC`, never `$REPO`. On the pinned pass `pin-root.sh` has already
  exported `MISSION_WORKDIR=<pin worktree>` and `REPO` is derived from it, so a `$REPO` body would
  tell the human to reconcile a detached throwaway whose drift is 0 by construction. Verified live:
  `MISSION_WORKDIR=~/.ailang-driver-pin/motoko`, `AILANG_DRIVER_SRC=~/dev/sunholo-data/ailang-motoko`
  at 170. The pre-existing STALE body's `$REPO` is correct there — that arm only fires on the
  pre-exec pass, where `REPO` is the clone that actually ran the stale code.

## Evidence

`tools/launchd/test_driver_notify.sh`: **17 → 27 arms**, awk-extracted from the real blocks rather
than retyped. Every mutant landed by sha256, `bash -n` rc=0, restored byte-identical from a `cp`
backup, red sets **produced by running them**:

| Mutant | Red set |
|---|---|
| neuter the whole check (`if false &&`) | drift-a, c, d, f, h, i, j |
| drop the doubling condition | drift-b (sole) |
| drop the `PIN_STATUS = pinned` guard | drift-e (sole) |
| drop the numeric `PIN_DRIFT` guard | drift-f (sole) |
| body from `$REPO` instead of `AILANG_DRIVER_SRC` | drift-a, drift-h |
| remove the threshold floor | drift-i (sole) |

`make test-launchd-drivers` rc=0 and `make check-changelog` rc=0 — **on darwin/arm64; the ubuntu
and windows legs are unrun locally.**

Independent evaluator (sonnet, generator≠judge): **PASS 90/100, zero blocking**. Three of its five
non-blocking findings are answered in the second commit; the other two are accepted as reported and
said so.

## Blast radius

`mission-control.sh` is shared by missions `v1`, `world` and `motoko`. All three gain this notice on
their next fire. `PIN_DRIFT_FILE` is defined in both the legacy and namespaced state branches and is
a net-new file, so no sibling state is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
