### PR TITLE
docs(serveapi): M4 — guide, rules, ARCHITECTURE, lint scope, CHANGELOG (refs #764)

### DIFF
--- a/.claude/rules/api-server.md
+++ b/.claude/rules/api-server.md
@@ -31,8 +31,11 @@ The parser has a hardcoded switch on annotation names. If a new annotation isn't
 
 One authorized-surface gateway decides membership for every endpoint enumeration
 and dispatch path. Loaded exports use `loadedExportMember`; embedded callbacks use
-`callerSurface` and the resulting `AuthorizedSurface`. Discovery and invocation
-must consume the same authorized surface rather than reconstructing authority.
+`protocol.CallerSurface` and the resulting `protocol.AuthorizedSurface`, defined
+in `serveapi/protocol/descriptor.go`. `loadedExportMember` remains the
+loaded-export gateway in `internal/apiserver`; `CallerSurface` remains the
+embedded-callback membership path. Discovery and invocation must consume the
+same authorized surface rather than reconstructing authority.
 
 `@nomcp` is the single sanctioned protocol-scoped narrowing: it is applied by the
 MCP projection only, after membership has been decided. It must remain visible to
@@ -52,4 +55,8 @@ All MCP tool names must satisfy `^[a-zA-Z0-9_-]{1,64}$` (Claude Desktop strict r
 3. `<lastModuleSegment>_<funcName>` sanitized fallback for collisions.
 4. `truncateWithHash` enforces the 64-char limit by appending a 7-char SHA1 suffix.
 
-`validateMCPName()` is the regex gatekeeper — every emitted name passes through it. When adding a new tool name source, route it through `mcpToolName` (do not handcraft names).
+`protocol.ValidateMCPName()` in `serveapi/protocol/descriptor.go` is the regex
+gatekeeper; `internal/apiserver/protocol_compat.go::validateMCPName()` is only a
+thin forwarding shim. Every emitted name passes through that validation. When
+adding a new tool name source, route generation through `mcpToolName` (do not
+handcraft names).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -38,6 +38,8 @@ row-polymorphic records and effects, and a curated standard library.
 | `cmd/ailang/` | Main CLI entry point; subcommand dispatch. |
 | `cmd/ailang-microrag-mcp/` | MCP server exposing AILANG docs/builtins as tools. |
 | `internal/` | All compiler and runtime code (see below). |
+| `serveapi/` | Public ready-made MCP/A2A embedding handlers and callback machinery. |
+| `serveapi/protocol/` | Public stdlib-only embedding contract: descriptors, host interfaces, wire types, framing, and validation. |
 | `stdlib/` | AILANG-language standard library (`std/io`, `std/list`, etc.). |
 | `examples/` | Runnable `.ail` programs grouped by feature. |
 | `prompts/` | Teaching prompts loaded by `ailang prompt`. |
@@ -106,6 +108,11 @@ scope to, and so contributors and AI agents know which subsystem they are in.
 | **bridge / sdk** | `internal/embed` (+ `internal/runtime`, `internal/schema`) |
 
 ### Enforced import directions
+
+The public embedding packages have a one-way boundary: `serveapi` may import
+`serveapi/protocol`, but `serveapi/protocol` must never import `serveapi`. The
+protocol package's standard-library-only closure and this direction are enforced
+by `make check-protocol-closure`.
 
 The **bridge** (`internal/embed`) is the *only* sanctioned path from the
 dashboard into the compiler. `internal/embed` exposes an `Engine` that loads

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -18,7 +18,7 @@ The ready-made `serveapi` facade remains source-compatible through type aliases
 and has 224 packages total, 31 non-stdlib packages, and nine external SDK module
 roots (plus the AILANG module itself), all pinned by the same closure gate. For
 contrast, importing the old pre-extraction seam pulled 479 non-stdlib packages,
-including 304 cloud or telemetry packages. The sole observable alias consequence
+including 325 cloud, telemetry, GCP or model-host packages under the design doc's V22 pattern (issue #764 reports 304 under its own narrower enumeration of the same closure). The sole observable alias consequence
 is that `reflect.Type.PkgPath()` for moved types now reports
 `github.com/sunholo-data/ailang/serveapi/protocol` rather than
 `github.com/sunholo-data/ailang/serveapi`.

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,25 @@
 
 ## [Unreleased]
 
+### Added — stdlib-only public serve-api protocol contract (`refs #764`)
+
+Embedders can now import `github.com/sunholo-data/ailang/serveapi/protocol` for
+the descriptor and authorization surface, host interfaces, A2A wire types and
+writers, MCP envelope framing and request IDs, and wire-error taxonomy without
+linking the ready-made handlers. At this merge point its build closure is 188
+packages total and exactly one non-stdlib package: the protocol package itself.
+`make check-protocol-closure`, wired into CI, enforces that standard-library-only
+contract.
+
+The ready-made `serveapi` facade remains source-compatible through type aliases
+and has 224 packages total, 31 non-stdlib packages, and nine external SDK module
+roots (plus the AILANG module itself), all pinned by the same closure gate. For
+contrast, importing the old pre-extraction seam pulled 479 non-stdlib packages,
+including 304 cloud or telemetry packages. The sole observable alias consequence
+is that `reflect.Type.PkgPath()` for moved types now reports
+`github.com/sunholo-data/ailang/serveapi/protocol` rather than
+`github.com/sunholo-data/ailang/serveapi`.
+
 ### Fixed — a HELD driver pin no longer hides an ever-staler source clone
 
 `tools/launchd/lib/pin-root.sh` re-execs each launchd mission driver out of a worktree pinned to

--- a/docs/docs/guides/serve-api.md
+++ b/docs/docs/guides/serve-api.md
@@ -1373,6 +1373,18 @@ log.Fatal(server.ListenAndServe())
 `Mount` registers `/mcp/`, `/.well-known/agent.json`, and `/a2a/`. A host that
 needs different paths can mount `MCPHandler()` and `A2AHandler()` itself.
 
+Hosts that need the shared wire contract but provide their own handlers can
+instead import `github.com/sunholo-data/ailang/serveapi/protocol`. That package
+contains descriptor types and validation, `CallerSurface`/`AuthorizedSurface`,
+host interfaces, A2A wire types and writers, MCP envelope framing and
+`RequestID`, and the wire-error taxonomy. Its build closure is standard-library
+only; `make check-protocol-closure` measures and enforces that guarantee in CI.
+
+The split is contract versus machinery: `serveapi/protocol` does not provide
+HTTP handlers or callback bounding. Import `serveapi` for the ready-made MCP and
+A2A handlers and bounded callback runner; its MCP handler brings the MCP SDK
+dependency subtree.
+
 ### Ownership boundary
 
 The host owns authentication, session identity, authorization policy, callback

--- a/make/code-health.mk
+++ b/make/code-health.mk
@@ -68,7 +68,7 @@ install-lint: ## Install/upgrade golangci-lint (auto-reinstalls when its build-G
 lint: prepare-embed ## Run linter (bug detectors only)
 	@echo "Running linter..."
 	@which golangci-lint > /dev/null || (echo "golangci-lint not found. Run 'make install-lint'" && exit 1)
-	@golangci-lint run ./cmd/... ./internal/... ./testutil/... > /tmp/lint.raw 2>&1; \
+	@golangci-lint run ./cmd/... ./internal/... ./serveapi/... ./testutil/... > /tmp/lint.raw 2>&1; \
 		LINT_RC=$$?; \
 		if grep -qE "can't load config|the Go language version" /tmp/lint.raw; then \
 			echo "$(RED)$(CROSS) golangci-lint config/toolchain error — run 'make install-lint':$(RESET)"; \
@@ -86,7 +86,7 @@ lint: prepare-embed ## Run linter (bug detectors only)
 			grep -v "^\t" | \
 			grep -v "^[[:space:]]*\^" | \
 			tee /tmp/lint.out; \
-		if grep -qE "^(internal|cmd|testutil)" /tmp/lint.out; then \
+		if grep -qE "^(internal|cmd|serveapi|testutil)" /tmp/lint.out; then \
 			echo "$(RED)$(CROSS) Lint errors found$(RESET)"; \
 			exit 1; \
 		fi; \


### PR DESCRIPTION
Final milestone (M4) of the protocol-only `serveapi` module sprint — `refs #764`.
M1 `d54672b85`, M2 `4a813b2c0`, M3 `ba2eeb4b4` are already on dev.

## What lands
- **`docs/docs/guides/serve-api.md`** — `serveapi/protocol` as the contract-only import, its stdlib-only closure, and the contract-vs-machinery split.
- **`.claude/rules/api-server.md`** — `CallerSurface`/`AuthorizedSurface`/`ValidateMCPName` now point at `serveapi/protocol/descriptor.go`; `internal/apiserver`'s `validateMCPName` documented as a thin forwarding shim. One-gateway invariant restated.
- **`ARCHITECTURE.md`** — first-ever `serveapi` entry plus the enforced one-way direction `serveapi → serveapi/protocol`.
- **`changelogs/v0.18-current.md`** — closure numbers measured at the merge base, alias back-compat, and the one observable change (`reflect.Type.PkgPath()` on moved types).
- **`make/code-health.mk`** — `./serveapi/...` added to `make lint`.

## Plan correction: M4.3 was under-specified, and its AC was vacuous as written
The plan asked only for `./serveapi/...` in the golangci-lint **scan** list. The `lint` target computes its verdict from a **second** path list — the `grep -qE "^(internal|cmd|testutil)"` alternation — so widening the scan alone lets golangci-lint *look* at `serveapi/` while the gate remains unable to *refuse* anything found there. Both lines are changed here.

Proven by a three-arm drill against a real `govet printf` defect injected into `serveapi/serveapi.go` (mutant asserted LANDED and BUILDS):

| arm | `make lint` |
|---|---|
| both hunks (as delivered) | **rc=2 — refuses** |
| scan hunk reverted, predicate kept | rc=0 — vacuous |
| predicate reverted, scan kept | rc=0 — vacuous |

Neither hunk alone suffices. Both files restored byte-identically (sha256), zero probe residue.

## Measured closure at the merge base
- `serveapi/protocol`: **188** packages total, **exactly 1** non-stdlib (itself) — the stdlib-only guarantee holds.
- `serveapi`: **224** total, **31** non-stdlib, **9** external module roots + the ailang module = the plan's 10-entry allowlist.
- For contrast, the pre-extraction seam pulled **479** non-stdlib packages, 304 cloud/telemetry.

## Gates — all re-run by the controller outside any sandbox
`make lint`, `make check-boundaries`, `make check-file-sizes`, `make check-protocol-closure`, `make test-check-protocol-closure`, scoped `go build`, `go vet` — all rc=0.
`make test` rc=0, **114 ok packages, 0 FAIL**, identical to the measured pristine base.
(`go build ./...` is deliberately not a gate — rc=1 on untouched dev.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
