### PR TITLE
feat(ci): protocol build-closure refusal gate + 5-arm self-test (M3, refs #764)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,12 @@ jobs:
     - name: Check architecture boundaries
       run: make check-boundaries
 
+    - name: Check protocol build closure
+      run: make check-protocol-closure
+
+    - name: Protocol build closure gate self-test
+      run: make test-check-protocol-closure
+
     - name: Check changelog index hygiene
       run: make check-changelog
 

--- a/make/code-health.mk
+++ b/make/code-health.mk
@@ -139,6 +139,9 @@ check-file-sizes: ## Check for files >800 lines (CI gate)
 check-boundaries: ## Check architecture layer boundaries (CI gate)
 	@bash scripts/check_boundaries.sh
 
+check-protocol-closure: ## Check serveapi protocol/facade build closures (CI gate)
+	@/bin/bash scripts/check_protocol_closure.sh
+
 check-changelog: ## Check root CHANGELOG.md stays an index, not a changelog (CI gate)
 	@bash scripts/check_changelog.sh
 

--- a/make/test.mk
+++ b/make/test.mk
@@ -7,7 +7,7 @@
 .PHONY: test-operator-assertions test-regression-guards test-builtin-consistency
 .PHONY: test-stdlib-canaries test-row-properties test-golden-types test-repl-smoke
 .PHONY: test-sim-stub test-stdlib-freeze verify-no-shim verify-lowering
-.PHONY: test-nightly-classifier test-launchd-drivers test-check-changelog test-check-autoclose
+.PHONY: test-nightly-classifier test-launchd-drivers test-check-changelog test-check-protocol-closure test-check-autoclose
 
 # Core tests. Depends on build so integration tests that shell out to the
 # ailang binary never see a stale bin/ailang — a stale binary caused phantom
@@ -58,6 +58,10 @@ test-launchd-drivers: ## Run launchd driver tests (pin-root + routing + notices 
 test-check-changelog: ## Run the changelog-index gate's own self-test (bash 3.2)
 	@/bin/bash scripts/test_check_changelog.sh
 	@/bin/bash -n scripts/check_changelog.sh
+
+test-check-protocol-closure: ## Run the protocol-closure gate's own self-test (bash 3.2)
+	@/bin/bash scripts/test_check_protocol_closure.sh
+	@/bin/bash -n scripts/check_protocol_closure.sh
 
 test-check-autoclose: ## Run the issue-autoclose gate's own self-test (bash 3.2)
 	@/bin/bash scripts/test_check_autoclose.sh

--- a/scripts/check_protocol_closure.sh
+++ b/scripts/check_protocol_closure.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Guard the BUILD closure of the public serveapi packages.
+#
+# This deliberately measures what a consumer LINKS. Test-only imports are out of
+# scope by design: they are not part of a consumer's build closure.
+set -uo pipefail
+
+PROTOCOL_PACKAGE="${1:-./serveapi/protocol}"
+SERVEAPI_PACKAGE="${2:-./serveapi}"
+PROTOCOL_SELF="github.com/sunholo-data/ailang/serveapi/protocol"
+SERVEAPI_SELF="github.com/sunholo-data/ailang/serveapi"
+GO_BIN="${GO_BIN:-go}"
+RED='\033[0;31m'; GREEN='\033[0;32m'; RESET='\033[0m'
+
+vacuous() {
+	printf "%b✗ vacuous enumeration (%s): %s%b\n" "$RED" "$1" "$2" "$RESET"
+}
+
+# R9: This function is intentionally separate. The dot-rule says a package is
+# non-stdlib exactly when its first path segment contains a dot.
+is_nonstdlib() {
+	_first=${1%%/*}
+	case "$_first" in
+		*.*) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+list_deps() {
+	_ld_package="$1"
+	_ld_output="$2"
+	_ld_error="$3"
+	"$GO_BIN" list -deps "$_ld_package" >"$_ld_output" 2>"$_ld_error"
+}
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PROTOCOL_DEPS="$TMP_DIR/protocol.deps"
+PROTOCOL_ERR="$TMP_DIR/protocol.err"
+list_deps "$PROTOCOL_PACKAGE" "$PROTOCOL_DEPS" "$PROTOCOL_ERR"
+PROTOCOL_RC=$?
+# R1
+if [ "$PROTOCOL_RC" -ne 0 ]; then
+	vacuous "protocol R1" "go list failed for $PROTOCOL_PACKAGE (rc=$PROTOCOL_RC)"
+	sed 's/^/    /' "$PROTOCOL_ERR"
+	exit 2
+fi
+# R2
+if [ ! -s "$PROTOCOL_DEPS" ]; then
+	vacuous "protocol R2" "dependency enumeration is empty"
+	exit 2
+fi
+# R3
+if ! grep -qxF "$PROTOCOL_SELF" "$PROTOCOL_DEPS"; then
+	vacuous "protocol R3" "known-positive $PROTOCOL_SELF is absent"
+	exit 2
+fi
+
+PROTOCOL_STDLIB=0
+PROTOCOL_NONSTDLIB=0
+PROTOCOL_VIOLATORS="$TMP_DIR/protocol.violators"
+: >"$PROTOCOL_VIOLATORS"
+while IFS= read -r _package; do
+	if is_nonstdlib "$_package"; then
+		PROTOCOL_NONSTDLIB=$((PROTOCOL_NONSTDLIB + 1))
+		# R5
+		case "$_package" in
+			"$PROTOCOL_SELF"*) ;;
+			*) printf '%s\n' "$_package" >>"$PROTOCOL_VIOLATORS" ;;
+		esac
+	else
+		PROTOCOL_STDLIB=$((PROTOCOL_STDLIB + 1))
+	fi
+done <"$PROTOCOL_DEPS"
+
+printf 'protocol non-stdlib count: %s\n' "$PROTOCOL_NONSTDLIB"
+# R4
+if [ "$PROTOCOL_STDLIB" -eq 0 ]; then
+	vacuous "protocol R4" "no stdlib package was enumerated"
+	exit 2
+fi
+if [ -s "$PROTOCOL_VIOLATORS" ]; then
+	printf "%b✗ protocol closure contains non-stdlib packages outside %s:%b\n" "$RED" "$PROTOCOL_SELF" "$RESET"
+	sed 's/^/    /' "$PROTOCOL_VIOLATORS"
+	exit 1
+fi
+
+SERVEAPI_DEPS="$TMP_DIR/serveapi.deps"
+SERVEAPI_ERR="$TMP_DIR/serveapi.err"
+list_deps "$SERVEAPI_PACKAGE" "$SERVEAPI_DEPS" "$SERVEAPI_ERR"
+SERVEAPI_RC=$?
+# R6
+if [ "$SERVEAPI_RC" -ne 0 ] || [ ! -s "$SERVEAPI_DEPS" ]; then
+	vacuous "serveapi R6" "go list failed or dependency enumeration is empty for $SERVEAPI_PACKAGE (rc=$SERVEAPI_RC)"
+	sed 's/^/    /' "$SERVEAPI_ERR"
+	exit 2
+fi
+# R7
+if ! grep -qxF "$SERVEAPI_SELF" "$SERVEAPI_DEPS"; then
+	vacuous "serveapi R7" "known-positive $SERVEAPI_SELF is absent"
+	exit 2
+fi
+
+SERVEAPI_ROOTS="$TMP_DIR/serveapi.roots"
+SERVEAPI_VIOLATORS="$TMP_DIR/serveapi.violators"
+"$GO_BIN" list -deps -f '{{if not .Standard}}{{with .Module}}{{.Path}}{{end}}{{end}}' "$SERVEAPI_PACKAGE" \
+	| sed '/^$/d' | sort -u >"$SERVEAPI_ROOTS"
+: >"$SERVEAPI_VIOLATORS"
+while IFS= read -r _root; do
+	# R8
+	case "$_root" in
+		github.com/sunholo-data/ailang|\
+		github.com/google/jsonschema-go|\
+		github.com/modelcontextprotocol/go-sdk|\
+		github.com/segmentio/asm|\
+		github.com/segmentio/encoding|\
+		github.com/yosida95/uritemplate/v3|\
+		golang.org/x/oauth2|\
+		golang.org/x/sync|\
+		golang.org/x/sys|\
+		golang.org/x/time) ;;
+		*) printf '%s\n' "$_root" >>"$SERVEAPI_VIOLATORS" ;;
+	esac
+done <"$SERVEAPI_ROOTS"
+
+if [ -s "$SERVEAPI_VIOLATORS" ]; then
+	printf "%b✗ serveapi closure contains disallowed module roots:%b\n" "$RED" "$RESET"
+	sed 's/^/    /' "$SERVEAPI_VIOLATORS"
+	exit 1
+fi
+
+printf "%b✓ protocol build closure is stdlib-only (%s non-stdlib package); serveapi module roots are allowed%b\n" \
+	"$GREEN" "$PROTOCOL_NONSTDLIB" "$RESET"

--- a/scripts/test_check_protocol_closure.sh
+++ b/scripts/test_check_protocol_closure.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Mutation-sensitive self-test for check_protocol_closure.sh (bash 3.2).
+set -u
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+GATE="$REPO_ROOT/scripts/check_protocol_closure.sh"
+PROTOCOL_INTRUDER="$REPO_ROOT/serveapi/protocol/zz_intruder.go"
+TEST_INTRUDER="$REPO_ROOT/serveapi/protocol/zz_intruder_test.go"
+SERVEAPI_INTRUDER="$REPO_ROOT/serveapi/zz_intruder.go"
+FAILED=0
+ARMS_RUN=0
+ARMS_EXPECTED=5
+OUT=""; RC=0
+
+pass() { echo "  ok   — $1"; ARMS_RUN=$((ARMS_RUN + 1)); }
+fail() { echo "  FAIL — $1"; FAILED=1; ARMS_RUN=$((ARMS_RUN + 1)); }
+die() { echo "  FAIL — $1"; cleanup; exit 1; }
+
+BEFORE_STATUS=$(cd "$REPO_ROOT" && git status --porcelain)
+cleanup() {
+	rm -f "$PROTOCOL_INTRUDER" "$TEST_INTRUDER" "$SERVEAPI_INTRUDER"
+}
+trap cleanup EXIT HUP INT TERM
+
+assert_restored() {
+	_now=$(cd "$REPO_ROOT" && git status --porcelain)
+	[ "$_now" = "$BEFORE_STATUS" ] || die "$1 cleanup did not restore byte-identical git status"
+}
+
+run_gate() {
+	OUT=$(cd "$REPO_ROOT" && /bin/bash "$GATE" "$@" 2>&1)
+	RC=$?
+}
+
+extract_count() {
+	printf '%s\n' "$1" | sed -n 's/^protocol non-stdlib count: \([0-9][0-9]*\)$/\1/p' | tail -1
+}
+
+echo "protocol closure gate:"
+[ -f "$GATE" ] || die "$GATE not found; refusing a vacuous green"
+[ ! -e "$PROTOCOL_INTRUDER" ] || die "$PROTOCOL_INTRUDER already exists"
+[ ! -e "$TEST_INTRUDER" ] || die "$TEST_INTRUDER already exists"
+[ ! -e "$SERVEAPI_INTRUDER" ] || die "$SERVEAPI_INTRUDER already exists"
+
+# Clean control and baseline count used by arm (i).
+run_gate
+CLEAN_OUT="$OUT"; CLEAN_RC=$RC; CLEAN_COUNT=$(extract_count "$OUT")
+if [ "$CLEAN_RC" -ne 0 ] || [ -z "$CLEAN_COUNT" ]; then
+	die "clean control failed (rc=$CLEAN_RC, count=${CLEAN_COUNT:-missing}): $CLEAN_OUT"
+fi
+
+# (i) Addition: a real non-test import must be seen, named, and move 1 -> 2.
+printf '%s\n' 'package protocol' '' 'import _ "github.com/google/uuid"' >"$PROTOCOL_INTRUDER"
+[ -s "$PROTOCOL_INTRUDER" ] || die "intruder arm setup did not land"
+grep -qF 'github.com/google/uuid' "$PROTOCOL_INTRUDER" || die "intruder arm setup lacks uuid"
+run_gate
+INTRUDER_COUNT=$(extract_count "$OUT")
+if [ "$RC" -ne 1 ]; then
+	fail "intruder arm expected rc=1, got rc=$RC: $OUT"
+elif ! printf '%s\n' "$OUT" | grep -qF 'github.com/google/uuid'; then
+	fail "intruder arm did not name github.com/google/uuid: $OUT"
+elif ! printf '%s\n' "$OUT" | grep -qF 'protocol closure contains non-stdlib packages'; then
+	fail "intruder arm was refused by the wrong branch: $OUT"
+elif [ "$CLEAN_COUNT" -ne 1 ] || [ "$INTRUDER_COUNT" -ne 2 ]; then
+	fail "intruder arm count did not move 1 -> 2 (observed $CLEAN_COUNT -> ${INTRUDER_COUNT:-missing})"
+else
+	pass "intruder named github.com/google/uuid; non-stdlib count moved $CLEAN_COUNT -> $INTRUDER_COUNT"
+fi
+rm -f "$PROTOCOL_INTRUDER"; assert_restored "intruder arm"
+
+# (ii) Vacuity: probe each independently-neuterable floor branch.
+VACUITY_FAILURE=""
+run_gate ./definitely/not/a/package
+[ "$RC" -eq 2 ] && printf '%s' "$OUT" | grep -qF 'vacuous enumeration (protocol R1)' || VACUITY_FAILURE="R1 probe: rc=$RC output=$OUT"
+printf '%s' "$OUT" | grep -q '✓' && VACUITY_FAILURE="R1 probe printed a checkmark: $OUT"
+
+FAKE_DIR=$(mktemp -d)
+printf '%s\n' '#!/bin/sh' 'exit 0' >"$FAKE_DIR/go"; chmod +x "$FAKE_DIR/go"
+OUT=$(cd "$REPO_ROOT" && GO_BIN="$FAKE_DIR/go" /bin/bash "$GATE" 2>&1); RC=$?
+[ "$RC" -eq 2 ] && printf '%s' "$OUT" | grep -qF 'vacuous enumeration (protocol R2)' || VACUITY_FAILURE="R2 probe: rc=$RC output=$OUT"
+rm -rf "$FAKE_DIR"
+
+run_gate ./cmd/astdump
+[ "$RC" -eq 2 ] && printf '%s' "$OUT" | grep -qF 'vacuous enumeration (protocol R3)' || VACUITY_FAILURE="R3 probe: rc=$RC output=$OUT"
+
+FAKE_DIR=$(mktemp -d)
+printf '%s\n' '#!/bin/sh' 'printf "%s\n" github.com/sunholo-data/ailang/serveapi/protocol' >"$FAKE_DIR/go"; chmod +x "$FAKE_DIR/go"
+OUT=$(cd "$REPO_ROOT" && GO_BIN="$FAKE_DIR/go" /bin/bash "$GATE" 2>&1); RC=$?
+[ "$RC" -eq 2 ] && printf '%s' "$OUT" | grep -qF 'vacuous enumeration (protocol R4)' || VACUITY_FAILURE="R4 probe: rc=$RC output=$OUT"
+rm -rf "$FAKE_DIR"
+
+run_gate ./serveapi/protocol ./definitely/not/a/package
+[ "$RC" -eq 2 ] && printf '%s' "$OUT" | grep -qF 'vacuous enumeration (serveapi R6)' || VACUITY_FAILURE="R6 probe: rc=$RC output=$OUT"
+
+run_gate ./serveapi/protocol ./cmd/astdump
+[ "$RC" -eq 2 ] && printf '%s' "$OUT" | grep -qF 'vacuous enumeration (serveapi R7)' || VACUITY_FAILURE="R7 probe: rc=$RC output=$OUT"
+
+if [ -n "$VACUITY_FAILURE" ]; then fail "vacuity arm — $VACUITY_FAILURE"; else pass "vacuity probes R1/R2/R3/R4/R6/R7 refuse with rc=2 and no checkmark"; fi
+
+# (iii) Restoration.
+run_gate
+if [ "$RC" -eq 0 ]; then pass "restoration arm clean gate passes"; else fail "restoration arm rc=$RC: $OUT"; fi
+
+# (iv) Scope: test-only imports deliberately do not enter a consumer's link closure.
+printf '%s\n' 'package protocol' '' 'import _ "github.com/google/uuid"' >"$TEST_INTRUDER"
+[ -s "$TEST_INTRUDER" ] || die "scope arm setup did not land"
+run_gate
+if [ "$RC" -eq 0 ]; then
+	pass "scope arm stays green: build closure models consumer links; test-only imports are never linked by a consumer"
+else
+	fail "scope arm expected rc=0, got rc=$RC: $OUT"
+fi
+rm -f "$TEST_INTRUDER"; assert_restored "scope arm"
+
+# (v) Serveapi addition: uuid is outside the ten-root facade allowlist.
+printf '%s\n' 'package serveapi' '' 'import _ "github.com/google/uuid"' >"$SERVEAPI_INTRUDER"
+[ -s "$SERVEAPI_INTRUDER" ] || die "serveapi arm setup did not land"
+run_gate
+if [ "$RC" -ne 1 ]; then
+	fail "serveapi arm expected rc=1, got rc=$RC: $OUT"
+elif ! printf '%s\n' "$OUT" | grep -qF 'github.com/google/uuid'; then
+	fail "serveapi arm did not name github.com/google/uuid: $OUT"
+else
+	pass "serveapi arm named disallowed root github.com/google/uuid"
+fi
+rm -f "$SERVEAPI_INTRUDER"; assert_restored "serveapi arm"
+
+if [ "$ARMS_RUN" -ne "$ARMS_EXPECTED" ]; then
+	echo "  FAIL — $ARMS_RUN of $ARMS_EXPECTED arms ran; refusing a vacuous green"
+	FAILED=1
+fi
+if [ "$FAILED" -eq 0 ]; then echo "protocol closure gate: OK ($ARMS_RUN arms)"; exit 0; fi
+echo "protocol closure gate: FAILED"
+exit 1


### PR DESCRIPTION
## M3 — the protocol build-closure refusal gate

Milestone M3 of `design_docs/planned/m-serveapi-protocol-only-module-sprint-plan.md` (refs #764). M1 (`#848`) and M2 (`#855`) are already on dev; M4 (docs, lint scope, CHANGELOG) remains, so this does **not** complete the issue.

**This milestone's deliverable is a REFUSAL**, so it is only done if something goes red when each refusal branch is removed — and if an *added* member is detected, not merely a removed one.

### The gate

`scripts/check_protocol_closure.sh`, two arms over the build closure:

| arm | assertion | measured at this tree |
|---|---|---|
| 1 · `./serveapi/protocol` | stdlib-only apart from the package itself | 188 deps = 187 stdlib + 1 self |
| 2 · `./serveapi` | external module roots ⊆ 10-entry inline allowlist | exactly the 10, re-measured at HEAD **after** M2 landed |

Nine labelled refusal branches. R1–R4 / R6–R7 are the anti-vacuity floor (`go list` rc, empty enumeration, missing known-positive self literal, no stdlib package present) → **exit 2, "vacuous enumeration", never a checkmark**. R5 / R8 are the substantive refusals → **exit 1, violators printed by name**. R9 is the stdlib dot-rule classifier, deliberately a separate function so it can be neutered independently.

### Self-test — five arms

`scripts/test_check_protocol_closure.sh`: intruder/**addition** arm (asserts the non-stdlib count *moves* 1→2 — a verdict flip alone does not pass), vacuity arm, restoration arm, scope arm, serveapi-arm addition.

### Deliberate scope

Stated in the script header: the gate measures the **build** closure — what a consumer *links*. Test-only imports are out of scope by design, and self-test arm (iv) pins that so it reads as a decision rather than an oversight.

### Mutation drill

All nine branches plus the design doc's Mutation 2 and Mutation 3 were neutered; **every one produced an observed self-test red**, each asserted LANDED by sha256 and asserted still-parsing under `bash -n`, so a syntax error could not masquerade as a guard firing. The controller independently reproduced the R5 mutation outside the executor's sandbox and restored byte-identical.

Known and **declared** limitation: the ci.yml wiring hunk has no test killer — the design doc's mutation row 6 already records that the wiring is guarded by AC5's grep rather than by a test, which is why AC5 is a criterion and not prose.

### Gates (controller-run, outside any sandbox, on darwin/arm64; the ubuntu and windows legs are unrun locally)

| command | rc |
|---|---|
| `make check-protocol-closure` | 0 |
| `make test-check-protocol-closure` | 0 (5 arms) |
| `grep -c check-protocol-closure .github/workflows/ci.yml` | 2 (≥2 required; base 0) |
| `/bin/bash -n` on both scripts | 0 |
| `make check-boundaries` | 0 |
| `go build` / `go test -count=1` / `go vet` on `./serveapi/... ./internal/apiserver/...` | 0 |

bash-3.2-safe — the rig runs 3.2.57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
