### PR TITLE
fix(eval): dev red on required test context — eval_suite.go crossed the 800-line ceiling

### DIFF
--- a/cmd/ailang/eval_suite.go
+++ b/cmd/ailang/eval_suite.go
@@ -261,56 +261,8 @@ func runEvalSuite() {
 	// (see resolveEvalModelList in eval_suite_models.go).
 	modelList := resolveEvalModelList(*models, *fullSuite, *agent)
 
-	// SAFETY (M-RIG single-GPU): agent runs on agent-only / local models (ollama-backed, e.g. qwen)
-	// MUST be serial. The rig is ONE GPU; concurrent trials thrash ollama and crash motoko (each
-	// produces a 0-byte JSONL -> "terminated without emitting run_summary"). --parallel defaults to
-	// 10, so a raw `eval-suite --agent` silently oversubscribes. Clamp to 1 here. Recurring footgun:
-	// the dead -agent-parallel flag, the 2026-05-22/23 rotations, and the 2026-06-22 contract_leap_year
-	// run that lost 7/8 trials to GPU contention. (Override with an isolated box only.)
-	// SERIALIZATION HAS TWO INDEPENDENT CAUSES — conflating them broke a run.
-	//
-	// (1) GPU contention: the rig is one GPU, and concurrent on-device trials
-	//     thrash ollama. Ollama CLOUD rows load nothing on the GPU (measured:
-	//     concurrent cloud requests at idle latency while a 45GB model held the
-	//     GPU at 100%, `ollama ps` unchanged), so they are exempt — that is D4.
-	//
-	// (2) motoko's FIXED BACKEND PORT: every motoko profile pins
-	//     backend.port 8080 and the harness never varies it, so two motoko runs
-	//     collide REGARDLESS OF ROUTE. This has nothing to do with the GPU.
-	//
-	// The first version of D4 gated only on (1) and let 8 motoko cloud trials
-	// start in the same second: 7 crashed at startup ("terminated without
-	// emitting run_summary"), 1 survived — the one that started 5s later, after
-	// the others died and freed the port. Re-run at --parallel 1, the identical
-	// set scored 8/8. The clamp had been protecting against (2) by accident, and
-	// removing it traded a false block for a real collision.
-	//
-	// Until motoko takes a per-run port, ANY motoko row serializes.
-	if *agent && *maxConcurrent > 1 && eval_harness.GlobalModelsConfig != nil {
-		for _, m := range modelList {
-			gpuBound := eval_harness.GlobalModelsConfig.UsesLocalGPU(m)
-			cli, _ := eval_harness.GlobalModelsConfig.GetAgentCLI(m)
-			motokoBound := cli == "motoko"
-			if !gpuBound && !motokoBound {
-				continue
-			}
-			// Name WHICH cause fired: they have different fixes and different
-			// resume conditions, and a single vague message is how they got
-			// conflated in the first place.
-			reason := "motoko's fixed backend port 8080 (collides regardless of route)"
-			if gpuBound {
-				reason = "single-GPU rig contention"
-				if motokoBound {
-					reason = "single-GPU rig contention + motoko's fixed port 8080"
-				}
-			}
-			if eval_harness.GlobalModelsConfig.SupportsAgentEval(m) && !eval_harness.GlobalModelsConfig.SupportsStandardEval(m) {
-				fmt.Fprintf(os.Stderr, "\u26a0 Serializing agent run \u2014 forcing --parallel 1 (was %d): %s.\n", *maxConcurrent, reason)
-				*maxConcurrent = 1
-				break
-			}
-		}
-	}
+	// Serialization clamp — see clampConcurrencyForSerializedLanes in eval_suite_models.go.
+	clampConcurrencyForSerializedLanes(*agent, maxConcurrent, modelList)
 
 	var benchmarkList []string
 	if *byConfidence != "" {

--- a/cmd/ailang/eval_suite_models.go
+++ b/cmd/ailang/eval_suite_models.go
@@ -66,3 +66,63 @@ func resolveEvalModelList(models string, fullSuite, agent bool) []string {
 	}
 	return modelList
 }
+
+// clampConcurrencyForSerializedLanes forces --parallel 1 when any selected agent
+// lane must run serially. Extracted verbatim from runEvalSuite so that
+// eval_suite.go stays under the 800-line ceiling `make check-file-sizes`
+// enforces; the decision, its two independent causes, and the operator-facing
+// message are unchanged.
+func clampConcurrencyForSerializedLanes(agent bool, maxConcurrent *int, modelList []string) {
+	// SAFETY (M-RIG single-GPU): agent runs on agent-only / local models (ollama-backed, e.g. qwen)
+	// MUST be serial. The rig is ONE GPU; concurrent trials thrash ollama and crash motoko (each
+	// produces a 0-byte JSONL -> "terminated without emitting run_summary"). --parallel defaults to
+	// 10, so a raw `eval-suite --agent` silently oversubscribes. Clamp to 1 here. Recurring footgun:
+	// the dead -agent-parallel flag, the 2026-05-22/23 rotations, and the 2026-06-22 contract_leap_year
+	// run that lost 7/8 trials to GPU contention. (Override with an isolated box only.)
+	// SERIALIZATION HAS TWO INDEPENDENT CAUSES — conflating them broke a run.
+	//
+	// (1) GPU contention: the rig is one GPU, and concurrent on-device trials
+	//
+	//	thrash ollama. Ollama CLOUD rows load nothing on the GPU (measured:
+	//	concurrent cloud requests at idle latency while a 45GB model held the
+	//	GPU at 100%, `ollama ps` unchanged), so they are exempt — that is D4.
+	//
+	// (2) motoko's FIXED BACKEND PORT: every motoko profile pins
+	//
+	//	backend.port 8080 and the harness never varies it, so two motoko runs
+	//	collide REGARDLESS OF ROUTE. This has nothing to do with the GPU.
+	//
+	// The first version of D4 gated only on (1) and let 8 motoko cloud trials
+	// start in the same second: 7 crashed at startup ("terminated without
+	// emitting run_summary"), 1 survived — the one that started 5s later, after
+	// the others died and freed the port. Re-run at --parallel 1, the identical
+	// set scored 8/8. The clamp had been protecting against (2) by accident, and
+	// removing it traded a false block for a real collision.
+	//
+	// Until motoko takes a per-run port, ANY motoko row serializes.
+	if agent && *maxConcurrent > 1 && eval_harness.GlobalModelsConfig != nil {
+		for _, m := range modelList {
+			gpuBound := eval_harness.GlobalModelsConfig.UsesLocalGPU(m)
+			cli, _ := eval_harness.GlobalModelsConfig.GetAgentCLI(m)
+			motokoBound := cli == "motoko"
+			if !gpuBound && !motokoBound {
+				continue
+			}
+			// Name WHICH cause fired: they have different fixes and different
+			// resume conditions, and a single vague message is how they got
+			// conflated in the first place.
+			reason := "motoko's fixed backend port 8080 (collides regardless of route)"
+			if gpuBound {
+				reason = "single-GPU rig contention"
+				if motokoBound {
+					reason = "single-GPU rig contention + motoko's fixed port 8080"
+				}
+			}
+			if eval_harness.GlobalModelsConfig.SupportsAgentEval(m) && !eval_harness.GlobalModelsConfig.SupportsStandardEval(m) {
+				fmt.Fprintf(os.Stderr, "\u26a0 Serializing agent run \u2014 forcing --parallel 1 (was %d): %s.\n", *maxConcurrent, reason)
+				*maxConcurrent = 1
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
## dev is red on a REQUIRED context, and it blocks every PR in the repo

`make check-file-sizes` runs as a step of the **required `test` job**. It went red on `dev` at
`2c8498886`, which took `cmd/ailang/eval_suite.go` from exactly **800** lines to **826**.

```
✗ cmd/ailang/eval_suite.go:      826 lines (exceeds 800)
```

This is not a style nit — `dev`'s own `test` context reads `completed/failure`, so nothing merges
until it is cleared. It was found while landing V1 mission iteration 285: PR #918's `test` job
failed on this **inherited** red, and neither of that PR's commits touches any file near the
ceiling (largest is `internal/format/decl.go` at 583, unchanged from base).

## The fix

Extracts the serialization clamp out of the ~780-line `runEvalSuite` into
`clampConcurrencyForSerializedLanes` in `eval_suite_models.go` — beside `resolveEvalModelList`,
which the extracted block's own comment already points at. **826 → 778.**

I picked that block deliberately: it is the one the overflowing commit added, it is coherent
(one decision), and it has only three inputs.

## Behaviour preservation is measured, not asserted

Comparing **code statements only** (the comment block was reflowed by `gofmt`, so a naive line
diff is misleading):

- original block: **22** statements · extracted function: **22** statements
- **exactly one** differs: `*agent` → `agent`, because the caller now passes it by value
- all **298** comment words preserved exactly

The two independent serialization causes the block documents — single-GPU contention and motoko's
fixed backend port 8080 — and the operator-facing message naming *which* one fired are unchanged.

## Verification, two arms on the gate

| | before | after |
|---|---|---|
| `make check-file-sizes` | **rc=2** `✗ 826 lines` | **rc=0** `✓ All files within 800 line limit` |

`go build ./cmd/ailang` rc=0 · `go vet ./cmd/ailang` rc=0 · `gofmt -l cmd/ailang/` clean ·
`go test ./cmd/ailang -count=1` rc=0 (`ok`, 21.9s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
