### PR TITLE
motoko row: the driver pin refused unconditionally — its onboarding key no longer exists

### DIFF
--- a/changelogs/v0.32-current.md
+++ b/changelogs/v0.32-current.md
@@ -4,6 +4,35 @@
 
 ## [Unreleased]
 
+### Fixed — the driver pin refused unconditionally, because its onboarding key no longer exists
+
+`tools/launchd/lib/pin-root.sh` gated the launchd driver pin on
+`~/.claude.json`'s `.projects[<path>].hasCompletedProjectOnboarding`. Claude Code has since
+retired that key. Measured 2026-08-26 on the rig, three readings in one call: the legacy key
+appears in **0 of 15** live project entries (whole-file grep: 0), `hasTrustDialogAccepted`
+in **15 of 15** (positive control fires), an invented key in **0** (negative control fires).
+So the predicate returned `false` for every path, the "neither path onboarded" branch was
+unconditionally true, and **every fire of every mission refused to pin** — running whatever the
+source clone's working tree happened to hold. Simulated across all three missions before the fix:
+motoko, v1 and world all `REFUSE-TO-PIN`. That is the class issue #558 exists to prevent,
+reinstated by the gate written for #558.
+
+The suite could not catch it: `test_pin_root.sh` writes its own synthetic `~/.claude.json`
+fixtures still carrying the retired key, and one arm actively **asserted that the only key which
+now exists must be refused** — a green gate pinning the production defect as correct.
+
+- `_pin_onboarded` now accepts either the legacy key or `hasTrustDialogAccepted`.
+- **Anti-vacuity floor**: when *neither* key appears in *any* project entry, the gate reports
+  Claude Code **schema drift** — a distinct, fail-closed diagnosis naming both keys — instead of
+  telling the human to onboard a directory that is already onboarded. The next rename is loud on
+  its first fire rather than silent forever.
+- Suite 35 → 42 arms, including the drift arm that asserts the two refusals are textually
+  distinct (asserting `STATUS=STALE` alone cannot tell them apart, which was the whole defect).
+
+After the fix, simulated against the real `~/.claude.json`: motoko `PIN-OK`, v1 `PIN-OK`,
+world still `REFUSE-TO-PIN` — a true verdict, since that clone genuinely carries neither key.
+
+
 ### Added — M-MESSAGE-PLANE-FAIL-LOUD: the message plane's silent seams now say so (4 milestones)
 
 A 2026-08-26 triage found 41 feedback tickets back to 2026-04-27, the newest 19 never seen —

--- a/changelogs/v0.32-current.md
+++ b/changelogs/v0.32-current.md
@@ -22,12 +22,18 @@ fixtures still carrying the retired key, and one arm actively **asserted that th
 now exists must be refused** — a green gate pinning the production defect as correct.
 
 - `_pin_onboarded` now accepts either the legacy key or `hasTrustDialogAccepted`.
-- **Anti-vacuity floor**: when *neither* key appears in *any* project entry, the gate reports
-  Claude Code **schema drift** — a distinct, fail-closed diagnosis naming both keys — instead of
-  telling the human to onboard a directory that is already onboarded. The next rename is loud on
-  its first fire rather than silent forever.
-- Suite 35 → 42 arms, including the drift arm that asserts the two refusals are textually
-  distinct (asserting `STATUS=STALE` alone cannot tell them apart, which was the whole defect).
+- **Anti-vacuity floor**: when `.projects` is non-empty and *neither* key appears in *any* entry,
+  the gate reports Claude Code **schema drift** — a distinct, fail-closed diagnosis naming both
+  keys — instead of telling the human to onboard a directory that is already onboarded. The next
+  rename is loud on its first fire rather than silent forever.
+- **Three refusals, three sentences.** The evaluator found the drift diagnosis was also emitted
+  for a missing, malformed or non-object `~/.claude.json` — telling the next reader the *gate*
+  needs a new key when the *file* is broken, which is this gate's own original defect one level
+  down. Unreadable now gets its own sentence; an empty `.projects` map routes to the ordinary
+  "nothing onboarded" refusal. All three stay fail-closed; only the diagnosis moves.
+- Suite 35 → 53 arms. The drift and unreadable arms assert the message TEXT, not just
+  `STATUS=STALE` — every refusal produces STALE, so status alone cannot tell them apart, which
+  was the whole defect.
 
 After the fix, simulated against the real `~/.claude.json`: motoko `PIN-OK`, v1 `PIN-OK`,
 world still `REFUSE-TO-PIN` — a true verdict, since that clone genuinely carries neither key.

--- a/tools/launchd/lib/pin-root.sh
+++ b/tools/launchd/lib/pin-root.sh
@@ -98,7 +98,7 @@ pin_root_to_committed_ref() {
     return 0
   fi
 
-  local ref src script wt target short drift fetch_s rc onboarding_key_count
+  local ref src script wt target short drift fetch_s rc onboarding_key_count projects_len
   ref="${AILANG_DRIVER_REF:-origin/dev}"
   fetch_s="${AILANG_DRIVER_FETCH_TIMEOUT:-120}"
   script=$(basename "$0")
@@ -196,9 +196,25 @@ pin_root_to_committed_ref() {
   elif ! command -v jq >/dev/null 2>&1; then
     _pin_stale "cannot verify Claude Code onboarding for $wt (jq not found) — refusing to pin into a possibly-unusable checkout"; return 1
   else
+    # THREE distinct refusals, because a diagnosis that cannot tell them apart sends the next
+    # reader down the wrong path — which is the exact defect this gate was fixed for.
+    #   (a) the file cannot be read as `.projects`-shaped  -> instrument unreadable
+    #   (b) `.projects` is non-empty and NO entry carries either key -> Claude Code schema drift
+    #   (c) `.projects` is readable and this path is simply not onboarded -> the human fix
+    # (a) and (b) are NOT the same event: (b) means the gate needs a new key, (a) means the file
+    # is missing/malformed. Both stay fail-closed; only the sentence changes.
+    projects_len=$(jq -r 'if (.projects|type) == "object" then (.projects|length) else "NOTOBJ" end' "$HOME/.claude.json" 2>/dev/null)
+    case "${projects_len:-}" in
+      ''|*[!0-9]*)
+        _pin_stale "cannot read a .projects object from $HOME/.claude.json (missing file, invalid JSON, or unexpected shape) — refusing to pin into an unverifiable checkout"; return 1 ;;
+    esac
     onboarding_key_count=$(jq '[.projects[]? | select(has("hasCompletedProjectOnboarding") or has("hasTrustDialogAccepted"))] | length' "$HOME/.claude.json" 2>/dev/null)
-    if [ "${onboarding_key_count:-0}" -eq 0 ]; then
-      _pin_stale "neither hasCompletedProjectOnboarding nor hasTrustDialogAccepted exists in ANY project entry of $HOME/.claude.json — Claude Code schema drift; the onboarding gate needs a new key, not human onboarding"; return 1
+    case "${onboarding_key_count:-}" in
+      ''|*[!0-9]*)
+        _pin_stale "could not count onboarding keys in $HOME/.claude.json — refusing to pin into an unverifiable checkout"; return 1 ;;
+    esac
+    if [ "$projects_len" -gt 0 ] && [ "$onboarding_key_count" -eq 0 ]; then
+      _pin_stale "neither hasCompletedProjectOnboarding nor hasTrustDialogAccepted exists in ANY of the $projects_len project entries of $HOME/.claude.json — Claude Code schema drift; the onboarding gate needs a new key, not human onboarding"; return 1
     elif [ "$(_pin_onboarded "$wt")" != "true" ] && [ "$(_pin_onboarded "$src")" != "true" ]; then
       _pin_stale "neither $wt nor its source clone $src is onboarded in Claude Code — every model probe would hang there (charter V22). Run once, interactively: cd $src && claude"; return 1
     fi

--- a/tools/launchd/lib/pin-root.sh
+++ b/tools/launchd/lib/pin-root.sh
@@ -98,7 +98,7 @@ pin_root_to_committed_ref() {
     return 0
   fi
 
-  local ref src script wt target short drift fetch_s rc
+  local ref src script wt target short drift fetch_s rc onboarding_key_count
   ref="${AILANG_DRIVER_REF:-origin/dev}"
   fetch_s="${AILANG_DRIVER_FETCH_TIMEOUT:-120}"
   script=$(basename "$0")
@@ -182,22 +182,26 @@ pin_root_to_committed_ref() {
   # onboarded anywhere) and accepts the worktree-of-a-good-clone shape. `$wt` is still checked
   # first because AILANG_DRIVER_PIN_DIR can point somewhere that is NOT a worktree of $src.
   #
-  # `hasCompletedProjectOnboarding`, NOT the `hasTrustDialogAccepted` the error text names —
-  # 76ee4056c measured ailang-world (trust=false, onboarded=true) WORKING, the control proving
-  # the flag the message points at is not the gate.
+  # Claude Code has used both `hasCompletedProjectOnboarding` (legacy) and
+  # `hasTrustDialogAccepted` (current) for this state, so either true value is sufficient.
   #
   # Undeterminable is treated as un-onboarded, deliberately: pinning blind risks ~12 min of hung
   # probes and a dead loop, refusing costs staleness that is already reported. jq lives at
   # /usr/bin/jq, inside launchd's default PATH, so its absence means something is genuinely wrong.
   _pin_onboarded() {  # $1 = path -> echoes true/false
-    jq -r --arg p "$1" '.projects[$p].hasCompletedProjectOnboarding // false' "$HOME/.claude.json" 2>/dev/null
+    jq -r --arg p "$1" '((.projects[$p].hasCompletedProjectOnboarding == true) or (.projects[$p].hasTrustDialogAccepted == true))' "$HOME/.claude.json" 2>/dev/null
   }
   if [ -n "${AILANG_DRIVER_SKIP_ONBOARD_CHECK:-}" ]; then
     :
   elif ! command -v jq >/dev/null 2>&1; then
     _pin_stale "cannot verify Claude Code onboarding for $wt (jq not found) — refusing to pin into a possibly-unusable checkout"; return 1
-  elif [ "$(_pin_onboarded "$wt")" != "true" ] && [ "$(_pin_onboarded "$src")" != "true" ]; then
-    _pin_stale "neither $wt nor its source clone $src is onboarded in Claude Code — every model probe would hang there (charter V22). Run once, interactively: cd $src && claude"; return 1
+  else
+    onboarding_key_count=$(jq '[.projects[]? | select(has("hasCompletedProjectOnboarding") or has("hasTrustDialogAccepted"))] | length' "$HOME/.claude.json" 2>/dev/null)
+    if [ "${onboarding_key_count:-0}" -eq 0 ]; then
+      _pin_stale "neither hasCompletedProjectOnboarding nor hasTrustDialogAccepted exists in ANY project entry of $HOME/.claude.json — Claude Code schema drift; the onboarding gate needs a new key, not human onboarding"; return 1
+    elif [ "$(_pin_onboarded "$wt")" != "true" ] && [ "$(_pin_onboarded "$src")" != "true" ]; then
+      _pin_stale "neither $wt nor its source clone $src is onboarded in Claude Code — every model probe would hang there (charter V22). Run once, interactively: cd $src && claude"; return 1
+    fi
   fi
 
   # MISSION_WORKDIR moves too, and that is the point: mission-control.sh:40 reads it AHEAD of

--- a/tools/launchd/test_pin_root.sh
+++ b/tools/launchd/test_pin_root.sh
@@ -147,7 +147,7 @@ echo "== 7. un-onboarded pin target => REFUSE, do not exec into a probe-hang =="
 # seen, and pinning into one makes every model probe hang to its timeout, then the driver refuses
 # with "NO usable model in prefs" — reading as a quota outage. Cost motoko its whole first fire
 # (charter V22). Staleness is the strictly smaller harm, so the pin must decline.
-printf '{"projects":{}}' > "$HOME/.claude.json"
+printf '{"projects":{"%s":{"hasTrustDialogAccepted":true}}}' "/some/unrelated/path" > "$HOME/.claude.json"
 UO=$(/bin/bash "$DRV" 2>&1)
 check "refuses to pin"                   "$UO" "STATUS=STALE"
 check "names the onboarding cause"       "$UO" "onboarded in Claude Code"
@@ -155,15 +155,16 @@ check "gives the exact human fix"        "$UO" "&& claude"
 check "fire still runs, unpinned"        "$UO" "MARKER=STALE-CONTENT"
 checkno "never reports pinned"           "$UO" "STATUS=pinned"
 
-echo "== 8. the gate reads the MEASURED flag, not the one the error text names =="
-# 76ee4056c: ailang-world has trust=false / onboarded=true and WORKS. So trust alone must not
-# satisfy the gate, or we would be right by accident and wrong in the reason.
+echo "== 8. current trust flag satisfies the onboarding gate =="
+# Measured, not assumed: on 2026-08-26 hasCompletedProjectOnboarding was absent from 15/15
+# live project entries while hasTrustDialogAccepted was present in 15/15 (control), so the
+# 2026-08-12 preference for hasCompletedProjectOnboarding is void.
 printf '{"projects":{"%s":{"hasTrustDialogAccepted":true}}}' "$T/pinwt" > "$HOME/.claude.json"
 TR=$(/bin/bash "$DRV" 2>&1)
-check "trust flag alone does NOT satisfy" "$TR" "STATUS=STALE"
+check "trust flag alone DOES satisfy"     "$TR" "STATUS=pinned"
 printf '{"projects":{"%s":{"hasCompletedProjectOnboarding":true}}}' "$T/pinwt" > "$HOME/.claude.json"
 OB=$(/bin/bash "$DRV" 2>&1)
-check "onboarding flag DOES satisfy"      "$OB" "STATUS=pinned"
+check "legacy onboarding flag DOES satisfy" "$OB" "STATUS=pinned"
 
 echo "== 8b. SOURCE-clone onboarding satisfies it — the case the first cut got WRONG =="
 # Measured 2026-08-12: `claude -p` runs fine from ~/.ailang-driver-pin/v1 while ~/.claude.json
@@ -175,13 +176,28 @@ SC=$(/bin/bash "$DRV" 2>&1)
 check "source onboarding is enough"       "$SC" "STATUS=pinned"
 check "and it really pinned"              "$SC" "MARKER=FRESH-CONTENT"
 
-echo "== 8c. NEITHER onboarded => still refuse (the motoko shape) =="
+echo "== 8c. SOURCE-clone trust satisfies it — the exact live rig shape =="
+printf '{"projects":{"%s":{"hasTrustDialogAccepted":true}}}' "$T/clone" > "$HOME/.claude.json"
+SCT=$(/bin/bash "$DRV" 2>&1)
+check "source trust is enough"            "$SCT" "STATUS=pinned"
+check "and source trust really pinned"    "$SCT" "MARKER=FRESH-CONTENT"
+
+echo "== 8d. NEITHER onboarded => still refuse (the motoko shape) =="
 # The gate must not have been widened into a no-op: a fresh clone with nothing onboarded anywhere
 # is exactly what cost motoko iteration 1, and it must still be refused.
 printf '{"projects":{"%s":{"hasCompletedProjectOnboarding":true}}}' "/some/unrelated/path" > "$HOME/.claude.json"
 NN=$(/bin/bash "$DRV" 2>&1)
 check "neither path onboarded => STALE"   "$NN" "STATUS=STALE"
 check "message names BOTH paths"          "$NN" "nor its source clone"
+
+echo "== 8e. schema drift is distinct from ordinary un-onboarded refusal =="
+printf '{"projects":{"%s":{"lastCost":1.25}}}' "/some/unrelated/path" > "$HOME/.claude.json"
+SD=$(/bin/bash "$DRV" 2>&1)
+check "schema drift => STALE"             "$SD" "STATUS=STALE"
+check "reason names schema drift"         "$SD" "Claude Code schema drift"
+check "reason names legacy key"           "$SD" "hasCompletedProjectOnboarding"
+check "reason names current key"          "$SD" "hasTrustDialogAccepted"
+checkno "not ordinary onboarding refusal" "$SD" "neither $T/pinwt nor its source clone"
 
 echo "== 9. undeterminable (no jq) fails SAFE, not open =="
 mkdir -p "$T/nojq"

--- a/tools/launchd/test_pin_root.sh
+++ b/tools/launchd/test_pin_root.sh
@@ -147,7 +147,9 @@ echo "== 7. un-onboarded pin target => REFUSE, do not exec into a probe-hang =="
 # seen, and pinning into one makes every model probe hang to its timeout, then the driver refuses
 # with "NO usable model in prefs" — reading as a quota outage. Cost motoko its whole first fire
 # (charter V22). Staleness is the strictly smaller harm, so the pin must decline.
-printf '{"projects":{"%s":{"hasTrustDialogAccepted":true}}}' "/some/unrelated/path" > "$HOME/.claude.json"
+# An EMPTY .projects map is "nothing is onboarded yet" — the ordinary refusal, NOT schema drift.
+# The gate distinguishes them on `.projects | length`, so this fixture stays the natural one.
+printf '{"projects":{}}' > "$HOME/.claude.json"
 UO=$(/bin/bash "$DRV" 2>&1)
 check "refuses to pin"                   "$UO" "STATUS=STALE"
 check "names the onboarding cause"       "$UO" "onboarded in Claude Code"
@@ -198,6 +200,31 @@ check "reason names schema drift"         "$SD" "Claude Code schema drift"
 check "reason names legacy key"           "$SD" "hasCompletedProjectOnboarding"
 check "reason names current key"          "$SD" "hasTrustDialogAccepted"
 checkno "not ordinary onboarding refusal" "$SD" "neither $T/pinwt nor its source clone"
+checkno "not the unreadable diagnosis"    "$SD" "cannot read a .projects object"
+
+echo "== 8f. an UNREADABLE ~/.claude.json is NOT schema drift — three refusals, three sentences =="
+# The whole point of the drift diagnosis is to tell the next reader that the GATE needs a new key.
+# Saying that about a malformed or missing file sends them to fix the wrong thing, which is this
+# gate's own original defect one level down. So invalid JSON, a non-object `.projects`, and a
+# missing file all get the unreadable sentence instead.
+printf '{"projects": ' > "$HOME/.claude.json"           # truncated => invalid JSON
+BJ=$(/bin/bash "$DRV" 2>&1)
+check "invalid JSON => STALE"             "$BJ" "STATUS=STALE"
+check "names the unreadable cause"        "$BJ" "cannot read a .projects object"
+checkno "not called schema drift"         "$BJ" "Claude Code schema drift"
+checkno "not ordinary onboarding refusal" "$BJ" "Run once, interactively"
+checkno "never reports pinned"            "$BJ" "STATUS=pinned"
+
+printf '{"projects":"not-an-object"}' > "$HOME/.claude.json"
+NO=$(/bin/bash "$DRV" 2>&1)
+check "non-object .projects => STALE"     "$NO" "STATUS=STALE"
+check "also names the unreadable cause"   "$NO" "cannot read a .projects object"
+checkno "also not called schema drift"    "$NO" "Claude Code schema drift"
+
+rm -f "$HOME/.claude.json"
+MF=$(/bin/bash "$DRV" 2>&1)
+check "missing file => STALE"             "$MF" "STATUS=STALE"
+check "missing file names it unreadable"  "$MF" "cannot read a .projects object"
 
 echo "== 9. undeterminable (no jq) fails SAFE, not open =="
 mkdir -p "$T/nojq"


### PR DESCRIPTION
## The defect

`tools/launchd/lib/pin-root.sh` gates the launchd driver pin on
`~/.claude.json`'s `.projects[<path>].hasCompletedProjectOnboarding`. **Claude Code has retired
that key.** Measured on the rig 2026-08-26, three readings in one call:

| reading | count |
|---|---|
| project entries carrying `hasCompletedProjectOnboarding` | **0 of 15** (whole-file grep: 0) |
| project entries carrying `hasTrustDialogAccepted` (positive control) | **15 of 15** |
| project entries carrying an invented key (negative control) | **0** |

So `_pin_onboarded` returned `false` for every path, the *"neither path onboarded"* branch was
unconditionally true, and **every fire of every mission on the rig refused to pin** — executing
whatever the source clone's working tree happened to hold. Simulated before the change:

```
motoko  wt=false src=false -> REFUSE-TO-PIN
v1      wt=false src=false -> REFUSE-TO-PIN
world   wt=false src=false -> REFUSE-TO-PIN
```

This iteration's own fire ran unpinned against a tree **152 commits behind** `origin/dev`, and V1
reported the same shape in the same window (`MISSION_WORKDIR unset`). That is the class tracked at
issue #558, reinstated by the gate written for #558.

**The suite could not catch it.** `test_pin_root.sh` writes its own synthetic `~/.claude.json`
fixtures that still carry the retired key — and its arm 8 actively asserted that *the only key
which now exists must be refused*. A green gate pinning the production defect as correct.

## The change

- `_pin_onboarded` accepts **either** the legacy key **or** `hasTrustDialogAccepted`.
- **Anti-vacuity floor** — when neither key appears in *any* project entry, the gate reports Claude
  Code **schema drift**: a distinct, still fail-closed diagnosis naming both keys, rather than
  advising a human to onboard a directory that is already onboarded. #558's fail-closed posture is
  deliberately unchanged; only the diagnosis moves, so the next rename is loud on its first fire.
- Suite **35 → 42** arms.

After the fix, against the real `~/.claude.json`: motoko **PIN-OK**, v1 **PIN-OK**, world
**REFUSE-TO-PIN** — a *true* verdict, since that clone genuinely carries neither key. The fix
restores discrimination rather than blanket-accepting.

## Gates — all controller-run OUTSIDE any sandbox, on **darwin/arm64** (windows/ubuntu legs unrun locally)

- `bash -n` on both files: rc=0
- `bash tools/launchd/test_pin_root.sh`: rc=0, **42 passed, 0 failed**
- `make test-launchd-drivers`: rc=0, **40 ok / 0 not ok**, including the connection probe
- `make check-changelog`: rc=0

## Mutation drill — anchored to the diff hunk by hunk, not to the defect

Each mutant asserted **LANDED** (sha256), **PARSING** (`bash -n`), and **effect-verified against the
parsed form** rather than the bytes; each restored byte-identical from a `cp` backup.

| mutant | result |
|---|---|
| **A** revert `_pin_onboarded` to legacy-key-only | **3 arms red** (the trust arms) — SOLE KILLER |
| **B** neuter the drift floor (`if false && …`) | **4 arms red** — and note *which*: `STATUS=STALE` stayed **green**, because the ordinary un-onboarded branch also produces STALE. Only the message-distinctness assertions discriminate. That is why the arm asserts text, not status. |
| **C** revert the supporting `local` declaration hunk | **ZERO killers**, suite green 42/42 — recorded as **unpinned**, not claimed as covered. The only observable is variable-scope leakage, which no behavioural arm here can see. |
| **D** revert arm 7's fixture to the empty `.projects` map | **2 arms red** — this adjudicates the executor's **self-reported** deviation by measurement, in both arms, and in its favour: with an empty map arm 7 reaches the drift branch, so changing that fixture was necessary. |

## Pre-existing, not touched

`shellcheck -S warning` is **rc=1 on both files at base and at head**, 5 findings each, identical
codes (4× SC2034, 3× SC2164). It is not a CI gate in this repo. Red at base is a finding, not this
diff's doing.

---

Mission `motoko` iteration 25. Executor `codex:gpt-5.6-sol`; evaluator `sonnet` (distinct provider,
so generator≠judge). Reported at #558's class; no issue is closed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Round 2 — evaluator remediation (`d418a51fa`)

Evaluator (sonnet, own worktree, distinct provider → generator≠judge): **PASS 98/100, ZERO
blocking**, round 1. It reproduced all seven controller claims exactly and added three attacks of
its own — jq edge cases, a self-constructed *widening-into-a-no-op* mutant (the suite caught it,
7 arms red), and precondition-neutering on all three new arms (all three died, so none passes for
a second reason).

Its one non-blocking finding named a defect **this branch introduced**, in the exact faculty the
branch exists to improve, so it was fixed here rather than filed: the new *schema drift*
diagnosis was emitted identically for a missing / invalid / non-object `~/.claude.json` — telling
the next reader the **gate** needs a new key when the **file** is broken. That is this gate's own
original defect one level down.

Three refusals, three sentences, all still fail-closed:

| `~/.claude.json` | diagnosis |
|---|---|
| missing · invalid JSON · `.projects` not an object | *cannot read a `.projects` object … refusing to pin into an unverifiable checkout* |
| `.projects` non-empty, **no** entry carries either key | *Claude Code schema drift* — now naming the entry count searched |
| readable, populated, this path not onboarded | the human fix, unchanged |

An **empty** `.projects` map is "nothing onboarded yet" — the third case, not the second. So arm
7's natural `{"projects":{}}` fixture is **restored**; the executor's earlier fixture change was a
correct workaround for the two-way split and is unnecessary under the three-way one.

Suite **42 → 53** arms. Drill re-run at the final tree, every mutant LANDED (sha256) + PARSING
(`bash -n`) + effect-verified against the queried form:

| mutant | result |
|---|---|
| **A** `_pin_onboarded` → legacy-key-only | 3 arms red — SOLE KILLER |
| **B** neuter the drift branch | 4 arms red |
| **E** neuter the unreadable branch | 3 arms red — and again `STATUS=STALE` stayed **green**, because the fall-through also refuses. The message text is the only discriminator, which is why the arms assert it. |
| **F** drop the `projects_len > 0` guard | 2 arms red — an empty map would be misdiagnosed as drift, exactly what the guard prevents |

Gates at the final tree, controller-run outside any sandbox, **darwin/arm64** (windows/ubuntu legs
unrun locally): `bash -n` ×2 rc=0 · `test_pin_root.sh` rc=0 **53 passed, 0 failed** ·
`make test-launchd-drivers` rc=0, **0 not-ok**, connection probe 40/40 · `make check-changelog`
rc=0. Live-rig simulation unchanged: motoko **PIN-OK**, v1 **PIN-OK**, world **REFUSE-TO-PIN**.
