### PR TITLE
fix(browser): verify the browser session root instead of assuming MkdirAll secured it

### DIFF
--- a/internal/browser/local/playwright.go
+++ b/internal/browser/local/playwright.go
@@ -67,7 +67,7 @@ func New(config Config) (*Provider, error) {
 	if config.BaseDir == "" {
 		config.BaseDir = filepath.Join(os.TempDir(), "ailang-browser")
 	}
-	if err := os.MkdirAll(config.BaseDir, 0700); err != nil {
+	if err := secureBrowserRoot(config.BaseDir); err != nil {
 		return nil, browser.NewFailure(browser.FailureProvision, "create browser root", err)
 	}
 	if config.Now == nil {

--- a/internal/browser/local/rootdir.go
+++ b/internal/browser/local/rootdir.go
@@ -1,0 +1,80 @@
+package local
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+// browserRootMode is the only permission a browser root may carry: owner-only.
+const browserRootMode os.FileMode = 0o700
+
+// secureBrowserRoot creates the browser session root and then VERIFIES it.
+//
+// os.MkdirAll alone is not sufficient here. The default root is a predictable
+// path under a world-writable parent (os.TempDir()), and MkdirAll returns nil
+// when the path already exists — it does not take ownership and does not
+// re-apply the mode. A local attacker who pre-creates that name, or points a
+// symlink at it, therefore keeps control of a directory we then write session
+// state into.
+//
+// That mattered less when sessions were anonymous. It matters now: an
+// authenticated run's Chromium profile lives under this root, and it holds live
+// session cookies for the leased account.
+//
+// So the post-condition is checked rather than assumed, and a root that fails it
+// is a loud provisioning failure rather than a silent downgrade.
+func secureBrowserRoot(dir string) error {
+	if dir == "" {
+		return fmt.Errorf("browser root path is empty")
+	}
+	if err := os.MkdirAll(dir, browserRootMode); err != nil {
+		return err
+	}
+
+	// Lstat, not Stat: Stat follows a symlink and would happily describe the
+	// attacker's target instead of the link itself.
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("browser root %s is a symlink; refusing to write session state through it", dir)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("browser root %s exists and is not a directory", dir)
+	}
+
+	// Windows does not model POSIX permission bits — Go reports 0777 for
+	// directories there regardless of ACL — so tightening and checking a mode
+	// there would be theatre. Access control on that platform is the user
+	// profile directory's ACL, not a mode.
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+
+	// A pre-existing directory keeps its old mode, because MkdirAll does not
+	// re-apply one. The provider owns this tree — it creates and deletes session
+	// directories inside it — so the right response to a loose mode is to
+	// TIGHTEN it, not to refuse an otherwise usable root. Chmod is also the
+	// ownership probe: it fails for a directory some other user created, which
+	// is precisely the case that must not be silently accepted.
+	if perm := info.Mode().Perm(); perm&0o077 != 0 {
+		if err := os.Chmod(dir, browserRootMode); err != nil {
+			return fmt.Errorf(
+				"browser root %s is group- or world-accessible (mode %04o) and could not be tightened: %w; "+
+					"an authenticated session's cookies would be readable by other local users",
+				dir, perm, err)
+		}
+	}
+
+	// Re-read rather than assume the chmod took effect.
+	final, err := os.Lstat(dir)
+	if err != nil {
+		return err
+	}
+	if perm := final.Mode().Perm(); perm&0o077 != 0 {
+		return fmt.Errorf("browser root %s is still mode %04o after tightening, want %04o", dir, perm, browserRootMode)
+	}
+	return nil
+}

--- a/internal/browser/local/rootdir_test.go
+++ b/internal/browser/local/rootdir_test.go
@@ -1,0 +1,145 @@
+package local
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestSecureBrowserRootCreatesOwnerOnlyDirectory(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "ailang-browser")
+
+	if err := secureBrowserRoot(root); err != nil {
+		t.Fatalf("secureBrowserRoot: %v", err)
+	}
+	info, err := os.Stat(root)
+	if err != nil {
+		t.Fatalf("stat root: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("root is not a directory")
+	}
+	if runtime.GOOS != "windows" {
+		if perm := info.Mode().Perm(); perm != browserRootMode {
+			t.Fatalf("root mode = %04o, want %04o", perm, browserRootMode)
+		}
+	}
+
+	// Every provider construction runs through here, so a second call must be a
+	// no-op rather than an error.
+	if err := secureBrowserRoot(root); err != nil {
+		t.Fatalf("second secureBrowserRoot: %v", err)
+	}
+}
+
+// The case MkdirAll alone cannot handle: the directory already exists, so
+// MkdirAll returns nil WITHOUT re-applying the mode. Left alone, an
+// authenticated session's Chromium profile would sit in a world-readable
+// directory.
+func TestSecureBrowserRootTightensAPreExistingLooseDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not meaningful on Windows")
+	}
+	root := filepath.Join(t.TempDir(), "ailang-browser")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+
+	// Control: MkdirAll accepts this happily, which is exactly the gap.
+	if err := os.MkdirAll(root, browserRootMode); err != nil {
+		t.Fatalf("expected MkdirAll to accept an existing 0755 dir, got %v", err)
+	}
+	if perm := mustPerm(t, root); perm != 0o755 {
+		t.Fatalf("control failed: MkdirAll changed the mode to %04o", perm)
+	}
+
+	if err := secureBrowserRoot(root); err != nil {
+		t.Fatalf("secureBrowserRoot: %v", err)
+	}
+	if perm := mustPerm(t, root); perm != browserRootMode {
+		t.Fatalf("root mode = %04o after tightening, want %04o", perm, browserRootMode)
+	}
+}
+
+// A symlink at the predictable path is the other half of the attack: MkdirAll
+// follows it and reports success, so session state lands wherever it points.
+func TestSecureBrowserRootRejectsASymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs elevation on Windows")
+	}
+	base := t.TempDir()
+	elsewhere := filepath.Join(base, "attacker-owned")
+	if err := os.MkdirAll(elsewhere, browserRootMode); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	root := filepath.Join(base, "ailang-browser")
+	if err := os.Symlink(elsewhere, root); err != nil {
+		t.Fatalf("symlink fixture: %v", err)
+	}
+
+	// Control: MkdirAll is happy to follow it.
+	if err := os.MkdirAll(root, browserRootMode); err != nil {
+		t.Fatalf("expected MkdirAll to accept the symlink, got %v", err)
+	}
+
+	err := secureBrowserRoot(root)
+	if err == nil {
+		t.Fatalf("a symlinked browser root was accepted")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("error %q does not name the symlink", err)
+	}
+}
+
+func TestSecureBrowserRootRejectsAFile(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "ailang-browser")
+	if err := os.WriteFile(root, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+
+	if err := secureBrowserRoot(root); err == nil {
+		t.Fatalf("a regular file was accepted as the browser root")
+	}
+}
+
+func TestSecureBrowserRootRejectsAnEmptyPath(t *testing.T) {
+	if err := secureBrowserRoot(""); err == nil {
+		t.Fatalf("an empty browser root path was accepted")
+	}
+}
+
+// New must surface an unsafe root as a structured provisioning failure rather
+// than continuing with it.
+func TestNewRefusesAnUnsafeBrowserRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs elevation on Windows")
+	}
+	base := t.TempDir()
+	elsewhere := filepath.Join(base, "attacker-owned")
+	if err := os.MkdirAll(elsewhere, browserRootMode); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	root := filepath.Join(base, "ailang-browser")
+	if err := os.Symlink(elsewhere, root); err != nil {
+		t.Fatalf("symlink fixture: %v", err)
+	}
+
+	provider, err := New(Config{BaseDir: root, NpxPath: "/usr/bin/true"})
+	if err == nil {
+		t.Fatalf("New accepted a symlinked browser root")
+	}
+	if provider != nil {
+		t.Fatalf("New returned a provider alongside an error")
+	}
+}
+
+func mustPerm(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("lstat %s: %v", path, err)
+	}
+	return info.Mode().Perm()
+}


### PR DESCRIPTION
Follow-up to #891, which merged before this fix was pushed. SonarCloud flagged a CRITICAL vulnerability on that PR (`new_security_rating: 4`, a D) and the finding is real, so it needs to land separately.

## The finding

`go:S5445` on `internal/browser/local/playwright.go` — the default browser session root is `filepath.Join(os.TempDir(), "ailang-browser")`, a predictable path under a world-writable parent.

There is a standing **Safe** verdict for `go:S5445` in our triage playbook, but it covers coordinator and eval *workspace* paths on the reasoning that they are single-tenant scratch. **That rationale does not transfer here.** As of #891 this directory can hold an authenticated Chromium profile with live session cookies for the leased account, so it was treated as a genuine finding rather than reusing an unrelated verdict.

## The gap

`os.MkdirAll(dir, 0700)` applies its mode **only when it creates** the directory. On a predictable path under a world-writable parent, a local user can pre-create that name — or point a symlink at it — and `MkdirAll` then returns `nil`, leaving them owning a directory we write session state into.

Both halves have control assertions in the tests, so the gap is demonstrated rather than asserted:

- `MkdirAll` accepts an existing `0755` directory and leaves the mode at `0755`
- `MkdirAll` follows a symlink and reports success

## The fix

`secureBrowserRoot` checks the post-condition instead of assuming it:

- **`Lstat`, not `Stat`** — `Stat` follows a symlink and would describe the attacker's target rather than the link. A symlinked root is refused outright.
- A non-directory is refused.
- A loose mode is **tightened, not refused**. The provider already owns this tree — it creates and deletes session directories inside it — so refusing an otherwise usable root would be unhelpful. `Chmod` doubles as the ownership probe: it fails for a directory another user created, which is exactly the case that must not be silently accepted.
- The mode is **re-read afterwards** rather than assumed to have taken effect.

Windows is exempted deliberately: Go reports `0777` for directories there regardless of ACL, so tightening and checking a mode would be theatre rather than protection. Access control on that platform is the profile directory's ACL.

## Note for reviewers

The first version of this check *rejected* loose modes instead of tightening them, which rejected every `t.TempDir()` — those are `0755`, not `0700`. Worth knowing because the failure surfaced only as `create browser root failed`: `browser.Failure` discards its cause by design, to keep provider errors from carrying secrets. That is the right default, and it also means diagnosing one needs a local reproduction.

## Verification

- `go test ./internal/browser/...` and `-race` clean on top of current `dev`
- `golangci-lint` 0 issues, `gofmt` clean
- `GOOS=windows` build + vet OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
