### PR TITLE
fix(ci): serveapi closure arm had no stdlib floor and an unfloored root query

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -8189,6 +8189,12 @@ Patch release on top of v0.18.0's M-MOTOKO-EXECUTOR-ADAPTER. Local smoke testing
 **LOC tally:** ~80 LOC AILANG-side (parser fallback, HealthCheck enhancement, env-var emit), ~250 LOC motoko-side (TS profile mirror, --headless/--version flags, sanitizer, cost env override, AILANG resolve_profile_dir + env_int). 11 new tests across both repos (3 parser fallback, 6 session-logger sanitization, 2 budget passthrough). One new design doc captures the v0.19.0 follow-up: M-FS-SANDBOX-DIAGNOSTICS for the silent-false `fileExists` issue.
 # Nightly evaluation
 
+### Fixed — serveapi closure checks refuse vacuous dependency and module-root enumerations
+
+The protocol-closure gate now requires the serveapi dependency list to contain a stdlib
+package, and independently requires its module-root query to succeed, return roots, and
+contain the facade's own module root.
+
 ### Fixed — motoko connection probe refuses vacuous routing verdicts
 
 The load-bearing motoko/OpenRouter connection probe is now exercised by the CI launchd-driver

--- a/scripts/check_protocol_closure.sh
+++ b/scripts/check_protocol_closure.sh
@@ -3,6 +3,9 @@
 #
 # This deliberately measures what a consumer LINKS. Test-only imports are out of
 # scope by design: they are not part of a consumer's build closure.
+# Both arms require a known-positive and at least one stdlib package. The
+# serveapi module-root enumeration is floored separately from its dependency
+# enumeration because those are two distinct go list calls.
 set -uo pipefail
 
 PROTOCOL_PACKAGE="${1:-./serveapi/protocol}"
@@ -102,10 +105,40 @@ if ! grep -qxF "$SERVEAPI_SELF" "$SERVEAPI_DEPS"; then
 	exit 2
 fi
 
+SERVEAPI_STDLIB=0
+while IFS= read -r _package; do
+	if ! is_nonstdlib "$_package"; then
+		SERVEAPI_STDLIB=$((SERVEAPI_STDLIB + 1))
+	fi
+done <"$SERVEAPI_DEPS"
+# R10
+if [ "$SERVEAPI_STDLIB" -eq 0 ]; then
+	vacuous "serveapi R10" "no stdlib package was enumerated"
+	exit 2
+fi
+
 SERVEAPI_ROOTS="$TMP_DIR/serveapi.roots"
+SERVEAPI_ROOTS_RAW="$TMP_DIR/serveapi.roots.raw"
+SERVEAPI_ROOTS_ERR="$TMP_DIR/serveapi.roots.err"
 SERVEAPI_VIOLATORS="$TMP_DIR/serveapi.violators"
 "$GO_BIN" list -deps -f '{{if not .Standard}}{{with .Module}}{{.Path}}{{end}}{{end}}' "$SERVEAPI_PACKAGE" \
-	| sed '/^$/d' | sort -u >"$SERVEAPI_ROOTS"
+	>"$SERVEAPI_ROOTS_RAW" 2>"$SERVEAPI_ROOTS_ERR"
+SERVEAPI_ROOTS_RC=$?
+# R11
+if [ "$SERVEAPI_ROOTS_RC" -ne 0 ]; then
+	vacuous "serveapi R11" "go list module-root enumeration failed for $SERVEAPI_PACKAGE (rc=$SERVEAPI_ROOTS_RC)"
+	sed 's/^/    /' "$SERVEAPI_ROOTS_ERR"
+	exit 2
+fi
+sed '/^$/d' "$SERVEAPI_ROOTS_RAW" | sort -u >"$SERVEAPI_ROOTS"
+if [ ! -s "$SERVEAPI_ROOTS" ]; then
+	vacuous "serveapi R11" "module-root enumeration is empty"
+	exit 2
+fi
+if ! grep -qxF 'github.com/sunholo-data/ailang' "$SERVEAPI_ROOTS"; then
+	vacuous "serveapi R11" "known-positive github.com/sunholo-data/ailang is absent"
+	exit 2
+fi
 : >"$SERVEAPI_VIOLATORS"
 while IFS= read -r _root; do
 	# R8

--- a/scripts/test_check_protocol_closure.sh
+++ b/scripts/test_check_protocol_closure.sh
@@ -95,7 +95,60 @@ run_gate ./serveapi/protocol ./definitely/not/a/package
 run_gate ./serveapi/protocol ./cmd/astdump
 [ "$RC" -eq 2 ] && printf '%s' "$OUT" | grep -qF 'vacuous enumeration (serveapi R7)' || VACUITY_FAILURE="R7 probe: rc=$RC output=$OUT"
 
-if [ -n "$VACUITY_FAILURE" ]; then fail "vacuity arm — $VACUITY_FAILURE"; else pass "vacuity probes R1/R2/R3/R4/R6/R7 refuse with rc=2 and no checkmark"; fi
+FAKE_DIR=$(mktemp -d)
+FAKE_GO="$FAKE_DIR/go"
+cat >"$FAKE_GO" <<'EOF'
+#!/bin/sh
+is_format=0
+package=
+for arg in "$@"; do
+	case "$arg" in
+		-f) is_format=1 ;;
+		./serveapi/protocol|./serveapi) package=$arg ;;
+	esac
+done
+if [ "$is_format" -eq 1 ]; then
+	case "${FAKE_MODE:-}" in
+		r11a) printf '%s\n' 'synthetic module-root failure' >&2; exit 7 ;;
+		r11b) exit 0 ;;
+		r11c) printf '%s\n' 'github.com/google/jsonschema-go'; exit 0 ;;
+		*) printf '%s\n' 'github.com/sunholo-data/ailang'; exit 0 ;;
+	esac
+fi
+case "$package" in
+	./serveapi/protocol)
+		printf '%s\n' 'github.com/sunholo-data/ailang/serveapi/protocol' 'fmt'
+		;;
+	./serveapi)
+		printf '%s\n' 'github.com/sunholo-data/ailang/serveapi'
+		[ "${FAKE_MODE:-}" = r10 ] || printf '%s\n' 'fmt'
+		;;
+	*) exit 9 ;;
+esac
+EOF
+chmod +x "$FAKE_GO"
+
+run_vacuity_probe() {
+	_probe_name=$1
+	_probe_mode=$2
+	_probe_reason=$3
+	_guard_name=${_probe_name%%(*}
+	OUT=$(cd "$REPO_ROOT" && FAKE_MODE="$_probe_mode" GO_BIN="$FAKE_GO" /bin/bash "$GATE" 2>&1)
+	RC=$?
+	if [ "$RC" -ne 2 ] || ! printf '%s' "$OUT" | grep -qF "vacuous enumeration (serveapi $_guard_name): $_probe_reason"; then
+		VACUITY_FAILURE="$_probe_name probe: rc=$RC output=$OUT"
+	elif printf '%s' "$OUT" | grep -q '✓'; then
+		VACUITY_FAILURE="$_probe_name probe printed a checkmark: $OUT"
+	fi
+}
+
+run_vacuity_probe R10 r10 'no stdlib package was enumerated'
+run_vacuity_probe 'R11(a)' r11a 'go list module-root enumeration failed for ./serveapi (rc=7)'
+run_vacuity_probe 'R11(b)' r11b 'module-root enumeration is empty'
+run_vacuity_probe 'R11(c)' r11c 'known-positive github.com/sunholo-data/ailang is absent'
+rm -rf "$FAKE_DIR"
+
+if [ -n "$VACUITY_FAILURE" ]; then fail "vacuity arm — $VACUITY_FAILURE"; else pass "vacuity probes R1/R2/R3/R4/R6/R7/R10/R11(a)/R11(b)/R11(c) refuse with rc=2 and no checkmark"; fi
 
 # (iii) Restoration.
 run_gate


### PR DESCRIPTION
## What

`scripts/check_protocol_closure.sh` guards two arms. The `./serveapi/protocol` arm carries four
anti-vacuity floors (`R1` rc, `R2` non-empty, `R3` known-positive, `R4` stdlib present). The
`./serveapi` arm carried only two — and had **two independent holes**, both reproduced
first-party at the base commit with a stub `go` that delegates every other call to the real
toolchain, so each mutation is precisely targeted and asserted landed.

**`R10` (was absent).** `go list -deps ./serveapi` reduced from **224** entries to the self
literal alone — zero stdlib — while the protocol call stayed at **188**. The gate still printed
its green checkmark at rc=0. This is arm 1's `R4` missing from arm 2.

**`R11` (was absent).** The module-root enumeration is a *second* `go list` call, and it is the
one the allowlist check actually consumes. Its exit status was discarded (head of a pipeline),
and nothing asserted non-emptiness or a known positive. Reducing that call alone from **10**
roots to **0** — plain deps untouched at 224 — left the violator loop iterating zero times and
the gate green at rc=0.

`R7` does not cover `R11`: `R7`'s known-positive is scoped to `SERVEAPI_DEPS`, a **different
enumeration** from `SERVEAPI_ROOTS`. A control scoped to another call proves nothing about this
one — which is why `R11`'s own known-positive leg queries the same file the allowlist loop reads.

## Evidence

Two mutation drills, independent and differently shaped.

**Executor** — each of `R10`, `R11(a)`, `R11(b)`, `R11(c)` neutered alone with `if false &&`,
asserted LANDED, asserted still parsing under `bash -n`, each producing an observed self-test
FAIL naming its probe, each restored from a `cp` backup with sha256 byte-identity.

**Controller** — the two stubs that produced the original false greens now yield **rc=2** naming
`R10` and `R11`, while the delegating control stays **rc=0**; arms asserted to differ
programmatically rather than eyeballed. Two further stubs cover the legs those did not reach: a
failing module-root call hits `R11` leg (a), and a root list omitting the self root hits `R11`
leg (c) with **rc=2** rather than the rc=1 allowlist branch — distinguishing those two is the
point of that probe.

## Gates

Re-run by the controller **outside the sandbox**, all rc=0: `check-protocol-closure`,
`test-check-protocol-closure`, `check-changelog`, `check-file-sizes`, `check-boundaries`, and
`bash -n` on both scripts. `ARMS_EXPECTED` stays **5** — no new arms, so the arm-count floor is
unchanged; the vacuity arm now names all ten probes.

**Scope, stated rather than implied:** the diff touches two shell scripts and one changelog
file. No Go source, so the Go suite is unaffected and was not re-run locally. Measured on
darwin/arm64; the CI matrix is the instrument for every other leg.

Queue row `m-protocol-closure-arm2-floor`, found by the iteration-268 `sonnet` evaluator.
Hardens the gate shipped for issue 764; that issue's own work is unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
