### PR TITLE
fix(make): lint and the stdlib self-test shared fixed /tmp paths across clones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,12 @@ jobs:
     - name: Protocol build closure gate self-test
       run: make test-check-protocol-closure
 
+    - name: Check make recipe tmpfile hygiene
+      run: make check-tmpfile-hygiene
+
+    - name: Make recipe tmpfile hygiene gate self-test
+      run: make test-check-tmpfile-hygiene
+
     - name: Check changelog index hygiene
       run: make check-changelog
 

--- a/changelogs/v0.18-current.md
+++ b/changelogs/v0.18-current.md
@@ -4,6 +4,14 @@
 
 ## [Unreleased]
 
+### Fixed — make gates isolate temporary files across concurrent clones
+
+`make lint` and `make verify-stdlib-selftest` now allocate and clean up unique temporary
+files per invocation, preventing concurrent runs in separate clones from sharing verdict data
+or restoring `std/option.ail` from another run's polluted backup. A mutation-sensitive
+`check-tmpfile-hygiene` CI gate refuses fixed `/tmp` paths in make recipes and pins its file
+enumeration and matcher against vacuous success.
+
 ### Fixed — Motoko connection-probe self-tests fail loudly when an arm hangs
 
 Every connection-probe self-test arm now has a configurable, validated wall-clock cap that

--- a/make/code-health.mk
+++ b/make/code-health.mk
@@ -71,14 +71,18 @@ lint: prepare-embed ## Run linter (bug detectors only)
 # Each check-code grep below mirrors a disable in .golangci.yml as belt-and-braces filtering.
 # The unused linter remains enabled and deliberately unfiltered so its findings can fail this gate.
 # The ^\t and ^[[:space:]]*\^ greps remove golangci-lint source-context lines, not findings.
-	@golangci-lint run ./cmd/... ./internal/... ./serveapi/... ./testutil/... > /tmp/lint.raw 2>&1; \
+	@LINT_RAW=$$(mktemp "$${TMPDIR:-/tmp}/ailang-lint-raw.XXXXXX") || exit 1; \
+		LINT_OUT=""; \
+		trap 'rm -f "$$LINT_RAW" "$$LINT_OUT"' EXIT; \
+		LINT_OUT=$$(mktemp "$${TMPDIR:-/tmp}/ailang-lint-out.XXXXXX") || exit 1; \
+		golangci-lint run ./cmd/... ./internal/... ./serveapi/... ./testutil/... > "$$LINT_RAW" 2>&1; \
 		LINT_RC=$$?; \
-		if grep -qE "can't load config|the Go language version" /tmp/lint.raw; then \
+		if grep -qE "can't load config|the Go language version" "$$LINT_RAW"; then \
 			echo "$(RED)$(CROSS) golangci-lint config/toolchain error — run 'make install-lint':$(RESET)"; \
-			cat /tmp/lint.raw; \
+			cat "$$LINT_RAW"; \
 			exit 1; \
 		fi; \
-		grep -v "(related information)" /tmp/lint.raw | \
+		grep -v "(related information)" "$$LINT_RAW" | \
 			grep -v "QF[0-9]" | \
 			grep -v "ST[0-9]" | \
 			grep -v "SA1019:" | \
@@ -87,8 +91,8 @@ lint: prepare-embed ## Run linter (bug detectors only)
 			grep -v "SA5012:" | \
 			grep -v "^\t" | \
 			grep -v "^[[:space:]]*\^" | \
-			tee /tmp/lint.out; \
-		if grep -qE "^(internal|cmd|serveapi|testutil)" /tmp/lint.out; then \
+			tee "$$LINT_OUT"; \
+		if grep -qE "^(internal|cmd|serveapi|testutil)" "$$LINT_OUT"; then \
 			echo "$(RED)$(CROSS) Lint errors found$(RESET)"; \
 			exit 1; \
 		fi; \
@@ -143,6 +147,13 @@ check-boundaries: ## Check architecture layer boundaries (CI gate)
 
 check-protocol-closure: ## Check serveapi protocol/facade build closures (CI gate)
 	@/bin/bash scripts/check_protocol_closure.sh
+
+check-tmpfile-hygiene: ## Refuse fixed /tmp paths in make recipes (CI gate)
+	@/bin/bash scripts/check_tmpfile_hygiene.sh
+
+test-check-tmpfile-hygiene: ## Run the tmpfile-hygiene gate's own self-test (bash 3.2)
+	@/bin/bash scripts/test_check_tmpfile_hygiene.sh
+	@/bin/bash -n scripts/check_tmpfile_hygiene.sh
 
 check-changelog: ## Check root CHANGELOG.md stays an index, not a changelog (CI gate)
 	@bash scripts/check_changelog.sh

--- a/make/examples.mk
+++ b/make/examples.mk
@@ -146,26 +146,28 @@ verify-stdlib: build ## Verify std/ library interface stability
 # a gate that goes red on a real change is.
 verify-stdlib-selftest: build ## Prove the stdlib freeze gate fails on a real interface change
 	@echo "Gate self-test: adding a temporary export to std/option..."
-	@cp std/option.ail /tmp/_selftest_option.ail; \
-	trap "cp /tmp/_selftest_option.ail std/option.ail; rm -f /tmp/_selftest_option.ail" EXIT; \
+	@SELFTEST_BK=$$(mktemp "$${TMPDIR:-/tmp}/ailang-selftest-option.XXXXXX") || exit 1; \
+	SELFTEST_OUT=$$(mktemp "$${TMPDIR:-/tmp}/ailang-selftest-out.XXXXXX") || { rm -f "$$SELFTEST_BK"; exit 1; }; \
+	cp std/option.ail "$$SELFTEST_BK"; \
+	trap 'cp "$$SELFTEST_BK" std/option.ail; rm -f "$$SELFTEST_BK" "$$SELFTEST_OUT"' EXIT; \
 	printf '\n-- temporary export injected by verify-stdlib-selftest\nexport pure func selftestCanary(x: int) -> int = x\n' >> std/option.ail; \
-	if tools/verify-stdlib.sh >/tmp/_selftest_out.txt 2>&1; then \
+	if tools/verify-stdlib.sh >"$$SELFTEST_OUT" 2>&1; then \
 		echo "❌ SELF-TEST FAIL: gate exited 0 despite a new export in std/option"; \
-		rm -f /tmp/_selftest_out.txt; exit 1; \
+		rm -f "$$SELFTEST_OUT"; exit 1; \
 	else \
 		echo "✓ gate exited non-zero on the injected export"; \
 	fi; \
-	if grep -q "option: interface changed" /tmp/_selftest_out.txt; then \
+	if grep -q "option: interface changed" "$$SELFTEST_OUT"; then \
 		echo "✓ gate named the changed module (std/option)"; \
 	else \
 		echo "❌ SELF-TEST FAIL: gate failed but never named std/option"; \
-		cat /tmp/_selftest_out.txt; rm -f /tmp/_selftest_out.txt; exit 1; \
+		cat "$$SELFTEST_OUT"; rm -f "$$SELFTEST_OUT"; exit 1; \
 	fi; \
-	if grep -q "selftestCanary" /tmp/_selftest_out.txt; then \
+	if grep -q "selftestCanary" "$$SELFTEST_OUT"; then \
 		echo "✓ gate showed the actual diff (the new symbol appears)"; \
 	else \
 		echo "❌ SELF-TEST FAIL: no diff shown — operators cannot see WHAT changed"; \
-		cat /tmp/_selftest_out.txt; rm -f /tmp/_selftest_out.txt; exit 1; \
+		cat "$$SELFTEST_OUT"; rm -f "$$SELFTEST_OUT"; exit 1; \
 	fi; \
-	rm -f /tmp/_selftest_out.txt; \
+	rm -f "$$SELFTEST_OUT"; \
 	echo "✅ stdlib gate self-test passed: interface change -> non-zero + named module + diff"

--- a/scripts/check_tmpfile_hygiene.sh
+++ b/scripts/check_tmpfile_hygiene.sh
@@ -4,8 +4,11 @@
 # SCOPE, stated rather than implied: this scans tab-led recipe lines and
 # column-0 variable assignments in `Makefile` + `make/*.mk`. It does NOT see a
 # fixed path reached via an `export FOO := ...` line, an included file outside
-# `make/`, or a path built at runtime from string concatenation. Those are
-# declared limitations, not oversights.
+# `make/`, a path built at runtime from string concatenation, a `.mk` file whose
+# name differs in case (the glob is case-sensitive), a `.mk` file nested in a
+# subdirectory of `make/` (the glob is not recursive), or an alternate root
+# makefile name such as `GNUmakefile` (which trips R1 rather than being scanned).
+# Those are declared limitations, not oversights; each was measured, iteration 273.
 set -u
 
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
@@ -18,7 +21,7 @@ instrument_failure() {
 	printf "%b✗ tmpfile hygiene instrument failure (%s): %s%b\n" "$RED" "$1" "$2" "$RESET"
 }
 
-TMP_DIR=$(mktemp -d)
+TMP_DIR=$(mktemp -d) || { echo "tmpfile hygiene instrument failure: mktemp -d failed" >&2; exit 2; }
 trap 'rm -rf "$TMP_DIR"' EXIT
 FILES="$TMP_DIR/files"
 VIOLATIONS="$TMP_DIR/violations"

--- a/scripts/check_tmpfile_hygiene.sh
+++ b/scripts/check_tmpfile_hygiene.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Refuse fixed /tmp paths in Makefile recipes.
+#
+# SCOPE, stated rather than implied: this scans tab-led recipe lines and
+# column-0 variable assignments in `Makefile` + `make/*.mk`. It does NOT see a
+# fixed path reached via an `export FOO := ...` line, an included file outside
+# `make/`, or a path built at runtime from string concatenation. Those are
+# declared limitations, not oversights.
+set -u
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+MK_ROOT="${MK_ROOT:-$REPO_ROOT}"
+# R4 floor: this repository currently enumerates Makefile plus 11 make/*.mk files.
+MK_FILES_EXPECTED="${MK_FILES_EXPECTED:-12}"
+RED='\033[0;31m'; GREEN='\033[0;32m'; RESET='\033[0m'
+
+instrument_failure() {
+	printf "%b✗ tmpfile hygiene instrument failure (%s): %s%b\n" "$RED" "$1" "$2" "$RESET"
+}
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+FILES="$TMP_DIR/files"
+VIOLATIONS="$TMP_DIR/violations"
+: >"$FILES"
+: >"$VIOLATIONS"
+
+if [ -e "$MK_ROOT/Makefile" ]; then
+	printf '%s\n' "$MK_ROOT/Makefile" >>"$FILES"
+fi
+for _file in "$MK_ROOT"/make/*.mk; do
+	[ -e "$_file" ] || continue
+	printf '%s\n' "$_file" >>"$FILES"
+done
+
+FILE_COUNT=$(wc -l <"$FILES" | tr -d ' ')
+# R1: the make-file enumeration must not be empty.
+if [ "$FILE_COUNT" -eq 0 ]; then
+	instrument_failure R1 "enumerated make-file set is empty under $MK_ROOT"
+	exit 2
+fi
+
+# R4: pin the enumeration floor so a silently narrowed glob cannot pass.
+case "$MK_FILES_EXPECTED" in
+	''|*[!0-9]*)
+		instrument_failure R4 "MK_FILES_EXPECTED must be a non-negative integer (got $MK_FILES_EXPECTED)"
+		exit 2
+		;;
+esac
+if [ "$FILE_COUNT" -lt "$MK_FILES_EXPECTED" ]; then
+	instrument_failure R4 "enumerated $FILE_COUNT files; expected at least $MK_FILES_EXPECTED"
+	exit 2
+fi
+
+TMP_OCCURRENCES=0
+while IFS= read -r _file; do
+	# R2: every member admitted by the enumerator must still exist and be readable.
+	if [ ! -f "$_file" ] || [ ! -r "$_file" ]; then
+		instrument_failure R2 "enumerated file is missing or unreadable: $_file"
+		exit 2
+	fi
+	_relative=${_file#"$MK_ROOT"/}
+	_file_violations="$TMP_DIR/file.violations"
+	_file_count="$TMP_DIR/file.count"
+	awk -v file="$_relative" -v count_file="$_file_count" '
+		BEGIN { count = 0 }
+		# Recipe lines (tab-led) AND column-0 make variable assignments: a fixed
+		# path parked in a variable and expanded in a recipe is the same defect,
+		# and a recipe-only scan cannot see it (measured, iteration 273 drill D5).
+		/^\t/ || /^[A-Za-z_][A-Za-z0-9_]*[[:space:]]*[:?+]?=/ {
+			field_count = split($0, fields, /[[:space:]]+/)
+			for (i = 1; i <= field_count; i++) {
+				rest = fields[i]
+				while (match(rest, /\/tmp(\/|\}\/)[^[:space:]";|&<>()]+/)) {
+					token = substr(rest, RSTART, RLENGTH)
+					count++
+					if (index(fields[i], "$") == 0 && index(fields[i], "XXXXXX") == 0) {
+						printf "%s:%d: %s\n", file, NR, token
+					}
+					rest = substr(rest, RSTART + RLENGTH)
+				}
+			}
+		}
+		END { print count > count_file }
+	' "$_file" >"$_file_violations"
+	AWK_RC=$?
+	if [ "$AWK_RC" -ne 0 ] || [ ! -s "$_file_count" ]; then
+		instrument_failure R2 "could not scan enumerated file $_file (rc=$AWK_RC)"
+		exit 2
+	fi
+	_file_tmp_count=$(cat "$_file_count")
+	TMP_OCCURRENCES=$((TMP_OCCURRENCES + _file_tmp_count))
+	cat "$_file_violations" >>"$VIOLATIONS"
+done <"$FILES"
+
+# R3: the matcher must see a known-positive in the same files used for the verdict.
+if [ "$TMP_OCCURRENCES" -eq 0 ]; then
+	instrument_failure R3 "no /tmp/ occurrence was observed in the enumerated make recipes"
+	exit 2
+fi
+
+if [ -s "$VIOLATIONS" ]; then
+	printf "%b✗ fixed /tmp path(s) found in make recipes:%b\n" "$RED" "$RESET"
+	sed 's/^/    /' "$VIOLATIONS"
+	exit 1
+fi
+
+printf "%b✓ tmpfile hygiene holds across %s make files%b\n" "$GREEN" "$FILE_COUNT" "$RESET"

--- a/scripts/test_check_tmpfile_hygiene.sh
+++ b/scripts/test_check_tmpfile_hygiene.sh
@@ -7,7 +7,7 @@ GATE="$REPO_ROOT/scripts/check_tmpfile_hygiene.sh"
 TMP_DIR=$(mktemp -d)
 FAILED=0
 ARMS_RUN=0
-ARMS_EXPECTED=9
+ARMS_EXPECTED=11
 OUT=""; RC=0
 
 pass() { echo "  ok   — $1"; ARMS_RUN=$((ARMS_RUN + 1)); }
@@ -106,7 +106,11 @@ fi
 # from the iteration-273 controller drill (D5), where it escaped with rc=0.
 VARFIX="$TMP_DIR/varfix"
 mkdir -p "$VARFIX"
-printf 'ITER_TMP := /tmp/via_variable.txt\nfixture:\n\t@echo hi > $(ITER_TMP)\n' >"$VARFIX/Makefile"
+# The decoy recipe line carries an ACCEPTED (`$`-bearing) /tmp path purely so R3's
+# known-positive is satisfied by the recipe scan alone. Without it, reverting the
+# variable-line widening trips R3 instead of this arm's own escape branch, and the
+# arm would pass for a reason unrelated to what it claims to test.
+printf 'ITER_TMP := /tmp/via_variable.txt\nfixture:\n\t@touch /tmp/decoy.$$\n\t@echo hi > $(ITER_TMP)\n' >"$VARFIX/Makefile"
 run_gate "$VARFIX" 1
 if [ "$RC" -eq 0 ]; then
 	fail "a fixed path defined in a make variable escaped the enumerator (rc=0)"
@@ -116,9 +120,33 @@ else
 	fail "refused but never named the variable-defined path: $OUT"
 fi
 
-# (9) Explicitly pin the self-test's own arm enumeration.
-if [ "$ARMS_RUN" -ne 8 ]; then
-	fail "arm-count precondition saw $ARMS_RUN of 8 substantive arms"
+# (9) R4a: a non-integer MK_FILES_EXPECTED is an instrument failure, not a count.
+run_gate "$REPO_ROOT" "not-a-number"
+if [ "$RC" -eq 0 ]; then
+	fail "R4a accepted a non-integer MK_FILES_EXPECTED"
+elif printf '%s' "$OUT" | grep -q 'R4'; then
+	pass "R4a refuses a non-integer MK_FILES_EXPECTED"
+else
+	fail "refused a non-integer MK_FILES_EXPECTED without naming R4: $OUT"
+fi
+
+# (10) R2a: an enumerated member that is not a readable regular file. A DIRECTORY named
+# `*.mk` passes the enumerator's -e test and must then be refused, not silently skipped.
+DIRFIX="$TMP_DIR/dirfix"
+mkdir -p "$DIRFIX/make/notafile.mk"
+printf 'fixture:\n\t@touch /tmp/ok.$$\n' >"$DIRFIX/Makefile"
+run_gate "$DIRFIX" 1
+if [ "$RC" -eq 0 ]; then
+	fail "R2a admitted a non-regular enumerated member (rc=0)"
+elif printf '%s' "$OUT" | grep -q 'R2'; then
+	pass "R2a refuses an enumerated member that is not a readable file"
+else
+	fail "refused a non-regular member without naming R2: $OUT"
+fi
+
+# (11) Explicitly pin the self-test's own arm enumeration.
+if [ "$ARMS_RUN" -ne 10 ]; then
+	fail "arm-count precondition saw $ARMS_RUN of 10 substantive arms"
 else
 	pass "arm-count floor reached all substantive arms"
 fi

--- a/scripts/test_check_tmpfile_hygiene.sh
+++ b/scripts/test_check_tmpfile_hygiene.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Mutation-sensitive self-test for check_tmpfile_hygiene.sh (bash 3.2).
+set -u
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+GATE="$REPO_ROOT/scripts/check_tmpfile_hygiene.sh"
+TMP_DIR=$(mktemp -d)
+FAILED=0
+ARMS_RUN=0
+ARMS_EXPECTED=9
+OUT=""; RC=0
+
+pass() { echo "  ok   — $1"; ARMS_RUN=$((ARMS_RUN + 1)); }
+fail() { echo "  FAIL — $1"; FAILED=1; ARMS_RUN=$((ARMS_RUN + 1)); }
+die() { echo "  FAIL — $1"; exit 1; }
+trap 'rm -rf "$TMP_DIR"' EXIT HUP INT TERM
+
+run_gate() {
+	OUT=$(MK_ROOT="$1" MK_FILES_EXPECTED="$2" /bin/bash "$GATE" 2>&1)
+	RC=$?
+}
+
+make_fixture() {
+	_fixture=$1
+	_line=$2
+	mkdir -p "$_fixture"
+	printf 'fixture:\n\t%s\n' "$_line" >"$_fixture/Makefile"
+}
+
+echo "tmpfile hygiene gate:"
+[ -f "$GATE" ] || die "$GATE not found; refusing a vacuous green"
+
+# (1) Real repository control.
+run_gate "$REPO_ROOT" 12
+RC_REAL=$RC
+if [ "$RC" -eq 0 ]; then pass "real repository passes"; else fail "real repository expected rc=0, got rc=$RC: $OUT"; fi
+
+# (2) Addition: a newly enumerated fixed path must be seen and named with its line.
+FIXED="$TMP_DIR/fixed"
+make_fixture "$FIXED" 'touch /tmp/newthing.txt'
+run_gate "$FIXED" 1
+RC_NEG=$RC
+if [ "$RC" -eq 0 ]; then
+	fail "fixed-path addition expected non-zero: $OUT"
+elif ! printf '%s\n' "$OUT" | grep -qF 'Makefile:2'; then
+	fail "fixed-path addition did not name Makefile:2: $OUT"
+elif ! printf '%s\n' "$OUT" | grep -qF '/tmp/newthing.txt'; then
+	fail "fixed-path addition did not name /tmp/newthing.txt: $OUT"
+else
+	pass "new fixed-path recipe was seen and named at Makefile:2"
+fi
+
+# (3) PID-suffixed paths are accepted.
+PID_FIXTURE="$TMP_DIR/pid"
+make_fixture "$PID_FIXTURE" 'touch /tmp/thing.$$$$'
+run_gate "$PID_FIXTURE" 1
+RC_POS=$RC
+if [ "$RC" -eq 0 ]; then pass "PID-suffixed path is accepted"; else fail "PID-suffixed path expected rc=0, got rc=$RC: $OUT"; fi
+
+# The negative and positive observations must be behaviorally distinct.
+[ "$RC_NEG" -ne "$RC_POS" ] || die "fixed and uniquified arms did not differ (both rc=$RC_NEG)"
+[ "$RC_NEG" -ne "$RC_REAL" ] || die "fixed addition and real control did not differ (both rc=$RC_NEG)"
+
+# (4) mktemp XXXXXX paths, including TMPDIR fallback syntax, are accepted.
+MKTEMP_FIXTURE="$TMP_DIR/mktemp"
+make_fixture "$MKTEMP_FIXTURE" 'f=$$(mktemp "$${TMPDIR:-/tmp}/thing.XXXXXX")'
+run_gate "$MKTEMP_FIXTURE" 1
+if [ "$RC" -eq 0 ]; then pass "mktemp XXXXXX path is accepted"; else fail "mktemp path expected rc=0, got rc=$RC: $OUT"; fi
+
+# (5) R1: empty make-file enumeration must fail as an instrument error.
+EMPTY="$TMP_DIR/empty"
+mkdir -p "$EMPTY"
+run_gate "$EMPTY" 0
+if [ "$RC" -ne 2 ]; then
+	fail "R1 empty file set expected rc=2, got rc=$RC: $OUT"
+elif ! printf '%s\n' "$OUT" | grep -qF 'instrument failure (R1)'; then
+	fail "R1 empty file set did not name R1: $OUT"
+else
+	pass "R1 refuses an empty make-file set"
+fi
+
+# (6) R3: a readable file set with no /tmp/ known-positive must fail.
+NO_TMP="$TMP_DIR/no-tmp"
+make_fixture "$NO_TMP" 'echo clean'
+run_gate "$NO_TMP" 1
+if [ "$RC" -ne 2 ]; then
+	fail "R3 no-/tmp control expected rc=2, got rc=$RC: $OUT"
+elif ! printf '%s\n' "$OUT" | grep -qF 'instrument failure (R3)'; then
+	fail "R3 no-/tmp control did not name R3: $OUT"
+else
+	pass "R3 refuses a file set with no /tmp/ occurrence"
+fi
+
+# (7) R4: an expected count above the actual enumeration must fail.
+run_gate "$PID_FIXTURE" 2
+if [ "$RC" -ne 2 ]; then
+	fail "R4 count floor expected rc=2, got rc=$RC: $OUT"
+elif ! printf '%s\n' "$OUT" | grep -qF 'instrument failure (R4)'; then
+	fail "R4 count floor did not name R4: $OUT"
+else
+	pass "R4 refuses an enumerated count below MK_FILES_EXPECTED"
+fi
+
+# (8) A fixed path parked in a column-0 make VARIABLE and expanded in a recipe is the
+# same defect, and a recipe-line-only scan cannot see it. Promoted into a committed arm
+# from the iteration-273 controller drill (D5), where it escaped with rc=0.
+VARFIX="$TMP_DIR/varfix"
+mkdir -p "$VARFIX"
+printf 'ITER_TMP := /tmp/via_variable.txt\nfixture:\n\t@echo hi > $(ITER_TMP)\n' >"$VARFIX/Makefile"
+run_gate "$VARFIX" 1
+if [ "$RC" -eq 0 ]; then
+	fail "a fixed path defined in a make variable escaped the enumerator (rc=0)"
+elif printf '%s' "$OUT" | grep -q 'via_variable.txt'; then
+	pass "a fixed path defined in a make variable is caught and named"
+else
+	fail "refused but never named the variable-defined path: $OUT"
+fi
+
+# (9) Explicitly pin the self-test's own arm enumeration.
+if [ "$ARMS_RUN" -ne 8 ]; then
+	fail "arm-count precondition saw $ARMS_RUN of 8 substantive arms"
+else
+	pass "arm-count floor reached all substantive arms"
+fi
+
+if [ "$ARMS_RUN" -ne "$ARMS_EXPECTED" ]; then
+	echo "  FAIL — $ARMS_RUN of $ARMS_EXPECTED arms ran; refusing a vacuous green"
+	FAILED=1
+fi
+if [ "$FAILED" -eq 0 ]; then echo "tmpfile hygiene gate: OK ($ARMS_RUN arms)"; exit 0; fi
+echo "tmpfile hygiene gate: FAILED"
+exit 1


### PR DESCRIPTION
## What

Two `make` targets wrote to **fixed `/tmp` literals**. Three missions plus interactive
sessions run on this rig from **separate clones** — they do not share a checkout, they do
share `/tmp` — so a concurrent run in another clone could decide, or corrupt, the result.

### `make lint` — the verdict was computed from a shared file

`golangci-lint` output went to `/tmp/lint.raw`; the filtered stream was `tee`d to
`/tmp/lint.out`; the target's **verdict** was then `grep`ed out of that shared file.
Measured, three arms:

| arm | grep rc | verdict |
|---|---|---|
| file holds a real finding | 0 | FAIL (correct) |
| a second run `tee`s over it first | 1 | PASS — **false green** |
| clean run greps another's findings | 0 | FAIL — **false red** |

`tee` truncates on open, so the window is the whole streaming write, not an instant.
There was also no cleanup: both files survived every run.

### `make verify-stdlib-selftest` — the shared file was a backup of a tracked source

The recipe copies `std/option.ail` to `/tmp/_selftest_option.ail`, appends a canary export,
and a `trap` restores the tracked file **from that backup**. Interleave two runs — A backs
up, A appends, B backs up (now polluted), A's trap restores — and the tracked file is left
carrying the canary. Reproduced deterministically at base (no timing luck):
`sha256 4a5ee1b2… → 6813b3c5…`, `git status` ` M std/option.ail`.

## Fix

Both targets allocate per-invocation `mktemp` files and remove them via a trap on every
exit path. `LINT_RC=$?` still immediately follows `golangci-lint`; the selftest's trap is
armed **before** the tracked file is touched. `make/test.mk` was already correct
(`$$`-suffixed) and is untouched — it is the reference implementation, and it supplies the
new gate's known-positive control.

New CI gate `check-tmpfile-hygiene` refuses fixed `/tmp` paths in make recipes, with four
anti-vacuity floors — R1 non-empty enumeration, R2 members readable, R3 a known-positive
**scoped to the same file set** (zero `/tmp` occurrences anywhere is an instrument failure,
not a clean tree), R4 an enumerated-count floor. Its self-test runs **nine** arms.

## Controller drill (mutants distinct from the executor's, anchored to the diff hunk by hunk)

- revert either make hunk → gate `rc=1`, naming the file — **each hunk has a killer**
- add a brand-new fixed path → caught and named (an *addition* proves the enumerator LOOKS,
  not merely that it FIRES)
- make-file set with no `/tmp` at all → R3 trips at `rc=2`
- **the one that matters:** inject a real unused function → `make lint` `rc=2` against a
  control `rc=0`. The refactor did **not** make the verdict vacuous.
- **blind spot the executor's self-test did not cover:** a fixed path parked in a column-0
  make *variable* and expanded in a recipe escaped at `rc=0`. The enumerator now scans
  variable assignments, the scope it still cannot see is declared in the script header, and
  the case is promoted from a probe into committed **arm 9** — which reds when the widening
  is reverted (mutant `rc=1` vs restored `rc=0`; restore verified byte-identical by sha256).

## Gates

All re-run by the controller **outside the sandbox**, all `rc=0`: `check-changelog`,
`check-file-sizes`, `check-boundaries`, `check-protocol-closure`,
`test-check-protocol-closure`, `check-tmpfile-hygiene`, `test-check-tmpfile-hygiene`,
`bash -n` on both scripts, `build`, `verify-stdlib-selftest`, `lint`.

Scope stated rather than implied: the diff touches two make files, two new shell scripts,
one workflow and one changelog — **no Go source**, so the Go suite is unaffected and was not
re-run. Measured on **darwin/arm64** under the rig's native **bash 3.2.57**, zero bash-4
constructs (control fired).

V1 mission iteration 273. Executor `codex:gpt-5.6-sol`; controller `opus`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
