### PR TITLE
refactor(serveapi): rewire serveapi, evict machinery from internal/apiserver (M2, refs #764)

### DIFF
--- a/internal/apiserver/authorized_surface_test.go
+++ b/internal/apiserver/authorized_surface_test.go
@@ -1,0 +1,69 @@
+package apiserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestLoadedNoMCPRemainsInStandaloneA2ACard(t *testing.T) {
+	srv := nomcpTestServer(t)
+	defer srv.Close()
+	card := srv.buildAgentCard(httptest.NewRequest(http.MethodGet, "/.well-known/agent.json", nil))
+	encoded, _ := json.Marshal(card["skills"])
+	if !strings.Contains(string(encoded), "getKeyUsage") {
+		t.Fatalf("@nomcp export missing from A2A card: %s", encoded)
+	}
+	if strings.Contains(string(encoded), "internalSecret") {
+		t.Fatalf("@noexpose export leaked into A2A card: %s", encoded)
+	}
+}
+
+func TestStandaloneMCPFeedbackCompatibilityBothDirections(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		config       Config
+		wantFeedback bool
+	}{
+		{"default", Config{}, true},
+		{"suppressed", Config{NoFeedbackTool: true}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := feedbackSurfaceServer(t, tc.config)
+			defer srv.Close()
+			result, _ := listFeedbackSurfaceTools(t, srv)
+			names := feedbackToolSet(result.Tools)
+			if !names["status"] {
+				t.Fatalf("positive control status missing; tools=%v", toolNames(result.Tools))
+			}
+			if names["submit_feedback"] != tc.wantFeedback {
+				t.Fatalf("submit_feedback present=%v want=%v; tools=%v", names["submit_feedback"], tc.wantFeedback, toolNames(result.Tools))
+			}
+		})
+	}
+}
+
+func TestLoadedExportMembershipAndNoMCPProjection(t *testing.T) {
+	tests := []struct {
+		name        string
+		routesOnly  bool
+		export      ExportInfo
+		member, mcp bool
+	}{
+		{"noexpose", false, ExportInfo{Name: "hidden", IsNoExpose: true}, false, false},
+		{"routes only non-route", true, ExportInfo{Name: "plain"}, false, false},
+		{"nomcp projection", false, ExportInfo{Name: "http_a2a_openapi", IsNoMCP: true}, true, false},
+		{"ordinary", false, ExportInfo{Name: "ordinary"}, true, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			member := loadedExportMember(tc.routesOnly, tc.export)
+			mcp := member && !tc.export.IsNoMCP
+			if member != tc.member || mcp != tc.mcp {
+				t.Fatalf("member=%v mcp=%v", member, mcp)
+			}
+		})
+	}
+}

--- a/internal/apiserver/mcp.go
+++ b/internal/apiserver/mcp.go
@@ -20,6 +20,13 @@ type MCPServer struct {
 	feedbackRL *IPRateLimiter // nil = disabled; only applied to submit_feedback
 }
 
+func mcpError(msg string) *mcp.CallToolResult {
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: msg}},
+		IsError: true,
+	}
+}
+
 // NewMCPServer creates an MCP server from an apiserver.Server.
 // All loaded modules' exported functions are registered as MCP tools.
 //

--- a/internal/apiserver/protocol_compat.go
+++ b/internal/apiserver/protocol_compat.go
@@ -8,67 +8,18 @@ import (
 	"github.com/sunholo-data/ailang/serveapi/protocol"
 )
 
-// TRANSITIONAL - deleted in M2
-type ToolDescriptor = protocol.ToolDescriptor
-
-// TRANSITIONAL - deleted in M2
-type AuthorizedSurface struct {
-	*protocol.AuthorizedSurface
-	tools []ToolDescriptor
-}
-
-// TRANSITIONAL - deleted in M2
-var ErrCallbackCapacity = protocol.ErrCallbackCapacity
-
-// TRANSITIONAL - deleted in M2
-func callerSurface(v []ToolDescriptor) (*AuthorizedSurface, error) {
-	surface, err := protocol.CallerSurface(v)
-	if err != nil {
-		return nil, err
-	}
-	return &AuthorizedSurface{AuthorizedSurface: surface, tools: surface.All()}, nil
-}
-
-// TRANSITIONAL - deleted in M2
 func validateMCPName(v string) error { return protocol.ValidateMCPName(v) }
 
-// TRANSITIONAL - deleted in M2
 var mcpToolNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
 
-// TRANSITIONAL - deleted in M2
 type a2aRequest = protocol.A2ARequest
 
-// TRANSITIONAL - deleted in M2
 type a2aTaskSendParams = protocol.A2ATaskSendParams
 
-// TRANSITIONAL - deleted in M2
-type a2aMessage = protocol.A2AMessage
-
-// TRANSITIONAL - deleted in M2
-//
-//nolint:unused // Preserved until embedded A2A wire machinery moves in M2.
-type a2aContent = protocol.A2AContent
-
-// TRANSITIONAL - deleted in M2
 func a2aError(w http.ResponseWriter, id json.RawMessage, code int, msg string) {
 	protocol.A2AError(w, id, code, msg)
 }
 
-// TRANSITIONAL - deleted in M2
 func a2aResult(w http.ResponseWriter, id json.RawMessage, result any) {
 	protocol.A2AResult(w, id, result)
 }
-
-// TRANSITIONAL - deleted in M2
-func requestID(body []byte) json.RawMessage { return protocol.RequestID(body) }
-
-// TRANSITIONAL - deleted in M2
-func writeMCPEnvelope(w http.ResponseWriter, id json.RawMessage, msg string) {
-	protocol.WriteMCPEnvelope(w, id, msg)
-}
-
-// TRANSITIONAL - deleted in M2
-func callbackMessage(err error) string { return protocol.CallbackMessage(err) }
-
-// TRANSITIONAL - deleted in M2
-func authorizationStatus(err error) int { return protocol.AuthorizationStatus(err) }

--- a/serveapi/a2a_handler.go
+++ b/serveapi/a2a_handler.go
@@ -1,28 +1,31 @@
-package apiserver
+package serveapi
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
+
+	"github.com/sunholo-data/ailang/serveapi/protocol"
 )
 
-// EmbeddedA2AConfig supplies request-scoped host operations without creating
+// embeddedA2AConfig supplies request-scoped host operations without creating
 // an internal dependency on the public serveapi package.
-type EmbeddedA2AConfig struct {
+type embeddedA2AConfig struct {
 	AgentName        string
 	AgentDescription string
 	AgentVersion     string
-	Runner           *CallbackRunner
+	Runner           *callbackRunner
 	Resolve          func(context.Context, *http.Request) (any, error)
 	Tools            func(context.Context, any) ([]ToolDescriptor, error)
 	Invoke           func(context.Context, any, string, json.RawMessage) (json.RawMessage, error)
 }
 
-type embeddedA2AHandler struct{ config EmbeddedA2AConfig }
+type embeddedA2AHandler struct{ config embeddedA2AConfig }
 
-// NewEmbeddedA2AHandler returns a recorder-friendly, request-scoped A2A handler.
-func NewEmbeddedA2AHandler(config EmbeddedA2AConfig) http.Handler {
+// newEmbeddedA2AHandler returns a recorder-friendly, request-scoped A2A handler.
+func newEmbeddedA2AHandler(config embeddedA2AConfig) http.Handler {
 	return &embeddedA2AHandler{config: config}
 }
 
@@ -44,25 +47,25 @@ func (h *embeddedA2AHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.handleTask(w, r, session, surface)
 }
 
-func (h *embeddedA2AHandler) resolveSurface(r *http.Request) (any, *AuthorizedSurface, error) {
-	session, err := RunCallback(r.Context(), h.config.Runner, func(ctx context.Context) (any, error) {
+func (h *embeddedA2AHandler) resolveSurface(r *http.Request) (any, *protocol.AuthorizedSurface, error) {
+	session, err := runCallback(r.Context(), h.config.Runner, func(ctx context.Context) (any, error) {
 		return h.config.Resolve(ctx, r)
 	})
 	if err != nil {
 		return nil, nil, err
 	}
-	descriptors, err := RunCallback(r.Context(), h.config.Runner, func(ctx context.Context) ([]ToolDescriptor, error) {
+	descriptors, err := runCallback(r.Context(), h.config.Runner, func(ctx context.Context) ([]ToolDescriptor, error) {
 		return h.config.Tools(ctx, session)
 	})
 	if err != nil {
 		return nil, nil, err
 	}
-	surface, err := callerSurface(descriptors)
+	surface, err := protocol.CallerSurface(descriptors)
 	return session, surface, err
 }
 
-func (h *embeddedA2AHandler) writeCard(w http.ResponseWriter, r *http.Request, surface *AuthorizedSurface) {
-	skills := make([]map[string]any, 0, len(surface.tools))
+func (h *embeddedA2AHandler) writeCard(w http.ResponseWriter, r *http.Request, surface *protocol.AuthorizedSurface) {
+	skills := make([]map[string]any, 0, len(surface.All()))
 	for _, descriptor := range surface.All() {
 		skills = append(skills, map[string]any{
 			"id": descriptor.Name, "name": descriptor.Name,
@@ -82,32 +85,32 @@ func (h *embeddedA2AHandler) writeCard(w http.ResponseWriter, r *http.Request, s
 	})
 }
 
-func (h *embeddedA2AHandler) handleTask(w http.ResponseWriter, r *http.Request, session any, surface *AuthorizedSurface) {
-	var req a2aRequest
+func (h *embeddedA2AHandler) handleTask(w http.ResponseWriter, r *http.Request, session any, surface *protocol.AuthorizedSurface) {
+	var req protocol.A2ARequest
 	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
-		a2aError(w, nil, -32700, "invalid JSON: "+err.Error())
+		protocol.A2AError(w, nil, -32700, "invalid JSON: "+err.Error())
 		return
 	}
 	if req.JSONRPC != "2.0" {
-		a2aError(w, req.ID, -32600, "expected jsonrpc: \"2.0\"")
+		protocol.A2AError(w, req.ID, -32600, "expected jsonrpc: \"2.0\"")
 		return
 	}
 	if req.Method != "tasks/send" {
-		a2aError(w, req.ID, -32601, "method not found: "+req.Method)
+		protocol.A2AError(w, req.ID, -32601, "method not found: "+req.Method)
 		return
 	}
-	var params a2aTaskSendParams
+	var params protocol.A2ATaskSendParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		a2aError(w, req.ID, -32602, "invalid params: "+err.Error())
+		protocol.A2AError(w, req.ID, -32602, "invalid params: "+err.Error())
 		return
 	}
 	skillID, _ := params.Metadata["skill_id"].(string)
 	if _, ok := surface.Lookup(skillID); !ok {
-		a2aError(w, req.ID, -32602, fmt.Sprintf("tool %q is not authorized", skillID))
+		protocol.A2AError(w, req.ID, -32602, fmt.Sprintf("tool %q is not authorized", skillID))
 		return
 	}
 	arguments := embeddedA2AArguments(params.Message)
-	result, err := RunCallback(r.Context(), h.config.Runner, func(ctx context.Context) (json.RawMessage, error) {
+	result, err := runCallback(r.Context(), h.config.Runner, func(ctx context.Context) (json.RawMessage, error) {
 		return h.config.Invoke(ctx, session, skillID, arguments)
 	})
 	if err != nil {
@@ -118,23 +121,23 @@ func (h *embeddedA2AHandler) handleTask(w http.ResponseWriter, r *http.Request, 
 	// different mistake from one that returns malformed JSON, and reporting the
 	// first as the second sends the embedder hunting for an encoding bug.
 	if len(result) == 0 {
-		a2aError(w, req.ID, -32603, "host callback returned no result")
+		protocol.A2AError(w, req.ID, -32603, "host callback returned no result")
 		return
 	}
 	var value any
 	if err := json.Unmarshal(result, &value); err != nil {
-		a2aError(w, req.ID, -32603, "host callback returned invalid JSON")
+		protocol.A2AError(w, req.ID, -32603, "host callback returned invalid JSON")
 		return
 	}
 	taskID := params.ID
 	if taskID == "" {
 		taskID = "embedded-task"
 	}
-	a2aResult(w, req.ID, map[string]any{"id": taskID, "status": map[string]any{"state": "completed"},
+	protocol.A2AResult(w, req.ID, map[string]any{"id": taskID, "status": map[string]any{"state": "completed"},
 		"artifacts": []map[string]any{{"parts": []map[string]any{{"type": "data", "data": map[string]any{"result": value}}, {"type": "text", "text": string(result)}}}}})
 }
 
-func embeddedA2AArguments(message a2aMessage) json.RawMessage {
+func embeddedA2AArguments(message protocol.A2AMessage) json.RawMessage {
 	for _, part := range message.Parts {
 		if part.Type == "data" && part.Data != nil {
 			if args, ok := part.Data["args"]; ok {
@@ -150,13 +153,13 @@ func embeddedA2AArguments(message a2aMessage) json.RawMessage {
 }
 
 func (h *embeddedA2AHandler) writeCallbackError(w http.ResponseWriter, r *http.Request, id json.RawMessage, card bool, err error) {
-	if status := authorizationStatus(err); status != 0 {
+	if status := protocol.AuthorizationStatus(err); status != 0 {
 		http.Error(w, err.Error(), status)
 		return
 	}
-	message := callbackMessage(err)
+	message := protocol.CallbackMessage(err)
 	if !card {
-		a2aError(w, id, -32603, message)
+		protocol.A2AError(w, id, -32603, message)
 		return
 	}
 	status := http.StatusInternalServerError
@@ -166,4 +169,12 @@ func (h *embeddedA2AHandler) writeCallbackError(w http.ResponseWriter, r *http.R
 		status = http.StatusServiceUnavailable
 	}
 	writeJSON(w, status, map[string]string{"error": message})
+}
+
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Printf("[API] failed to write response: %v", err)
+	}
 }

--- a/serveapi/callbacks.go
+++ b/serveapi/callbacks.go
@@ -1,27 +1,29 @@
-package apiserver
+package serveapi
 
 import (
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/sunholo-data/ailang/serveapi/protocol"
 )
 
-// CallbackRunner bounds handler wait time and concurrently started host calls.
+// callbackRunner bounds handler wait time and concurrently started host calls.
 // A slot remains occupied until host code actually returns, even after timeout.
-type CallbackRunner struct {
+type callbackRunner struct {
 	timeout time.Duration
 	slots   chan struct{}
 }
 
-// NewCallbackRunner constructs a callback runner from effective positive limits.
-func NewCallbackRunner(timeout time.Duration, maxConcurrent int) (*CallbackRunner, error) {
+// newCallbackRunner constructs a callback runner from effective positive limits.
+func newCallbackRunner(timeout time.Duration, maxConcurrent int) (*callbackRunner, error) {
 	if timeout <= 0 {
 		return nil, fmt.Errorf("callback timeout must be positive")
 	}
 	if maxConcurrent <= 0 {
 		return nil, fmt.Errorf("maximum concurrent callbacks must be positive")
 	}
-	return &CallbackRunner{timeout: timeout, slots: make(chan struct{}, maxConcurrent)}, nil
+	return &callbackRunner{timeout: timeout, slots: make(chan struct{}, maxConcurrent)}, nil
 }
 
 type callbackResult[T any] struct {
@@ -29,9 +31,9 @@ type callbackResult[T any] struct {
 	err   error
 }
 
-// RunCallback executes callback with a bounded context. In-process callbacks
+// runCallback executes callback with a bounded context. In-process callbacks
 // cannot be forcibly terminated; a non-cooperative callback keeps its slot.
-func RunCallback[T any](ctx context.Context, runner *CallbackRunner, callback func(context.Context) (T, error)) (T, error) {
+func runCallback[T any](ctx context.Context, runner *callbackRunner, callback func(context.Context) (T, error)) (T, error) {
 	var zero T
 	callCtx, cancel := context.WithTimeout(ctx, runner.timeout)
 	defer cancel()
@@ -42,7 +44,7 @@ func RunCallback[T any](ctx context.Context, runner *CallbackRunner, callback fu
 		if ctx.Err() != nil {
 			return zero, ctx.Err()
 		}
-		return zero, ErrCallbackCapacity
+		return zero, protocol.ErrCallbackCapacity
 	}
 
 	result := make(chan callbackResult[T], 1)

--- a/serveapi/callbacks_test.go
+++ b/serveapi/callbacks_test.go
@@ -1,4 +1,4 @@
-package apiserver
+package serveapi
 
 import (
 	"context"
@@ -8,17 +8,19 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/sunholo-data/ailang/serveapi/protocol"
 )
 
 func TestCallbackRunnerTimeoutAndStopsChain(t *testing.T) {
-	runner, err := NewCallbackRunner(20*time.Millisecond, 1)
+	runner, err := newCallbackRunner(20*time.Millisecond, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	release := make(chan struct{})
 	defer close(release)
 	start := time.Now()
-	_, err = RunCallback(context.Background(), runner, func(context.Context) (int, error) {
+	_, err = runCallback(context.Background(), runner, func(context.Context) (int, error) {
 		<-release
 		return 1, nil
 	})
@@ -37,11 +39,11 @@ func TestCallbackRunnerTimeoutAndStopsChain(t *testing.T) {
 	// call on a saturated runner is rejected without host code ever being entered.
 	// This fails if the token is released when the handler stops waiting.
 	var next atomic.Int32
-	_, nextErr := RunCallback(context.Background(), runner, func(context.Context) (int, error) {
+	_, nextErr := runCallback(context.Background(), runner, func(context.Context) (int, error) {
 		next.Add(1)
 		return 0, nil
 	})
-	if !errors.Is(nextErr, ErrCallbackCapacity) {
+	if !errors.Is(nextErr, protocol.ErrCallbackCapacity) {
 		t.Fatalf("follow-up call error = %v, want capacity exceeded", nextErr)
 	}
 	if next.Load() != 0 {
@@ -50,12 +52,12 @@ func TestCallbackRunnerTimeoutAndStopsChain(t *testing.T) {
 }
 
 func TestCallbackRunnerObservedDeadlineAndFastCall(t *testing.T) {
-	runner, err := NewCallbackRunner(5*time.Second, 4)
+	runner, err := newCallbackRunner(5*time.Second, 4)
 	if err != nil {
 		t.Fatal(err)
 	}
 	now := time.Now()
-	deadline, err := RunCallback(context.Background(), runner, func(ctx context.Context) (time.Time, error) {
+	deadline, err := runCallback(context.Background(), runner, func(ctx context.Context) (time.Time, error) {
 		deadline, ok := ctx.Deadline()
 		if !ok {
 			t.Fatal("callback context has no deadline")
@@ -68,14 +70,14 @@ func TestCallbackRunnerObservedDeadlineAndFastCall(t *testing.T) {
 	if deadline.Before(now.Add(4*time.Second)) || deadline.After(now.Add(6*time.Second)) {
 		t.Fatalf("observed deadline %v outside expected window from %v", deadline, now)
 	}
-	value, err := RunCallback(context.Background(), runner, func(context.Context) (int, error) { return 137, nil })
+	value, err := runCallback(context.Background(), runner, func(context.Context) (int, error) { return 137, nil })
 	if err != nil || value != 137 {
 		t.Fatalf("fast callback = (%d, %v)", value, err)
 	}
 }
 
 func TestCallbackRunnerBoundsConcurrencyAndRecovers(t *testing.T) {
-	runner, err := NewCallbackRunner(30*time.Millisecond, 4)
+	runner, err := newCallbackRunner(30*time.Millisecond, 4)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,12 +90,12 @@ func TestCallbackRunnerBoundsConcurrencyAndRecovers(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				_, callErr := RunCallback(context.Background(), runner, func(context.Context) (int, error) {
+				_, callErr := runCallback(context.Background(), runner, func(context.Context) (int, error) {
 					starts.Add(1)
 					<-release
 					return 0, nil
 				})
-				if errors.Is(callErr, ErrCallbackCapacity) {
+				if errors.Is(callErr, protocol.ErrCallbackCapacity) {
 					overloads.Add(1)
 				}
 			}()
@@ -125,15 +127,15 @@ func TestCallbackRunnerBoundsConcurrencyAndRecovers(t *testing.T) {
 		t.Fatal("capacity did not recover after callbacks returned")
 	}
 
-	fastRunner, _ := NewCallbackRunner(time.Second, 4)
+	fastRunner, _ := newCallbackRunner(time.Second, 4)
 	var fastOverloads atomic.Int32
 	var wg sync.WaitGroup
 	for range 40 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, callErr := RunCallback(context.Background(), fastRunner, func(context.Context) (int, error) { return 1, nil })
-			if errors.Is(callErr, ErrCallbackCapacity) {
+			_, callErr := runCallback(context.Background(), fastRunner, func(context.Context) (int, error) { return 1, nil })
+			if errors.Is(callErr, protocol.ErrCallbackCapacity) {
 				fastOverloads.Add(1)
 			}
 		}()

--- a/serveapi/embedded_a2a_test.go
+++ b/serveapi/embedded_a2a_test.go
@@ -1,4 +1,4 @@
-package apiserver
+package serveapi
 
 import (
 	"context"
@@ -16,11 +16,11 @@ import (
 
 func embeddedA2A(t *testing.T, host embeddedTestHost, timeout time.Duration, capacity int) http.Handler {
 	t.Helper()
-	runner, err := NewCallbackRunner(timeout, capacity)
+	runner, err := newCallbackRunner(timeout, capacity)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return NewEmbeddedA2AHandler(EmbeddedA2AConfig{
+	return newEmbeddedA2AHandler(embeddedA2AConfig{
 		AgentName: "sentinel-agent", AgentDescription: "sentinel-description", AgentVersion: "9.8.7",
 		Runner: runner, Resolve: host.resolve, Tools: host.tools, Invoke: host.invoke,
 	})
@@ -281,66 +281,6 @@ func TestEmbeddedA2ABlockedPrincipalDoesNotBlockAnother(t *testing.T) {
 	}
 	close(releaseA)
 	<-doneA
-}
-
-func TestLoadedNoMCPRemainsInStandaloneA2ACard(t *testing.T) {
-	srv := nomcpTestServer(t)
-	defer srv.Close()
-	card := srv.buildAgentCard(httptest.NewRequest(http.MethodGet, "/.well-known/agent.json", nil))
-	encoded, _ := json.Marshal(card["skills"])
-	if !strings.Contains(string(encoded), "getKeyUsage") {
-		t.Fatalf("@nomcp export missing from A2A card: %s", encoded)
-	}
-	if strings.Contains(string(encoded), "internalSecret") {
-		t.Fatalf("@noexpose export leaked into A2A card: %s", encoded)
-	}
-}
-
-func TestStandaloneMCPFeedbackCompatibilityBothDirections(t *testing.T) {
-	for _, tc := range []struct {
-		name         string
-		config       Config
-		wantFeedback bool
-	}{
-		{"default", Config{}, true},
-		{"suppressed", Config{NoFeedbackTool: true}, false},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			srv := feedbackSurfaceServer(t, tc.config)
-			defer srv.Close()
-			result, _ := listFeedbackSurfaceTools(t, srv)
-			names := feedbackToolSet(result.Tools)
-			if !names["status"] {
-				t.Fatalf("positive control status missing; tools=%v", toolNames(result.Tools))
-			}
-			if names["submit_feedback"] != tc.wantFeedback {
-				t.Fatalf("submit_feedback present=%v want=%v; tools=%v", names["submit_feedback"], tc.wantFeedback, toolNames(result.Tools))
-			}
-		})
-	}
-}
-
-func TestLoadedExportMembershipAndNoMCPProjection(t *testing.T) {
-	tests := []struct {
-		name        string
-		routesOnly  bool
-		export      ExportInfo
-		member, mcp bool
-	}{
-		{"noexpose", false, ExportInfo{Name: "hidden", IsNoExpose: true}, false, false},
-		{"routes only non-route", true, ExportInfo{Name: "plain"}, false, false},
-		{"nomcp projection", false, ExportInfo{Name: "http_a2a_openapi", IsNoMCP: true}, true, false},
-		{"ordinary", false, ExportInfo{Name: "ordinary"}, true, true},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			member := loadedExportMember(tc.routesOnly, tc.export)
-			mcp := member && !tc.export.IsNoMCP
-			if member != tc.member || mcp != tc.mcp {
-				t.Fatalf("member=%v mcp=%v", member, mcp)
-			}
-		})
-	}
 }
 
 // TestEmbeddedA2AEmptyAndInvalidResultsAreDistinguishable covers the two ways a

--- a/serveapi/embedded_mcp_replay_test.go
+++ b/serveapi/embedded_mcp_replay_test.go
@@ -11,7 +11,7 @@
 // The anti-vacuity control exists because assertions over a battery that stopped
 // reflecting anywhere would pass while measuring nothing. It forces at least one case to
 // genuinely contain the payload before the (a)/(b)/(c) checks are trusted.
-package apiserver
+package serveapi
 
 import (
 	"context"
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/sunholo-data/ailang/serveapi/protocol"
 )
 
 const htmlPayload = "<script>alert(1)</script>"
@@ -204,7 +206,7 @@ func TestEmbeddedMCPReplayDefaultsContentTypeWhenTransportOmitsIt(t *testing.T) 
 // inheriting it, and "the encoder escapes by default" is exactly such an inheritance.
 func TestWriteMCPEnvelopeIsLabelled(t *testing.T) {
 	recorder := httptest.NewRecorder()
-	writeMCPEnvelope(recorder, json.RawMessage(`"`+htmlPayload+`"`), "invalid MCP request body")
+	protocol.WriteMCPEnvelope(recorder, json.RawMessage(`"`+htmlPayload+`"`), "invalid MCP request body")
 
 	if got := recorder.Header().Get("Content-Type"); got != "application/json" {
 		t.Fatalf("Content-Type = %q, want application/json", got)

--- a/serveapi/embedded_mcp_test.go
+++ b/serveapi/embedded_mcp_test.go
@@ -1,4 +1,4 @@
-package apiserver
+package serveapi
 
 import (
 	"bytes"
@@ -25,11 +25,11 @@ type embeddedTestHost struct {
 
 func embeddedHandler(t *testing.T, host embeddedTestHost, timeout time.Duration, capacity int) http.Handler {
 	t.Helper()
-	runner, err := NewCallbackRunner(timeout, capacity)
+	runner, err := newCallbackRunner(timeout, capacity)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return NewEmbeddedMCPHandler(EmbeddedMCPConfig{
+	return newEmbeddedMCPHandler(embeddedMCPConfig{
 		AgentName: "embedded-test", AgentVersion: "1", Runner: runner,
 		Resolve: host.resolve, Tools: host.tools, Invoke: host.invoke,
 	})

--- a/serveapi/mcp_handler.go
+++ b/serveapi/mcp_handler.go
@@ -1,4 +1,4 @@
-package apiserver
+package serveapi
 
 import (
 	"bytes"
@@ -9,26 +9,27 @@ import (
 	"sync"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/sunholo-data/ailang/serveapi/protocol"
 )
 
-// EmbeddedMCPConfig supplies the request-scoped host operations used by the
+// embeddedMCPConfig supplies the request-scoped host operations used by the
 // public serveapi facade without introducing an internal-to-public import.
-type EmbeddedMCPConfig struct {
+type embeddedMCPConfig struct {
 	AgentName    string
 	AgentVersion string
-	Runner       *CallbackRunner
+	Runner       *callbackRunner
 	Resolve      func(context.Context, *http.Request) (any, error)
 	Tools        func(context.Context, any) ([]ToolDescriptor, error)
 	Invoke       func(context.Context, any, string, json.RawMessage) (json.RawMessage, error)
 }
 
 type embeddedMCPHandler struct {
-	config    EmbeddedMCPConfig
+	config    embeddedMCPConfig
 	transport http.Handler
 }
 
 type embeddedMCPContext struct {
-	surface *AuthorizedSurface
+	surface *protocol.AuthorizedSurface
 	session any
 	failure *embeddedCallbackFailure
 }
@@ -40,9 +41,9 @@ type embeddedCallbackFailure struct {
 
 type embeddedMCPContextKey struct{}
 
-// NewEmbeddedMCPHandler builds the stateless SDK transport once. The server
+// newEmbeddedMCPHandler builds the stateless SDK transport once. The server
 // returned to it is still new for every authorized POST.
-func NewEmbeddedMCPHandler(config EmbeddedMCPConfig) http.Handler {
+func newEmbeddedMCPHandler(config embeddedMCPConfig) http.Handler {
 	h := &embeddedMCPHandler{config: config}
 	h.transport = mcp.NewStreamableHTTPHandler(h.serverForRequest,
 		&mcp.StreamableHTTPOptions{Stateless: true})
@@ -57,17 +58,17 @@ func (h *embeddedMCPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, mcp.DefaultMaxRequestBodyBytes+1))
 	if err != nil || len(body) > mcp.DefaultMaxRequestBodyBytes {
-		writeMCPEnvelope(w, requestID(body), "invalid MCP request body")
+		protocol.WriteMCPEnvelope(w, protocol.RequestID(body), "invalid MCP request body")
 		return
 	}
 	r.Body = io.NopCloser(bytes.NewReader(body))
-	id := requestID(body)
+	id := protocol.RequestID(body)
 
-	session, err := RunCallback(r.Context(), h.config.Runner, func(ctx context.Context) (any, error) {
+	session, err := runCallback(r.Context(), h.config.Runner, func(ctx context.Context) (any, error) {
 		return h.config.Resolve(ctx, r)
 	})
 	if err != nil {
-		if status := authorizationStatus(err); status != 0 {
+		if status := protocol.AuthorizationStatus(err); status != 0 {
 			http.Error(w, err.Error(), status)
 			return
 		}
@@ -75,16 +76,16 @@ func (h *embeddedMCPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	descriptors, err := RunCallback(r.Context(), h.config.Runner, func(ctx context.Context) ([]ToolDescriptor, error) {
+	descriptors, err := runCallback(r.Context(), h.config.Runner, func(ctx context.Context) ([]ToolDescriptor, error) {
 		return h.config.Tools(ctx, session)
 	})
 	if err != nil {
 		writeMCPCallbackError(w, id, err)
 		return
 	}
-	surface, err := callerSurface(descriptors)
+	surface, err := protocol.CallerSurface(descriptors)
 	if err != nil {
-		writeMCPEnvelope(w, id, err.Error())
+		protocol.WriteMCPEnvelope(w, id, err.Error())
 		return
 	}
 
@@ -99,7 +100,7 @@ func (h *embeddedMCPHandler) serveTransport(w http.ResponseWriter, r *http.Reque
 	buffer := newBufferedResponseWriter()
 	defer func() {
 		if recover() != nil {
-			writeMCPEnvelope(w, id, "host tool registration failed")
+			protocol.WriteMCPEnvelope(w, id, "host tool registration failed")
 		}
 	}()
 	h.transport.ServeHTTP(buffer, r)
@@ -108,7 +109,7 @@ func (h *embeddedMCPHandler) serveTransport(w http.ResponseWriter, r *http.Reque
 	message := requestContext.failure.message
 	requestContext.failure.mu.Unlock()
 	if message != "" {
-		writeMCPEnvelope(w, id, message)
+		protocol.WriteMCPEnvelope(w, id, message)
 		return
 	}
 	for name, values := range buffer.header {
@@ -155,14 +156,14 @@ func (h *embeddedMCPHandler) serverForRequest(r *http.Request) *mcp.Server {
 			Name: descriptor.Name, Description: descriptor.Description,
 			InputSchema: descriptor.InputSchema, OutputSchema: descriptor.OutputSchema,
 		}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			result, err := RunCallback(ctx, h.config.Runner, func(callCtx context.Context) (json.RawMessage, error) {
+			result, err := runCallback(ctx, h.config.Runner, func(callCtx context.Context) (json.RawMessage, error) {
 				return h.config.Invoke(callCtx, requestContext.session, descriptor.Name, req.Params.Arguments)
 			})
 			if err != nil {
 				requestContext.failure.mu.Lock()
-				requestContext.failure.message = callbackMessage(err)
+				requestContext.failure.message = protocol.CallbackMessage(err)
 				requestContext.failure.mu.Unlock()
-				return mcpError(callbackMessage(err)), nil
+				return mcpError(protocol.CallbackMessage(err)), nil
 			}
 			return &mcp.CallToolResult{
 				Content:           []mcp.Content{&mcp.TextContent{Text: string(result)}},
@@ -174,7 +175,7 @@ func (h *embeddedMCPHandler) serverForRequest(r *http.Request) *mcp.Server {
 }
 
 func writeMCPCallbackError(w http.ResponseWriter, id json.RawMessage, err error) {
-	writeMCPEnvelope(w, id, callbackMessage(err))
+	protocol.WriteMCPEnvelope(w, id, protocol.CallbackMessage(err))
 }
 
 // mcpError creates an MCP tool error result shared by standalone and embedded servers.

--- a/serveapi/serveapi.go
+++ b/serveapi/serveapi.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sunholo-data/ailang/internal/apiserver"
+	"github.com/sunholo-data/ailang/serveapi/protocol"
 )
 
 const (
@@ -20,59 +20,15 @@ const (
 	DefaultMaxConcurrentCallbacks = 64
 )
 
-type Session any
-
-type SessionResolver interface {
-	ResolveSession(context.Context, *http.Request) (Session, error)
-}
-
-type ToolSource interface {
-	Tools(context.Context, Session) ([]ToolDescriptor, error)
-}
-
-type Invoker interface {
-	Invoke(context.Context, Session, Invocation) (InvocationResult, error)
-}
-
-type ToolDescriptor struct {
-	Name         string
-	Description  string
-	InputSchema  json.RawMessage
-	OutputSchema json.RawMessage
-	Tags         []string
-	Examples     []string
-}
-
-type Invocation struct {
-	Name      string
-	Arguments json.RawMessage
-}
-
-type InvocationResult struct {
-	Value json.RawMessage
-}
-
-type AgentInfo struct {
-	Name        string
-	Description string
-	Version     string
-}
-
-// AuthorizationError maps resolver rejection to an HTTP 401 or 403 response.
-type AuthorizationError struct {
-	Status int
-	Err    error
-}
-
-func (e *AuthorizationError) Error() string {
-	if e.Err != nil {
-		return e.Err.Error()
-	}
-	return http.StatusText(e.Status)
-}
-
-func (e *AuthorizationError) Unwrap() error   { return e.Err }
-func (e *AuthorizationError) HTTPStatus() int { return e.Status }
+type Session = protocol.Session
+type SessionResolver = protocol.SessionResolver
+type ToolSource = protocol.ToolSource
+type Invoker = protocol.Invoker
+type ToolDescriptor = protocol.ToolDescriptor
+type Invocation = protocol.Invocation
+type InvocationResult = protocol.InvocationResult
+type AgentInfo = protocol.AgentInfo
+type AuthorizationError = protocol.AuthorizationError
 
 type Config struct {
 	Resolver               SessionResolver
@@ -87,7 +43,7 @@ type Config struct {
 // later milestones; M1 establishes and validates the host contract.
 type Server struct {
 	config     Config
-	runner     *apiserver.CallbackRunner
+	runner     *callbackRunner
 	mcpHandler http.Handler
 	a2aHandler http.Handler
 }
@@ -120,48 +76,32 @@ func New(cfg Config) (*Server, error) {
 	if cfg.MaxConcurrentCallbacks == 0 {
 		cfg.MaxConcurrentCallbacks = DefaultMaxConcurrentCallbacks
 	}
-	runner, err := apiserver.NewCallbackRunner(cfg.CallbackTimeout, cfg.MaxConcurrentCallbacks)
+	runner, err := newCallbackRunner(cfg.CallbackTimeout, cfg.MaxConcurrentCallbacks)
 	if err != nil {
 		return nil, fmt.Errorf("configure callback runner: %w", err)
 	}
 	s := &Server{config: cfg, runner: runner}
-	s.mcpHandler = apiserver.NewEmbeddedMCPHandler(apiserver.EmbeddedMCPConfig{
+	s.mcpHandler = newEmbeddedMCPHandler(embeddedMCPConfig{
 		AgentName: cfg.Agent.Name, AgentVersion: cfg.Agent.Version, Runner: runner,
 		Resolve: func(ctx context.Context, request *http.Request) (any, error) {
 			return cfg.Resolver.ResolveSession(ctx, request)
 		},
-		Tools: func(ctx context.Context, session any) ([]apiserver.ToolDescriptor, error) {
-			descriptors, err := cfg.Tools.Tools(ctx, session)
-			if err != nil {
-				return nil, err
-			}
-			result := make([]apiserver.ToolDescriptor, len(descriptors))
-			for i, descriptor := range descriptors {
-				result[i] = apiserver.ToolDescriptor(descriptor)
-			}
-			return result, nil
+		Tools: func(ctx context.Context, session any) ([]ToolDescriptor, error) {
+			return cfg.Tools.Tools(ctx, session)
 		},
 		Invoke: func(ctx context.Context, session any, name string, arguments json.RawMessage) (json.RawMessage, error) {
 			result, err := cfg.Invoker.Invoke(ctx, session, Invocation{Name: name, Arguments: arguments})
 			return result.Value, err
 		},
 	})
-	s.a2aHandler = apiserver.NewEmbeddedA2AHandler(apiserver.EmbeddedA2AConfig{
+	s.a2aHandler = newEmbeddedA2AHandler(embeddedA2AConfig{
 		AgentName: cfg.Agent.Name, AgentDescription: cfg.Agent.Description, AgentVersion: cfg.Agent.Version,
 		Runner: runner,
 		Resolve: func(ctx context.Context, request *http.Request) (any, error) {
 			return cfg.Resolver.ResolveSession(ctx, request)
 		},
-		Tools: func(ctx context.Context, session any) ([]apiserver.ToolDescriptor, error) {
-			descriptors, err := cfg.Tools.Tools(ctx, session)
-			if err != nil {
-				return nil, err
-			}
-			result := make([]apiserver.ToolDescriptor, len(descriptors))
-			for i, descriptor := range descriptors {
-				result[i] = apiserver.ToolDescriptor(descriptor)
-			}
-			return result, nil
+		Tools: func(ctx context.Context, session any) ([]ToolDescriptor, error) {
+			return cfg.Tools.Tools(ctx, session)
 		},
 		Invoke: func(ctx context.Context, session any, name string, arguments json.RawMessage) (json.RawMessage, error) {
 			result, err := cfg.Invoker.Invoke(ctx, session, Invocation{Name: name, Arguments: arguments})

--- a/serveapi/serveapi_external_test.go
+++ b/serveapi/serveapi_external_test.go
@@ -13,8 +13,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/sunholo-data/ailang/internal/apiserver"
 )
 
 type fixtureHost struct{}
@@ -65,7 +63,7 @@ func TestNewValidationAndEffectiveDefaultDeadline(t *testing.T) {
 		t.Fatal(err)
 	}
 	now := time.Now()
-	deadline, err := apiserver.RunCallback(context.Background(), server.runner, func(ctx context.Context) (time.Time, error) {
+	deadline, err := runCallback(context.Background(), server.runner, func(ctx context.Context) (time.Time, error) {
 		deadline, ok := ctx.Deadline()
 		if !ok {
 			t.Fatal("callback context has no deadline")
@@ -78,7 +76,7 @@ func TestNewValidationAndEffectiveDefaultDeadline(t *testing.T) {
 	if deadline.Before(now.Add(4*time.Second)) || deadline.After(now.Add(6*time.Second)) {
 		t.Fatalf("default deadline %v outside observed window from %v", deadline, now)
 	}
-	value, err := apiserver.RunCallback(context.Background(), server.runner, func(context.Context) (int, error) { return 137, nil })
+	value, err := runCallback(context.Background(), server.runner, func(context.Context) (int, error) { return 137, nil })
 	if err != nil || value != 137 {
 		t.Fatalf("fast callback = (%d, %v)", value, err)
 	}


### PR DESCRIPTION
M2 of the protocol-only serveapi module (refs #764). M1 landed in #848.

Moves the embedded machinery out of `internal/apiserver` into `serveapi`, unexports it,
turns the moved types into aliases, and deletes the M1 transitional shims.

## Measured outside the sandbox, base -> after

| gate | base | after | target |
|---|---|---|---|
| non-stdlib deps of `./serveapi` | 480 | **31** | <=40 (plan predicted 31) |
| module roots of `./serveapi` | 67 | **10** | exactly the 10 of design doc 4.3 |
| `serveapi` imports `internal/apiserver` | 1 | **0** (rc=1) | 0 — control `./cmd/ailang` = 2, rc=0 |
| `TRANSITIONAL` in `protocol_compat.go` | 16 | **0** | 0 — control `protocol.` = 5, still forwards |
| `go build` / `go test` / `go vet` (scoped) | rc=0 | **rc=0**, 4/4 pkgs ok | rc=0 |
| `golangci-lint` (scoped) | rc=0 | **rc=0**, 0 issues | rc=0 |

Base values were measured first-party on a pristine tree before routing; the sprint plan's own
base column predates M1 and is stale by one on the dep count.

## Deviation from plan M2.4 — self-reported, adjudicated by measurement

Three test funcs stay in `internal/apiserver`, not the one the plan named. The two extra
(`TestLoadedNoMCPRemainsInStandaloneA2ACard`, `TestStandaloneMCPFeedbackCompatibilityBothDirections`)
exercise the **standalone** server through unexported identifiers (`nomcpTestServer`,
`srv.buildAgentCard`, `Config`, `feedbackSurfaceServer`) defined in apiserver-only test files that
were never scheduled to move.

Two-arm check: tree as delivered `go vet` rc=0; with one of them moved into `serveapi`, rc=1
`undefined: nomcpTestServer`. Moving them would force new exported symbols, which M2.2 forbids
("net new public symbols in serveapi: zero"). Their bodies are byte-identical to the parent commit.

The plan's own arithmetic was inconsistent — it says "the other 9 test funcs move" where the file
holds 9 in total. All 9 funcs + 4 helpers are accounted for: 6 funcs + 4 helpers moved, 3 stayed.

## AC6 oracle

`git diff --numstat` reads 2+/4- against a "<=3 changed lines" oracle. The 4th line is the blank
import-group separator gofmt removes once the last import in the group goes; running gofmt on
(parent minus that import) reproduces the file byte-for-byte. No assertion changed.

## Independent evaluation

Sonnet evaluator (distinct provider from the codex executor — generator != judge), in its own
clean worktree: **PASS 95/100, zero blocking**. It re-derived all 8 gate-table rows first-party
and ran adversarial mutation drills. Two mutants survived and are recorded as follow-ups, both
verified **pre-existing** (byte-identical copies of the pre-move code, not introduced here):
the card-path error-envelope JSON key in `a2a_handler.go`, and `IsError` on the moved `mcpError`
in `mcp_handler.go`.

Platform: gates run on darwin/arm64; the windows and ubuntu CI legs are unrun locally.

Co-Authored-By: codex gpt-5.6-sol

🤖 Generated with [Claude Code](https://claude.com/claude-code)
