### PR TITLE
motoko row 6g: bound the process GROUP, not just the wrapper PID

### DIFF
--- a/tools/eval/motoko_connection_probe.sh
+++ b/tools/eval/motoko_connection_probe.sh
@@ -225,32 +225,53 @@ lane_start=""
 lane_end=""
 lane_rc=0
 run_lane() {
-  local lane=$1 peers_file=$2 raw_file=$3 driver_log=$4 deadline pid now terminate_deadline
+  local lane=$1 peers_file=$2 raw_file=$3 driver_log=$4 deadline pid now terminate_deadline group_safe
   lane_rc=0
   lane_start=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   : > "$raw_file"
+  set -m
   "$ailang_bin" eval-suite --agent --models "$lane" --benchmarks "$benchmark" --trials 1 --dry-run=false \
     > "$driver_log" 2>&1 &
   pid=$!
+  # A live negative PID proves the child PID is its PGID. Since it is not this
+  # shell's PID, the job group is distinct and a negative-PID kill is safe.
+  if jobs -p 2>/dev/null | grep -qx -- "$pid" && [[ "$pid" != "$$" ]] && kill -0 "-$pid" 2>/dev/null; then
+    group_safe=1
+  else
+    group_safe=0
+  fi
+  set +m
   deadline=$(( $(date +%s) + timeout_secs ))
   while kill -0 "$pid" 2>/dev/null; do
     now=$(date +%s)
     if (( now > deadline )); then
-      kill "$pid" 2>/dev/null || true
+      if (( group_safe )); then
+        kill -TERM "-$pid" 2>/dev/null || true
+      else
+        echo "INSTRUMENT FAILURE: refusing process-group TERM for pid $pid because it does not lead a distinct job group" >&2
+        kill "$pid" 2>/dev/null || true
+      fi
       terminate_deadline=$(( $(date +%s) + 5 ))
       while kill -0 "$pid" 2>/dev/null; do
         (( $(date +%s) <= terminate_deadline )) || {
-          kill -9 "$pid" 2>/dev/null || true
+          if (( group_safe )); then
+            kill -9 "-$pid" 2>/dev/null || true
+          else
+            echo "INSTRUMENT FAILURE: refusing process-group KILL for pid $pid because it does not lead a distinct job group" >&2
+            kill -9 "$pid" 2>/dev/null || true
+          fi
+          { wait "$pid"; } >/dev/null 2>&1 || true
           instrument_failure "lane $lane exceeded its bounded termination deadline"
         }
         sleep 1
       done
+      { wait "$pid"; } >/dev/null 2>&1 || true
       instrument_failure "lane $lane exceeded ${timeout_secs}s sampling deadline"
     fi
     sample_tree "$pid" "$raw_file" "$deadline"
     sleep 1
   done
-  wait "$pid" || lane_rc=$?
+  { wait "$pid"; } 2>/dev/null || lane_rc=$?
   lane_end=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   classify_lsof "$or_file" "$raw_file" | cut -f2- | LC_ALL=C sort -u > "$peers_file"
   echo "lane=$lane driver_rc=$lane_rc peers:" >&2

--- a/tools/eval/motoko_connection_probe.sh
+++ b/tools/eval/motoko_connection_probe.sh
@@ -248,7 +248,7 @@ run_lane() {
       if (( group_safe )); then
         kill -TERM "-$pid" 2>/dev/null || true
       else
-        echo "INSTRUMENT FAILURE: refusing process-group TERM for pid $pid because it does not lead a distinct job group" >&2
+        echo "INSTRUMENT DEGRADED: refusing process-group TERM for pid $pid because it does not lead a distinct job group" >&2
         kill "$pid" 2>/dev/null || true
       fi
       terminate_deadline=$(( $(date +%s) + 5 ))
@@ -257,7 +257,7 @@ run_lane() {
           if (( group_safe )); then
             kill -9 "-$pid" 2>/dev/null || true
           else
-            echo "INSTRUMENT FAILURE: refusing process-group KILL for pid $pid because it does not lead a distinct job group" >&2
+            echo "INSTRUMENT DEGRADED: refusing process-group KILL for pid $pid because it does not lead a distinct job group" >&2
             kill -9 "$pid" 2>/dev/null || true
           fi
           { wait "$pid"; } >/dev/null 2>&1 || true

--- a/tools/eval/test_motoko_connection_probe.sh
+++ b/tools/eval/test_motoko_connection_probe.sh
@@ -26,12 +26,21 @@ require_line() {
 }
 
 run_bounded() {
-  local stdout_file=$1 stderr_file=$2 cap_secs=$3 pid deadline terminate_deadline rc
+  local stdout_file=$1 stderr_file=$2 cap_secs=$3 pid deadline terminate_deadline rc group_safe
   shift 3
   [[ "${1:-}" == -- ]] || return 2
   shift
+  set -m
   "$@" < /dev/null >"$stdout_file" 2>"$stderr_file" &
   pid=$!
+  # A live negative PID proves the child PID is its PGID. Since it is not this
+  # shell's PID, the job group is distinct and a negative-PID kill is safe.
+  if jobs -p 2>/dev/null | grep -qx -- "$pid" && [[ "$pid" != "$$" ]] && kill -0 "-$pid" 2>/dev/null; then
+    group_safe=1
+  else
+    group_safe=0
+  fi
+  set +m
   deadline=$(( $(date +%s) + cap_secs ))
   # Backoff, NOT a flat `sleep 1`. A flat one-second poll charges every arm a full
   # second it never used to pay: measured 30s -> 66-93s for the whole suite, which
@@ -40,21 +49,31 @@ run_bounded() {
   poll=0.05
   while kill -0 "$pid" 2>/dev/null; do
     if (( $(date +%s) > deadline )); then
-      kill "$pid" 2>/dev/null || true
+      if (( group_safe )); then
+        kill -TERM "-$pid" 2>/dev/null || true
+      else
+        echo "instrument failure: refusing process-group TERM for pid $pid because it does not lead a distinct job group" >&2
+        kill "$pid" 2>/dev/null || true
+      fi
       terminate_deadline=$(( $(date +%s) + 5 ))
       while kill -0 "$pid" 2>/dev/null && (( $(date +%s) <= terminate_deadline )); do
         sleep 1
       done
       if kill -0 "$pid" 2>/dev/null; then
-        kill -9 "$pid" 2>/dev/null || true
+        if (( group_safe )); then
+          kill -9 "-$pid" 2>/dev/null || true
+        else
+          echo "instrument failure: refusing process-group KILL for pid $pid because it does not lead a distinct job group" >&2
+          kill -9 "$pid" 2>/dev/null || true
+        fi
       fi
-      wait "$pid" 2>/dev/null || true
+      { wait "$pid"; } >/dev/null 2>&1 || true
       return 199
     fi
     sleep "$poll"
     case "$poll" in 0.05) poll=0.2 ;; 0.2) poll=1 ;; esac
   done
-  wait "$pid"
+  { wait "$pid"; } 2>/dev/null
   rc=$?
   return "$rc"
 }
@@ -353,6 +372,43 @@ if kill -0 "$cap_pid" 2>/dev/null; then
   exit 1
 fi
 pass_arm "arm cap terminates a hung command and reports it"
+
+# A wrapper-only kill satisfies the preceding PID check while leaving its sleep
+# grandchild reparented and alive. Give the fixture a distinctive duration and cwd,
+# then enumerate that cwd so the assertion observes the grandchild itself.
+orphan_fixture_secs=2849
+orphan_fixture_dir="$tmp_dir/orphan-fixture-$orphan_fixture_secs"
+mkdir "$orphan_fixture_dir"
+orphan_fixture_dir=$(CDPATH='' cd -- "$orphan_fixture_dir" && pwd -P)
+orphan_fixture_pids() {
+  lsof -a -c sleep -d cwd 2>/dev/null |
+    awk -v fixture_dir="$orphan_fixture_dir" 'NR > 1 && $NF == fixture_dir { print $2 }'
+}
+cleanup_orphan_fixture() {
+  local survivor_pid
+  for survivor_pid in $(orphan_fixture_pids); do
+    kill "$survivor_pid" 2>/dev/null || true
+  done
+}
+orphan_pre_count=$(orphan_fixture_pids | awk 'NF { count++ } END { print count+0 }')
+if (( orphan_pre_count != 0 )); then
+  cleanup_orphan_fixture
+  echo "not ok - arm cap kills a wrapper grandchild: PRE count is $orphan_pre_count, expected 0" >&2
+  exit 1
+fi
+run_bounded "$tmp_dir/orphan.stdout" "$tmp_dir/orphan.stderr" 1 -- \
+  /bin/bash -c 'cd "$1" && /bin/bash -c '\''sleep "$1" & wait'\'' grandchild "$2"' \
+    wrapper "$orphan_fixture_dir" "$orphan_fixture_secs"
+orphan_cap_rc=$?
+orphan_survivor_count=$(orphan_fixture_pids | awk 'NF { count++ } END { print count+0 }')
+cleanup_orphan_fixture
+sleep 0.05
+orphan_post_count=$(orphan_fixture_pids | awk 'NF { count++ } END { print count+0 }')
+if (( orphan_cap_rc != 199 || orphan_survivor_count != 0 || orphan_post_count != 0 )); then
+  echo "not ok - arm cap kills a wrapper grandchild (rc=$orphan_cap_rc survivors=$orphan_survivor_count post_cleanup=$orphan_post_count)" >&2
+  exit 1
+fi
+pass_arm "arm cap kills a wrapper grandchild"
 
 # report_arm_cap is the code that implements this milestone's headline promise — the
 # named `not ok` line plus the captured output tails. The arm above reaches run_bounded


### PR DESCRIPTION
## Row 6g — the cap killed the wrapper and left the grandchild running

`run_bounded` (self-test) and `run_lane` (production) both bounded a child with a wall-clock
cap and, on expiry, killed the **wrapper PID only**. A hung grandchild is reparented to
`PPID 1` and survives. The suite's existing "process survived" check passed for exactly the
reason it should have failed: the wrapper really was dead.

Reproduced first-party against the shipped code **before any edit**, controls firing:

```
PRE  live fixtures        : 0     (clean start)
cap fires                 : rc=199
survivors AFTER the cap   : 1     <-- ps shows PPID 1
wrapper still alive       : 0     <-- the wrapper really did die
POST cleanup              : 0     (instrument returns to zero)
```

### Mechanism, measured before it was written

`setsid` does not exist on macOS and every process-group precedent in this repo is Go-side
(`SysProcAttr{Setpgid:true}`), unusable from bash. The shell mechanism is job control.
Both arms measured, and they differ:

| | wrapper pgid | vs script's own pgid | orphans after kill |
|---|---|---|---|
| without `set -m` | 9361 | **equal** — a group kill would kill the suite | 1 |
| with `set -m` | 9379 (== pid) | differs | 0 |

That is why the group kill is **guarded** rather than unconditional: `jobs -p` membership,
`pid != $$`, and a live `kill -0 "-$pid"` must all hold, else it reports a degraded
instrument and falls back to the single-PID kill.

### The new arm

Scopes by a unique fixture **cwd** via `lsof -c sleep`, not by matching a sleep duration,
and asserts PRE 0 / survivors 0 / POST 0. Duration-matching would have been wrong — it
matches any process whose argv merely *mentions* the string, which briefly fooled the
controller's own leak check during verification.

### Mutation drill (controller, then reproduced by the judge)

Each mutant asserted LANDED (sha256), PARSING (`bash -n`), and **effect-verified against the
parsed form** rather than the bytes; restored byte-identical from a `cp` backup.

| Mutant | Result |
|---|---|
| group kill → single-PID kill | **SOLE KILLER** — `survivors=1`, 34 arms green before it |
| neuter `set -m` | safety refusal fires ×2, suite **reports** the failure instead of killing itself |
| revert the production hunk entirely | **suite stays green 40/40** — zero killers |

### Known gap, filed rather than silently widened

The third mutant is the honest result of walking the diff hunk-by-hunk: the **production
`run_lane` change — the half the row calls "the one that matters" — is pinned by nothing but
`bash -n`.** Filed as row **6i**. The self-test half is genuinely pinned; this PR does not
claim otherwise.

### Evaluation

Judge: sonnet in its own worktree (executor was codex, so generator≠judge holds).
**Round 1 PASS 82/100, zero blocking.** It reproduced all five controller claims exactly,
could not construct a false positive for the `group_safe` guard, and confirmed `set -m`
leaks no job-status lines into the suite output. Its one finding about a defect *this PR
introduced* — the degrade path borrowing `INSTRUMENT FAILURE:`, the hard-abort's prefix,
without aborting — is fixed in the second commit. Its other two findings are pre-existing or
forward-looking and went to the queue.

### Gates

`bash -n` both files rc=0 · suite **39 → 40 arms**, rc=0, 0 `not ok`, run **outside** the
codex sandbox (in-sandbox it is unsatisfiable — arm 33's loopback bind terminates the
session) · no process leaks, checked on `comm == sleep` rather than argv substring ·
refusal-branch drift gate unchanged at 24 · darwin/arm64, which is the only platform this
CI job runs on (`runs-on: macos-latest`, deliberately, for bash 3.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
