### PR TITLE
fix(make): test-stdlib-freeze has never been able to run — delegate the accepted name to the live 45-module gate

### DIFF
--- a/.agents/skills/sprint-executor/resources/developer_tools.md
+++ b/.agents/skills/sprint-executor/resources/developer_tools.md
@@ -64,7 +64,7 @@ make doctor                # Validate builtin registry
 
 # Stdlib
 make test-stdlib-canaries  # Test stdlib health (std/io, std/net)
-make test-stdlib-freeze    # Verify stdlib interfaces haven't changed
+make test-stdlib-freeze    # Verify stdlib interfaces haven't changed (alias of verify-stdlib)
 make freeze-stdlib         # Generate SHA256 golden files for stdlib
 make verify-stdlib         # Verify stdlib against golden hashes
 
@@ -139,7 +139,7 @@ make freeze-stdlib         # Update golden hashes
 
 # 4. Run health checks
 make test-stdlib-canaries  # Tests std/io, std/net work
-make test-stdlib-freeze    # Verify stdlib interface freeze
+make test-stdlib-freeze    # Verify stdlib interface freeze (alias of verify-stdlib)
 ```
 
 ### Stdlib Tools

--- a/.claude/skills/sprint-executor/resources/developer_tools.md
+++ b/.claude/skills/sprint-executor/resources/developer_tools.md
@@ -64,7 +64,7 @@ make doctor                # Validate builtin registry
 
 # Stdlib
 make test-stdlib-canaries  # Test stdlib health (std/io, std/net)
-make test-stdlib-freeze    # Verify stdlib interfaces haven't changed
+make test-stdlib-freeze    # Verify stdlib interfaces haven't changed (alias of verify-stdlib)
 make freeze-stdlib         # Generate SHA256 golden files for stdlib
 make verify-stdlib         # Verify stdlib against golden hashes
 
@@ -139,7 +139,7 @@ make freeze-stdlib         # Update golden hashes
 
 # 4. Run health checks
 make test-stdlib-canaries  # Tests std/io, std/net work
-make test-stdlib-freeze    # Verify stdlib interface freeze
+make test-stdlib-freeze    # Verify stdlib interface freeze (alias of verify-stdlib)
 ```
 
 ### Stdlib Tools

--- a/Makefile
+++ b/Makefile
@@ -54,16 +54,10 @@ WARNING := ⚠️
 ARROW := →
 LINE := ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-# Stdlib paths (for freeze/verify)
-STDLIB := std/option.ail std/result.ail std/list.ail std/string.ail std/io.ail
-FREEZE_DIR := goldens/stdlib
-TOOLS := ailang
-
 # Export for sub-Makefiles
 export BINARY BUILD_DIR VERSION COMMIT BUILD_TIME
 export GOCMD GOBUILD GOCLEAN GOTEST GOGET GOMOD GOFMT GOVET LDFLAGS
 export GREEN RED YELLOW CYAN BOLD RESET CHECKMARK CROSS WARNING ARROW LINE
-export STDLIB FREEZE_DIR TOOLS
 
 # =============================================================================
 # INCLUDE SUB-MAKEFILES

--- a/changelogs/v0.32-current.md
+++ b/changelogs/v0.32-current.md
@@ -4,6 +4,16 @@
 
 ## [Unreleased]
 
+### Fixed — `make test-stdlib-freeze` now delegates to the live stdlib interface gate
+
+`make test-stdlib-freeze` previously aborted at prerequisite resolution with rc=2 because
+its `goldens/stdlib` directory has never existed on any ref. The historical target now
+delegates to the CI-wired `verify-stdlib` implementation over `.stdlib-golden/`, and the
+dead five-module recipe plus its orphan `STDLIB`, `FREEZE_DIR`, and `TOOLS` variables have
+been removed. `verify-stdlib-selftest` now also proves that a missing golden is reported
+and that the historical alias still reaches the live gate; the missing-golden arm owns an
+independent backup and EXIT trap so it restores the moved golden on success and failure.
+
 ### Fixed — every pi lane was running at 32,000 output tokens, not the declared 65,536
 
 pi-ai's `buildBaseOptions` (`dist/providers/simple-options.js:4`) computes

--- a/design_docs/planned/v0_33_4/m-stdlib-freeze-gate-path-mismatch-sprint-plan.md
+++ b/design_docs/planned/v0_33_4/m-stdlib-freeze-gate-path-mismatch-sprint-plan.md
@@ -1,0 +1,322 @@
+# Sprint Plan: M-STDLIB-FREEZE-GATE — Retire the Rotted Freeze Duplicate, Alias the Accepted Name to the Live Gate
+
+**Design doc**: [m-stdlib-freeze-gate-path-mismatch.md](m-stdlib-freeze-gate-path-mismatch.md)
+**Sprint ID**: `M-STDLIB-FREEZE-GATE`
+**Target**: v0.33.4
+**Estimated**: 0.5 day (3 milestones, 1 commit each)
+**Base**: `da96b98a5` (detached pin), tree clean apart from `design_docs/planned/v0_33_4/`
+**Quorum**: design doc cleared 2 rounds, routed under the narrow-refinement carve-out (Round-3 controller measurements V22–V35).
+
+---
+
+## Summary
+
+`make test-stdlib-freeze` — the stdlib **interface** freeze gate accepted in v0.2.0 — has been
+unrunnable for the whole life of the repository. It aborts at **rc=2 during prerequisite
+resolution** (`No rule to make target 'goldens/stdlib/option.sha256'`), so its recipe body has
+never executed. `goldens/stdlib/` has never existed in any commit on any ref. The live gate is
+`verify-stdlib` (`tools/verify-stdlib.sh` over `.stdlib-golden/`, 45 modules, CI-wired at
+`ci.yml:142` and `:145`).
+
+This sprint **deduplicates**: the historical name becomes a delegation alias of the live gate, the
+fossil recipe and its three orphan variables are deleted, and two permanent arms are added to
+`verify-stdlib-selftest` so both the newly-reachable branch (missing golden) and the alias itself
+stay red-provable in CI.
+
+### THIS IS NOT THE `fmt` GATE
+
+Decision **D-39** (`design_docs/v1-mission.md:106`) rules: *"do NOT wire or freeze the `fmt` gate
+until [the width limit] lands and the second `fmt --write` pass has run, or the collapsed form gets
+frozen as canonical by the gate rather than by a ruling."* That is `fmt-check-ail`, which stays in
+`notWiredIntoCIVerify` untouched. This sprint touches the stdlib **interface** freeze gate only.
+**Do not wire, unwire, freeze, or edit anything `fmt`-related in any milestone.** If a milestone
+appears to require an `fmt` change, stop and report instead.
+
+---
+
+## Executor Protocol (READ FIRST)
+
+1. **NO GIT WRITE OPERATIONS.** The executor runs under a sandbox and must NOT run `git add`,
+   `git commit`, `git checkout`, `git restore`, `git stash`, `git reset`, `git clean`, `git mv`,
+   `git rm`, `git branch`, or `git push`. **The controller commits.** Read-only git
+   (`git status`, `git diff`, `git log`, `git ls-files`, `git grep`) is fine and is used by the
+   acceptance criteria.
+2. **Because git cannot restore anything, every mutation drill backs up with `cp` first and
+   restores with `cp`/`mv`.** A drill that relies on `git checkout -- <file>` is not executable
+   here and is a plan violation.
+3. **Cumulative snapshots.** After each milestone `k` completes and its acceptance criteria are
+   green, copy the current state of every file the sprint has touched *so far* into `.snap/M<k>/`,
+   preserving relative paths:
+   ```
+   .snap/M1/{Makefile, make/test.mk}
+   .snap/M2/{Makefile, make/test.mk, make/examples.mk}
+   .snap/M3/{Makefile, make/test.mk, make/examples.mk, changelogs/v0.32-current.md,
+             .claude/skills/sprint-executor/resources/developer_tools.md,
+             .agents/skills/sprint-executor/resources/developer_tools.md}
+   ```
+   `.snap/` is **not** in `.gitignore`, so it will appear in `git status --porcelain`. Every
+   acceptance criterion below that inspects `git status` is therefore **path-scoped**
+   (`git status --porcelain -- <paths>`) or **before/after-differenced** — never "must be empty"
+   against the whole tree. Tell the controller to delete `.snap/` before committing.
+4. **One commit per milestone**, in order. Milestones are independently committable: M1 alone leaves
+   the tree green; M2 alone leaves it green; M3 is docs.
+5. **Never run `make freeze-stdlib`.** It rewrites all 45 goldens. Nothing in this sprint changes a
+   stdlib interface, so a re-freeze can only launder a real regression. V34 measured all 5 legacy
+   STDLIB modules already hash-match their goldens — **this fix makes the gate GREEN, not red.**
+
+---
+
+## Baselines (controller-measured on a pristine tree at `da96b98a5`, re-confirmed by the planner)
+
+| Command | rc at base | Use |
+|---|---|---|
+| `make test-stdlib-freeze` | **2** (`No rule to make target 'goldens/stdlib/option.sha256'`) | the defect |
+| `make verify-stdlib` | 0 (`✓ All 45 stdlib interfaces stable`) | acceptance gate |
+| `make verify-stdlib-selftest` | 0 | acceptance gate |
+| `make check-file-sizes` | 0 | acceptance gate |
+| `make check-changelog` | 0 | acceptance gate (M3) |
+| `make check-skills` | 0 | acceptance gate (M3) |
+| `go build ./internal/...` | 0 | acceptance gate |
+| `go test ./internal/cihygiene/` | 0 (`ok`) | acceptance gate |
+| `go build ./...` | **1** — `cmd/wasm` and `gen/main` have no native `main` | **ALREADY RED AT BASE. MUST NOT be used as an acceptance gate.** |
+
+Instrument shapes confirmed at base, used by the criteria below:
+
+| Query | Value at base | Meaning |
+|---|---|---|
+| `make -pn 2>/dev/null \| grep -c 'goldens/stdlib'` | **7** | make's own view still carries the dead path |
+| `make -pn 2>/dev/null \| grep -cE '^(STDLIB\|FREEZE_DIR\|TOOLS) '` | **3** | the three orphan variables |
+| `make -pn 2>/dev/null \| grep -cE '^BINARY '` | **1** | **positive control** for the line above |
+| `make -pn 2>/dev/null \| grep -E '^test-stdlib-freeze:'` | `test-stdlib-freeze: goldens/stdlib/option.sha256 …` (5 prereqs) | the fossil's prerequisites |
+| `make -pn 2>/dev/null \| grep -E '^verify-stdlib:'` | `verify-stdlib: build` | the alias inherits fresh-binary resolution |
+| `bash -c 'source tools/stdlib-iface-lib.sh; stdlib_modules \| wc -l'` | **45** | filesystem-derived module count |
+| `ls .stdlib-golden/*.sha256 \| wc -l` | **45** | goldens present and committed |
+
+`make -pn` prints **recipe text as well as the rule database** (confirmed: `selftestCanary`
+appears in it twice). Two consequences the executor must respect:
+
+* **M1's replacement comment must not contain the string `goldens/stdlib`**, or acceptance
+  criterion M1-AC3 (`grep -c 'goldens/stdlib'` → 0) will fail on the comment. Refer to it as
+  "the never-existing golden directory" if you need to.
+* This is also why the mutation drills can assert "the mutation landed" against make's own view
+  rather than against file bytes.
+
+---
+
+## Proposed Milestones
+
+### Milestone 1 — Delegate the name, delete the fossil
+
+**Files**: `make/test.mk`, `Makefile`. **Est. LOC**: −22 / +5.
+
+**Changes**
+
+1. `make/test.mk:183-201` — delete the `# Stdlib freeze` comment, the 5 golden prerequisites and
+   the entire recipe body; replace with a bare delegation alias:
+   ```make
+   # Stdlib freeze — historical name, kept because v0.2.0 acceptance docs and the
+   # sprint-executor skill reference it. The live gate is verify-stdlib
+   # (tools/verify-stdlib.sh over .stdlib-golden/); do not grow a second implementation.
+   test-stdlib-freeze: verify-stdlib ## Verify std/ interfaces haven't changed (alias of verify-stdlib)
+   ```
+   No recipe body. `verify-stdlib: build` (V28), so the alias inherits fresh-binary resolution.
+2. `make/test.mk:9` — `test-stdlib-freeze` stays in `.PHONY`. **Do not remove it.**
+3. `Makefile:58,59,60` — delete `STDLIB`, `FREEZE_DIR`, `TOOLS`.
+4. `Makefile:66` — delete the whole line `export STDLIB FREEZE_DIR TOOLS`.
+
+Deletion safety is measured, not linter-driven (`.claude/rules/coding-standards.md`): 4 `$(FREEZE_DIR)`
+consumers, 1 `$(STDLIB)`, 1 `$(TOOLS)` — **all inside the recipe being deleted**; zero Go `Getenv`
+consumers (V23, control V24 fired); zero bare-shell consumers outside makefiles (V25/V26, control
+V27 fired — the 2 apparent `$STDLIB` hits are `$STDLIB_DIR`, a *different* variable defined locally
+at `tools/stdlib-iface-lib.sh:8`).
+
+**Acceptance criteria** (each is a command that can fail; run each with rc captured *without* a pipe
+where the rc is the assertion):
+
+| # | Command | Expected |
+|---|---|---|
+| M1-AC1 | `make test-stdlib-freeze; echo rc=$?` | **rc=0** (was rc=2) and output ends `✓ All 45 stdlib interfaces stable` |
+| M1-AC2 | `make -pn 2>/dev/null \| grep -qE '^test-stdlib-freeze:[[:space:]]*verify-stdlib[[:space:]]*$'` | **rc=0** — make's own view: the sole prerequisite is `verify-stdlib` |
+| M1-AC3 | `test "$(make -pn 2>/dev/null \| grep -c 'goldens/stdlib')" -eq 0` | **rc=0** (was 7) |
+| M1-AC4 | `test "$(make -pn 2>/dev/null \| grep -cE '^(STDLIB\|FREEZE_DIR\|TOOLS) ')" -eq 0` | **rc=0** (was 3) |
+| M1-AC5 | `test "$(make -pn 2>/dev/null \| grep -cE '^BINARY ')" -eq 1` | **rc=0** — positive control proving M1-AC4's instrument still sees variables |
+| M1-AC6 | `make -n test-stdlib-freeze 2>&1 \| grep -q 'tools/verify-stdlib.sh'` | **rc=0** — the trace reaches the ONE implementation |
+| M1-AC7 | `test "$(make -n test-stdlib-freeze 2>&1 \| grep -c 'shasum\|iface --module')" -eq 0` | **rc=0** — no second implementation survived |
+| M1-AC8 | `make verify-stdlib; echo rc=$?` | **rc=0** |
+| M1-AC9 | `make verify-stdlib-selftest; echo rc=$?` | **rc=0** |
+| M1-AC10 | `go test ./internal/cihygiene/; echo rc=$?` | **rc=0** — no new exemption entry needed (V10: `test-*` is outside both asserted prefix classes) |
+| M1-AC11 | `make check-file-sizes; echo rc=$?` and `go build ./internal/...; echo rc=$?` | **rc=0** both |
+| M1-AC12 | `git status --porcelain -- .stdlib-golden std; echo "[$(git status --porcelain -- .stdlib-golden std)]"` | **empty** — M1 must not touch a golden or a stdlib source |
+
+**Mutation drill M1** — doc rows 1–5 and 8. Backup/restore with `cp`, never git.
+
+> Setup once: `BK=$(mktemp -d)`; before each row, `cp` the file(s) you are about to mutate into
+> `$BK`. After each row, restore by `cp` and re-run row 8 (the control) to prove the tree is back.
+
+| Row | Mutation | Assert the mutation LANDED (effect, not bytes) | Mutant still builds/parses | Named arm that MUST go red | Expected |
+|---|---|---|---|---|---|
+| 1 | `printf '%064d\n' 0 > .stdlib-golden/option.sha256` | `test "$(./bin/ailang iface std/option \| shasum -a 256 \| awk '{print $1}')" != "$(cat .stdlib-golden/option.sha256)"` → rc=0. **Control**: the same comparison for `result` with `=` → rc=0 (unmutated golden still matches) | `make -n test-stdlib-freeze >/dev/null 2>&1` rc=0 | `make test-stdlib-freeze` (floor 6, reached via the alias) | **rc=1**, output contains `option: interface changed!` and a `Diff (golden → current):` block |
+| 2 | `rm .stdlib-golden/option.sha256` | `test -e .stdlib-golden/option.sha256` → **rc=1**. **Control**: `test -e .stdlib-golden/result.sha256` → rc=0 | `make -n test-stdlib-freeze >/dev/null 2>&1` rc=0 | `make test-stdlib-freeze` (floor 2) | **rc=1**, output contains `option: no golden file — module is UNCOVERED` |
+| 3 | `mv .stdlib-golden "$BK/gold"` | `test -d .stdlib-golden` → **rc=1** | `make -n test-stdlib-freeze >/dev/null 2>&1` rc=0 | `make test-stdlib-freeze` (floor 1) | **rc=1**, and `grep -c 'no golden file' <out>` equals **45** — enumerated, not a single abort |
+| 4 | `cp tools/stdlib-iface-lib.sh "$BK/"; sed -i '' 's/^STDLIB_DIR="std"$/STDLIB_DIR="std-nonexistent"/' tools/stdlib-iface-lib.sh` | `bash -c 'source tools/stdlib-iface-lib.sh; stdlib_modules 2>/dev/null \| wc -l'` prints **0**. **Control**: the same command at base printed **45** | `bash -n tools/stdlib-iface-lib.sh` rc=0 | `tools/verify-stdlib.sh` (floor 3 — the loop-runs-zero-times trap) | **rc=1**, stderr contains `no modules found under std-nonexistent/ — refusing to report success` |
+| 5 | `cp tools/stdlib-iface-lib.sh "$BK/"; sed -i '' 's#^    AILANG="./bin/ailang"$#    AILANG="/usr/bin/true"#' tools/stdlib-iface-lib.sh` | `bash -c 'source tools/stdlib-iface-lib.sh; resolve_ailang; echo "$AILANG"'` prints `/usr/bin/true` | `bash -n tools/stdlib-iface-lib.sh` rc=0 | `tools/verify-stdlib.sh` (floor 4 — rc=0 with empty stdout) | **rc=1**, and `grep -c 'produced no output' <out>` equals **45** |
+| 8 | **CONTROL, must stay GREEN** — clean tree, no mutation | `git status --porcelain -- .stdlib-golden std tools` is **empty** | n/a | `make test-stdlib-freeze` **and** `make verify-stdlib-selftest` | **rc=0 both**; `✓ All 45 stdlib interfaces stable` |
+
+Row 8 is the known-positive control. **Run it before row 1 and again after every restore.** If row 8
+is ever red, rows 1–5 prove nothing and the drill must stop and be reported.
+
+---
+
+### Milestone 2 — Two permanent selftest arms (missing-golden + alias-integrity)
+
+**File**: `make/examples.mk` (target `verify-stdlib-selftest`, currently ending at `:169`).
+**Est. LOC**: +22.
+
+**Changes** — append two arms to the *same* target, each as its **own `@(...)` recipe line, i.e. its
+own shell**. The existing canary arm and its EXIT trap are **not edited**.
+
+**Why isolated shells is a hard requirement, not a style preference** (V21, quorum round 1): the
+existing trap restores `std/option.ail` ONLY and knows nothing about `.stdlib-golden/`; and
+`trap ... EXIT` is per-shell, so a second `trap` in the same shell **replaces** the first. An arm
+that leans on the existing trap would permanently delete the developer's
+`.stdlib-golden/option.sha256`.
+
+1. **Missing-golden arm** — use the exact recipe text in the design doc (§M2, lines 133–146): its own
+   `mktemp` backup of `.stdlib-golden/option.sha256`, its own EXIT trap restoring exactly that file,
+   `rm` the golden, require `tools/verify-stdlib.sh` to exit non-zero, and require the output to
+   contain `option: no golden file` (stable ASCII prefix of `option: no golden file — module is
+   UNCOVERED`, `verify-stdlib.sh:33`). Every `exit 1` inside the arm fires that arm's own trap.
+2. **Alias-integrity arm** — read-only, no backup/trap needed. The design doc proposes
+   `make -n test-stdlib-freeze | grep -q 'verify-stdlib'`. **Strengthen it**: `-n` output would also
+   match `verify-stdlib-selftest` or any other `verify-stdlib*` target, so assert make's rule
+   database instead, then additionally assert the trace:
+   ```make
+   	@echo "Gate self-test (alias-integrity arm): the historical name must reach the live gate..."
+   	@$(MAKE) -pn 2>/dev/null | grep -qE '^test-stdlib-freeze:[[:space:]]*verify-stdlib[[:space:]]*$$' || { \
+   		echo "❌ SELF-TEST FAIL: test-stdlib-freeze no longer delegates to verify-stdlib"; exit 1; }
+   	@$(MAKE) -n test-stdlib-freeze 2>&1 | grep -q 'tools/verify-stdlib.sh' || { \
+   		echo "❌ SELF-TEST FAIL: test-stdlib-freeze does not reach tools/verify-stdlib.sh"; exit 1; }
+   	@echo "✓ alias intact: test-stdlib-freeze -> verify-stdlib -> tools/verify-stdlib.sh"
+   ```
+   (Recursive `$(MAKE)` inside a recipe is fine here — both invocations are `-n`, so nothing is
+   built. Escape `$` as `$$` in the make recipe.)
+
+**Ordering**: put the missing-golden arm *after* the canary arm (so a canary failure still aborts
+before any golden is touched) and the alias arm last.
+
+**Acceptance criteria**
+
+| # | Command | Expected |
+|---|---|---|
+| M2-AC1 | `make verify-stdlib-selftest; echo rc=$?` | **rc=0** |
+| M2-AC2 | `make verify-stdlib-selftest 2>&1 \| grep -c '^✓\|^✅'` | **≥ 6** — three canary `✓`s + the canary `✅` + the missing-golden `✓` + the alias `✓` |
+| M2-AC3 | `make verify-stdlib-selftest 2>&1 \| grep -q 'missing golden -> non-zero + module reported UNCOVERED'` | **rc=0** |
+| M2-AC4 | `make verify-stdlib-selftest 2>&1 \| grep -q 'alias intact'` | **rc=0** |
+| M2-AC5 | run `make verify-stdlib-selftest`, then `git status --porcelain -- .stdlib-golden std` | **empty** — restore-safety on the SUCCESS path |
+| M2-AC6 | `shasum -a 256 .stdlib-golden/option.sha256 > /tmp/g.pre; make verify-stdlib-selftest; shasum -a 256 .stdlib-golden/option.sha256 > /tmp/g.post; diff /tmp/g.pre /tmp/g.post` | **rc=0** |
+| M2-AC7 | `test "$(ls .stdlib-golden/*.sha256 \| wc -l \| tr -d ' ')" -eq 45` | **rc=0** — no golden was consumed |
+| M2-AC8 | `make check-file-sizes; echo rc=$?` · `go test ./internal/cihygiene/; echo rc=$?` · `make verify-stdlib; echo rc=$?` · `go build ./internal/...; echo rc=$?` | **rc=0** all four |
+| M2-AC9 | `ls "${TMPDIR:-/tmp}"/ailang-selftest-* 2>/dev/null \| wc -l` after a full run | **0** — no leaked temp files (`make check-tmpfile-hygiene` also stays rc=0) |
+
+**Mutation drill M2** — doc rows 6, 7, 9 plus one planner-added mutant for the canary arm.
+
+| Row | Mutation | Assert the mutation LANDED (effect, not bytes) | Mutant still builds/parses | Named arm that MUST go red | Expected |
+|---|---|---|---|---|---|
+| 6 | none — the canary arm injects and reverts its own `selftestCanary` export | `make -pn 2>/dev/null \| grep -c 'selftestCanary'` equals **2** (the recipe carries the injection and the assertion) | n/a | canary arm of `make verify-stdlib-selftest` | **rc=0 for the selftest**, output contains `gate exited non-zero on the injected export`, `gate named the changed module`, and `gate showed the actual diff` |
+| **6b** (planner addition — proves the canary arm's assertion has teeth) | `cp make/examples.mk "$BK/"` then change the canary arm's injected payload from the `export pure func selftestCanary…` line to a comment-only payload (`-- selftestCanary`), so the interface does **not** change | `make -pn 2>/dev/null \| grep -c 'export pure func selftestCanary'` goes **1 → 0** (make's own view of the recipe) | `make -n verify-stdlib >/dev/null 2>&1` rc=0 | canary arm | **rc=1**, output contains `SELF-TEST FAIL: gate exited 0 despite a new export in std/option` |
+| 7 | `cp make/test.mk "$BK/"` then replace the alias line with `test-stdlib-freeze: ;` | `make -pn 2>/dev/null \| grep -cE '^test-stdlib-freeze:[[:space:]]*verify-stdlib[[:space:]]*$'` goes **1 → 0** — make's own view, not file bytes | `make -n verify-stdlib >/dev/null 2>&1` rc=0 (makefile still parses) | **alias-integrity arm** of `make verify-stdlib-selftest` | **rc=1**, output contains `test-stdlib-freeze no longer delegates to verify-stdlib` |
+| 9 | `cp make/examples.mk "$BK/"` then change the missing-golden arm's expected pattern from `option: no golden file` to `ZZZ-NEVER-PRINTED`, forcing that arm to fail **while the golden is removed** | `make -pn 2>/dev/null \| grep -c 'ZZZ-NEVER-PRINTED'` goes **0 → 1** — make's own view of the recipe | `make -n verify-stdlib-selftest >/dev/null 2>&1` rc=0 | **missing-golden arm** | see the sequence below |
+
+**Row 9 is the restore-on-FAILURE proof** demanded by quorum round 1. Run it exactly as:
+
+```bash
+shasum -a 256 .stdlib-golden/option.sha256 > /tmp/r9.pre
+git status --porcelain -- .stdlib-golden std make tools Makefile > /tmp/r9.st.pre
+make verify-stdlib-selftest; echo "selftest rc=$?"          # MUST be non-zero
+shasum -a 256 .stdlib-golden/option.sha256 > /tmp/r9.post
+git status --porcelain -- .stdlib-golden std make tools Makefile > /tmp/r9.st.post
+diff /tmp/r9.pre /tmp/r9.post; echo "golden-sha diff rc=$?"  # MUST be 0
+diff /tmp/r9.st.pre /tmp/r9.st.post; echo "status diff rc=$?" # MUST be 0
+git status --porcelain -- .stdlib-golden std; echo "[$(git status --porcelain -- .stdlib-golden std)]"
+```
+
+**Required:** selftest **rc≠0**, golden-sha diff **rc=0**, status diff **rc=0**, and
+`git status --porcelain -- .stdlib-golden std` **empty** — i.e. the arm's own EXIT trap restored
+`.stdlib-golden/option.sha256` on its **failure** path. (The status comparison is path-scoped and
+before/after-differenced because `.snap/` and the sprint's own in-progress edits are legitimately
+present; a bare "must be empty over the whole tree" is unsatisfiable mid-sprint and would make this
+criterion vacuous or permanently red.) Then restore `make/examples.mk` from `$BK` and re-run row 8
+from the M1 drill — it must be green again.
+
+---
+
+### Milestone 3 — Changelog + skill-doc correction
+
+**Files**: `changelogs/v0.32-current.md`, `.claude/skills/sprint-executor/resources/developer_tools.md`,
+`.agents/skills/sprint-executor/resources/developer_tools.md`. **Est. LOC**: +18.
+
+**Changes**
+
+1. `changelogs/v0.32-current.md` under `## [Unreleased]` → `### Fixed`: an entry naming
+   `make test-stdlib-freeze`, the rc=2 prerequisite abort, `goldens/stdlib` never having existed on
+   any ref, the delegation to `verify-stdlib`/`.stdlib-golden/`, the deletion of `STDLIB`/`FREEZE_DIR`/
+   `TOOLS`, and the two new selftest arms. **Do NOT touch root `CHANGELOG.md`** — `check-changelog`
+   asserts it stays an index.
+2. Both `developer_tools.md` copies, lines 67 and 142: annotate the target as an alias, e.g.
+   `make test-stdlib-freeze    # Verify stdlib interfaces haven't changed (alias of verify-stdlib)`.
+   The two files are **byte-identical today** — keep them so.
+3. `design_docs/implemented/v0_2_0/*` are immutable historical records. **Do not edit them.**
+
+**Acceptance criteria**
+
+| # | Command | Expected |
+|---|---|---|
+| M3-AC1 | `make check-changelog; echo rc=$?` | **rc=0** |
+| M3-AC2 | `make check-skills; echo rc=$?` | **rc=0** |
+| M3-AC3 | `awk '/^## \[Unreleased\]/,/^## \[v/' changelogs/v0.32-current.md \| grep -q 'test-stdlib-freeze'` | **rc=0** — the entry is in the Unreleased section, not appended anywhere |
+| M3-AC4 | `git diff --name-only -- CHANGELOG.md \| wc -l` → `0`; `git diff --name-only -- design_docs/implemented \| wc -l` → `0` | **rc=0** both — index and historical records untouched |
+| M3-AC5 | `diff .claude/skills/sprint-executor/resources/developer_tools.md .agents/skills/sprint-executor/resources/developer_tools.md` | **rc=0** — the two copies stay identical |
+| M3-AC6 | `grep -c 'alias of verify-stdlib' .claude/skills/sprint-executor/resources/developer_tools.md` | **≥ 1** (and the same for the `.agents/` copy) |
+| M3-AC7 | **The doc's claim must be TRUE, not merely present**: for each target named on the stdlib lines of `developer_tools.md`, `make -pn 2>/dev/null \| grep -qE "^<target>:"` | **rc=0** for `test-stdlib-freeze` and `verify-stdlib` |
+| M3-AC8 | `make -pn 2>/dev/null \| grep -qE '^test-stdlib-freeze:[[:space:]]*verify-stdlib[[:space:]]*$'` | **rc=0** — the alias the docs now describe still holds |
+| M3-AC9 | `make verify-stdlib-selftest; echo rc=$?` and `make test-stdlib-freeze; echo rc=$?` | **rc=0** both — M3 did not regress M1/M2 |
+
+**Mutation drill M3** — M3-AC7 is the drill: it is a *doc-truth* check, not a doc-presence check.
+Mutant: temporarily add `make test-stdlib-frozen  # typo` to a scratch copy of the stdlib lines and
+run M3-AC7's loop over it — it must report the missing target and exit non-zero. Restore the scratch
+copy. (Run this against a copy under `$BK`, not the tracked file.)
+
+---
+
+## Explicitly Out of Scope
+
+- **Anything `fmt`.** D-39 forbids wiring/freezing the `fmt` gate until the width limit lands.
+  `fmt-check-ail` stays exempt in `internal/cihygiene/gate_wiring_test.go`. Do not touch it.
+- **Adding a `test-stdlib-freeze` step to `.github/workflows/ci.yml`.** After M1 it is the same
+  script as `verify-stdlib`; a second step would run it twice per job. Same reasoning as the
+  recorded `verify-lowering` exemption (`gate_wiring_test.go:39`). The alias-integrity arm is what
+  makes "the name reaches the gated path" CI-enforced.
+- **Adding an exemption entry to `notWiredIntoCI`/`notWiredIntoCIVerify`.** `test-stdlib-freeze`
+  matches neither asserted prefix class (`check-*`/`test-check-*` at `:130`, `verify-*` +
+  `fmt-check-ail` at `:134`), so it trips nothing (V10). If `go test ./internal/cihygiene/` goes red,
+  something else broke — do **not** answer it with an exemption.
+- **Renaming or moving `.stdlib-golden/`** (90 committed files, CI-proven).
+- **A `STDLIB_DIR` env override** — deferred with reason in the design doc (§M2): `freeze-stdlib.sh`
+  sources the same lib, so an override becomes a footgun that silently re-freezes the wrong tree.
+- **A permanent empty-enumeration arm** — proven by one-time mutation (M1 drill row 4) instead.
+- **`go build ./...` as a gate** — red at base (`cmd/wasm`, `gen/main`).
+- **`make ci` end-to-end as a gate** — `verify-examples-toplevel` is red at HEAD on
+  `examples/ai_modes.ail` (recorded in `notWiredIntoCIVerify`), unrelated to this sprint.
+
+## Sprint Success Criteria
+
+- [ ] `make test-stdlib-freeze` rc=0 and its `-n` trace names `tools/verify-stdlib.sh` (M1-AC1, M1-AC6)
+- [ ] `goldens/stdlib` and `STDLIB`/`FREEZE_DIR`/`TOOLS` gone from make's own view, with the `BINARY` control still firing (M1-AC3, M1-AC4, M1-AC5)
+- [ ] M1 drill rows 1–5 all red with the named message; row 8 control green before and after every row
+- [ ] `make verify-stdlib-selftest` rc=0 with both new arms reporting, and M2 drill rows 6b, 7, 9 all red on the correct named arm
+- [ ] Restore-on-failure proven (row 9): golden sha unchanged and path-scoped `git status --porcelain` unchanged after a FAILING selftest
+- [ ] `go test ./internal/cihygiene/` rc=0 with **no** new exemption entry
+- [ ] `make verify-stdlib`, `make check-file-sizes`, `make check-changelog`, `make check-skills`, `go build ./internal/...` all rc=0
+- [ ] CHANGELOG entry under `## [Unreleased]` in `changelogs/v0.32-current.md`; root `CHANGELOG.md` and `design_docs/implemented/` untouched
+- [ ] Nothing `fmt`-related changed (D-39)
+- [ ] `.snap/M1`, `.snap/M2`, `.snap/M3` present and cumulative; `.snap/` removed before the controller commits

--- a/design_docs/planned/v0_33_4/m-stdlib-freeze-gate-path-mismatch.md
+++ b/design_docs/planned/v0_33_4/m-stdlib-freeze-gate-path-mismatch.md
@@ -1,0 +1,361 @@
+# M-STDLIB-FREEZE-GATE-PATH-MISMATCH: Retire the Rotted Freeze Duplicate, Alias the Accepted Name to the Live Gate
+
+**Status**: Planned
+**Target**: v0.33.4
+**Priority**: P1 (a gate accepted in v0.2.0 is unrunnable; it was the purpose-built independent check on iteration 282's 30-file `std/` reformat and was dead when needed)
+**Estimated**: 0.5 day
+**Dependencies**: None
+**Queue row**: `m-stdlib-freeze-gate-path-mismatch` (filed iteration 282, [v1-mission.md](../../v1-mission.md) queue)
+**Quorum**: authored unattended (mission loop) → design-quorum REQUIRED before planning, per the design-doc-creator skill. No freeze items — every decision below is agent-resolvable.
+
+---
+
+## Problem Statement
+
+`make test-stdlib-freeze` — the stdlib interface-stability gate whose v0.2.0 acceptance
+checkbox reads "`make test-stdlib-freeze` target works (SHA256 matching)"
+([M-S1-B.md:100](../../implemented/v0_2_0/M-S1-B.md)) — exits **rc=2 during prerequisite
+resolution**, before its recipe body runs:
+
+```
+make: *** No rule to make target `goldens/stdlib/option.sha256', needed by `test-stdlib-freeze'.  Stop.
+```
+
+`Makefile:59` sets `FREEZE_DIR := goldens/stdlib`; that directory does not exist and has
+**never existed in any commit on any ref of this repository** — verified exhaustively over
+all history, with in-scope positive controls proving the instrument fires (V18–V20). The
+v0.2.0 recipe in M-S1-B.md (`mkdir -p goldens/stdlib`) could only ever have created it in a
+developer's local working tree; no commit ever carried it. The real goldens live in
+`.stdlib-golden/` (90 committed files: 45 modules x {json, sha256}), written by
+`tools/freeze-stdlib.sh` via the shared `GOLDEN_DIR=".stdlib-golden"` in
+`tools/stdlib-iface-lib.sh:9`. The target is wired into **zero** workflows, so dev stays
+green over the corpse. Sprint-executor skill docs still recommend the broken target by name
+(`developer_tools.md:67,142`, in both the `.claude/` and `.agents/` skill trees).
+
+**NOTE on the queue row**: it attributes the golden-writing to `tools/freeze-stdlib.sh`
+directly. Verified relationship: `freeze-stdlib.sh` is the executable *entry point*; it
+`source`s `tools/stdlib-iface-lib.sh`, which defines `GOLDEN_DIR=".stdlib-golden"` plus the
+shared module enumeration and JSON generation. `tools/verify-stdlib.sh` sources the same lib
+— by design, so freezer and verifier cannot disagree on binary, module list, or JSON shape.
+
+## Root Cause: the recipe is not one bug, it is a fossil (three independent rots)
+
+The `make/test.mk:184-201` recipe would fail even if the path were patched:
+
+1. **Wrong path** — `$(FREEZE_DIR)` = `goldens/stdlib` vs. the real `.stdlib-golden/`.
+   The five `$(FREEZE_DIR)/*.sha256` prerequisites have no rule, so make aborts at
+   rc=2 and the recipe body — including its own missing-golden floor at test.mk:193
+   (`if [ ! -f $$golden ]; then echo "MISSING $$golden"; ok=1;`) — is unreachable.
+2. **Invalid CLI invocation** — the body runs `$(TOOLS) iface --module "$name" --json`.
+   The current binary rejects it: `flag provided but not defined: -module` (rc=2,
+   verified — see log V9). The v0.2.0-era flag form no longer exists; the live scripts
+   invoke `ailang iface "std/$module"`.
+3. **Wrong binary + wrong coverage** — `TOOLS := ailang` resolves from PATH (the
+   stale-system-binary trap `resolve_ailang` in the lib was written to close), and
+   `STDLIB` hardcodes 5 of 45 modules. The lib's own comment (stdlib-iface-lib.sh:29-31)
+   calls the 5-module hardcode "worse than none, because it reads as coverage."
+
+**History**: the gate family was accepted in v0.2.0 (M-S1-B). Commit `80019d4e0`
+("revive verify-stdlib — dead since v0.0.12") rebuilt the *tools-side* gate properly —
+all-45-module enumeration, real error surfacing, `.stdlib-golden/` goldens, a CI-run
+red-on-change selftest — but left the make-side duplicate in `test.mk` untouched. Since
+then the repo has had one live gate and one corpse with the historically accepted name.
+
+**Systemic check (audit before patching)**: this is not a one-off path typo to fix in
+place. The modern gate already exists, is CI-wired, and already carries the anti-vacuity
+floors this design must provide. The systemic fix is *deduplication*: one gate, one name
+reaching it, zero parallel implementations that can drift again. Drift between duplicate
+implementations of this exact gate is precisely what already happened once.
+
+## Decision (a): canonical golden path is `.stdlib-golden/`
+
+Justification, not assertion:
+
+| Criterion | `.stdlib-golden/` | `goldens/stdlib/` |
+|---|---|---|
+| Exists / populated | YES — 90 files committed to git (V4) | NO — `test -d` fails (V1); never in any commit on any ref (V18–V19) |
+| Written by | `tools/freeze-stdlib.sh` (live, `make freeze-stdlib` at examples.mk:133) | nothing (V5: no writer anywhere in repo) |
+| Read by | `tools/verify-stdlib.sh` (live, CI at ci.yml:142) | only the dead recipe (V5) |
+| CI-verified today | YES — `verify-stdlib` + `verify-stdlib-selftest` (V7) | never (V6) |
+| Coverage | all 45 `std/` modules, filesystem-derived | 5 hardcoded modules |
+
+Repointing the tools at `goldens/stdlib` would rewrite 90 committed files, 3 scripts, and
+CI-proven behavior to satisfy one dead recipe. Repointing the recipe at `.stdlib-golden`
+would still leave rots #2 and #3 and a second implementation to drift. Canonical =
+`.stdlib-golden/`; the recipe is retired, not repaired.
+
+## Solution Design
+
+### M1 — Delegate the name, delete the fossil (core fix, one commit)
+
+In `make/test.mk`, replace lines 184-201 with a delegation alias:
+
+```make
+# Stdlib freeze — historical name, kept because v0.2.0 acceptance docs and the
+# sprint-executor skill reference it. The live gate is verify-stdlib
+# (tools/verify-stdlib.sh over .stdlib-golden/); do not grow a second implementation.
+test-stdlib-freeze: verify-stdlib ## Verify std/ interfaces haven't changed (alias of verify-stdlib)
+```
+
+`test-stdlib-freeze` stays in `.PHONY` (test.mk:9). `verify-stdlib` already depends on
+`build` (examples.mk:137), so the alias inherits fresh-binary resolution.
+
+In `Makefile`, delete `STDLIB` (:58), `FREEZE_DIR` (:59), `TOOLS` (:60) and remove them
+from the `export` at :66. This is a measured deletion, not a linter-driven one
+(per `.claude/rules/coding-standards.md`): `make -pn` shows `FREEZE_DIR` consumed only by
+the dead recipe (V8), and a repo-wide grep for consumers of the three exported names over
+`examples/ scripts/ tools/ .github/` returns zero hits with a positive control (V8).
+
+Precedent for alias-shape: `verify-lowering` is an accepted alias of the wired
+`verify-no-shim` and is exempted from gate-wiring with the recorded reason "wiring this
+adds an alias, not coverage" (`internal/cihygiene/gate_wiring_test.go:39`).
+
+### M2 — Permanent selftest arms (one commit)
+
+`make verify-stdlib-selftest` (examples.mk:147, CI at ci.yml:145) today proves ONE red
+branch: canary export → "interface changed" + diff shown. Add two cheap arms to the same
+target.
+
+**Restore-safety constraint (quorum round 1, confirmed by reading the recipe, V21):** the
+existing EXIT trap restores `std/option.ail` ONLY, from a backup of `std/option.ail` — it
+has no knowledge of `.stdlib-golden/`. A missing-golden arm that leans on it would
+permanently delete `.stdlib-golden/option.sha256` from the developer's tree. Additionally,
+`trap ... EXIT` is per-shell and a second trap in the same shell **replaces** the first, so
+the arms must not share a shell. Therefore: **each arm runs as its own `@(...)` recipe line
+(its own shell), takes its OWN mktemp backup, and installs its OWN EXIT trap that restores
+exactly what that arm moved. The canary arm's trap and the golden arm's trap are fully
+independent; neither is edited.** Every `exit 1` inside an arm still fires that arm's trap,
+so restore holds on all failure paths, not just success.
+
+1. **Missing-golden arm** — exact recipe text (same mktemp/cp/trap idiom as the canary
+   arm at examples.mk:149-153, but backing up the GOLDEN, in an isolated shell):
+
+   ```make
+   	@echo "Gate self-test (missing-golden arm): removing option's golden..."
+   	@( GOLDEN_BK=$$(mktemp "$${TMPDIR:-/tmp}/ailang-selftest-golden.XXXXXX") || exit 1; \
+   	ARM_OUT=$$(mktemp "$${TMPDIR:-/tmp}/ailang-selftest-arm-out.XXXXXX") || { rm -f "$$GOLDEN_BK"; exit 1; }; \
+   	cp .stdlib-golden/option.sha256 "$$GOLDEN_BK" || { rm -f "$$GOLDEN_BK" "$$ARM_OUT"; exit 1; }; \
+   	trap 'cp "$$GOLDEN_BK" .stdlib-golden/option.sha256; rm -f "$$GOLDEN_BK" "$$ARM_OUT"' EXIT; \
+   	rm -f .stdlib-golden/option.sha256; \
+   	if tools/verify-stdlib.sh >"$$ARM_OUT" 2>&1; then \
+   		echo "❌ SELF-TEST FAIL: gate exited 0 with option's golden missing"; exit 1; \
+   	fi; \
+   	grep -q "option: no golden file" "$$ARM_OUT" || { \
+   		echo "❌ SELF-TEST FAIL: gate failed but never reported option as UNCOVERED"; \
+   		cat "$$ARM_OUT"; exit 1; }; \
+   	echo "✓ missing golden -> non-zero + module reported UNCOVERED" )
+   ```
+
+   Failure-path audit: mktemp failures exit before anything is moved (nothing to
+   restore); the `cp`-backup failure cleans up temps with the golden untouched; from the
+   `trap` line onward, every exit path — gate-green failure, wrong-message failure,
+   success — fires the trap, which restores the golden from the arm's own backup. The
+   expected full message is `option: no golden file — module is UNCOVERED`
+   (verify-stdlib.sh:33, V13); the grep matches the stable ASCII prefix.
+2. **Alias-integrity arm**: `make -n test-stdlib-freeze | grep -q 'verify-stdlib'` —
+   the historical name must still reach the live gate. This is the guard against the
+   alias itself rotting the way the recipe did. (`test-*` is outside the gate-wiring
+   test's asserted prefix classes — see Conflict Surface — so this arm is the only
+   automated check on the alias.) Read-only: no backup/trap needed.
+
+**Considered and deferred**: a permanent empty-enumeration arm. It would require making
+`STDLIB_DIR` in `stdlib-iface-lib.sh` env-overridable so the selftest can point it at an
+empty directory — but `freeze-stdlib.sh` sources the same lib, so an override variable
+becomes a footgun where a stray exported `STDLIB_DIR` silently re-freezes the wrong tree.
+The empty-enumeration floor already exists and fails loudly (verify-stdlib.sh:23-26,
+`refusing to report success`, exit 1); it is proven by one-time reviewer mutation
+(section (d), row 4) instead of a permanent arm. Revisit only if `std/` layout changes.
+
+### M3 — Docs + changelog (one commit)
+
+- CHANGELOG entry under v0.33.4 (fixed category).
+- One-line correction in the two `developer_tools.md` skill copies: note the target is an
+  alias of `verify-stdlib`. (Both files currently recommend the broken name — after M1
+  they become *correct again* with no edit, so this is clarity, not repair.)
+- Historical docs in `design_docs/implemented/v0_2_0/` are immutable records — untouched.
+
+## CI Wiring (c)
+
+After M1 the accepted name and the CI gate are the same script, so CI wiring is already
+in place and stays where it is:
+
+- `verify-stdlib` runs in `.github/workflows/ci.yml:142` and in the `ci` aggregate
+  (`make/ci.mk:11`).
+- `verify-stdlib-selftest` (red-on-change proof, extended by M2) runs at `ci.yml:145`
+  and in `make/ci.mk:11`.
+
+Adding a separate `test-stdlib-freeze` CI step would run the identical script twice per
+job; we deliberately do NOT do that (same reasoning as the recorded `verify-lowering`
+exemption). The alias-integrity arm in M2 is what makes "the name reaches the gated path"
+itself CI-enforced. The gate-wiring assertion (`TestGateTargetsAreWiredIntoAWorkflow`)
+requires `verify-stdlib` to be wired (gate_wiring_test.go:191-192 fails the *instrument*
+if verify-stdlib is not found), so the underlying gate cannot silently fall out of CI.
+
+## Anti-Vacuity Floors (b)
+
+All vacuity paths land in the ONE delegated implementation. Floors are inherited, cited,
+and (for the branches the selftest can safely exercise) permanently re-proven in CI:
+
+| # | Vacuity path | Guard after this design | Where |
+|---|---|---|---|
+| 1 | Golden **dir** missing entirely | Every module hits the no-golden branch → `UNCOVERED` per module → exit 1. Loud, enumerated, non-abort | verify-stdlib.sh:31-37 |
+| 2 | **One** golden file missing | Same branch, names the module; M2 arm 1 keeps this red-provable in CI | verify-stdlib.sh:31-37 |
+| 3 | **Empty module enumeration** (the loop-zero-times-then-`exit 0` trap) | Pre-loop check: `no modules found under std/ — refusing to report success`, exit 1 — the loop is never entered on empty input | verify-stdlib.sh:22-26 |
+| 4 | `ailang iface` **emits nothing** (rc=0, empty stdout) | `[ ! -s "$outfile" ]` → `produced no output` → module fails | stdlib-iface-lib.sh:52-56 |
+| 5 | `ailang iface` **fails** | rc captured, stderr surfaced (not `2>/dev/null`-discarded), module fails | stdlib-iface-lib.sh:46-51 |
+| 6 | Hash **mismatch** | `interface changed!` + expected/got + unified diff; CI selftest proves this branch goes red on a real export change | verify-stdlib.sh:53-62 |
+| 7 | The **alias itself** rots (this bug's own shape) | M2 arm 2: `make -n test-stdlib-freeze` must name verify-stdlib | new, examples.mk |
+
+Note the old recipe's floor (test.mk:193) guarded only path 2, and unreachably — make's
+prerequisite abort preempted it. Prerequisite-based freshness is exactly the mechanism
+that turned a stale path into an un-runnable gate; the delegated design has no
+golden-file prerequisites, so a missing golden is a *loud in-recipe failure*, never a
+missing-rule abort.
+
+## (d) Reviewer Proof of Non-VacUITY — one mutation per guarded branch
+
+Run from a clean tree; every mutation must be reverted afterwards (`git status` clean).
+Each row names the arm that MUST go red; a green run on any row rejects the implementation.
+
+| # | Mutation | Command | MUST go red, with |
+|---|---|---|---|
+| 1 | Perturb one golden sha: `printf '%064d\n' 0 > .stdlib-golden/option.sha256` | `make test-stdlib-freeze` | rc!=0; `option: interface changed!` + diff (floor 6, via the alias) |
+| 2 | Remove one golden: `rm .stdlib-golden/option.sha256` | `make test-stdlib-freeze` | rc!=0; `option: no golden file — module is UNCOVERED` (floor 2) |
+| 3 | Remove the whole dir: `mv .stdlib-golden /tmp/g.bak` | `make test-stdlib-freeze` | rc!=0; 45 x `UNCOVERED` lines, one per module (floor 1) |
+| 4 | Empty enumeration: in a scratch worktree, `git mv std std.away` (or temp-edit `STDLIB_DIR="std-nonexistent"` in the lib) | `tools/verify-stdlib.sh` | rc!=0; `no modules found under ... — refusing to report success` (floor 3) — proves loop-zero-times is NOT green |
+| 5 | Silent-empty iface: temp-edit `iface_json` to `: > "$outfile"; return 0` before the size check... or simpler, stub `AILANG` to `/usr/bin/true` via temp-edit of `resolve_ailang` | `tools/verify-stdlib.sh` | rc!=0; `produced no output` per module (floor 4) |
+| 6 | Interface change: `make verify-stdlib-selftest` (no manual mutation — the target injects/reverts a canary export itself) | `make verify-stdlib-selftest` | rc=0 *for the selftest* while asserting the GATE went red, named `option`, and showed `selftestCanary` in the diff |
+| 7 | Alias rot: temp-edit test.mk alias to `test-stdlib-freeze: ;` | `make verify-stdlib-selftest` (with M2 arm 2) | rc!=0; alias-integrity arm reports the name no longer reaches verify-stdlib |
+| 8 | Control (must stay GREEN): clean tree | `make test-stdlib-freeze && make verify-stdlib-selftest` | rc=0 both; `All 45 stdlib interfaces stable` |
+| 9 | **Restore-on-FAILURE** (not just on success): temp-edit the missing-golden arm's expected `grep` pattern to a string the gate never prints, forcing that arm to fail mid-flight with the golden removed | `shasum -a 256 .stdlib-golden/option.sha256; make verify-stdlib-selftest; echo rc=$$?; git status --porcelain; shasum -a 256 .stdlib-golden/option.sha256` | selftest rc!=0 AND afterwards `git status --porcelain` is EMPTY AND the golden's sha256 is identical to before — the arm's own trap restored `.stdlib-golden/option.sha256` on its failure path. (Revert the temp-edit; row 8 must then be green again) |
+
+Row 8 is the known-positive control: if it is red at HEAD, the instrument is broken and
+rows 1-7 prove nothing. Row 9 is the restore-on-failure proof demanded by quorum round 1:
+a trap that only demonstrably runs on success is not evidence the tree survives a red run.
+
+## Conflict Surface
+
+Derived by command (V5, V8, V10-V12), not memory. This design touches `Makefile`,
+`make/test.mk`, `make/examples.mk` — no parser/typechecker/codegen files, so the
+language-conflict enumeration is N/A; the build-surface enumeration is:
+
+| Surface | Relationship | Decision |
+|---|---|---|
+| `FREEZE_DIR`, `STDLIB`, `TOOLS` (Makefile:58-60, exported :66) | Sole consumer is the dead recipe (make -pn + repo grep, V8). Exported, but zero env consumers in `examples/ scripts/ tools/ .github/` (V8) | DELETE all three + export entries |
+| `verify-stdlib` (examples.mk:137), `freeze-stdlib` (:133), `verify-stdlib-selftest` (:147), `tools/*.sh` | The live gate. M1 REUSES (alias prerequisite). M2 EXTENDS verify-stdlib-selftest — additive arms only, each in its own recipe-line shell with its own backup + EXIT trap (the existing canary trap restores `std/option.ail` ONLY, V21); the canary arm's assertions and trap are untouched | reuse / additive-extend |
+| `.github/workflows/ci.yml:142,145` + `make/ci.mk:11` | Already invoke the live gate | unchanged |
+| `TestGateTargetsAreWiredIntoAWorkflow` (internal/cihygiene/gate_wiring_test.go) | Asserted prefix classes are `check-*`/`test-check-*` (:130) and `verify-*` + `fmt-check-ail` (:134). `test-stdlib-freeze` is in NEITHER class, so the alias needs no exemption entry and trips nothing (V10). The test *requires* verify-stdlib to be wired (:191) | no change needed; cite in commit |
+| `check-golden-drift` (make/test.mk:242, in `make ci`) | Despite the name, reads ONLY `internal/parser/testdata/parser/` (V11) — it does not see `.stdlib-golden/` and is unaffected | no overlap; named here to preempt confusion |
+| Sprint-executor skill docs (`.claude/skills/.../developer_tools.md:67,142` + `.agents/` copy) | Recommend `make test-stdlib-freeze` by name (V12) | become live again via alias; M3 adds clarifying line |
+| Historical docs `implemented/v0_2_0/{M-S1-B,M-S1,M-S1_STDLIB_STATUS}.md` | Name the target (V12) | immutable records, untouched |
+| `test-stdlib-freeze` in `.PHONY` (test.mk:9) | Stays — alias target is phony | keep |
+
+## Non-Goals
+
+- No renaming/moving of `.stdlib-golden/` (90 committed files; CI-proven).
+- No new freeze framework, no Go code, no new make variables.
+- No expansion of the gate-wiring test's prefix classes to cover `test-*` (deliberately
+  narrow per its own comment, gate_wiring_test.go:22).
+- No `STDLIB_DIR` env override (deferred with reason, M2).
+
+## Axiom / Language-Surface Note
+
+No language semantics, syntax, stdlib *content*, or `ailang` binary behavior changes —
+build tooling only. The 12-axiom scoring matrix does not apply; no `ailang check`-able
+language claims are made in this doc (the only CLI claims are about flag parsing, V9).
+
+## Related Documents
+
+- [M-S1-B.md](../../implemented/v0_2_0/M-S1-B.md) — v0.2.0 acceptance of the original target (historical).
+- Commit `80019d4e0` — "fix(stdlib-gate): revive verify-stdlib — dead since v0.0.12" (the tools-side revival this design completes on the make side).
+- `make/examples.mk:141-147` comment block — the prior art on "a green gate is not evidence; a gate that goes red on a real change is."
+- [v1-mission.md](../../v1-mission.md) queue row `m-stdlib-freeze-gate-path-mismatch` (iteration 282 measurements).
+- No planned/ doc overlaps this topic (duplicate gate: closest matches are the implemented v0_2_0 M-S1 family above — historical, not duplicative).
+
+## Success Criteria
+
+- [ ] `make test-stdlib-freeze` exits 0 on a clean tree and its trace shows `tools/verify-stdlib.sh` (not a second implementation)
+- [ ] `STDLIB`/`FREEZE_DIR`/`TOOLS` absent from `Makefile` and from `make -pn` output
+- [ ] Mutation rows 1-3 red via `make test-stdlib-freeze`; row 8 control green
+- [ ] `make verify-stdlib-selftest` passes with the two new arms, and mutation row 7 reds it
+- [ ] **Restore-on-failure proven** (mutation row 9): after a FAILING selftest run the worktree is byte-identical — `git status --porcelain` empty AND `.stdlib-golden/option.sha256`'s sha256 unchanged
+- [ ] `go test ./internal/cihygiene/` green (no new exemption entries needed)
+- [ ] Full `make ci` unaffected except the strengthened selftest
+- [ ] CHANGELOG updated
+
+## Verification Log
+
+All commands run 2026-08-26 in `/Users/voightkampff/.ailang-driver-pin/v1` at HEAD
+`da96b98a5` (detached), clean tree. Outputs elided to the load-bearing lines.
+
+| # | Claim | Command | Observed |
+|---|---|---|---|
+| V1 | `goldens/stdlib` ABSENT; `.stdlib-golden` EXISTS, populated (control in same call) | `test -d goldens/stdlib && echo EXISTS \|\| echo ABSENT; ls .stdlib-golden/ \| head` | `goldens/stdlib ABSENT`; listing shows `ai.json ai.sha256 ... option.sha256 ... zip.sha256` (92 entries incl. `.`/`..`) |
+| V2 | `test-stdlib-freeze` aborts rc=2 in prerequisite resolution | `make test-stdlib-freeze; echo rc=$?` | ``make: *** No rule to make target `goldens/stdlib/option.sha256', needed by `test-stdlib-freeze'.  Stop.`` then `rc=2` (matches controller's two-arm measurement: rc=2 on both stale-PATH and fresh ldflags-stamped binaries) |
+| V3 | Control: surrounding stdlib tooling works — `verify-stdlib` green over all 45 modules | `make verify-stdlib >/tmp/v.out 2>&1; echo rc=$?; tail -1 /tmp/v.out` | `rc=0`; `✓ All 45 stdlib interfaces stable` |
+| V4 | Goldens are COMMITTED (CI can see them) | `git ls-files .stdlib-golden \| wc -l` | `90` (45 x json+sha256; first entries `ai.json`, `ai.sha256`) |
+| V5 | `goldens/stdlib` has no writer/reader outside Makefile:59 + dead recipe; the live gate wiring is examples.mk + tools + ci.yml | `grep -rn 'FREEZE_DIR\|test-stdlib-freeze\|verify-stdlib\|freeze-stdlib\|stdlib-golden' Makefile make/ tools/ .github/ scripts/` | Hits ONLY: Makefile:59,:66; make/test.mk:9,:184-193; make/examples.mk:133-154; make/ci.mk:11; tools/{freeze,verify}-stdlib.sh + lib:9; ci.yml:142,:145. No other `goldens/stdlib` reference exists |
+| V6 | `test-stdlib-freeze` wired into NO workflow (control: verify-stdlib IS, same file) | `grep -n 'test-stdlib-freeze\|verify-stdlib' .github/workflows/ci.yml` | Zero `test-stdlib-freeze` hits; `142: run: make verify-stdlib`, `145: run: make verify-stdlib-selftest` (controller's independent control: `verify-examples` appears 5x in ci.yml) |
+| V7 | Live gate + red-on-change selftest run in CI and `make ci` | `grep -n 'verify-stdlib' make/ci.mk .github/workflows/ci.yml` | `ci.mk:11` lists both in `ci:`; ci.yml:142,:145 as above |
+| V8 | Sole consumer of `FREEZE_DIR`/`STDLIB`/`TOOLS` is the dead recipe; no env consumers of the exports (with positive control) | `make -pn \| grep -n 'goldens/stdlib'` ; `grep -rn '\$(STDLIB)\|\$(TOOLS)' Makefile make/` ; `grep -rn 'FREEZE_DIR\|\$STDLIB\b\|\${STDLIB}\|\$TOOLS\b\|\${TOOLS}' examples/ scripts/ tools/ .github/` ; control `grep -c STDLIB Makefile` | make -pn: FREEZE_DIR + the 5 prereq stubs + test-stdlib-freeze only. `$(STDLIB)` only test.mk:188; `$(TOOLS)` only test.mk:191. Env grep: `NO HITS`; control: `2` |
+| V9 | Dead recipe's CLI form is invalid on the current binary (rot #2) | `./bin/ailang iface --module "std/option" --json; echo rc=$?` | `flag provided but not defined: -module` + usage; `rc=2`. (Binary present: `bin/ailang`, built Aug 26) |
+| V10 | Gate-wiring test's prefix classes EXCLUDE `test-stdlib-freeze`; alias precedent recorded; verify-stdlib wiring is itself asserted | read `internal/cihygiene/gate_wiring_test.go` | `:130` `check-`/`test-check-` prefixes; `:134` `verify-` + `fmt-check-ail`; `:39` verify-lowering alias exemption ("adds an alias, not coverage"); `:191` instrument-fails unless `verify-stdlib` found among wired targets |
+| V11 | `check-golden-drift` does NOT read `.stdlib-golden` | `sed -n '/^check-golden-drift/,/^$/p' make/test.mk` | recipe diffs only `internal/parser/testdata/parser/` |
+| V12 | Broken name still recommended by skill docs; historical docs reference it | `grep -rn 'test-stdlib-freeze' . \| grep -v .git \| grep -v ^./make/` | `.claude/skills/sprint-executor/resources/developer_tools.md:67,142` + `.agents/` copy; `implemented/v0_2_0/{M-S1-B.md:100 (via :90-110 read), M-S1.md:107, M-S1_STDLIB_STATUS.md:48}`; mission docs |
+| V13 | Anti-vacuity floors exist at cited lines (positive-existence) | `grep -n 'refusing to report success\|no golden file\|produced no output\|interface changed' tools/verify-stdlib.sh tools/stdlib-iface-lib.sh` | verify-stdlib.sh:24 (empty enumeration), :33 (UNCOVERED), :54 (mismatch); stdlib-iface-lib.sh:54 (empty output). Module list is filesystem-derived (`stdlib_modules`, lib:32-34) |
+| V14 | `freeze-stdlib.sh` sources the lib (queue-row attribution corrected); lib defines `GOLDEN_DIR=".stdlib-golden"` at :9 | `cat tools/freeze-stdlib.sh tools/stdlib-iface-lib.sh` | `source "$SCRIPT_DIR/stdlib-iface-lib.sh"` in freeze-stdlib.sh (~:13); `GOLDEN_DIR=".stdlib-golden"` at lib:9; freezer writes `$GOLDEN_DIR/$module.{json,sha256}` |
+| V15 | Tools-side revival history | `git log --oneline -5 -- tools/stdlib-iface-lib.sh tools/verify-stdlib.sh` | `80019d4e0 fix(stdlib-gate): revive verify-stdlib — dead since v0.0.12, and the loader bug behind it` |
+| V16 | `verify-stdlib-selftest` currently proves only the mismatch branch (basis for M2) | `sed -n '147,169p' make/examples.mk` | single canary-export arm: asserts non-zero exit, module named, diff shows `selftestCanary`. No missing-golden or alias arm |
+| V17 | No planned design doc already covers this (duplicate gate; control: search DOES find the implemented v0_2_0 family) | `grep -rln 'stdlib-golden\|verify-stdlib' design_docs/planned/ design_docs/implemented/` | planned/: no topic-overlapping doc (only mission-log/status files reference the queue row); implemented/: v0_2_0 M-S1 family + unrelated sprint plans |
+| V18 | No commit on ANY ref ever ADDED or touched a `goldens/stdlib` path | `git log --all --oneline --diff-filter=A -- 'goldens/stdlib/*'` ; `git log --all --oneline -- 'goldens/stdlib'` | 0 commits from both (measured this session by the quorum controller, same HEAD) |
+| V19 | Exhaustive: no tree object in the entire history contains a `goldens/stdlib/` path | scan of `git rev-list --all` (400 commits), `git ls-tree -r --name-only` per commit, grepped for `^goldens/stdlib/` | NO hit in any tree object (measured this session by the quorum controller, same HEAD) |
+| V20 | Controls — the SAME instrument fires on in-scope positives | `git log --all --oneline --diff-filter=A -- '.stdlib-golden/*'` ; log query for any `goldens` path | `.stdlib-golden/*` adds → 2 commits; any `goldens` path → 5 log entries. The empty V18/V19 results are measurements, not blind spots |
+| V21 | Existing selftest EXIT trap restores `std/option.ail` ONLY — it has no knowledge of `.stdlib-golden/` (basis for M2's independent-backup requirement) | `sed -n '149,153p' make/examples.mk` | `cp std/option.ail "$SELFTEST_BK"; trap 'cp "$SELFTEST_BK" std/option.ail; rm -f "$SELFTEST_BK" "$SELFTEST_OUT"' EXIT` — backs up and restores std/option.ail, nothing else |
+
+V18–V20 settle the history question: `goldens/stdlib` has **never existed in this
+repository's history, on any ref**. The v0.2.0 M-S1-B.md recipe (`mkdir -p goldens/stdlib`,
+:90-93) would have created it only in a developer's local working tree — never in a commit.
+
+## Quorum Verification Log
+
+**Round 1 (design-quorum, iteration 283): BLOCKED**, two objections. Direction (delegate
+to verify-stdlib, delete the fossil) was not disputed by either reviewer.
+
+| Objection | Reviewer | Resolution |
+|---|---|---|
+| Problem Statement asserted "goldens/stdlib never held the goldens" while the V-log flagged exactly that as unverified | gpt5-6-sol | **REFUTED BY MEASUREMENT** — the assumption was correct. Controller ran the full-history scan at HEAD `da96b98a5`: zero adds, zero log entries, zero hits across all 400 tree objects on all refs, with two in-scope positive controls proving the instrument fires (V18–V20). Caveat deleted; claim promoted to VERIFIED with cited rows. |
+| M2's missing-golden arm relied on "the existing EXIT trap" to restore the moved golden — but that trap restores `std/option.ail` only (V21); as written, M2 would permanently delete `.stdlib-golden/option.sha256` | gemini-3-1-pro | **ACCEPTED — M2 REDESIGNED.** The arm now runs in its own recipe-line shell with its OWN mktemp backup and OWN EXIT trap restoring exactly what it moved, covering every failure path (exact recipe text shown in M2). The two arms have INDEPENDENT backup/restore; no shared trap (a second `trap EXIT` in one shell would replace the first). New acceptance criterion + mutation row 9 prove restore-on-FAILURE: after a failing selftest, `git status --porcelain` empty and the golden's sha256 unchanged. |
+
+## Round-3 controller measurements (narrow-refinement carve-out)
+
+Round 2 returned BLOCKED on two objections. **Neither disputed the design DIRECTION** (delegation to
+`verify-stdlib` + deleting the fossil was uncontested in both rounds); both asked for premise
+verification. Per the mission skill's rule 3f the controller MEASURED them rather than forwarding
+them, and per the narrow-refinement carve-out applies the reviewers' own requested fix — the
+verification rows below — instead of spending a third authoring run.
+
+**Surface log (rule from iteration 257).** R1: history premise (`gpt5-6-sol`) + selftest trap scope
+(`gemini-3-1-pro`). R2: exported-variable consumer scope (`gpt5-6-sol`) + `verify-stdlib`
+prerequisites and V-log completeness (`gemini-3-1-pro`). The surfaces differ per round and do **not**
+localise onto one consumer, so this is not a decomposition signal; all four objections are
+evidence-completeness asks against a design neither reviewer has challenged.
+
+| Row | Claim under test | Command | Observed | Verdict |
+|---|---|---|---|---|
+| V22 | `STDLIB`/`FREEZE_DIR`/`TOOLS` are exported (Makefile:66), so an env consumer could exist outside make syntax | `sed -n '66p' Makefile` | `export STDLIB FREEZE_DIR TOOLS` | Objection's premise TRUE — audit widened below |
+| V23 | No Go code reads them from the environment | `grep -rIn 'Getenv("<V>")' --include='*.go' .` | `FREEZE_DIR` **0**, `STDLIB` **0**, `TOOLS` **0** | REFUTED (no consumers) |
+| V24 | Control for V23 — the instrument can see a real `Getenv` | `grep -rIn 'Getenv("AILANG_SEED")' --include='*.go' .` | **1** | Control FIRED |
+| V25 | No shell consumer outside makefiles | `git grep -InE '\$\{?<V>\}?([^A-Za-z0-9_]\|$)' -- ':!*.mk' ':!Makefile'` | bare `$STDLIB` **0**, `$FREEZE_DIR` **0**, `$TOOLS` **0** | REFUTED (no consumers) |
+| V26 | The 2 apparent `$STDLIB` hits are a DIFFERENT, locally-defined variable | `git grep -In '\$STDLIB' -- ':!*.mk' ':!Makefile'` | `tools/stdlib-iface-lib.sh:33` and `tools/verify-stdlib.sh:24`, both `$STDLIB_DIR`; defined locally at `tools/stdlib-iface-lib.sh:8` `STDLIB_DIR="std"` | Substring false positive — not a consumer |
+| V27 | Control for V25/V26 — the `git grep` instrument fires | `git grep -In '$GOCACHE'` → **5**; `STDLIB_DIR` refs → **2** | non-zero both | Control FIRED |
+| V28 | `verify-stdlib` really depends on `build` (make's own view, not a file grep) | `make -pn \| grep -E '^verify-stdlib:'` | `verify-stdlib: build` | CONFIRMED |
+| V29 | `verify-stdlib-selftest` likewise | `make -pn \| grep -E '^verify-stdlib-selftest:'` | `verify-stdlib-selftest: build` | CONFIRMED |
+| V30 | The dead target's prerequisites are the absent goldens | `make -pn \| grep -E '^test-stdlib-freeze:'` | `test-stdlib-freeze: goldens/stdlib/option.sha256 …` (5 entries) | CONFIRMED |
+| V31 | `STDLIB` hardcodes 5 modules while the live gate derives 45 | `make -pn \| grep '^STDLIB :='` ; `ls .stdlib-golden/*.sha256 \| wc -l` | `std/option.ail std/result.ail std/list.ail std/string.ail std/io.ail` (5); goldens **45** | CONFIRMED |
+| V32 | The repo already documents that the 5-module gate is worse than none | `sed -n '25,35p' tools/stdlib-iface-lib.sh` | *"The old scripts hardcoded MODULES=… 5 of 45. A freeze gate covering 11% of the surface is worse than none, because it reads as coverage."* | CONFIRMED — corroborates the design |
+| V33 | The delegated script already has an empty-enumeration floor | `sed -n '22,24p' tools/verify-stdlib.sh` | `if [ -z "$MODULES" ]; then … "✗ no modules found under $STDLIB_DIR/ — refusing to report success"` | CONFIRMED |
+| V34 | The goldens are CURRENT — the fix makes the gate green, not red | for each of the 5 STDLIB modules: `ailang iface std/<m> \| shasum -a 256` vs `.stdlib-golden/<m>.sha256` | **5 of 5 MATCH**; negative control (`io` vs `option`'s golden) DIFFERS | CONFIRMED |
+| V35 | Baselines for the acceptance gates on pristine `origin/dev` | each run with rc captured without a pipe | `verify-stdlib` **0**, `verify-stdlib-selftest` **0**, `check-file-sizes` **0**, `go build ./internal/...` **0**, `go build ./...` **1 (already red at base — excluded from the gate list)** | CONFIRMED |
+
+**Disposition:** both round-2 objections REFUTED by measurement; deletion safety established
+repo-wide including the environment channel. Routed to sprint-planner under the carve-out.

--- a/make/examples.mk
+++ b/make/examples.mk
@@ -171,3 +171,22 @@ verify-stdlib-selftest: build ## Prove the stdlib freeze gate fails on a real in
 	fi; \
 	rm -f "$$SELFTEST_OUT"; \
 	echo "✅ stdlib gate self-test passed: interface change -> non-zero + named module + diff"
+	@echo "Gate self-test (missing-golden arm): removing option's golden..."
+	@( GOLDEN_BK=$$(mktemp "$${TMPDIR:-/tmp}/ailang-selftest-golden.XXXXXX") || exit 1; \
+	ARM_OUT=$$(mktemp "$${TMPDIR:-/tmp}/ailang-selftest-arm-out.XXXXXX") || { rm -f "$$GOLDEN_BK"; exit 1; }; \
+	cp .stdlib-golden/option.sha256 "$$GOLDEN_BK" || { rm -f "$$GOLDEN_BK" "$$ARM_OUT"; exit 1; }; \
+	trap 'cp "$$GOLDEN_BK" .stdlib-golden/option.sha256; rm -f "$$GOLDEN_BK" "$$ARM_OUT"' EXIT; \
+	rm -f .stdlib-golden/option.sha256; \
+	if tools/verify-stdlib.sh >"$$ARM_OUT" 2>&1; then \
+		echo "❌ SELF-TEST FAIL: gate exited 0 with option's golden missing"; exit 1; \
+	fi; \
+	grep -q "option: no golden file" "$$ARM_OUT" || { \
+		echo "❌ SELF-TEST FAIL: gate failed but never reported option as UNCOVERED"; \
+		cat "$$ARM_OUT"; exit 1; }; \
+	echo "✓ missing golden -> non-zero + module reported UNCOVERED" )
+	@echo "Gate self-test (alias-integrity arm): the historical name must reach the live gate..."
+	@$(MAKE) -pn 2>/dev/null | grep -qE '^test-stdlib-freeze:[[:space:]]*verify-stdlib[[:space:]]*$$' || { \
+		echo "❌ SELF-TEST FAIL: test-stdlib-freeze no longer delegates to verify-stdlib"; exit 1; }
+	@$(MAKE) -n test-stdlib-freeze 2>&1 | grep -q 'tools/verify-stdlib.sh' || { \
+		echo "❌ SELF-TEST FAIL: test-stdlib-freeze does not reach tools/verify-stdlib.sh"; exit 1; }
+	@echo "✓ alias intact: test-stdlib-freeze -> verify-stdlib -> tools/verify-stdlib.sh"

--- a/make/test.mk
+++ b/make/test.mk
@@ -180,25 +180,10 @@ test-sim-stub: install ## Test Go codegen pipeline (sim_stub example)
 	@echo "Testing sim_stub example..."
 	@cd examples/sim_stub && make clean && make test
 
-# Stdlib freeze
-test-stdlib-freeze: $(FREEZE_DIR)/option.sha256 $(FREEZE_DIR)/result.sha256 \
-                    $(FREEZE_DIR)/list.sha256 $(FREEZE_DIR)/string.sha256 \
-                    $(FREEZE_DIR)/io.sha256 ## Verify std/ interfaces haven't changed
-	@ok=0; \
-	for m in $(STDLIB); do \
-	  name=$$(basename $${m} .ail | sed 's/^/std\//'); \
-	  tmp=$$(mktemp); \
-	  $(TOOLS) iface --module "$$name" --json > $$tmp || ok=1; \
-	  sum=$$(shasum -a 256 $$tmp | awk '{print $$1}'); \
-	  golden="$(FREEZE_DIR)/$$(basename $$name).sha256"; \
-	  if [ ! -f $$golden ]; then echo "MISSING $$golden"; ok=1; else \
-	    exp=$$(cat $$golden); \
-	    if [ "$$sum" != "$$exp" ]; then \
-	      echo "MISMATCH $$name"; ok=1; \
-	    fi; \
-	  fi; \
-	done; \
-	exit $$ok
+# Stdlib freeze — historical name, kept because v0.2.0 acceptance docs and the
+# sprint-executor skill reference it. The live gate is verify-stdlib
+# (tools/verify-stdlib.sh over .stdlib-golden/); do not grow a second implementation.
+test-stdlib-freeze: verify-stdlib ## Verify std/ interfaces haven't changed (alias of verify-stdlib)
 
 # Fuzzing
 # fuzz-parser retries the Go-fuzzing fuzztime-boundary "context deadline exceeded"


### PR DESCRIPTION
## The gate has never been able to run

`make test-stdlib-freeze` is **rc=2 at HEAD and has been since v0.1** (`602b25f03`, 2025-10-01).
It is not a gate that rotted — it is a gate that never worked.

`Makefile:59` set `FREEZE_DIR := goldens/stdlib`, and **that directory has never existed on any
ref**: 0 adds, 0 log entries, and an exhaustive scan of `git rev-list --all` (400 commits,
`git ls-tree -r`) finds it in no tree object. Controls fired (`.stdlib-golden` 2 adds; any
`goldens` path 5 log entries). So make died at *prerequisite resolution*, before the recipe body
ran — which means the recipe's own missing-golden floor was **unreachable**.

Measured in two arms on byte-identical trees (stale PATH binary and a freshly ldflags-stamped
one): rc=2 in both, so it was never a binary-version artifact.

Two further independent rots, found by fixing the path and looking:

- the recipe called `ailang iface --module "$name" --json`; **both flags were removed** (module is
  now positional, JSON is the default). `--module` → rc=2.
- worse, when `iface` failed the recipe hashed its *error output* and reported `MISMATCH std/io` —
  a tool failure wearing an interface change's clothes.
- it was wired into **no** workflow (0 hits across `.github/workflows/`; control: `verify-examples`
  appears 5 times in `ci.yml`).

This is *a guard is not a gate* in its purest form, and it is the instrument that should have
independently checked the 30-file `std/` reformat two iterations ago.

## Why delegate instead of repair

A modern replacement already exists and is CI-wired: `verify-stdlib` (+ `verify-stdlib-selftest`)
at `ci.yml:142` and `:145`, covering **all 45** modules from `.stdlib-golden/`. The fossil covered
**5** — and `tools/stdlib-iface-lib.sh` already says why that is worse than nothing:

> The old scripts hardcoded MODULES="io list option result string": 5 of 45. A freeze gate covering
> 11% of the surface is worse than none, because it reads as coverage.

So `test-stdlib-freeze` becomes an alias of the live gate rather than a second implementation.
`STDLIB`/`FREEZE_DIR`/`TOOLS` are deleted: measured sole-consumed by the dead recipe (4/1/1 hits,
all `make/test.mk:184-193`), with **no** Go `os.Getenv` and **no** bare shell consumer repo-wide
despite the `export` line (controls fired; the two apparent `$STDLIB` hits are `$STDLIB_DIR`, a
locally-defined variable).

The goldens were already current — all 5 old modules hash-match, negative control differs — so this
turns the gate green rather than red. It now reports **"✓ All 45 stdlib interfaces stable"**.

## Two new permanent selftest arms

A guard is not a gate until something reds when you remove it.

- **missing-golden** — removes option's golden, requires non-zero + the module named `UNCOVERED`.
- **alias-integrity** — asserts make's own rule database plus a dry-run trace reaching
  `tools/verify-stdlib.sh`.

Both came out of the design quorum, which **BLOCKED this twice**, and both objections were measured
rather than forwarded:

- `gemini-3-1-pro` blocked the first draft for relying on the pre-existing canary EXIT trap. The
  objection was **CONFIRMED**: that trap restores `std/option.ail` *only*, so the draft would have
  **permanently deleted** `.stdlib-golden/option.sha256`. The arm now runs in its own recipe-line
  shell with its own `mktemp` backup and its own trap, installed *before* the `rm` so restore holds
  on the failure paths too (`trap EXIT` is per-shell — a second trap replaces the first).
- the sprint planner then caught that the doc's alias assertion `grep -q 'verify-stdlib'` **also
  matches `verify-stdlib-selftest`**, so an alias repointed at a different target would have passed.
  Now anchored: `^test-stdlib-freeze:[[:space:]]*verify-stdlib[[:space:]]*$`.

## Gates (controller-run, outside the executor's sandbox, rc captured without a pipe)

`test-stdlib-freeze` **0** · `verify-stdlib` **0** · `verify-stdlib-selftest` **0** ·
`check-file-sizes` **0** · `check-changelog` **0** · `go build ./internal/...` **0**.
Re-run after rebase onto current `origin/dev`. Gates ran on **darwin/arm64**; the ubuntu and
windows legs are unrun locally. Note `go build ./...` is rc=1 **at base** (`cmd/wasm`, `gen/main`
have no native `main`) and is deliberately not used as a gate.

A 10-row mutation drill accompanied the sprint; each row asserts the mutation's *intended effect*
against make's own view rather than file bytes, and asserts the mutant still parses.

## Noted, not fixed here

`make check-skills` stays **green** while the two `developer_tools.md` skill copies differ — so it
does not enforce their byte-identity. Filed for the queue.

Reported at the mission bookkeeping thread; queue row `m-stdlib-freeze-gate-path-mismatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
