### PR TITLE
fix(lint): make lint filtered `unused` findings out of its own verdict

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,14 @@
 
 ## [Unreleased]
 
+### Fixed — lint no longer hides unused code
+
+`make lint` filtered `unused` findings before its failure predicate, so a dead
+function anywhere under `cmd/`, `internal/`, `serveapi/`, or `testutil/` left
+the gate printing a green checkmark at rc=0. The filter is removed, and the two
+live findings it hid—`geminiPassThreshold` and `getArrayElementType`—are
+resolved.
+
 ### Added — stdlib-only public serve-api protocol contract (`refs #764`)
 
 Embedders can now import `github.com/sunholo-data/ailang/serveapi/protocol` for

--- a/internal/eval_harness/gemini_evaluator_bridge.go
+++ b/internal/eval_harness/gemini_evaluator_bridge.go
@@ -447,11 +447,6 @@ func ensureTrailingNL(s string) string {
 // M2 — Reasoning-only evaluator directive + structured verdict parse/validate
 // ============================================================================
 
-// geminiPassThreshold is the sprint-evaluator convention: pass requires
-// score >= 70 (and no blockers). Matches the sprint-evaluator skill's
-// pass_threshold.
-const geminiPassThreshold = 70
-
 // evaluatorReasoningInstruction is the compile-time reasoning-only directive
 // prelude, mirroring managedAgentsBridgeInstruction's role for the extract-out
 // path. It tells the sandboxed evaluator it has NO repo/test access and must
@@ -491,7 +486,7 @@ const evaluatorTruncationNote = "\nThe DIFF BUNDLE is marked TRUNCATED: some fil
 type GeminiVerdict struct {
 	// Score is 0..100; pass threshold is 70 (sprint-evaluator convention).
 	Score int `json:"score"`
-	// Pass is score >= 70 AND no blockers.
+	// Pass is score >= 70 AND no blockers; 70 matches the sprint-evaluator skill's pass_threshold.
 	Pass bool `json:"pass"`
 	// Blockers are hard-fail reasons; a non-empty Blockers ⇒ Pass==false
 	// regardless of Score.

--- a/internal/gen/golang/codegen_ops.go
+++ b/internal/gen/golang/codegen_ops.go
@@ -356,7 +356,9 @@ func (g *Generator) getListElementType(list *core.List) string {
 // generateArray generates a distinct Go slice literal for arrays.
 // M-ARRAY-SHOW-DIVERGES-RUN-VS-COMPILE: ArrayVal preserves array identity at runtime.
 func (g *Generator) generateArray(arr *core.Array) error {
-	// Both formerly dynamic and typed branches must carry the same array identity.
+	// Arrays deliberately emit an untyped ArrayVal wrapper to preserve array identity.
+	// M-ARRAY-SHOW-DIVERGES-RUN-VS-COMPILE removed the per-element typed branch;
+	// reintroducing one would make run and compile diverge again.
 	g.write("ArrayVal{")
 
 	for i, elem := range arr.Elements {
@@ -369,38 +371,6 @@ func (g *Generator) generateArray(arr *core.Array) error {
 	}
 	g.write("}")
 	return nil
-}
-
-// getArrayElementType extracts the Go element type for an array from CoreTypeInfo.
-// M-TYPE1: Returns empty string if type is unknown or not an array type.
-func (g *Generator) getArrayElementType(arr *core.Array) string {
-	if g.coreTypeInfo == nil {
-		return ""
-	}
-
-	nodeID := arr.NodeID
-	if nodeID == 0 {
-		return ""
-	}
-
-	typ, ok := g.coreTypeInfo[nodeID]
-	if !ok {
-		return ""
-	}
-
-	// Map the type to Go and extract element type
-	goType, err := g.TypeMapper.MapType(typ)
-	if err != nil {
-		return ""
-	}
-
-	// Check if it's a slice type and extract element type
-	goTypeStr := string(goType)
-	if len(goTypeStr) > 2 && goTypeStr[:2] == "[]" {
-		return goTypeStr[2:]
-	}
-
-	return ""
 }
 
 // generateTuple preserves tuple identity for canonical rendering and matching.

--- a/make/code-health.mk
+++ b/make/code-health.mk
@@ -68,6 +68,9 @@ install-lint: ## Install/upgrade golangci-lint (auto-reinstalls when its build-G
 lint: prepare-embed ## Run linter (bug detectors only)
 	@echo "Running linter..."
 	@which golangci-lint > /dev/null || (echo "golangci-lint not found. Run 'make install-lint'" && exit 1)
+# Each check-code grep below mirrors a disable in .golangci.yml as belt-and-braces filtering.
+# The unused linter remains enabled and deliberately unfiltered so its findings can fail this gate.
+# The ^\t and ^[[:space:]]*\^ greps remove golangci-lint source-context lines, not findings.
 	@golangci-lint run ./cmd/... ./internal/... ./serveapi/... ./testutil/... > /tmp/lint.raw 2>&1; \
 		LINT_RC=$$?; \
 		if grep -qE "can't load config|the Go language version" /tmp/lint.raw; then \
@@ -82,7 +85,6 @@ lint: prepare-embed ## Run linter (bug detectors only)
 			grep -v "SA9003:" | \
 			grep -v "SA5011:" | \
 			grep -v "SA5012:" | \
-			grep -v "is unused" | \
 			grep -v "^\t" | \
 			grep -v "^[[:space:]]*\^" | \
 			tee /tmp/lint.out; \


### PR DESCRIPTION
## What

`make lint` piped golangci-lint's output through `grep -v "is unused"` **before** the failure
predicate, so `unused` findings could never fail the gate. A dead function anywhere under `cmd/`,
`internal/`, `serveapi/` or `testutil/` left it printing `✓ Lint complete (no bugs detected)` at
rc=0.

Queue row `m-lint-unused-filter-vacuity`, surfaced by the iteration-269 sprint evaluator and
reproduced first-party here.

## The measurement

At the base commit, with **no mutant at all**, the gate was already vacuous in the live tree:

| | base | this PR |
|---|---|---|
| `golangci-lint` on scope | `2 issues: * unused: 2` | `0 issues.` |
| `make lint` | **rc=0** `✓ Lint complete (no bugs detected)` | rc=0, genuinely |

## Systemic audit

Every *other* check-code grep in the chain (`QF`, `ST`, `SA1019`, `SA9003`, `SA5011`, `SA5012`)
mirrors an explicit disable in `.golangci.yml`'s staticcheck `checks` list. `unused` is **enabled**
there. So `is unused` was the only filter suppressing a check the config turns on — exactly one
line was wrong, and the remaining greps drop source-context lines rather than findings.

## The two findings it was hiding

Both were investigated against CLAUDE.md's rule that unused code is never deleted on the linter's
say-so:

- **`geminiPassThreshold`** — born dead at `ae5f0a00f` (comment + declaration, zero call sites,
  never referenced). The threshold is applied by the model returning the verdict, not by our code.
  Its provenance is preserved on the `Pass` field comment. No runtime behaviour changed.
- **`getArrayElementType`** — was wired at `ea88158ef` (1 call site) and **deliberately unwired**
  by `d3b0185f5`, the `M-ARRAY-SHOW-DIVERGES-RUN-VS-COMPILE` fix, whose diff replaces the call with
  `g.write("ArrayVal{")`. Re-wiring it would reintroduce that divergence, so `generateArray` now
  records the decision. Control: its twin `getListElementType` still has a live call site.

## Drill

Mutant asserted **LANDED** (grep count 1) and **BUILDS** (`go build` rc=0) before any red was read.

- **Arm A** — fixed tree, no mutant → `make lint` rc=0, `0 issues.`
- **Arm B** (addition-shaped, proves the gate *looks*) — dead unexported const → **rc=2**, naming
  the mutant file
- **Arm C** (sole-killer control) — same mutant, filter line restored → **rc=0**, vacuous again

Arms asserted to differ; `make/code-health.mk` restored byte-identical by sha256. Run twice with
two different mutant shapes and packages (executor: dead func in `internal/gen/golang`; controller:
dead const in `internal/eval_harness`).

## Gates (all re-run outside the executor sandbox, on darwin/arm64)

`make lint` · scoped `go build` · `go vet` · `go test` · `make check-changelog` ·
`check-file-sizes` · `check-boundaries` · full `make test` — **all rc=0**, `make test` at
**114 ok / 0 FAIL**, identical to the measured base. Linux and Windows legs unrun locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
