### PR TITLE
fix(prompt): versions.json carried v0.16.6's pre-edit hash — dev is red on the required 'test' context

### DIFF
--- a/prompts/versions.json
+++ b/prompts/versions.json
@@ -657,7 +657,7 @@
     },
     "v0.16.6": {
       "file": "prompts/v0.16.6.md",
-      "hash": "875b9cb27b4d81bef1c9d414c96997be3821c6f542d328bfe9c66254d14541c2",
+      "hash": "43d4ebd680202845b08a5c68849a772219077ef5015b8c5416d08bb43538ea61",
       "description": "v0.16.5 + strict-evaluation guidance for fused takeFlatMap and allocating-f takeMap forms.",
       "created": "2026-08-12",
       "tags": [


### PR DESCRIPTION
`1a3104a49` edited `prompts/v0.16.6.md` without touching `prompts/versions.json` (measured: 0 of its 2 changed files). The manifest still records the pre-edit digest, so the integrity check fired:

```
hash mismatch for "v0.16.6": expected 875b9cb2..., got 43d4ebd6...
```

`TestAILANGPromptLoading` and `TestPromptDisambiguation` FAIL on **pristine origin/dev** (`b822d7f18`) — I verified this in a clean worktree, so it is inherited, not from any PR. It is the required `test` context, so **every PR in the repo is blocked**.

The embedded mirror `cmd/ailang/prompts/v0.16.6.md` already hashes to the same `43d4ebd6…`, so only the manifest was stale. One line. Two arms on the same tree: **rc=1 before, rc=0 after**.

**Named, not silently ratified:** v0.16.6 is the *active* prompt and its content has now changed under a pinned version id, while `versions.json` itself notes that *"v0.16.5 remains served byte-identical for pinned eval baselines"*. Frozen archives are immutable by policy; the active one is evidently a live surface. Whether an active prompt version may be edited in place — and what that implies for eval baselines pinned to v0.16.6 — is raised for a human ruling in the mission bookkeeping thread rather than decided here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)