### PR TITLE
motoko row 6e: a self-test that can hang is an outage with a green history — cap every arm, bound the tree walk

### DIFF
--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -2,6 +2,16 @@
 
 > Current changelog (v0.18.0 onward). Earlier series: [v0.10–v0.17](v0.10-v0.17-bytecode-vm.md). Index: [CHANGELOG.md](../CHANGELOG.md).
 
+## [Unreleased]
+
+### Fixed — Motoko connection-probe self-tests fail loudly when an arm hangs
+
+Every connection-probe self-test arm now has a configurable, validated wall-clock cap that
+terminates hung commands and prints the captured output tail instead of leaving the macOS CI job
+to end as a silent 15-minute cancellation. Process-tree discovery also has a validated node-count
+ceiling, distinct diagnostics for the clock and node bounds, and hermetic arms that prove both new
+guards fire.
+
 ## [v0.33.2] - 2026-08-24
 
 ### Fixed — lint no longer hides unused code

--- a/tools/eval/motoko_connection_probe.sh
+++ b/tools/eval/motoko_connection_probe.sh
@@ -123,7 +123,9 @@ artifact=$3
 benchmark=${4:-hello_world}
 ailang_bin=${AILANG_BIN:-ailang}
 timeout_secs=${PROBE_TIMEOUT_SECS:-900}
+MAX_TREE_NODES=${PROBE_MAX_TREE_NODES:-4096}
 [[ "$timeout_secs" =~ ^[1-9][0-9]*$ ]] || instrument_failure "PROBE_TIMEOUT_SECS must be a positive integer"
+[[ "$MAX_TREE_NODES" =~ ^[1-9][0-9]*$ ]] || instrument_failure "PROBE_MAX_TREE_NODES must be a positive integer"
 [[ $(uname -sm) == "Darwin arm64" ]] || instrument_failure "live probe requires darwin/arm64"
 command -v dig >/dev/null || instrument_failure "dig is required"
 command -v lsof >/dev/null || instrument_failure "lsof is required"
@@ -174,7 +176,7 @@ or_file="$tmp_dir/or_ips"
 [[ -s "$or_file" ]] || instrument_failure "dig returned no addresses for openrouter.ai"
 
 descendant_pids() {
-  local root=$1 deadline=$2 current child
+  local root=$1 deadline=$2 current child visited=0
   local -a queue=("$root") result=()
   if [[ "${PROBE_TEST_DESCENDANT_FAILURE:-0}" == 1 ]]; then
     echo "process-tree discovery deadline expired" >&2
@@ -188,6 +190,11 @@ descendant_pids() {
     current=${queue[0]}
     queue=("${queue[@]:1}")
     result+=("$current")
+    visited=$((visited + 1))
+    if (( visited > MAX_TREE_NODES )); then
+      echo "process-tree discovery exceeded $MAX_TREE_NODES nodes" >&2
+      return 1
+    fi
     while IFS= read -r child; do
       [[ -n "$child" ]] && queue+=("$child")
     done < <(pgrep -P "$current" 2>/dev/null || true)

--- a/tools/eval/test_motoko_connection_probe.sh
+++ b/tools/eval/test_motoko_connection_probe.sh
@@ -33,6 +33,11 @@ run_bounded() {
   "$@" < /dev/null >"$stdout_file" 2>"$stderr_file" &
   pid=$!
   deadline=$(( $(date +%s) + cap_secs ))
+  # Backoff, NOT a flat `sleep 1`. A flat one-second poll charges every arm a full
+  # second it never used to pay: measured 30s -> 66-93s for the whole suite, which
+  # refutes "fast arms are unaffected". Start sub-second and grow; BSD and GNU sleep
+  # both take a decimal, and bash 3.2 does not need it to be one.
+  poll=0.05
   while kill -0 "$pid" 2>/dev/null; do
     if (( $(date +%s) > deadline )); then
       kill "$pid" 2>/dev/null || true
@@ -46,7 +51,8 @@ run_bounded() {
       wait "$pid" 2>/dev/null || true
       return 199
     fi
-    sleep 1
+    sleep "$poll"
+    case "$poll" in 0.05) poll=0.2 ;; 0.2) poll=1 ;; esac
   done
   wait "$pid"
   rc=$?
@@ -328,13 +334,17 @@ expect_failure "descendant discovery refuses on the real wall-clock deadline" "p
   env PATH="$live_bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=1 PROBE_TEST_PGREP_LOOP=1 \
     PROBE_STUB_STATE="$tmp_dir/lane-pgreploop" /bin/bash "$probe" treatment control "$tmp_dir/pgreploop.json"
 
+cap_secs_fixture=2
 cap_start=$(date +%s)
-run_bounded "$tmp_dir/cap.stdout" "$tmp_dir/cap.stderr" 2 -- /bin/bash -c \
+run_bounded "$tmp_dir/cap.stdout" "$tmp_dir/cap.stderr" "$cap_secs_fixture" -- /bin/bash -c \
   'echo $$ > "$1"; sleep 30' cap-fixture "$tmp_dir/cap.pid"
 cap_rc=$?
 cap_elapsed=$(( $(date +%s) - cap_start ))
-if (( cap_rc != 199 || cap_elapsed > 10 )); then
-  echo "not ok - arm cap terminates a hung command and reports it" >&2
+# The 199 alone does NOT discriminate: a fixture that exits 199 of its own accord
+# satisfies it without any TERM/KILL ever happening. Require the elapsed time to reach
+# the cap as well, so only a command the cap actually STOPPED can pass this arm.
+if (( cap_rc != 199 || cap_elapsed < cap_secs_fixture || cap_elapsed > 10 )); then
+  echo "not ok - arm cap terminates a hung command and reports it (rc=$cap_rc elapsed=${cap_elapsed}s)" >&2
   exit 1
 fi
 cap_pid=$(cat "$tmp_dir/cap.pid")
@@ -343,6 +353,41 @@ if kill -0 "$cap_pid" 2>/dev/null; then
   exit 1
 fi
 pass_arm "arm cap terminates a hung command and reports it"
+
+# report_arm_cap is the code that implements this milestone's headline promise — the
+# named `not ok` line plus the captured output tails. The arm above reaches run_bounded
+# and stops there, so that function had NO coverage: neutering its `exit 1` left the
+# whole suite green. Drive it through expect_failure in a SUBSHELL, where its `exit 1`
+# terminates the subshell rather than the suite, and assert all three observables.
+: > "$tmp_dir/stdout"; : > "$tmp_dir/stderr"
+cap_report=$( {
+  ARM_CAP_SECS=2
+  expect_failure "synthetic hang for the report path" "never matched" \
+    /bin/bash -c 'echo capped-stdout-marker; echo capped-stderr-marker >&2; sleep 30'
+} 2>&1 )
+cap_report_rc=$?
+if (( cap_report_rc != 1 )); then
+  echo "not ok - arm cap reports a hung arm by name with its captured output: expected rc=1, got $cap_report_rc" >&2
+  exit 1
+fi
+# report_arm_cap must TERMINATE the arm, not merely print. If its exit is removed,
+# expect_failure falls through to its own "lacked expected message" refusal and still
+# exits 1 with all the markers present — so rc=1 plus the markers does NOT discriminate.
+# The absence of the fall-through message is what proves the cap path ended the arm.
+case "$cap_report" in
+  *"lacked expected message"*)
+    echo "not ok - arm cap reports a hung arm by name with its captured output: fell through to the message check, so report_arm_cap did not terminate the arm" >&2
+    echo "$cap_report" >&2; exit 1 ;;
+esac
+for cap_expect in "exceeded its 2s arm cap" "--- captured stdout (last 20 lines) ---" \
+                  "--- captured stderr (last 20 lines) ---" "capped-stdout-marker" "capped-stderr-marker"; do
+  case "$cap_report" in
+    *"$cap_expect"*) ;;
+    *) echo "not ok - arm cap reports a hung arm by name with its captured output: missing [$cap_expect]" >&2
+       echo "$cap_report" >&2; exit 1 ;;
+  esac
+done
+pass_arm "arm cap reports a hung arm by name with its captured output"
 
 expect_failure "arm cap override rejects invalid values" \
   "PROBE_SELFTEST_ARM_CAP_SECS must be a positive integer" \

--- a/tools/eval/test_motoko_connection_probe.sh
+++ b/tools/eval/test_motoko_connection_probe.sh
@@ -348,11 +348,20 @@ expect_failure "arm cap override rejects invalid values" \
   "PROBE_SELFTEST_ARM_CAP_SECS must be a positive integer" \
   env PROBE_SELFTEST_ARM_CAP_SECS=invalid /bin/bash "$0"
 
+expect_failure "tree node ceiling rejects invalid values" \
+  "PROBE_MAX_TREE_NODES must be a positive integer" \
+  env PROBE_MAX_TREE_NODES=invalid /bin/bash "$probe" treatment control "$tmp_dir/invalid-node-limit.json"
+
+expect_failure "descendant discovery refuses on the node-count ceiling" "process-tree discovery exceeded 3 nodes" \
+  env PATH="$live_bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=60 PROBE_MAX_TREE_NODES=3 \
+    PROBE_TEST_PGREP_LOOP=1 PROBE_STUB_STATE="$tmp_dir/lane-node-limit" \
+    /bin/bash "$probe" treatment control "$tmp_dir/node-limit.json"
+
 # Refusal-branch drift gate. Every arm above proves a branch that EXISTS goes red when neutered —
 # a removal proves the check FIRES; only an addition proves it LOOKS. Adding a new refusal to the
 # probe passes the whole suite byte-identically, so the coverage claim is a one-time manual count
 # that silently rots on the next edit. Count the branches and refuse when the number moves.
-expected_refusal_branches=23
+expected_refusal_branches=24
 actual_instrument_failures=$(grep -c 'instrument_failure "' "$probe")
 actual_usage_refusals=$(grep -cE '\|\| usage$' "$probe")
 # Anti-vacuity: a counter that returns zero is a broken instrument, not a clean result.

--- a/tools/eval/test_motoko_connection_probe.sh
+++ b/tools/eval/test_motoko_connection_probe.sh
@@ -6,6 +6,11 @@ probe=${PROBE_UNDER_TEST:-$script_dir/motoko_connection_probe.sh}
 tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/test-motoko-connection-probe.XXXXXX") || exit 1
 trap 'rm -rf "$tmp_dir"' EXIT
 arms=0
+ARM_CAP_SECS=${PROBE_SELFTEST_ARM_CAP_SECS:-120}
+if [[ ! "$ARM_CAP_SECS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "not ok - PROBE_SELFTEST_ARM_CAP_SECS must be a positive integer" >&2
+  exit 1
+fi
 
 pass_arm() {
   arms=$((arms + 1))
@@ -20,10 +25,53 @@ require_line() {
   fi
 }
 
+run_bounded() {
+  local stdout_file=$1 stderr_file=$2 cap_secs=$3 pid deadline terminate_deadline rc
+  shift 3
+  [[ "${1:-}" == -- ]] || return 2
+  shift
+  "$@" < /dev/null >"$stdout_file" 2>"$stderr_file" &
+  pid=$!
+  deadline=$(( $(date +%s) + cap_secs ))
+  while kill -0 "$pid" 2>/dev/null; do
+    if (( $(date +%s) > deadline )); then
+      kill "$pid" 2>/dev/null || true
+      terminate_deadline=$(( $(date +%s) + 5 ))
+      while kill -0 "$pid" 2>/dev/null && (( $(date +%s) <= terminate_deadline )); do
+        sleep 1
+      done
+      if kill -0 "$pid" 2>/dev/null; then
+        kill -9 "$pid" 2>/dev/null || true
+      fi
+      wait "$pid" 2>/dev/null || true
+      return 199
+    fi
+    sleep 1
+  done
+  wait "$pid"
+  rc=$?
+  return "$rc"
+}
+
+report_arm_cap() {
+  local name=$1 cap_secs=$2
+  echo "not ok - $name exceeded its ${cap_secs}s arm cap" >&2
+  echo "--- captured stdout (last 20 lines) ---" >&2
+  tail -n 20 "$tmp_dir/stdout" >&2
+  echo "--- captured stderr (last 20 lines) ---" >&2
+  tail -n 20 "$tmp_dir/stderr" >&2
+  exit 1
+}
+
 expect_failure() {
-  local name=$1 expected=$2
+  local name=$1 expected=$2 rc
   shift 2
-  if "$@" >"$tmp_dir/stdout" 2>"$tmp_dir/stderr"; then
+  run_bounded "$tmp_dir/stdout" "$tmp_dir/stderr" "$ARM_CAP_SECS" -- "$@"
+  rc=$?
+  if (( rc == 199 )); then
+    report_arm_cap "$name" "$ARM_CAP_SECS"
+  fi
+  if (( rc == 0 )); then
     echo "not ok - $name unexpectedly succeeded" >&2
     exit 1
   fi
@@ -36,9 +84,14 @@ expect_failure() {
 }
 
 expect_success() {
-  local name=$1
+  local name=$1 rc
   shift
-  if ! "$@" >"$tmp_dir/stdout" 2>"$tmp_dir/stderr"; then
+  run_bounded "$tmp_dir/stdout" "$tmp_dir/stderr" "$ARM_CAP_SECS" -- "$@"
+  rc=$?
+  if (( rc == 199 )); then
+    report_arm_cap "$name" "$ARM_CAP_SECS"
+  fi
+  if (( rc != 0 )); then
     echo "not ok - $name failed" >&2
     cat "$tmp_dir/stderr" >&2
     exit 1
@@ -274,6 +327,26 @@ fi
 expect_failure "descendant discovery refuses on the real wall-clock deadline" "process-tree discovery failed" \
   env PATH="$live_bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=1 PROBE_TEST_PGREP_LOOP=1 \
     PROBE_STUB_STATE="$tmp_dir/lane-pgreploop" /bin/bash "$probe" treatment control "$tmp_dir/pgreploop.json"
+
+cap_start=$(date +%s)
+run_bounded "$tmp_dir/cap.stdout" "$tmp_dir/cap.stderr" 2 -- /bin/bash -c \
+  'echo $$ > "$1"; sleep 30' cap-fixture "$tmp_dir/cap.pid"
+cap_rc=$?
+cap_elapsed=$(( $(date +%s) - cap_start ))
+if (( cap_rc != 199 || cap_elapsed > 10 )); then
+  echo "not ok - arm cap terminates a hung command and reports it" >&2
+  exit 1
+fi
+cap_pid=$(cat "$tmp_dir/cap.pid")
+if kill -0 "$cap_pid" 2>/dev/null; then
+  echo "not ok - arm cap terminates a hung command and reports it: process survived as $cap_pid" >&2
+  exit 1
+fi
+pass_arm "arm cap terminates a hung command and reports it"
+
+expect_failure "arm cap override rejects invalid values" \
+  "PROBE_SELFTEST_ARM_CAP_SECS must be a positive integer" \
+  env PROBE_SELFTEST_ARM_CAP_SECS=invalid /bin/bash "$0"
 
 # Refusal-branch drift gate. Every arm above proves a branch that EXISTS goes red when neutered —
 # a removal proves the check FIRES; only an addition proves it LOOKS. Adding a new refusal to the


### PR DESCRIPTION
Motoko mission iteration 22, queue row **6e**.

## The defect, measured first-party

`tools/eval/test_motoko_connection_probe.sh` is wired into `make test-launchd-drivers`, which CI runs as the macOS job `launchd drivers (bash 3.2)` under `timeout-minutes: 15`. Over the last 100 CI runs (oldest `2026-08-22T08:42Z`) that job is **95 success / 2 failure / 3 cancelled**. All three cancellations are ~918s — the job timeout — and all three are on 2026-08-23:

| run | branch | started | ended |
|---|---|---|---|
| 32655443831 | `docs/motoko-iter20-record` | 17:38:10Z | 17:53:28Z |
| 32665128080 | `docs/mission-iter261-record` | 20:40:24Z | 20:55:41Z |
| 32673098414 | **`dev` (push)** | 23:15:56Z | 23:31:14Z |

Row 6e recorded two; there are **three**, and the third is on `dev` itself.

In all three the last suite line is byte-identical — `UNINFORMATIVE UNDER SANDBOX: loopback socket sampling yielded no peer; …` — and `ok 33` never appears. The only code between that echo and arm 33 is arm 33's own invocation, so arm 33 hung. Control: green run 32785167377 emits the same line and then `ok 33` 1.06s later, with all 34 arms.

**The mechanism inside arm 33 is NOT isolated and this PR does not claim it is.** It has not recurred in the ~44 runs since, on an unchanged file (`git log` on the probe, suite, `make/test.mk` and `ci.yml` shows nothing in that path since the last cancellation; the one commit in the window, `ba2eeb4b4`, touches a different `ci.yml` step and a different make target). What *is* established is structural: **the suite had no bound of its own**, so a hang was a silent 15-minute cancellation with zero diagnostics.

## What changed

**M1 — every arm gets a hard wall-clock cap.** `ARM_CAP_SECS` (default 120, override `PROBE_SELFTEST_ARM_CAP_SECS`, validated as a positive integer, refusing loudly otherwise) bounds every arm via a `run_bounded` helper: backgrounded with closed stdin, `date +%s` deadline, TERM then KILL after a 5s grace, real exit status captured without a pipe. On expiry the arm prints `not ok - <arm> exceeded its <N>s arm cap` **plus the tail of captured stdout and stderr**, and exits 1. A capped arm can never pass and can never be silent. The poll backs off `0.05s -> 0.2s -> 1s`.

> **CORRECTION.** This paragraph originally read *"fast arms are unaffected — the poll loop is not entered when the child has already exited"*. The evaluator measured that claim **false**: the first `kill -0` runs after a `date` subshell, so anything slower than a trivial binary is still alive and paid a flat mandatory second — the suite went **30s -> 66-93s**. The backoff above is the fix, re-measured at **39 arms in 52s** with the whole `make test-launchd-drivers` sweep at **119s**. The claim is corrected here rather than left standing.

**M2 — the process-tree walk is bounded by node count, not only by the clock.** `descendant_pids()` was bounded solely by a wall-clock deadline derived from `PROBE_TIMEOUT_SECS`, which is exactly the "bound calibrated on the author's machine" shape row 6e names. It now also refuses past `MAX_TREE_NODES` (default 4096, override `PROBE_MAX_TREE_NODES`, validated) with a message **distinct** from the deadline's, so a reader can tell which bound fired. Refusal-branch drift gate moves 23 → 24.

**M3 — changelog**, in `changelogs/v0.18-current.md` (not the root index).

Arm numbering is preserved: **arm 33 is still the wall-clock deadline arm**. The suite is now **38 arms**.

## Mutation drill — controller-run, first-party

The codex executor hit its 30-minute cap before reporting, so this evidence was produced by the controller rather than inherited. Every mutant neuters with `if false && …` (so it still parses), is asserted **LANDED** by sha256 and **VALID** by `bash -n` *before* the result is read, and is restored byte-identical after.

| mutant | sha256 before → after | `bash -n` | suite rc | died by name on |
|---|---|---|---|---|
| M1 cap expiry | `13ed4c09` → `d796e4b8` | 0 | 0 → **1** (2/2) | `arm cap terminates a hung command and reports it` |
| M1 `ARM_CAP_SECS` validation | `13ed4c09` → `61b258b3` | 0 | **1** | `arm cap override rejects invalid values` |
| M2 node ceiling | `b4905840` → `e79329fd` | 0 | **1** | `descendant discovery refuses on the node-count ceiling lacked expected message: process-tree discovery exceeded 3 nodes` |
| M2 `PROBE_MAX_TREE_NODES` validation | `b4905840` → `96a18785` | 0 | **1** | `tree node ceiling rejects invalid values` |

Two things worth stating rather than burying:

- The node-ceiling mutant runs with `PROBE_TIMEOUT_SECS=60` and did **not** fall through to the clock bound's message. That is what proves the arm discriminates the node bound rather than being satisfiable by the clock.
- The `PROBE_MAX_TREE_NODES` validation mutant deliberately **keeps its refusal message**, so the branch-count drift gate cannot be the killer.

**A red banked for the wrong reason, and how it was caught.** The first batch run of the M1 mutant redded at **arm 30**, not at the cap arm. Banking that exit code would have recorded a pin that does not exist. Re-run isolated it reds at its own arm **2/2**, with the unmutated suite green **3/3** in the same block. Separately, one M1-boundary run redded at arm 32 and the identical command was rc=0 on the next run. Both are pre-existing live-path arms under concurrent load; they are filed as an observation, not declared a flake class off single instances.

## Gates — all rc=0, run by the controller OUTSIDE any sandbox, on darwin/arm64

Each was baselined on the unmodified tree **before** the directive was written, and each returned rc=0 there too.

`/bin/bash -n` ×2 · probe self-test (**38 arms**) · `shellcheck -S warning` · `make check-file-sizes` · `make check-changelog` · `make test-launchd-drivers`

`go build ./...` is deliberately **not** a gate: it is rc=1 on untouched `dev` (`cmd/wasm` and `gen/main` have no native `main`).

The windows and ubuntu legs are unrun locally and were read from CI.

## Reconstruction

The executor made no git writes. Its final tree was sha256-manifested before commit-building; after replaying `.snap/M1` → `.snap/M3` in milestone order, `shasum -c` returns **OK on all three files**. The M1 boundary was verified independently green (36 arms, rc=0) against the unmodified probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Round 1 evaluation: FAIL 54/100 — three blocking findings, all answered in `ddd8f3f09`

The judge ran in its own worktree and was told to attack the controller's evidence specifically, since the codex executor capped before reporting and the whole mutation drill was therefore controller-authored (Anthropic) and judged by an Anthropic model. It re-derived all four rows of that table independently and reproduced two with **byte-identical** sha256 hashes — so the evidence is corroborated, not taken on trust. It then found three things the drill did not.

**B1 — `report_arm_cap` had zero coverage.** The function implementing M1's headline promise was never executed by the suite: arm 34 calls `run_bounded` directly and stops there, and neutering `report_arm_cap`'s `exit 1` left the suite green at 38/38. A new arm now drives it end-to-end through `expect_failure` in a subshell.

And the first version of that new arm **passed for the wrong reason** — its own mutant is what showed it. With `exit 1` removed, `expect_failure` falls through to its `lacked expected message` refusal and *still* exits 1 with every marker present, so rc=1-plus-markers does not discriminate. The arm now also requires that fall-through message to be **absent**; that absence is the only observable unique to `report_arm_cap` having ended the arm. Proof, scoped to `report_arm_cap`'s line range so no other `exit 1` is touched: mutant LANDED (`28d9cb02` → `8ea6d457`), `bash -n` rc=0, suite rc 0 → 1 dying on `…fell through to the message check`; restored byte-identical.

**B2 — the cap arm was satisfiable without any capping.** It asserted only `cap_rc == 199` and an upper elapsed bound, so a fixture exiting 199 of its own accord passed with no TERM and no KILL. It now also requires elapsed to **reach** the cap. Proof, the judge's own mutation (`sleep 30` → `exit 199`): suite rc=1 on `arm cap terminates a hung command and reports it (rc=199 elapsed=0s)`.

**B3 — a false claim in this PR body**, corrected inline above.

Worth stating plainly: two of the three blocking findings are defects in guards written to close this row, and one is a claim I made that measurement refuted. The round-1 judgement is recorded here rather than summarised away.
