### PR TITLE
fix(format): a record parameter lost its parens, so the formatter emitted source that could not be re-parsed

### DIFF
--- a/changelogs/v0.32-current.md
+++ b/changelogs/v0.32-current.md
@@ -4,6 +4,51 @@
 
 ## [Unreleased]
 
+### Fixed — `ailang fmt` emitted source that could not be re-parsed when a function type took a record parameter
+
+`std/cognition.ail` was valid input (`ailang check` rc=0) whose formatted output failed
+to re-parse, and the formatter said so itself: *"formatted output failed to re-parse
+(formatter defect)"*. Reduced to two lines:
+
+```ailang
+export func f(cb: ({a: string}) -> ()) -> () { g(cb) }
+```
+
+The printer drops the parentheses around a function type's sole parameter, because
+`int -> int` is the taught spelling and always emitting `(int) -> int` rewrote ten of the
+teaching prompt's own examples. `bareArrowSafe` decided when that was legal as a
+BLACKLIST — parens were kept for `FuncType` (arrow associativity) and `TupleType`
+(read as multiple parameters), and dropped for everything else. A record parameter
+therefore emitted `{ a: string } -> ()`, whose leading `{` the parser reads as a BLOCK:
+`PAR_UNEXPECTED_TOKEN ... expected ), got -> instead`.
+
+`bareArrowSafe` is now a WHITELIST. `SimpleType`, `TypeVar`, `ListType`, `ArrayType` and
+`TypeApp` may drop their parens; `FuncType`, `TupleType` and `RecordType` may not; a
+`LabelledType` recurses on its base, since `{a: int}<L>` still opens with `{`; and
+anything else defaults to KEEPING them. The direction matters more than the one case
+fixed: under a blacklist a type node added later is silently unsound, while under a
+whitelist it is merely verbose.
+
+Behaviour is unchanged for every shape the prompt teaches — `string -> ()` still emits
+bare. Measured across `std/`: round-trip failures 1 → 0 (ok 39 → 40); across
+`examples/`: 0 → 0, no regression.
+
+**Why CI never saw it.** Every formatter corpus test walked `../../examples` only, so
+`std/`'s 46 files — including the sole round-trip offender in the repo — were outside the
+gate by construction (0 test references to `std/`, control: 1 to `examples/`). A new
+`TestFormatterOutputAlwaysReParses` sweeps both roots and asserts the one property whose
+violation means the formatter emitted unreadable source, with anti-vacuity floors: a
+missing root and a root contributing zero parse-valid files each fail loudly rather than
+passing as a clean sweep. `TestBareArrowSoundnessByConstruct` pins the construct class
+directly. The existing comment gate was deliberately left alone — its acceptance ceiling
+is calibrated on `examples/` alone, so widening it would fail for comment-attachment
+reasons belonging to a different work item.
+
+Mutation drill: restoring the blacklist reproduces the defect (`fmt` rc 0 → 2), reds both
+new tests, and — with them skipped — leaves the rest of the package green (rc=0), so the
+class had no prior coverage at all.
+
+
 ### Fixed — `fmt-check-ail` scanned a directory that has never existed, and called an empty scan a pass
 
 `make fmt-check-ail` enumerated `find examples stdlib -name '*.ail'`. This repo has no

--- a/internal/format/roundtrip_soundness_test.go
+++ b/internal/format/roundtrip_soundness_test.go
@@ -118,6 +118,11 @@ func TestBareArrowSoundnessByConstruct(t *testing.T) {
 		{"tuple_param", "module t\nexport func f(cb: ((int, string)) -> bool) -> bool { g(cb) }\n"},
 		{"simple_param", "module t\nexport func f(cb: (string) -> ()) -> () { g(cb) }\n"},
 		{"list_param", "module t\nexport func f(cb: ([int]) -> ()) -> () { g(cb) }\n"},
+		// LabelledType delegates to its base. A record-based label
+		// (`{a: string}<secret>`) is unreachable — the parser rejects it in type
+		// position — so the recursion is exercised here through simple bases.
+		{"labelled_param", "module t\nexport func f(cb: (string<secret>) -> ()) -> () { g(cb) }\n"},
+		{"refined_param", "module t\nexport func f(cb: (string{not secret}) -> ()) -> () { g(cb) }\n"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/format/roundtrip_soundness_test.go
+++ b/internal/format/roundtrip_soundness_test.go
@@ -26,15 +26,24 @@ import (
 // (inlineInteriorRefusalCeiling), so adding std/ would have failed it for
 // comment-attachment reasons belonging to a different work item.
 
-// soundnessRoots are the two trees that ship AILANG source. A root that does not
-// exist is a hard failure, not a skip: a mistyped root returns zero files and
-// reads exactly like a clean sweep.
+// soundnessRoots covers BOTH trees that ship AILANG source. A root that does not
+// exist is a hard failure, not a skip: a mistyped root enumerates zero files and
+// reads exactly like a clean sweep (the `stdlib/` that fmt-check-ail scanned for
+// months).
 var soundnessRoots = []string{"../../std", "../../examples"}
 
-// TestFormatterOutputAlwaysReParses walks every shipped .ail file. For each file
-// that parses cleanly, the printer's output (with comments, the real CLI path)
-// must itself parse. A refusal is fine — fail-closed is the designed behaviour —
-// but SUCCESSFUL output that cannot be re-read is a soundness defect.
+// TestFormatterOutputAlwaysReParses walks every shipped .ail file and asserts the
+// printer's output re-parses. Output that cannot be re-read is a soundness defect.
+//
+// It calls Source (the comment-free skeleton), NOT SourceWithComments, and that is
+// a deliberate scoping rather than a weakening. The property under test belongs to
+// TYPE EMISSION, which both paths share — measured: under the pre-fix printer this
+// sweep still catches std/cognition.ail. Comment attachment adds nothing to this
+// class and costs ~1670x more: SourceWithComments over std/ takes 13.4s (jwt.ail
+// alone 4.5s, sem.ail 3.6s, ai.ail 2.9s, against a ~200us parse), which pushed
+// internal/format past the 600s coverage-gate timeout. Source() over the same 46
+// files takes 8ms. Comment-path round-tripping over examples/ is already asserted
+// by TestCorpusCommentGate.
 func TestFormatterOutputAlwaysReParses(t *testing.T) {
 	perRoot := map[string]int{}
 	var emitted, refused int
@@ -63,7 +72,7 @@ func TestFormatterOutputAlwaysReParses(t *testing.T) {
 			}
 			perRoot[root]++
 
-			out, ferr := SourceWithComments(prog, data, Options{})
+			out, ferr := Source(prog, Options{})
 			if ferr != nil {
 				refused++ // fail-closed refusal: not a soundness violation
 				return nil

--- a/internal/format/roundtrip_soundness_test.go
+++ b/internal/format/roundtrip_soundness_test.go
@@ -1,0 +1,140 @@
+package format
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/lexer"
+	"github.com/sunholo-data/ailang/internal/parser"
+)
+
+// roundtrip_soundness_test.go pins the FORMATTER SOUNDNESS property:
+//
+//	if the printer emits output for a parse-clean file, that output must re-parse.
+//
+// This is weaker than the corpus comment gate (it says nothing about comment
+// attachment or idempotence) and deliberately so: it is the one property whose
+// violation means `ailang fmt` produced source the compiler cannot read.
+//
+// It exists because `std/cognition.ail` violated it undetected. Every formatter
+// corpus test walked `../../examples` ONLY, so std/'s 46 files — including the
+// sole round-trip offender in the whole repo — were invisible to CI by
+// construction. Widening the existing comment gate instead was rejected: that
+// gate carries an acceptance ceiling calibrated on examples/ alone
+// (inlineInteriorRefusalCeiling), so adding std/ would have failed it for
+// comment-attachment reasons belonging to a different work item.
+
+// soundnessRoots are the two trees that ship AILANG source. A root that does not
+// exist is a hard failure, not a skip: a mistyped root returns zero files and
+// reads exactly like a clean sweep.
+var soundnessRoots = []string{"../../std", "../../examples"}
+
+// TestFormatterOutputAlwaysReParses walks every shipped .ail file. For each file
+// that parses cleanly, the printer's output (with comments, the real CLI path)
+// must itself parse. A refusal is fine — fail-closed is the designed behaviour —
+// but SUCCESSFUL output that cannot be re-read is a soundness defect.
+func TestFormatterOutputAlwaysReParses(t *testing.T) {
+	perRoot := map[string]int{}
+	var emitted, refused int
+	var defects []string
+
+	for _, root := range soundnessRoots {
+		if _, err := os.Stat(root); err != nil {
+			t.Fatalf("corpus root %s is missing: %v (a root that does not exist "+
+				"enumerates zero files and reads like a clean sweep)", root, err)
+		}
+		err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() || !strings.HasSuffix(path, ".ail") {
+				return nil
+			}
+			data, rerr := os.ReadFile(path)
+			if rerr != nil {
+				return rerr
+			}
+			p := parser.New(lexer.New(string(data), path))
+			prog := p.Parse()
+			if len(p.Errors()) > 0 || prog == nil || prog.File == nil {
+				return nil // not formatter-eligible (negative fixtures, mid-edit files)
+			}
+			perRoot[root]++
+
+			out, ferr := SourceWithComments(prog, data, Options{})
+			if ferr != nil {
+				refused++ // fail-closed refusal: not a soundness violation
+				return nil
+			}
+			emitted++
+
+			rp := parser.New(lexer.New(string(out), path))
+			if reprog := rp.Parse(); len(rp.Errors()) > 0 || reprog == nil || reprog.File == nil {
+				msg := "re-parse produced no file"
+				if len(rp.Errors()) > 0 {
+					msg = rp.Errors()[0].Error()
+				}
+				defects = append(defects, path+": "+msg)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", root, err)
+		}
+	}
+
+	t.Logf("SOUNDNESS: emitted=%d refused=%d defects=%d (per-root parse-valid: %v)",
+		emitted, refused, len(defects), perRoot)
+
+	// Anti-vacuity floor. Each root must contribute, or the sweep is not covering
+	// what its name claims — the exact failure that hid this defect.
+	for _, root := range soundnessRoots {
+		if perRoot[root] == 0 {
+			t.Fatalf("corpus root %s contributed ZERO parse-valid files — instrument failure, not a pass", root)
+		}
+	}
+	if emitted == 0 {
+		t.Fatal("printer emitted output for ZERO files — instrument failure, not a pass")
+	}
+	for _, d := range defects {
+		t.Errorf("FORMATTER SOUNDNESS DEFECT: %s", d)
+	}
+}
+
+// TestBareArrowSoundnessByConstruct pins the construct class directly: a sole
+// parameter of a function type may drop its parentheses only when the result
+// re-parses to the same thing. The record case is the one that regressed.
+func TestBareArrowSoundnessByConstruct(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"record_param", "module t\nexport func f(cb: ({a: string}) -> ()) -> () { g(cb) }\n"},
+		{"record_param_with_effects", "module t\nexport func f(cb: ({a: string}) -> () ! {Msg}) -> () ! {Msg} { g(cb) }\n"},
+		{"open_record_param", "module t\nexport func f(cb: ({a: string, ...}) -> ()) -> () { g(cb) }\n"},
+		{"func_param", "module t\nexport func f(cb: ((int) -> int) -> int) -> int { g(cb) }\n"},
+		{"tuple_param", "module t\nexport func f(cb: ((int, string)) -> bool) -> bool { g(cb) }\n"},
+		{"simple_param", "module t\nexport func f(cb: (string) -> ()) -> () { g(cb) }\n"},
+		{"list_param", "module t\nexport func f(cb: ([int]) -> ()) -> () { g(cb) }\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := parser.New(lexer.New(tc.src, tc.name))
+			prog := p.Parse()
+			if len(p.Errors()) > 0 || prog == nil || prog.File == nil {
+				t.Fatalf("fixture does not parse: %v", p.Errors())
+			}
+			out, err := Source(prog, Options{})
+			if err != nil {
+				t.Fatalf("Source: %v", err)
+			}
+			rp := parser.New(lexer.New(string(out), tc.name))
+			if reprog := rp.Parse(); len(rp.Errors()) > 0 || reprog == nil {
+				t.Errorf("formatted output failed to re-parse: %v\n--- emitted ---\n%s",
+					rp.Errors(), out)
+			}
+		})
+	}
+}

--- a/internal/format/types.go
+++ b/internal/format/types.go
@@ -149,18 +149,32 @@ func (p *printer) funcTypeString(n *ast.FuncType) (string, error) {
 // bareArrowSafe reports whether a sole parameter type can drop its parentheses
 // without changing what the result re-parses to.
 //
-// Two shapes must keep them:
+// Three shapes must keep them:
 //   - a FuncType parameter, because the arrow is RIGHT-associative: `(int ->
 //     int) -> int` and `int -> int -> int` are different types;
 //   - a TupleType parameter, because `(int, string) -> bool` is read as a
 //     TWO-parameter function type, not as one tuple parameter — the only
-//     spelling for the latter is `((int, string)) -> bool`.
+//     spelling for the latter is `((int, string)) -> bool`;
+//   - a RecordType parameter, because the emitted `{ a: int } -> ()` opens with
+//     `{`, which the parser reads as a BLOCK and not as a type. This is the
+//     defect that made `std/cognition.ail` (whose `subscribeMsg` takes a record-
+//     shaped callback) emit source that failed to re-parse.
 func bareArrowSafe(t ast.Type) bool {
-	switch t.(type) {
-	case *ast.FuncType, *ast.TupleType:
+	switch n := t.(type) {
+	case *ast.FuncType, *ast.TupleType, *ast.RecordType:
 		return false
-	default:
+	case *ast.LabelledType:
+		// A label/refinement prints as `<base><suffix>`, so safety is decided
+		// entirely by the base: `{a: int}<L>` still opens with `{`.
+		return bareArrowSafe(n.Base)
+	case *ast.SimpleType, *ast.TypeVar, *ast.ListType, *ast.ArrayType, *ast.TypeApp:
 		return true
+	default:
+		// Whitelist, not blacklist: an ast.Type node added later must default to
+		// KEEPING its parentheses. Verbose output is a cosmetic defect; dropping
+		// parens that turn out to be load-bearing emits source that does not
+		// re-parse, which is a soundness defect.
+		return false
 	}
 }
 


### PR DESCRIPTION
## The defect

`std/cognition.ail` is valid input (`ailang check` rc=0) whose `ailang fmt` output **failed to re-parse**. The formatter caught it itself and refused, fail-closed — so no file was ever corrupted, but `ailang fmt` could not format one of the repo's own stdlib modules, and this is a tool we ship and teach to eval models.

Reduced from 83 lines to two:

```ailang
export func f(cb: ({a: string}) -> ()) -> () { g(cb) }
```

## Mechanism

The printer drops parentheses around a function type's sole parameter, deliberately: `int -> int` is the spelling `ailang prompt` teaches, and always emitting `(int) -> int` once rewrote ten of the prompt's own examples.

`bareArrowSafe` decided when that was legal as a **blacklist** — keep parens for `FuncType` (arrow associativity) and `TupleType` (reads as two parameters), drop for everything else. A record parameter therefore emitted `{ a: string } -> ()`, whose leading `{` the parser reads as a **block**:

```
PAR_UNEXPECTED_TOKEN at std/cognition.ail:80:127: expected next token to be ), got -> instead
```

## Fix

`bareArrowSafe` becomes a **whitelist**: `SimpleType`/`TypeVar`/`ListType`/`ArrayType`/`TypeApp` may drop parens; `FuncType`/`TupleType`/`RecordType` may not; `LabelledType` recurses on its base (`{a: int}<L>` still opens with `{`); anything else defaults to keeping them.

The direction matters more than the single case: under a blacklist an `ast.Type` node added later is **silently unsound**, under a whitelist it is merely verbose. Every shape the prompt teaches is unchanged — `string -> ()` still emits bare.

## Why CI never saw it

Every formatter corpus test walked `../../examples` **only**. `std/`'s 46 files — including the sole round-trip offender in the whole repo — were outside the gate by construction. Measured: **0** test references to `std/`, control **1** to `examples/`.

`TestFormatterOutputAlwaysReParses` now sweeps both roots and asserts the one property whose violation means the formatter emitted unreadable source, with anti-vacuity floors — a missing root, or a root contributing zero parse-valid files, fails loudly rather than reading as a clean sweep. `TestBareArrowSoundnessByConstruct` pins the construct class directly.

The existing comment gate was **deliberately not widened**: its `inlineInteriorRefusalCeiling` is calibrated on `examples/` alone, so adding `std/` would fail it for comment-attachment reasons that belong to the separate `m-fmt-attach-boundary-class` row (38 files).

## Measurements

| | before | after |
|---|---|---|
| `std/` round-trip failures | 1 | **0** |
| `std/` fmt ok / err | 39 / 7 | **40 / 6** |
| `examples/` round-trip failures | 0 | 0 |
| soundness sweep coverage | examples only | examples (397) + std (46) |

The 6 remaining `std/` errors are comment-attachment refusals, untouched here — a different work item.

## Mutation drill

Restoring the blacklist: mutant **LANDED** (sha256 differs), **BUILDS** (rc=0), and its **intended effect asserted against the system's own view** rather than file bytes — `ailang fmt std/cognition.ail` goes rc 0 → 2 with the defect message back.

- Both new tests **red** under the mutant.
- Inverse arm: whole package with those two tests **skipped** → **rc=0**, so they are the sole killers and this class had **no prior coverage at all**.
- Restored from a copy (not `git checkout`, the worktree had uncommitted work), sha256 byte-identical; package green.

A first mutant attempt produced **no** intended effect (rc stayed 0) because deleting `RecordType` from the unsafe case merely falls through to the new `default: return false`. Recorded rather than smoothed over: that is exactly the "LANDED is necessary, not sufficient" trap.

## Gates

`darwin/arm64`; ubuntu and windows legs unrun locally. Under a freshly built, correctly-stamped binary on `PATH`: `go test ./internal/format/... ./cmd/ailang/...` rc=0, `check-changelog`, `check-golden-drift`, `check-file-sizes`, `check-skills`, `check-tmpfile-hygiene`, `go vet`, `go build ./cmd/ailang` all rc=0, gofmt drift 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
