### PR TITLE
fix(test): bump the motoko lane tripwire to 22 — dev is red on a required context

### DIFF
--- a/internal/executor/motoko/provider_preflight_test.go
+++ b/internal/executor/motoko/provider_preflight_test.go
@@ -159,13 +159,14 @@ func TestRequireProviderCredential_UnresolvableModel_LoudRefusal(t *testing.T) {
 }
 
 // TestRequireProviderCredential_AllMotokoLanesResolve (T-B6b): every
-// agent_model_name across the 20 `agent_cli: "motoko"` lanes in
+// agent_model_name across the 22 `agent_cli: "motoko"` lanes in
 // internal/eval_harness/models.yml must resolve to a non-empty provider via
 // ai.GuessProvider. This is the coverage gate that fails a future motoko lane
-// whose model string is unresolvable — TODAY, all 20 begin with ollama/ or
+// whose model string is unresolvable — TODAY, all 22 begin with ollama/ or
 // openrouter/ (design doc §12.2 enumerates the original 17, since extended by
-// motoko-or-sonnet-5, motoko-local-qwen3-8-27b-microrag, and
-// motoko-cloud-gpt-oss-20b).
+// motoko-or-sonnet-5, motoko-local-qwen3-8-27b-microrag,
+// motoko-cloud-gpt-oss-20b, and — added by 4394a2a59 — motoko-cloud-kimi-k3
+// and motoko-cloud-deepseek-v4-flash).
 //
 // The count is a deliberate tripwire: adding a lane must be a conscious act that
 // re-runs the resolvability check, not a silent widening. Bump it WITH the lane.
@@ -174,8 +175,8 @@ func TestRequireProviderCredential_AllMotokoLanesResolve(t *testing.T) {
 	if len(lanes) == 0 {
 		t.Skip("could not locate internal/eval_harness/models.yml; lane-coverage gate not run")
 	}
-	if len(lanes) != 20 {
-		t.Errorf("expected 20 motoko lanes in models.yml, found %d — bump this count in the same commit that adds a lane", len(lanes))
+	if len(lanes) != 22 {
+		t.Errorf("expected 22 motoko lanes in models.yml, found %d — bump this count in the same commit that adds a lane", len(lanes))
 	}
 	for _, m := range lanes {
 		if ai.GuessProvider(m) == "" {


### PR DESCRIPTION
## What

`dev` is red on the **required `test` context**, which blocks every PR in the repo. One integer.

`4394a2a59` ("feat(eval): kimi-k3 + deepseek-v4-flash cloud rows") added two `agent_cli: "motoko"` lanes to `internal/eval_harness/models.yml` without bumping the deliberate count tripwire in `TestRequireProviderCredential_AllMotokoLanesResolve` — which is exactly what that test's own error text asks for: *"bump this count in the same commit that adds a lane"*. The gate did its job; the bump was missed.

## Attribution — measured, not inferred

Lane count vs tripwire per commit, using the same `agent_cli`/`agent_model_name` walk the test itself uses (control: the pattern reads **22** on the HEAD working tree, so a zero would have been a broken enumerator, not an absence):

| commit | lanes | tripwire | |
|---|---|---|---|
| `e49ed32f3` | 20 | 20 | consistent |
| **`4394a2a59`** | **22** | **20** | **breaks here** |
| `d574ae957` | 22 | 20 | inherited |
| `46136949d` | 22 | 20 | inherited (`origin/dev` HEAD) |

Not a provider outage: the failing job ran **17 steps** and a real step (`Run tests`) failed. The three sibling `Build` legs are fail-fast cancellations, not independent failures.

## Evidence

- **Two arms, identical tree, exit codes captured without a pipe**: pristine base `rc=1`, with this change `rc=0`. The arms **differ**, so this measures the change rather than the environment.
- **Non-vacuity proven with an ADDITION mutant, not a removal** — a removal shows a gate *fires*; only an addition shows it still *looks*. Appending a 23rd motoko lane moves the enumerator 22 → 23 (asserted against the enumerator the gate consumes, not against file bytes), the mutant builds (`go build ./internal/eval_harness/` rc=0), and the test reds with `expected 22 motoko lanes in models.yml, found 23`. `models.yml` restored from a copy — never `git checkout --` — and re-verified byte-identical by sha256.
- Both new lanes resolve: the CI log reports only the count error and no `GuessProvider` failure; both model strings begin `ollama/`.
- `gofmt -l internal/executor/motoko/` clean.

## Scope

The comment block above the test enumerated the lanes by name, so it is updated in the same change — the prose and the constant cannot drift apart.

Gates run on **darwin/arm64**; ubuntu and windows legs unrun locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
