### PR TITLE
feat(prompts): freeze a prompt version's bytes at first banked use (D-41(c), M1)

### DIFF
--- a/cmd/ailang/prompt.go
+++ b/cmd/ailang/prompt.go
@@ -13,6 +13,11 @@ import (
 // runPrompt handles the 'ailang prompt' command
 // Displays AILANG teaching prompt for AI code generation
 func runPrompt() {
+	sub := flag.Args()[1:]
+	if len(sub) > 0 && sub[0] == "freeze" {
+		runPromptFreeze(sub[1:])
+		return
+	}
 	// Parse prompt subcommand flags
 	promptFS := flag.NewFlagSet("prompt", flag.ExitOnError)
 	versionFlag := promptFS.String("version", "", "Prompt version to display (e.g., v0.3.24, v0.4.2, or 'latest')")
@@ -142,6 +147,11 @@ OPTIONS:
   --list              List all available prompt versions
   --info              Show metadata for specified version (requires --version)
   --help              Show this help message
+
+FREEZE:
+  ailang prompt freeze <version>  Freeze a corpus-evidenced prompt version
+  ailang prompt freeze --migrate  Record the initial banked/legacy split
+  ailang prompt freeze --check    Check derivation and hash-integrity invariants
 
 EXAMPLES:
   # Display current/latest prompt

--- a/cmd/ailang/prompt_freeze.go
+++ b/cmd/ailang/prompt_freeze.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// runPromptFreeze implements `ailang prompt freeze [<version>] [--migrate] [--check] [--repo DIR]`.
+// Exit codes: 0 green; 1 violations found (--check); 2 usage/IO error.
+func runPromptFreeze(args []string) {
+	version := ""
+	if len(args) > 0 && len(args[0]) > 0 && args[0][0] != '-' {
+		version, args = args[0], args[1:]
+	}
+	fs := flag.NewFlagSet("prompt freeze", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	migrate := fs.Bool("migrate", false, "migrate all existing prompt versions")
+	check := fs.Bool("check", false, "check prompt freeze invariants")
+	repo := fs.String("repo", "", "repository root")
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+	if *repo == "" {
+		var err error
+		*repo, err = findFreezeRepoRoot()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+	}
+	if fs.NArg() == 1 {
+		if version != "" {
+			fmt.Fprintln(os.Stderr, "only one prompt version may be specified")
+			os.Exit(2)
+		}
+		version = fs.Arg(0)
+	} else if fs.NArg() > 1 {
+		fmt.Fprintln(os.Stderr, "usage: ailang prompt freeze [<version>] [--migrate] [--check] [--repo DIR]")
+		os.Exit(2)
+	}
+	selected := 0
+	if version != "" {
+		selected++
+	}
+	if *migrate {
+		selected++
+	}
+	if *check {
+		selected++
+	}
+	if selected != 1 {
+		fmt.Fprintln(os.Stderr, "exactly one of <version>, --migrate, or --check is required")
+		os.Exit(2)
+	}
+	today := time.Now().UTC().Format("2006-01-02")
+	if *migrate {
+		b, l, m, err := migrateRegistries(*repo, today)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+		fmt.Printf("migrated prompt registry: %d banked, %d legacy, %d mutable\n", b, l, m)
+		return
+	}
+	if *check {
+		violations, err := checkRegistries(*repo)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+		for _, v := range violations {
+			fmt.Fprintln(os.Stderr, v)
+		}
+		if len(violations) > 0 {
+			os.Exit(1)
+		}
+		return
+	}
+	if err := freezeVersion(*repo, version, today); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+}
+
+func findFreezeRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("repository root not found")
+		}
+		dir = parent
+	}
+}

--- a/cmd/ailang/prompt_freeze_core.go
+++ b/cmd/ailang/prompt_freeze_core.go
@@ -32,20 +32,7 @@ type orderedRegistry struct {
 	Notes         []string
 }
 
-type registryJSON struct {
-	SchemaVersion string                    `json:"schema_version"`
-	Versions      map[string]*registryEntry `json:"versions"`
-	Active        string                    `json:"active"`
-	Notes         []string                  `json:"notes"`
-}
-
 func (e *registryEntry) UnmarshalJSON(data []byte) error {
-	type wire struct {
-		File, Hash, Description, Created string
-		Tags                             []string
-		Notes                            string
-		Frozen                           *eval_harness.FrozenMarker
-	}
 	var w struct {
 		File        string                     `json:"file"`
 		Hash        string                     `json:"hash"`

--- a/cmd/ailang/prompt_freeze_core.go
+++ b/cmd/ailang/prompt_freeze_core.go
@@ -1,0 +1,386 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/sunholo-data/ailang/internal/eval_harness"
+)
+
+type registryPair struct{ Source, Mirror string }
+
+type registryEntry struct {
+	File, Hash, Description, Created string
+	Tags                             []string
+	Notes                            string
+	Frozen                           *eval_harness.FrozenMarker
+}
+
+type orderedRegistry struct {
+	SchemaVersion string
+	VersionKeys   []string
+	Versions      map[string]*registryEntry
+	RawEntries    map[string]json.RawMessage
+	Active        string
+	Notes         []string
+}
+
+type registryJSON struct {
+	SchemaVersion string                    `json:"schema_version"`
+	Versions      map[string]*registryEntry `json:"versions"`
+	Active        string                    `json:"active"`
+	Notes         []string                  `json:"notes"`
+}
+
+func (e *registryEntry) UnmarshalJSON(data []byte) error {
+	type wire struct {
+		File, Hash, Description, Created string
+		Tags                             []string
+		Notes                            string
+		Frozen                           *eval_harness.FrozenMarker
+	}
+	var w struct {
+		File        string                     `json:"file"`
+		Hash        string                     `json:"hash"`
+		Description string                     `json:"description"`
+		Created     string                     `json:"created"`
+		Tags        []string                   `json:"tags"`
+		Notes       string                     `json:"notes"`
+		Frozen      *eval_harness.FrozenMarker `json:"frozen"`
+	}
+	if err := json.Unmarshal(data, &w); err != nil {
+		return err
+	}
+	*e = registryEntry{w.File, w.Hash, w.Description, w.Created, w.Tags, w.Notes, w.Frozen}
+	return nil
+}
+
+func loadOrderedRegistry(path string) (*orderedRegistry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var raw struct {
+		SchemaVersion string          `json:"schema_version"`
+		Versions      json.RawMessage `json:"versions"`
+		Active        string          `json:"active"`
+		Notes         []string        `json:"notes"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	var versions map[string]*registryEntry
+	var rawEntries map[string]json.RawMessage
+	if err := json.Unmarshal(raw.Versions, &versions); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(raw.Versions, &rawEntries); err != nil {
+		return nil, err
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw.Versions))
+	if _, err := dec.Token(); err != nil {
+		return nil, err
+	}
+	keys := make([]string, 0, len(versions))
+	for dec.More() {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, tok.(string))
+		var skip json.RawMessage
+		if err := dec.Decode(&skip); err != nil {
+			return nil, err
+		}
+	}
+	return &orderedRegistry{raw.SchemaVersion, keys, versions, rawEntries, raw.Active, raw.Notes}, nil
+}
+
+func writeOrderedRegistry(path string, r *orderedRegistry) error {
+	var b bytes.Buffer
+	b.WriteString("{\n  \"schema_version\": ")
+	writeJSON(&b, r.SchemaVersion)
+	b.WriteString(",\n  \"versions\": {")
+	for i, k := range r.VersionKeys {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString("\n    ")
+		writeJSON(&b, k)
+		b.WriteString(": ")
+		entryBytes, err := marshalEntryPreserving(r.RawEntries[k], r.Versions[k])
+		if err != nil {
+			return err
+		}
+		lines := strings.Split(string(entryBytes), "\n")
+		b.WriteString(lines[0])
+		for _, line := range lines[1:] {
+			b.WriteString("\n    ")
+			b.WriteString(line)
+		}
+	}
+	b.WriteString("\n  },\n  \"active\": ")
+	writeJSON(&b, r.Active)
+	b.WriteString(",\n  \"notes\": ")
+	n, _ := json.MarshalIndent(r.Notes, "", "  ")
+	lines := strings.Split(string(n), "\n")
+	b.WriteString(lines[0])
+	for _, line := range lines[1:] {
+		b.WriteString("\n  ")
+		b.WriteString(line)
+	}
+	b.WriteString("\n}\n")
+	return os.WriteFile(path, b.Bytes(), 0o644)
+}
+
+func marshalEntryPreserving(raw json.RawMessage, e *registryEntry) ([]byte, error) {
+	if len(raw) > 0 {
+		raw = normalizeRawEntry(raw)
+		var original registryEntry
+		if err := json.Unmarshal(raw, &original); err == nil {
+			if original.Frozen != nil || e.Frozen == nil {
+				if (original.Frozen == nil) == (e.Frozen == nil) {
+					return raw, nil
+				}
+			} else {
+				marker, err := json.MarshalIndent(e.Frozen, "", "  ")
+				if err != nil {
+					return nil, err
+				}
+				trimmed := bytes.TrimSpace(raw)
+				base := bytes.TrimSpace(trimmed[:len(trimmed)-1])
+				out := append(append(append([]byte{}, base...), []byte(",\n  \"frozen\": ")...), appendIndented(marker, "  ")...)
+				return append(out, []byte("\n}")...), nil
+			}
+		}
+	}
+	return marshalEntry(e)
+}
+
+func normalizeRawEntry(raw json.RawMessage) json.RawMessage {
+	lines := strings.Split(string(bytes.TrimSpace(raw)), "\n")
+	for i := 1; i < len(lines); i++ {
+		lines[i] = strings.TrimPrefix(lines[i], "    ")
+	}
+	return json.RawMessage(strings.Join(lines, "\n"))
+}
+
+func appendIndented(data []byte, prefix string) []byte {
+	lines := strings.Split(string(data), "\n")
+	var b strings.Builder
+	b.WriteString(lines[0])
+	for _, line := range lines[1:] {
+		b.WriteByte('\n')
+		b.WriteString(prefix)
+		b.WriteString(line)
+	}
+	return []byte(b.String())
+}
+
+func writeJSON(b *bytes.Buffer, v string) { x, _ := json.Marshal(v); b.Write(x) }
+func marshalEntry(e *registryEntry) ([]byte, error) {
+	type ordered struct {
+		File        string                     `json:"file"`
+		Hash        string                     `json:"hash"`
+		Description string                     `json:"description"`
+		Created     string                     `json:"created"`
+		Tags        []string                   `json:"tags"`
+		Notes       string                     `json:"notes"`
+		Frozen      *eval_harness.FrozenMarker `json:"frozen,omitempty"`
+	}
+	return json.MarshalIndent(ordered{e.File, e.Hash, e.Description, e.Created, e.Tags, e.Notes, e.Frozen}, "", "  ")
+}
+
+type corpusEvidence struct {
+	Count   int
+	Example string
+}
+
+func scanCorpus(repoRoot string) (map[string]corpusEvidence, error) {
+	cmd := exec.Command("git", "ls-files", "eval_results/baselines/*.json")
+	cmd.Dir = repoRoot
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git ls-files: %w", err)
+	}
+	result := map[string]corpusEvidence{}
+	for _, rel := range strings.Fields(string(out)) {
+		data, err := os.ReadFile(filepath.Join(repoRoot, rel))
+		if err != nil {
+			return nil, err
+		}
+		var row struct {
+			PromptVersion string `json:"prompt_version"`
+		}
+		if err := json.Unmarshal(data, &row); err != nil {
+			return nil, fmt.Errorf("%s: %w", rel, err)
+		}
+		if row.PromptVersion != "" {
+			ev := result[row.PromptVersion]
+			ev.Count++
+			if ev.Example == "" {
+				ev.Example = rel
+			}
+			result[row.PromptVersion] = ev
+		}
+	}
+	return result, nil
+}
+
+var corpusScanner = scanCorpus
+
+func promptRegistryPair(root string) registryPair {
+	return registryPair{filepath.Join(root, "prompts", "versions.json"), filepath.Join(root, "cmd", "ailang", "prompts", "versions.json")}
+}
+func fileHash(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:]), nil
+}
+
+func migrateRegistries(repoRoot, today string) (int, int, int, error) {
+	pair := promptRegistryPair(repoRoot)
+	r, err := loadOrderedRegistry(pair.Source)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	if r.Active == "latest" || r.Versions[r.Active] == nil {
+		return 0, 0, 0, fmt.Errorf("active prompt %q is not a concrete registry key", r.Active)
+	}
+	evidence, err := corpusScanner(repoRoot)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	for _, id := range r.VersionKeys {
+		e := r.Versions[id]
+		if id == r.Active || e.Frozen != nil {
+			continue
+		}
+		if !eval_harness.IsHexSHA256(e.Hash) {
+			return 0, 0, 0, fmt.Errorf("%s: recorded hash is not enforceable", id)
+		}
+		actual, xerr := fileHash(filepath.Join(repoRoot, e.File))
+		if xerr != nil {
+			return 0, 0, 0, xerr
+		}
+		if actual != e.Hash {
+			return 0, 0, 0, fmt.Errorf("%s: file bytes do not match recorded hash", id)
+		}
+	}
+	for _, id := range r.VersionKeys {
+		e := r.Versions[id]
+		if id == r.Active || e.Frozen != nil {
+			continue
+		}
+		ev := evidence[id]
+		reason := "legacy"
+		if ev.Count > 0 {
+			reason = "banked"
+		}
+		e.Frozen = &eval_harness.FrozenMarker{At: today, Reason: reason, EvidenceCount: ev.Count, EvidenceExample: ev.Example}
+	}
+	if err := writeOrderedRegistry(pair.Source, r); err != nil {
+		return 0, 0, 0, err
+	}
+	if err := writeOrderedRegistry(pair.Mirror, r); err != nil {
+		return 0, 0, 0, err
+	}
+	banked, legacy, mutable := 0, 0, 0
+	for _, e := range r.Versions {
+		if e.Frozen == nil {
+			mutable++
+		} else if e.Frozen.Reason == "banked" {
+			banked++
+		} else if e.Frozen.Reason == "legacy" {
+			legacy++
+		}
+	}
+	return banked, legacy, mutable, nil
+}
+
+func freezeVersion(repoRoot, versionID, today string) error {
+	pair := promptRegistryPair(repoRoot)
+	r, err := loadOrderedRegistry(pair.Source)
+	if err != nil {
+		return err
+	}
+	e := r.Versions[versionID]
+	if e == nil {
+		return fmt.Errorf("prompt version %q not found", versionID)
+	}
+	evidence, err := corpusScanner(repoRoot)
+	if err != nil {
+		return err
+	}
+	ev := evidence[versionID]
+	if ev.Count == 0 {
+		return fmt.Errorf("prompt version %q has no banked corpus evidence", versionID)
+	}
+	if !eval_harness.IsHexSHA256(e.Hash) {
+		return fmt.Errorf("%s: recorded hash is not enforceable", versionID)
+	}
+	actual, err := fileHash(filepath.Join(repoRoot, e.File))
+	if err != nil {
+		return err
+	}
+	if actual != e.Hash {
+		return fmt.Errorf("%s: file bytes do not match recorded hash", versionID)
+	}
+	if e.Frozen == nil {
+		e.Frozen = &eval_harness.FrozenMarker{At: today, Reason: "banked", EvidenceCount: ev.Count, EvidenceExample: ev.Example}
+	}
+	if err := writeOrderedRegistry(pair.Source, r); err != nil {
+		return err
+	}
+	return writeOrderedRegistry(pair.Mirror, r)
+}
+
+func checkRegistries(repoRoot string) ([]string, error) {
+	pair := promptRegistryPair(repoRoot)
+	source, err := loadOrderedRegistry(pair.Source)
+	if err != nil {
+		return nil, err
+	}
+	mirror, err := loadOrderedRegistry(pair.Mirror)
+	if err != nil {
+		return nil, err
+	}
+	evidence, err := corpusScanner(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	var v []string
+	for id, ev := range evidence {
+		if e := source.Versions[id]; e != nil && e.Frozen == nil {
+			v = append(v, fmt.Sprintf("corpus-evidenced but not frozen: %s (%d citations, e.g. %s)", id, ev.Count, ev.Example))
+		}
+	}
+	for _, id := range source.VersionKeys {
+		e := source.Versions[id]
+		if e.Frozen != nil {
+			if !eval_harness.IsHexSHA256(e.Hash) {
+				v = append(v, fmt.Sprintf("frozen version %s: recorded hash is not a 64-hex sha256 (unenforceable freeze)", id))
+			} else if h, xerr := fileHash(filepath.Join(repoRoot, e.File)); xerr != nil {
+				return nil, xerr
+			} else if h != e.Hash {
+				v = append(v, fmt.Sprintf("frozen version %s: file bytes do not match recorded hash", id))
+			}
+		}
+		a, _ := json.Marshal(e)
+		b, _ := json.Marshal(mirror.Versions[id])
+		if !bytes.Equal(a, b) {
+			v = append(v, fmt.Sprintf("cmd/ailang/prompts/versions.json: entry %s differs from source", id))
+		}
+	}
+	return v, nil
+}

--- a/cmd/ailang/prompt_freeze_test.go
+++ b/cmd/ailang/prompt_freeze_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func freezeFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	os.MkdirAll(filepath.Join(root, "prompts"), 0o755)
+	os.MkdirAll(filepath.Join(root, "cmd", "ailang", "prompts"), 0o755)
+	r := &orderedRegistry{SchemaVersion: "1.0", Versions: map[string]*registryEntry{}, RawEntries: map[string]json.RawMessage{}, Active: "active", Notes: []string{"fixture"}}
+	for _, id := range []string{"b1", "b2", "b3", "l1", "l2", "l3", "l4", "active"} {
+		content := []byte("prompt " + id)
+		h := sha256.Sum256(content)
+		e := &registryEntry{File: "prompts/" + id + ".md", Hash: hex.EncodeToString(h[:]), Description: id, Created: "2026-01-01", Tags: []string{"test"}, Notes: "fixture"}
+		r.VersionKeys = append(r.VersionKeys, id)
+		r.Versions[id] = e
+		os.WriteFile(filepath.Join(root, e.File), content, 0o644)
+	}
+	writeOrderedRegistry(filepath.Join(root, "prompts", "versions.json"), r)
+	writeOrderedRegistry(filepath.Join(root, "cmd", "ailang", "prompts", "versions.json"), r)
+	old := corpusScanner
+	corpusScanner = func(string) (map[string]corpusEvidence, error) {
+		return map[string]corpusEvidence{"b1": {210, "eval_results/baselines/a.json"}, "b2": {38, "eval_results/baselines/b.json"}, "b3": {1, "eval_results/baselines/c.json"}}, nil
+	}
+	t.Cleanup(func() { corpusScanner = old })
+	return root
+}
+func split(r *orderedRegistry) (int, int, int, string) {
+	b, l, m, mID := 0, 0, 0, ""
+	for id, e := range r.Versions {
+		if e.Frozen == nil {
+			m++
+			mID = id
+		} else if e.Frozen.Reason == "banked" {
+			b++
+		} else if e.Frozen.Reason == "legacy" {
+			l++
+		}
+	}
+	return b, l, m, mID
+}
+
+func TestPromptFreezeMigrate_SplitCounts(t *testing.T) {
+	root := freezeFixture(t)
+	path := filepath.Join(root, "prompts", "versions.json")
+	before, _ := os.ReadFile(path)
+	r, _ := loadOrderedRegistry(path)
+	writeOrderedRegistry(path, r)
+	round, _ := os.ReadFile(path)
+	if !bytes.Equal(before, round) {
+		t.Fatal("ordered writer changed unmigrated input")
+	}
+	b, l, m, err := migrateRegistries(root, "2026-08-27")
+	if err != nil || b != 3 || l != 4 || m != 1 {
+		t.Fatalf("%d/%d/%d %v", b, l, m, err)
+	}
+	r, _ = loadOrderedRegistry(path)
+	b, l, m, id := split(r)
+	if b != 3 || l != 4 || m != 1 || id != "active" || r.Versions["b1"].Frozen.EvidenceCount != 210 {
+		t.Fatalf("bad split %d/%d/%d %s", b, l, m, id)
+	}
+}
+func TestPromptFreezeMigrate_WritesBothRegistries(t *testing.T) {
+	root := freezeFixture(t)
+	migrateRegistries(root, "2026-08-27")
+	a, _ := os.ReadFile(filepath.Join(root, "prompts", "versions.json"))
+	b, _ := os.ReadFile(filepath.Join(root, "cmd", "ailang", "prompts", "versions.json"))
+	if len(b) == 0 || !bytes.Equal(a, b) {
+		t.Fatal("registries differ")
+	}
+	r, _ := loadOrderedRegistry(filepath.Join(root, "cmd", "ailang", "prompts", "versions.json"))
+	x, y, z, _ := split(r)
+	if x != 3 || y != 4 || z != 1 {
+		t.Fatalf("mirror split %d/%d/%d", x, y, z)
+	}
+}
+func TestPromptFreezeMigrate_RefusesStaleHash(t *testing.T) {
+	root := freezeFixture(t)
+	p := filepath.Join(root, "prompts", "b1.md")
+	os.WriteFile(p, []byte("tampered"), 0o644)
+	aPath := filepath.Join(root, "prompts", "versions.json")
+	bPath := filepath.Join(root, "cmd", "ailang", "prompts", "versions.json")
+	a, _ := os.ReadFile(aPath)
+	b, _ := os.ReadFile(bPath)
+	_, _, _, err := migrateRegistries(root, "2026-08-27")
+	if err == nil || !strings.Contains(err.Error(), "b1") {
+		t.Fatalf("unexpected %v", err)
+	}
+	aa, _ := os.ReadFile(aPath)
+	bb, _ := os.ReadFile(bPath)
+	if !bytes.Equal(a, aa) || !bytes.Equal(b, bb) {
+		t.Fatal("registry changed on refusal")
+	}
+}
+func TestPromptFreezeMigrate_Idempotent(t *testing.T) {
+	root := freezeFixture(t)
+	migrateRegistries(root, "2026-08-27")
+	aPath := filepath.Join(root, "prompts", "versions.json")
+	a, _ := os.ReadFile(aPath)
+	migrateRegistries(root, "2026-08-28")
+	b, _ := os.ReadFile(aPath)
+	if !bytes.Equal(a, b) {
+		t.Fatal("second migration changed bytes")
+	}
+}
+func TestPromptFreezeCheck_GreenOnMigratedFixture(t *testing.T) {
+	root := freezeFixture(t)
+	migrateRegistries(root, "2026-08-27")
+	v, err := checkRegistries(root)
+	if err != nil || len(v) != 0 {
+		t.Fatalf("%v %v", v, err)
+	}
+}
+func TestPromptFreezeCheck_RedOnMissingMarker(t *testing.T) {
+	root := freezeFixture(t)
+	migrateRegistries(root, "2026-08-27")
+	pair := promptRegistryPair(root)
+	r, _ := loadOrderedRegistry(pair.Source)
+	r.Versions["b1"].Frozen = nil
+	writeOrderedRegistry(pair.Source, r)
+	writeOrderedRegistry(pair.Mirror, r)
+	v, err := checkRegistries(root)
+	if err != nil || len(v) != 1 || !strings.Contains(v[0], "b1") || !strings.Contains(v[0], "corpus-evidenced but not frozen") {
+		t.Fatalf("%v %v", v, err)
+	}
+}
+func TestRealRegistry_PostMigrationSplitCounts(t *testing.T) {
+	source, err := loadOrderedRegistry(filepath.Join("..", "..", "prompts", "versions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mirror, err := loadOrderedRegistry(filepath.Join("prompts", "versions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, l, m, id := split(source)
+	if b != 19 || l != 39 || m != 1 || id != "v0.16.6" {
+		t.Fatalf("split %d/%d/%d %s", b, l, m, id)
+	}
+	a, _ := json.Marshal(source.Versions)
+	z, _ := json.Marshal(mirror.Versions)
+	if !bytes.Equal(a, z) {
+		t.Fatal("registries differ")
+	}
+	h, err := fileHash(filepath.Join("..", "..", source.Versions["aver"].File))
+	if err != nil || h != source.Versions["aver"].Hash {
+		t.Fatalf("aver hash %s %v", h, err)
+	}
+}

--- a/cmd/ailang/prompts/versions.json
+++ b/cmd/ailang/prompts/versions.json
@@ -10,7 +10,13 @@
         "baseline",
         "production"
       ],
-      "notes": "Original teaching prompt from v0.3.0 release. Comprehensive coverage of language features with clear syntax rules and examples."
+      "notes": "Original teaching prompt from v0.3.0 release. Comprehensive coverage of language features with clear syntax rules and examples.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.0-hints": {
       "file": "prompts/v0.3.0-hints.md",
@@ -21,7 +27,13 @@
         "experimental",
         "error-hints"
       ],
-      "notes": "Adds 6 common error pattern sections (PAR_001, TC_REC_001, TC_INT_001, EQ_001, CAP_001, MOD_001) with wrong/correct examples. Hypothesis: Explicit error warnings reduce first-attempt failures and improve repair success rate."
+      "notes": "Adds 6 common error pattern sections (PAR_001, TC_REC_001, TC_INT_001, EQ_001, CAP_001, MOD_001) with wrong/correct examples. Hypothesis: Explicit error warnings reduce first-attempt failures and improve repair success rate.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.2": {
       "file": "prompts/v0.3.2.md",
@@ -32,7 +44,13 @@
         "production",
         "planning"
       ],
-      "notes": "Adds proactive architecture planning with :propose and :scaffold commands. Includes plan schema, validation rules, and best practices. Teaches AI agents to validate architecture BEFORE coding. Derived from v0.3.0-hints with 24 validation error codes added."
+      "notes": "Adds proactive architecture planning with :propose and :scaffold commands. Includes plan schema, validation rules, and best practices. Teaches AI agents to validate architecture BEFORE coding. Derived from v0.3.0-hints with 24 validation error codes added.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.5": {
       "file": "prompts/v0.3.5.md",
@@ -42,7 +60,13 @@
       "tags": [
         "production"
       ],
-      "notes": "Adds support for: 1) Anonymous function syntax func(x) -> T { body }, 2) letrec keyword for recursive lambdas, 3) intToFloat/floatToInt builtins. Derived from v0.3.0 baseline."
+      "notes": "Adds support for: 1) Anonymous function syntax func(x) -> T { body }, 2) letrec keyword for recursive lambdas, 3) intToFloat/floatToInt builtins. Derived from v0.3.0 baseline.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.8": {
       "file": "prompts/v0.3.8.md",
@@ -52,7 +76,13 @@
       "tags": [
         "production"
       ],
-      "notes": "Major improvements: 1) std/prelude auto-imported (no more Ord/Eq imports needed), 2) Record update syntax {r | field: val}, 3) Multi-line ADTs with optional leading pipe, 4) Operator lowering fixes. 49.1% success rate (+10.5% from v0.3.7). All v0.3.5 features included."
+      "notes": "Major improvements: 1) std/prelude auto-imported (no more Ord/Eq imports needed), 2) Record update syntax {r | field: val}, 3) Multi-line ADTs with optional leading pipe, 4) Operator lowering fixes. 49.1% success rate (+10.5% from v0.3.7). All v0.3.5 features included.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.9": {
       "file": "prompts/v0.3.9.md",
@@ -62,7 +92,13 @@
       "tags": [
         "production"
       ],
-      "notes": "AI API integration features: 1) JSON encoding with std/json (encode, jo, ja, kv, js, jnum), 2) HTTP headers with httpRequest() and Result-based error handling, 3) NetError ADT (Transport, InvalidHeader, DisallowedHost, BodyTooLarge), 4) Verified with real Claude Haiku API call. All v0.3.8 features included."
+      "notes": "AI API integration features: 1) JSON encoding with std/json (encode, jo, ja, kv, js, jnum), 2) HTTP headers with httpRequest() and Result-based error handling, 3) NetError ADT (Transport, InvalidHeader, DisallowedHost, BodyTooLarge), 4) Verified with real Claude Haiku API call. All v0.3.8 features included.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.12": {
       "file": "prompts/v0.3.12.md",
@@ -72,7 +108,13 @@
       "tags": [
         "production"
       ],
-      "notes": "Recovery release restoring show() builtin (accidentally removed in v0.3.10). Prominent show() examples added to teach proper string conversion. All v0.3.9 features included. Testing hypothesis: Emphasizing show() will reduce syntax errors and improve AILANG success rates from 0% baseline."
+      "notes": "Recovery release restoring show() builtin (accidentally removed in v0.3.10). Prominent show() examples added to teach proper string conversion. All v0.3.9 features included. Testing hypothesis: Emphasizing show() will reduce syntax errors and improve AILANG success rates from 0% baseline.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.15": {
       "file": "prompts/v0.3.15.md",
@@ -84,7 +126,13 @@
         "latest",
         "vision-aligned"
       ],
-      "notes": "MAJOR upgrade addressing vision benchmark failures: 1) Effect system docs (~200 lines), 2) State threading patterns (~80 lines), 3) Canonical list operations (~120 lines). Targets: Effect 6%\u219270%, State 0%\u219260%, Canonical 0%\u219270%. Expected: 36.5%\u219270% AILANG success."
+      "notes": "MAJOR upgrade addressing vision benchmark failures: 1) Effect system docs (~200 lines), 2) State threading patterns (~80 lines), 3) Canonical list operations (~120 lines). Targets: Effect 6%\u219270%, State 0%\u219260%, Canonical 0%\u219270%. Expected: 36.5%\u219270% AILANG success.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.6": {
       "file": "prompts/v0.3.6.md",
@@ -95,7 +143,13 @@
         "experimental",
         "failed"
       ],
-      "notes": "FAILED: Two iterations showed 10% worse performance than v0.3.5. Longer prompts with anti-patterns and import checklists caused information overload. Conclusion: Prompt engineering is counter-productive; language changes (auto-import, record update syntax) are the solution."
+      "notes": "FAILED: Two iterations showed 10% worse performance than v0.3.5. Longer prompts with anti-patterns and import checklists caused information overload. Conclusion: Prompt engineering is counter-productive; language changes (auto-import, record update syntax) are the solution.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.2.0": {
       "file": "prompts/v0.2.0.md",
@@ -105,7 +159,13 @@
       "tags": [
         "historical"
       ],
-      "notes": "Pre-records, pre-recursion, pre-blocks. Kept for historical comparison."
+      "notes": "Pre-records, pre-recursion, pre-blocks. Kept for historical comparison.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "python": {
       "file": "prompts/python.md",
@@ -116,7 +176,13 @@
         "control",
         "python"
       ],
-      "notes": "Used for baseline comparison - how well do models do with Python vs AILANG?"
+      "notes": "Used for baseline comparison - how well do models do with Python vs AILANG?",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 6537,
+        "evidence_example": "eval_results/baselines/v0.11.2/agent/adt_option_python_claude-sonnet-4-5_1776087516.json"
+      }
     },
     "v0.3.16": {
       "file": "prompts/v0.3.16.md",
@@ -128,7 +194,13 @@
         "latest",
         "ai-first"
       ],
-      "notes": "Entry-module prelude: print builtin automatically available in modules with 'export func main' (no import needed). Libraries still explicit. AI-First DX: minimize syntactic entropy for benchmarks while keeping libraries explicit. All v0.3.15 features included."
+      "notes": "Entry-module prelude: print builtin automatically available in modules with 'export func main' (no import needed). Libraries still explicit. AI-First DX: minimize syntactic entropy for benchmarks while keeping libraries explicit. All v0.3.15 features included.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.17": {
       "file": "prompts/v0.3.17.md",
@@ -138,7 +210,13 @@
       "tags": [
         "production"
       ],
-      "notes": "Fix httpRequest documentation: remove false HTTP headers limitation and add httpRequest() examples"
+      "notes": "Fix httpRequest documentation: remove false HTTP headers limitation and add httpRequest() examples",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.18": {
       "file": "prompts/v0.3.18.md",
@@ -149,7 +227,13 @@
         "experimental",
         "failed"
       ],
-      "notes": "FAILED: Over-optimization (-59% tokens) collapsed success rate to 4.8%. Removed too many examples and context. See .claude/skills/prompt-manager/OPTIMIZATION_FAILURE_ANALYSIS.md"
+      "notes": "FAILED: Over-optimization (-59% tokens) collapsed success rate to 4.8%. Removed too many examples and context. See .claude/skills/prompt-manager/OPTIMIZATION_FAILURE_ANALYSIS.md",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.19": {
       "file": "prompts/v0.3.19.md",
@@ -161,7 +245,13 @@
         "latest",
         "optimized"
       ],
-      "notes": "SUCCESS: Phase 1 optimization (-2.5% tokens, 5189\u21925058 words). Added quick reference, condensed verbose sections, kept all 64 examples. Validated: 41.9% AILANG success rate. Conservative incremental approach proven effective."
+      "notes": "SUCCESS: Phase 1 optimization (-2.5% tokens, 5189\u21925058 words). Added quick reference, condensed verbose sections, kept all 64 examples. Validated: 41.9% AILANG success rate. Conservative incremental approach proven effective.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.20": {
       "file": "prompts/v0.3.20.md",
@@ -173,7 +263,13 @@
         "testing",
         "broken"
       ],
-      "notes": "BROKEN: Incorrect pattern matching syntax in Quick Reference (pipes before patterns). Caused -4.8% regression (40.0% \u2192 35.2%). Fixed in v0.3.21. Added testing features from v0.3.20: unit tests (test \"name\" = expr) and property-based tests (property \"name\" (x: type) = expr). Includes 100-case generation with automatic shrinking. Size: 5262 words (+4% from v0.3.19). Run with: ailang test file.ail"
+      "notes": "BROKEN: Incorrect pattern matching syntax in Quick Reference (pipes before patterns). Caused -4.8% regression (40.0% \u2192 35.2%). Fixed in v0.3.21. Added testing features from v0.3.20: unit tests (test \"name\" = expr) and property-based tests (property \"name\" (x: type) = expr). Includes 100-case generation with automatic shrinking. Size: 5262 words (+4% from v0.3.19). Run with: ailang test file.ail",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.21": {
       "file": "prompts/v0.3.21.md",
@@ -185,7 +281,13 @@
         "testing",
         "hotfix"
       ],
-      "notes": "CRITICAL HOTFIX: Fixed 3 syntax errors in v0.3.20: (1) Pattern matching (no pipes before patterns, commas between arms), (2) Import syntax (no quotes on module paths), (3) Tuple destructuring (use `match tuple { (x, y) => ... }` NOT `let (x, y) = tuple`). State threading examples corrected. All v0.3.20 testing features included. Expected: AILANG success 35.2% \u2192 40.0%+"
+      "notes": "CRITICAL HOTFIX: Fixed 3 syntax errors in v0.3.20: (1) Pattern matching (no pipes before patterns, commas between arms), (2) Import syntax (no quotes on module paths), (3) Tuple destructuring (use `match tuple { (x, y) => ... }` NOT `let (x, y) = tuple`). State threading examples corrected. All v0.3.20 testing features included. Expected: AILANG success 35.2% \u2192 40.0%+",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 210,
+        "evidence_example": "eval_results/baselines/v0.3.21-with-repair/adt_option_ailang_claude-haiku-4-5_1761578492.json"
+      }
     },
     "v0.3.22": {
       "file": "prompts/v0.3.22.md",
@@ -197,7 +299,13 @@
         "latest",
         "m-eval-http-fix"
       ],
-      "notes": "M-EVAL-HTTP-FIX Milestone 2: (1) Enhanced parser error messages for JavaScript/Python patterns (PAR014: const keyword, PAR015: bare assignment), (2) HTTP POST example moved from line 218 \u2192 line 107 (-51% position). Target: Reduce api_call_json failures from 75% by guiding AIs toward correct AILANG syntax earlier in prompt. All v0.3.21 testing features included."
+      "notes": "M-EVAL-HTTP-FIX Milestone 2: (1) Enhanced parser error messages for JavaScript/Python patterns (PAR014: const keyword, PAR015: bare assignment), (2) HTTP POST example moved from line 218 \u2192 line 107 (-51% position). Target: Reduce api_call_json failures from 75% by guiding AIs toward correct AILANG syntax earlier in prompt. All v0.3.21 testing features included.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.23": {
       "file": "prompts/v0.3.23.md",
@@ -208,7 +316,13 @@
         "production",
         "latest"
       ],
-      "notes": "Add note: print() auto-adds newline, don't concatenate \\n"
+      "notes": "Add note: print() auto-adds newline, don't concatenate \\n",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 32,
+        "evidence_example": "eval_results/baselines/v0.3.23/agent/fizzbuzz_ailang_claude-haiku-4-5_1761670751.json"
+      }
     },
     "v0.3.24": {
       "file": "prompts/v0.3.24.md",
@@ -219,7 +333,13 @@
         "production",
         "latest"
       ],
-      "notes": "Add zero-argument function call syntax documentation"
+      "notes": "Add zero-argument function call syntax documentation",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.4.0": {
       "file": "prompts/v0.4.0.md",
@@ -229,7 +349,13 @@
       "tags": [
         "production"
       ],
-      "notes": "Add Env effect, Net effect, and v0.4.0 features"
+      "notes": "Add Env effect, Net effect, and v0.4.0 features",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 38,
+        "evidence_example": "eval_results/baselines/v0.4.0/agent/deterministic_list_transform_ailang_claude-haiku-4-5_1761990967.json"
+      }
     },
     "v0.4.1": {
       "file": "prompts/v0.4.1.md",
@@ -240,7 +366,13 @@
         "production",
         "latest"
       ],
-      "notes": "Added syntactic sugar documentation: S-CONS (:: cons operator, expressions only), S-ARROWTYPE (-> function types), S-CALL0 (f() zero-arg calls, NOW WORKS at statement level!). IMPORTANT: :: sugar only works in expressions, NOT in patterns - use ::(h, t) in match. Includes --strict-syntax flag documentation. M-S-CALL0: Completed statement-level parsing for f() calls."
+      "notes": "Added syntactic sugar documentation: S-CONS (:: cons operator, expressions only), S-ARROWTYPE (-> function types), S-CALL0 (f() zero-arg calls, NOW WORKS at statement level!). IMPORTANT: :: sugar only works in expressions, NOT in patterns - use ::(h, t) in match. Includes --strict-syntax flag documentation. M-S-CALL0: Completed statement-level parsing for f() calls.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 76,
+        "evidence_example": "eval_results/baselines/v0.4.1/agent/deterministic_list_transform_ailang_claude-haiku-4-5_1762109126.json"
+      }
     },
     "v0.4.2": {
       "file": "prompts/v0.4.2.md",
@@ -251,7 +383,13 @@
         "production",
         "latest"
       ],
-      "notes": "Fix stdlib docs + remove Cons reference + clarify S-CONS limitation"
+      "notes": "Fix stdlib docs + remove Cons reference + clarify S-CONS limitation",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 38,
+        "evidence_example": "eval_results/baselines/v0.4.3/agent/deterministic_list_transform_ailang_claude-haiku-4-5_1762447321.json"
+      }
     },
     "v0.4.4": {
       "file": "prompts/v0.4.4.md",
@@ -262,7 +400,13 @@
         "production",
         "latest"
       ],
-      "notes": "Add S-CONS pattern sugar (x :: xs syntax)"
+      "notes": "Add S-CONS pattern sugar (x :: xs syntax)",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 38,
+        "evidence_example": "eval_results/baselines/v0.4.4/agent/deterministic_list_transform_ailang_claude-haiku-4-5_1763061148.json"
+      }
     },
     "v0.4.5": {
       "file": "prompts/v0.4.5.md",
@@ -273,7 +417,13 @@
         "production",
         "latest"
       ],
-      "notes": "Fix string concatenation (++) operator type inference"
+      "notes": "Fix string concatenation (++) operator type inference",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 38,
+        "evidence_example": "eval_results/baselines/v0.4.5/agent/deterministic_list_transform_ailang_claude-haiku-4-5_1763304852.json"
+      }
     },
     "v0.4.6": {
       "file": "prompts/v0.4.6.md",
@@ -284,7 +434,13 @@
         "production",
         "latest"
       ],
-      "notes": "Add teaching improvements: What NOT to have, multi-module, JSON, operators, effects emphasis, HTTP/Net capabilities"
+      "notes": "Add teaching improvements: What NOT to have, multi-module, JSON, operators, effects emphasis, HTTP/Net capabilities",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 38,
+        "evidence_example": "eval_results/baselines/v0.4.6/agent/deterministic_list_transform_ailang_claude-haiku-4-5_1763581870.json"
+      }
     },
     "v0.4.7": {
       "file": "prompts/v0.4.7.md",
@@ -295,7 +451,13 @@
         "production",
         "latest"
       ],
-      "notes": "Add inline tests documentation with cross-function deps (M-TESTING-DEPS)"
+      "notes": "Add inline tests documentation with cross-function deps (M-TESTING-DEPS)",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 62,
+        "evidence_example": "eval_results/baselines/v0.4.7/agent/deterministic_list_transform_ailang_claude-haiku-4-5_1764275585.json"
+      }
     },
     "v0.4.8": {
       "file": "prompts/v0.4.8.md",
@@ -306,7 +468,13 @@
         "production",
         "latest"
       ],
-      "notes": "Add mandatory template, stronger structure emphasis"
+      "notes": "Add mandatory template, stronger structure emphasis",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 138,
+        "evidence_example": "eval_results/baselines/v0.4.8/agent/adt_option_ailang_claude-haiku-4-5_1764418074.json"
+      }
     },
     "v0.4.10": {
       "file": "prompts/v0.4.10.md",
@@ -317,7 +485,13 @@
         "production",
         "latest"
       ],
-      "notes": "Add Array type with O(1) indexed access"
+      "notes": "Add Array type with O(1) indexed access",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.5.0": {
       "file": "prompts/v0.5.0.md",
@@ -328,7 +502,13 @@
         "production",
         "latest"
       ],
-      "notes": "Add AI effect for multi-provider AI oracle"
+      "notes": "Add AI effect for multi-provider AI oracle",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 138,
+        "evidence_example": "eval_results/baselines/v0.5.0/agent/adt_option_ailang_claude-haiku-4-5_1764697665.json"
+      }
     },
     "v0.5.2": {
       "file": "prompts/v0.5.2.md",
@@ -339,7 +519,13 @@
         "production",
         "latest"
       ],
-      "notes": "Add relaxed module matching (--relax-modules flag, AILANG_RELAX_MODULES env var)"
+      "notes": "Add relaxed module matching (--relax-modules flag, AILANG_RELAX_MODULES env var)",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.5.10": {
       "file": "prompts/v0.5.10.md",
@@ -350,7 +536,13 @@
         "production",
         "optimized"
       ],
-      "notes": "REWRITE v2: Added back critical sections lost in streamlining. Includes negative examples (\u274c WRONG / \u2705 RIGHT) for let/in scoping and curried function calls. Key sections: Block vs expression let bindings, curried function chaining, Option patterns, ADT state machine. 2,204 words (71% smaller than v0.4.4)."
+      "notes": "REWRITE v2: Added back critical sections lost in streamlining. Includes negative examples (\u274c WRONG / \u2705 RIGHT) for let/in scoping and curried function calls. Key sections: Block vs expression let bindings, curried function chaining, Option patterns, ADT state machine. 2,204 words (71% smaller than v0.4.4).",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.5.11": {
       "file": "prompts/v0.5.11.md",
@@ -362,7 +554,13 @@
         "semantic-caching",
         "embeddings"
       ],
-      "notes": "Major additions: (1) Semantic Caching Doctrine - SharedMem/SharedIndex as cognitive working memory, namespace conventions, canonical patterns (cache-or-compute, deduplication, multi-agent CAS). (2) Embeddings Doctrine - when/what/how to use neural embeddings for paraphrase detection, hybrid retrieval pattern. All v0.5.10 features included."
+      "notes": "Major additions: (1) Semantic Caching Doctrine - SharedMem/SharedIndex as cognitive working memory, namespace conventions, canonical patterns (cache-or-compute, deduplication, multi-agent CAS). (2) Embeddings Doctrine - when/what/how to use neural embeddings for paraphrase detection, hybrid retrieval pattern. All v0.5.10 features included.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.6.2": {
       "file": "prompts/v0.6.2.md",
@@ -374,7 +572,13 @@
         "record-patterns",
         "deriving-eq"
       ],
-      "notes": "Record pattern matching for destructuring records in match expressions. Syntax: {name}, {name: var}, {name, age}, {user: {name}} for nested patterns, {name, ...} for rest patterns. M-DX19: Auto-derive Eq for ADT types using `type Color = Red | Green | Blue deriving (Eq)` syntax. Enables == and != operators via structural equality comparison. All v0.5.11 features included."
+      "notes": "Record pattern matching for destructuring records in match expressions. Syntax: {name}, {name: var}, {name, age}, {user: {name}} for nested patterns, {name, ...} for rest patterns. M-DX19: Auto-derive Eq for ADT types using `type Color = Red | Green | Blue deriving (Eq)` syntax. Enables == and != operators via structural equality comparison. All v0.5.11 features included.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 114,
+        "evidence_example": "eval_results/baselines/v0.6.2/agent/adt_option_ailang_claude-haiku-4-5_1767366188.json"
+      }
     },
     "v0.6.3": {
       "file": "prompts/v0.6.3.md",
@@ -385,7 +589,13 @@
         "production",
         "stdlib-docs"
       ],
-      "notes": "AGENT DISCOVERABILITY: Added explicit documentation for std/math (floatToInt, intToFloat, floor, ceil, round) and expanded std/string (substring, contains, stringToInt, intToStr, floatToStr). Analysis of agent transcripts showed models were implementing their own broken versions of functions that already exist in stdlib but weren't documented in the prompt."
+      "notes": "AGENT DISCOVERABILITY: Added explicit documentation for std/math (floatToInt, intToFloat, floor, ceil, round) and expanded std/string (substring, contains, stringToInt, intToStr, floatToStr). Analysis of agent transcripts showed models were implementing their own broken versions of functions that already exist in stdlib but weren't documented in the prompt.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.6.4": {
       "file": "prompts/v0.6.4.md",
@@ -396,7 +606,13 @@
         "production",
         "json-helpers"
       ],
-      "notes": "JSON CONVENIENCE FUNCTIONS: Added getString, getNumber, getInt, getBool, getArray, getObject to std/json.ail. These combine get()+asX() to reduce nested Option matching from 4 levels to 2. Also added prominent import reminder warning to reduce 'forgot to import' errors. Target: json_parse benchmark turns <25 (down from 47 in v0.6.3)."
+      "notes": "JSON CONVENIENCE FUNCTIONS: Added getString, getNumber, getInt, getBool, getArray, getObject to std/json.ail. These combine get()+asX() to reduce nested Option matching from 4 levels to 2. Also added prominent import reminder warning to reduce 'forgot to import' errors. Target: json_parse benchmark turns <25 (down from 47 in v0.6.3).",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.6.5": {
       "file": "prompts/v0.6.5.md",
@@ -410,7 +626,13 @@
         "prelude-fix",
         "language-gaps"
       ],
-      "notes": "PRELUDE FIX: println is now in prelude (no import needed), print (no newline) requires import std/io (print). STDLIB GAPS (M-STDLIB-GAPS): Added std/list functions (nth, last, any, findIndex), std/string join and chars, JSON array extraction. LANGUAGE GAP WARNINGS (from agent analysis): Added letrec for recursive lambdas section, type annotations for HOFs section, expanded 'What AILANG Does NOT Have' table (tuple let-destructuring, lambda tuple syntax outside foldl, nested func syntax)."
+      "notes": "PRELUDE FIX: println is now in prelude (no import needed), print (no newline) requires import std/io (print). STDLIB GAPS (M-STDLIB-GAPS): Added std/list functions (nth, last, any, findIndex), std/string join and chars, JSON array extraction. LANGUAGE GAP WARNINGS (from agent analysis): Added letrec for recursive lambdas section, type annotations for HOFs section, expanded 'What AILANG Does NOT Have' table (tuple let-destructuring, lambda tuple syntax outside foldl, nested func syntax).",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 1,
+        "evidence_example": "eval_results/baselines/v0.6.5/agent/agent/config_file_parser_ailang_claude-haiku-4-5_1767632692.json"
+      }
     },
     "v0.6.6": {
       "file": "prompts/v0.6.6.md",
@@ -422,7 +644,13 @@
         "row-polymorphism",
         "width-subtyping"
       ],
-      "notes": "RECORD WIDTH SUBTYPING (M-GAP4): Added open record types for functions that accept extra fields. Syntax: {field: T | r} with explicit row variable, or {field: T, ...} sugar with fresh variable. Exact records (default) reject extra fields. Open records enable generic field extractors and flexible APIs."
+      "notes": "RECORD WIDTH SUBTYPING (M-GAP4): Added open record types for functions that accept extra fields. Syntax: {field: T | r} with explicit row variable, or {field: T, ...} sugar with fresh variable. Exact records (default) reject extra fields. Open records enable generic field extractors and flexible APIs.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 92,
+        "evidence_example": "eval_results/baselines/v0.7.0/agent/adt_option_ailang_claude-sonnet-4-5_1769088989.json"
+      }
     },
     "v0.7.0": {
       "file": "prompts/v0.7.0.md",
@@ -434,7 +662,13 @@
         "latest",
         "gap-analysis"
       ],
-      "notes": "Gap analysis integration from v0.6.2\u2192v0.7.0 eval comparison: (1) Strengthened block brace requirements with explicit examples, (2) Added import checklist reminder, (3) Enhanced JSON patterns with getString/getNumber examples. Target: Reduce AILANG eval failures from import errors and missing braces."
+      "notes": "Gap analysis integration from v0.6.2\u2192v0.7.0 eval comparison: (1) Strengthened block brace requirements with explicit examples, (2) Added import checklist reminder, (3) Enhanced JSON patterns with getString/getNumber examples. Target: Reduce AILANG eval failures from import errors and missing braces.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.7.3": {
       "file": "prompts/v0.7.3.md",
@@ -446,7 +680,13 @@
         "effectful-combinators",
         "structured-ai-output"
       ],
-      "notes": "Structured AI output: callJson (schema-enforced), callJsonSimple (no schema) for validated JSON responses from AI providers. All 4 providers wired (Gemini, OpenAI, Anthropic, Ollama). Effectful list combinators: mapE, filterE, foldlE, flatMapE, forEachE for effect-polymorphic HOFs. Pure flatMap added. Effect row variable syntax enabled."
+      "notes": "Structured AI output: callJson (schema-enforced), callJsonSimple (no schema) for validated JSON responses from AI providers. All 4 providers wired (Gemini, OpenAI, Anthropic, Ollama). Effectful list combinators: mapE, filterE, foldlE, flatMapE, forEachE for effect-polymorphic HOFs. Pure flatMap added. Effect row variable syntax enabled.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.7.4": {
       "file": "prompts/v0.7.4.md",
@@ -459,7 +699,13 @@
         "smt-verification",
         "contracts"
       ],
-      "notes": "Static contract verification: ailang verify command uses Z3 to mathematically prove requires/ensures contracts hold for ALL inputs. Covers decidable fragment (int/bool/enum ADTs, arithmetic, comparison, if/let/match). Shows counterexamples when violations found. Flags: --verbose (SMT-LIB), --json (machine-readable), --strict (fail on skipped). Replaced old --experimental-binop-shim requirement."
+      "notes": "Static contract verification: ailang verify command uses Z3 to mathematically prove requires/ensures contracts hold for ALL inputs. Covers decidable fragment (int/bool/enum ADTs, arithmetic, comparison, if/let/match). Shows counterexamples when violations found. Flags: --verbose (SMT-LIB), --json (machine-readable), --strict (fail on skipped). Replaced old --experimental-binop-shim requirement.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 61,
+        "evidence_example": "eval_results/baselines/v0.8.0/agent/adt_option_ailang_claude-sonnet-4-5_1771081134.json"
+      }
     },
     "v0.7.4-compact": {
       "file": "prompts/v0.7.4-compact.md",
@@ -470,7 +716,13 @@
         "production",
         "compact"
       ],
-      "notes": "Conservative 71% size reduction. Keeps: type system table, effect syntax, module syntax, contract syntax, critical gotchas. Removes: extended examples, design rationale, historical notes. For full reference: ailang prompt"
+      "notes": "Conservative 71% size reduction. Keeps: type system table, effect syntax, module syntax, contract syntax, critical gotchas. Removes: extended examples, design rationale, historical notes. For full reference: ailang prompt",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.8.0": {
       "file": "prompts/v0.8.0.md",
@@ -480,7 +732,13 @@
       "tags": [
         "production"
       ],
-      "notes": "Add getArgs/stdin docs, fix CLI args benchmark gap"
+      "notes": "Add getArgs/stdin docs, fix CLI args benchmark gap",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.8.1": {
       "file": "prompts/v0.8.1.md",
@@ -491,7 +749,13 @@
         "production",
         "latest"
       ],
-      "notes": "Contracts section rewritten with agent-centric framing (specify-implement-verify workflow). Updated all examples to use stdlib imports (std/string, std/list) instead of raw builtins. Moved contracts before Testing to reflect importance. Documents stdlib transparency in Z3 verification."
+      "notes": "Contracts section rewritten with agent-centric framing (specify-implement-verify workflow). Updated all examples to use stdlib imports (std/string, std/list) instead of raw builtins. Moved contracts before Testing to reflect importance. Documents stdlib transparency in Z3 verification.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.8.2": {
       "file": "prompts/v0.8.2.md",
@@ -502,7 +766,13 @@
         "production",
         "streaming-dx"
       ],
-      "notes": "M-STREAM-DX sprint: (1) Added zipWith to std/list docs, (2) Added std/bytes section (fromString, toString, toBase64, fromBase64, slice), (3) Added std/stream section (connect, transmit, transmitBinary, ssePost, withSSE, SSEData events), (4) Added newtype record field access docs (single-constructor ADT auto-unwrap), (5) Added show recommendation over intToStr/floatToStr for simple cases."
+      "notes": "M-STREAM-DX sprint: (1) Added zipWith to std/list docs, (2) Added std/bytes section (fromString, toString, toBase64, fromBase64, slice), (3) Added std/stream section (connect, transmit, transmitBinary, ssePost, withSSE, SSEData events), (4) Added newtype record field access docs (single-constructor ADT auto-unwrap), (5) Added show recommendation over intToStr/floatToStr for simple cases.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.9.0": {
       "file": "prompts/v0.9.0.md",
@@ -514,7 +784,13 @@
         "latest",
         "streaming"
       ],
-      "notes": "M-ASYNC-IO Phase 1+2: (1) Multi-source multiplexing (selectEvents, sourceOfConn, asyncReadStdinLines), (2) Subprocess stdout streaming (asyncExecProcess with SourceBytes events), (3) Correct StreamEvent ADT (11 variants including SourceText, SourceBytes), (4) Fixed return types to StreamErrorKind. All v0.8.2 features included."
+      "notes": "M-ASYNC-IO Phase 1+2: (1) Multi-source multiplexing (selectEvents, sourceOfConn, asyncReadStdinLines), (2) Subprocess stdout streaming (asyncExecProcess with SourceBytes events), (3) Correct StreamEvent ADT (11 variants including SourceText, SourceBytes), (4) Fixed return types to StreamErrorKind. All v0.8.2 features included.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 57,
+        "evidence_example": "eval_results/baselines/v0.11.2/agent/adt_option_ailang_claude-sonnet-4-5_1776087513.json"
+      }
     },
     "v0.11.4": {
       "file": "prompts/v0.11.4.md",
@@ -524,7 +800,13 @@
       "tags": [
         "production"
       ],
-      "notes": "Add v0.10.x + v0.11.x: short-circuit semantics, Map/iter/jwt/trace stdlib, parseFoldStep, bitwise ops, new string builtins, exit(), polymorphic comparison lambdas"
+      "notes": "Add v0.10.x + v0.11.x: short-circuit semantics, Map/iter/jwt/trace stdlib, parseFoldStep, bitwise ops, new string builtins, exit(), polymorphic comparison lambdas",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 62,
+        "evidence_example": "eval_results/baselines/v0.12.0/agent/adt_option_ailang_claude-sonnet-4-5_1776436817.json"
+      }
     },
     "v0.12.1": {
       "file": "prompts/v0.12.1.md",
@@ -536,7 +818,13 @@
         "latest",
         "string-interpolation"
       ],
-      "notes": "M-CONCAT-DISAMBIG Phase 1: Introduces \"${expr}\" interpolation as the idiomatic way to build strings. Desugars to concat_String(..., show(expr), ...) chains via Show type-class dispatch (show_String is identity). Supports nested braces, arbitrary expressions, and \\${ escape. ++ still works for strings today but will be restricted to lists only in v0.13.0 (Phase 2)."
+      "notes": "M-CONCAT-DISAMBIG Phase 1: Introduces \"${expr}\" interpolation as the idiomatic way to build strings. Desugars to concat_String(..., show(expr), ...) chains via Show type-class dispatch (show_String is identity). Supports nested braces, arbitrary expressions, and \\${ escape. ++ still works for strings today but will be restricted to lists only in v0.13.0 (Phase 2).",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 51,
+        "evidence_example": "eval_results/baselines/v0.13.0/agent/api_call_json_ailang_claude-sonnet-4-5_1776772769.json"
+      }
     },
     "go": {
       "file": "prompts/go.md",
@@ -547,7 +835,13 @@
         "control",
         "go"
       ],
-      "notes": "Used for Go vs AILANG baseline comparison in multi-language evals"
+      "notes": "Used for Go vs AILANG baseline comparison in multi-language evals",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "javascript": {
       "file": "prompts/javascript.md",
@@ -558,7 +852,13 @@
         "control",
         "javascript"
       ],
-      "notes": "Used for JavaScript vs AILANG baseline comparison in multi-language evals"
+      "notes": "Used for JavaScript vs AILANG baseline comparison in multi-language evals",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "moonbit": {
       "file": "prompts/moonbit.md",
@@ -570,11 +870,17 @@
         "moonbit",
         "three-camps"
       ],
-      "notes": "Closest ML-family peer to AILANG in the three-camps survey (verification camp via constrained sampling, MoonBitlang ICSE 2024). Targets apples-to-apples FP comparison on smoke + selected gap benchmarks. Built single-file `moon run` runner (no project scaffold needed)."
+      "notes": "Closest ML-family peer to AILANG in the three-camps survey (verification camp via constrained sampling, MoonBitlang ICSE 2024). Targets apples-to-apples FP comparison on smoke + selected gap benchmarks. Built single-file `moon run` runner (no project scaffold needed).",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "aver": {
       "file": "prompts/aver.md",
-      "hash": "190bf4244a00bb0605d41ac01d4de415a6131a3a961aa6bca1689b23bc4d521d",
+      "hash": "1f5c9654e39c411bcbedc35446ffa96c1d6dc8d7b9dd0fbec01b95ecf35f0157",
       "description": "Aver language teaching prompt for eval harness (M-THREE-CAMPS Verification-camp peer)",
       "created": "2026-05-21",
       "tags": [
@@ -583,7 +889,13 @@
         "three-camps",
         "verification"
       ],
-      "notes": "Verification-camp peer with verify blocks, decision blocks (ADRs in code), Lean 4 proof export. Indentation-based, match-only branching, namespaced constructors. Installed via `cargo install aver-lang` (aver-lang 0.21.0 verified). Single-file `aver run` mode."
+      "notes": "Verification-camp peer with verify blocks, decision blocks (ADRs in code), Lean 4 proof export. Indentation-based, match-only branching, namespaced constructors. Installed via `cargo install aver-lang` (aver-lang 0.21.0 verified). Single-file `aver run` mode.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.16.0": {
       "file": "prompts/v0.16.0.md",
@@ -596,7 +908,13 @@
         "labels",
         "m-taint-types"
       ],
-      "notes": "Adds Phase 1+2 IFC label syntax to the AILANG teaching prompt. Includes the inbox-injection worked example and the DECLASS rule. AI modes section added in M-AI-EFFECT-MODES (v0.15.0)."
+      "notes": "Adds Phase 1+2 IFC label syntax to the AILANG teaching prompt. Includes the inbox-injection worked example and the DECLASS rule. AI modes section added in M-AI-EFFECT-MODES (v0.15.0).",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.16.1": {
       "file": "prompts/v0.16.1.md",
@@ -607,7 +925,13 @@
         "production",
         "stdlib-coverage"
       ],
-      "notes": "Additive patch over v0.16.0 (no syntax changes). Closes ~50 stdlib documentation gaps surfaced by M-VERA-BENCH audit. Worst pre-fix offenders: std/clock (0/2 documented), std/datetime (1/22), std/math trig family (0/10), std/option helpers (3/6), std/result helpers (2/6). Token budget impact: ~600 extra tokens. Same hash discipline as prior versions."
+      "notes": "Additive patch over v0.16.0 (no syntax changes). Closes ~50 stdlib documentation gaps surfaced by M-VERA-BENCH audit. Worst pre-fix offenders: std/clock (0/2 documented), std/datetime (1/22), std/math trig family (0/10), std/option helpers (3/6), std/result helpers (2/6). Token budget impact: ~600 extra tokens. Same hash discipline as prior versions.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.16.2": {
       "file": "prompts/v0.16.2.md",
@@ -619,7 +943,13 @@
         "latest",
         "output-discipline"
       ],
-      "notes": "Active from v0.26.0 benchmark cycle. Additive patch over v0.16.1 (no syntax changes): adds an Output Discipline section instructing exact byte-for-byte stdout (no labels/prefixes/status lines). Validated by A/B on claude-opus-4-8 standard (14/24 -> 19/24; type_unify 1/3->3/3, mini_interpreter 2/3->3/3, csv_to_json 0/3->2/3; zero control regressions). Removes a verbosity grading tax that disproportionately hit frontier models. Full multi-model re-baseline deferred to the next release."
+      "notes": "Active from v0.26.0 benchmark cycle. Additive patch over v0.16.1 (no syntax changes): adds an Output Discipline section instructing exact byte-for-byte stdout (no labels/prefixes/status lines). Validated by A/B on claude-opus-4-8 standard (14/24 -> 19/24; type_unify 1/3->3/3, mini_interpreter 2/3->3/3, csv_to_json 0/3->2/3; zero control regressions). Removes a verbosity grading tax that disproportionately hit frontier models. Full multi-model re-baseline deferred to the next release.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.16.3": {
       "file": "prompts/v0.16.3.md",
@@ -630,7 +960,13 @@
         "production",
         "fmt-discoverability"
       ],
-      "notes": "Additive patch over v0.16.2 (no syntax changes, byte-identical prefix): appends a ~6-line Formatting section so agents can discover `ailang fmt`. Command-usage only (no code snippet) to avoid an `ailang check` verification surface. Activated as part of the fmt adoption rollout; v0.16.2 remains served byte-identical for pinned eval baselines."
+      "notes": "Additive patch over v0.16.2 (no syntax changes, byte-identical prefix): appends a ~6-line Formatting section so agents can discover `ailang fmt`. Command-usage only (no code snippet) to avoid an `ailang check` verification surface. Activated as part of the fmt adoption rollout; v0.16.2 remains served byte-identical for pinned eval baselines.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.16.4": {
       "file": "prompts/v0.16.4.md",
@@ -641,7 +977,13 @@
         "production",
         "dialect-alignment"
       ],
-      "notes": "Two fixes, both verified against the toolchain rather than assumed. (1) v0.16.3 taught that `letrec` with a `= ...` body is a PARSE ERROR; it type-checks AND runs correctly (verified with `ailang check` + `ailang run`) -- the claim went stale when M-SYNTAX-AI-FORGIVING R1 made an equation body a `;`-separated statement sequence. Teaching models to avoid valid syntax is the same failure class as `ailang fmt` contradicting the prompt. The section now states both forms work and recommends the block because that is what fmt emits. (2) `List[T]` -> `[T]` in 4 places (1 ailang block, 3 prose): `[T]` is taught 64 times and is what fmt emits, so `List[T]` was a spelling fmt would rewrite. Both parse to the identical TypeApp. v0.16.3 remains served byte-identical for pinned eval baselines."
+      "notes": "Two fixes, both verified against the toolchain rather than assumed. (1) v0.16.3 taught that `letrec` with a `= ...` body is a PARSE ERROR; it type-checks AND runs correctly (verified with `ailang check` + `ailang run`) -- the claim went stale when M-SYNTAX-AI-FORGIVING R1 made an equation body a `;`-separated statement sequence. Teaching models to avoid valid syntax is the same failure class as `ailang fmt` contradicting the prompt. The section now states both forms work and recommends the block because that is what fmt emits. (2) `List[T]` -> `[T]` in 4 places (1 ailang block, 3 prose): `[T]` is taught 64 times and is what fmt emits, so `List[T]` was a spelling fmt would rewrite. Both parse to the identical TypeApp. v0.16.3 remains served byte-identical for pinned eval baselines.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.16.5": {
       "file": "prompts/v0.16.5.md",
@@ -653,7 +995,13 @@
         "latest",
         "stdlib-discoverability"
       ],
-      "notes": "Prompted by issue #609, where a field agent reported a string's raw bytes were 'unreachable from AILANG' and asked for toInts. The reach claim was FALSE -- byteAt has shipped since v0.21.0 and was already taught in the bytes function list, and byteAt+length transcodes the reporter's exact Latin-1 payload correctly at HEAD (verified with ailang run before any change). What was actually missing was discoverability and shape. The common-imports line read `import std/bytes (fromString, toString, toBase64, fromBase64, length, slice)` -- not one byte-level function -- so an agent copying that canonical line saw a bytes module with no way into the bytes. The toInts entry also states explicitly that charCode/string indexing return U+FFFD for non-UTF-8 bytes and that fromString+toInts is the way through, because that specific wrong turn is what the report documented. v0.16.4 remains served byte-identical for pinned eval baselines."
+      "notes": "Prompted by issue #609, where a field agent reported a string's raw bytes were 'unreachable from AILANG' and asked for toInts. The reach claim was FALSE -- byteAt has shipped since v0.21.0 and was already taught in the bytes function list, and byteAt+length transcodes the reporter's exact Latin-1 payload correctly at HEAD (verified with ailang run before any change). What was actually missing was discoverability and shape. The common-imports line read `import std/bytes (fromString, toString, toBase64, fromBase64, length, slice)` -- not one byte-level function -- so an agent copying that canonical line saw a bytes module with no way into the bytes. The toInts entry also states explicitly that charCode/string indexing return U+FFFD for non-UTF-8 bytes and that fromString+toInts is the way through, because that specific wrong turn is what the report documented. v0.16.4 remains served byte-identical for pinned eval baselines.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.16.6": {
       "file": "prompts/v0.16.6.md",

--- a/design_docs/planned/m-prompt-version-freeze-on-first-bank-sprint-plan.md
+++ b/design_docs/planned/m-prompt-version-freeze-on-first-bank-sprint-plan.md
@@ -1,0 +1,558 @@
+# Sprint Plan — M-PROMPT-VERSION-FREEZE
+
+**Design doc**: [`m-prompt-version-freeze-on-first-bank.md`](m-prompt-version-freeze-on-first-bank.md) (PLANNED, quorum-cleared at r3)
+**Sprint ID**: `M-PROMPT-VERSION-FREEZE`
+**Ruling**: decision-ledger row **D-41**, option **(c)** — a prompt version is mutable until first banked use, then frozen.
+**Base commit**: `70f4e0660` (`origin/dev`). Worktree HEAD `fa23e950e` adds only the design doc, so the code tree under test **is** `70f4e0660`.
+**Worktree**: `/Users/voightkampff/dev/sunholo-data/.wt-iter291`, branch `sprint/iter291-prompt-freeze`
+**Risk**: M1 **medium** (one blocking pre-existing defect, §2; one existing-test constraint, §3). M2 medium (git plumbing). M3 **high** (behaviour change on the live eval path). M4 medium.
+
+---
+
+## 0. SCOPE RULING (binding, from the mission controller)
+
+**M1 is the ONLY milestone to be EXECUTED this iteration.** M1 is the design doc's own declared
+*"minimum viable ruling-compliance"*: it makes the BANKED/NEVER-BANKED state representable,
+records it for all 59 versions in **both** registries, and enforces it with a teaching error on
+the standard-mode path.
+
+**M2, M3 and M4 are planned in full here but are follow-on iterations.** Each is specified to be
+**independently landable** on top of M1 alone: no milestone depends on a later one, each ends with
+its own green gate set, and §9 gives the file-ownership split that keeps the commits bisectable.
+
+If the executor finishes M1 early it must **stop** and report, not start M2.
+
+---
+
+## 1. EXECUTOR GROUND RULES — read before anything else
+
+1. **The executor may NOT run any git write operation.** No `git add`, `commit`, `stash`,
+   `checkout`, `branch`, `restore`, `rebase`, `tag`. The controller builds commits. Read-only git
+   (`git ls-files`, `git status`, `git diff`, `git merge-base`, `git show`) is fine and is required
+   by the corpus predicate.
+2. **Snapshots**: on finishing each milestone, copy the **full content** of every file that
+   milestone created or modified into `.snap/M<k>/`, preserving repo-relative paths, **cumulatively**
+   (`.snap/M2/` contains M1's files too). This iteration that means `.snap/M1/` only.
+3. **`go test -run <Nonexistent>` exits rc=0.** Any gate of the form "this test exists and passes"
+   MUST be `go test <pkg> -run '<Name>' -v > /tmp/o 2>&1; grep -c -- '--- PASS: <Name>' /tmp/o`
+   and assert the expected integer. A bare `rc=0` is a vacuous gate here.
+4. **Capture rc without a pipe**: `cmd > /tmp/out 2>&1; rc=$?`. Never `${PIPESTATUS[0]}` (empty in
+   zsh), never `|| echo 0` wrapped around `grep -c`.
+5. **`go build ./...` is rc=1 at base** (pre-existing, unrelated to this work). It is
+   **DISQUALIFIED** as an acceptance command. Scope every build gate to touched packages.
+6. Tests must never mutate the shared working tree. All fixtures under `t.TempDir()`. The one
+   exception is the two *real* registry files, which M1's migration legitimately rewrites — that
+   is the product, not a test side effect.
+
+---
+
+## 2. Measured baselines
+
+### 2.1 Supplied by the controller at `70f4e0660` (use as-is, do not re-derive)
+
+| # | Command | rc |
+|---|---|---|
+| B1 | `test -z "$(gofmt -l internal/eval_harness cmd/ailang)"` | 0 |
+| B2 | `go build ./cmd/ailang ./internal/eval_harness/...` | 0 |
+| B3 | `go build ./...` | **1 — RED AT BASE, DISQUALIFIED** |
+| B4 | `go vet ./internal/eval_harness/... ./cmd/ailang/` | 0 |
+| B5 | `make check-file-sizes` | 0 |
+| B6 | `go test ./internal/eval_harness/...` | 0 |
+| B7 | `go test ./cmd/ailang/ -run 'TestAILANGPromptLoading|TestPromptDisambiguation'` | 0, **2 PASS** |
+
+### 2.2 Measured first-party by the sprint-planner at `fa23e950e` (this plan adds `internal/prompt` to the gate scope; M1 edits that package, so it needed its own baseline)
+
+| # | Command | Observed |
+|---|---|---|
+| P1 | `test -z "$(gofmt -l internal/eval_harness cmd/ailang internal/prompt)"` | rc=0 |
+| P2 | `go build ./cmd/ailang ./internal/eval_harness/... ./internal/prompt/...` | rc=0 |
+| P3 | `go vet ./internal/prompt/` | rc=0 |
+| P4 | `go test ./internal/prompt/` | rc=0, `ok … 0.350s` |
+| P5 | `go test ./cmd/ailang/ -run 'TestAILANGPromptLoading\|TestPromptDisambiguation' -v \| grep -c -- '--- PASS'` | `2` (confirms B7 in the grep form gates must use) |
+| P6 | corpus sweep — `git ls-files 'eval_results/baselines/*.json' \| xargs jq -r 'if has("prompt_version") then .prompt_version else "ABSENT" end' \| sort \| uniq -c \| sort -rn` | `9522 ABSENT, 6537 python, 210 v0.3.21, 138 v0.5.0, 138 v0.4.8, 114 v0.6.2, 92 v0.6.6, 76 v0.4.1, 62 v0.4.7, 62 v0.11.4, 61 v0.7.4, 57 v0.9.0, 51 v0.12.1, 38×(v0.4.0,.2,.4,.5,.6), 32 v0.3.23, 1 v0.6.5` — **17,343 total, agrees exactly with doc rows V-F and N-2** |
+| P7 | corpus sweep wall-clock | **1.87 s** over 195 MB / 17,343 files. `--check`'s derivation (Q1) is cheap enough for `make ci`. |
+| P8 | registry∩corpus (re-derivation of V-I) — `jq --arg k … '.versions\|has($k)'` for all 19 corpus ids | 19 × `true`; **positive control** `python` → `true`, **negative control** `v9.9.9-nonexistent` → `false` |
+| P9 | split arithmetic — `comm -23 <(all 59 keys) <(19 corpus ids)` | rest = 40; minus active `v0.16.6` = **39**; non-AILANG members of the 39 are exactly `aver, go, javascript, moonbit` — **19 + 39 + 1 = 59 confirmed** |
+| P10 | `shasum -a 256 prompts/versions.json cmd/ailang/prompts/versions.json` | identical `97decb4d7dd3…ef06c99e` (re-confirms V-J); `diff <(jq -S '.versions\|keys' src) <(… mirror)` empty |
+| P11 | **whole-registry hash audit** (new; not in the doc) | **1 mismatch: `aver`** — see §2.3. Control: the other 58 agree. |
+| P12 | mirror `.md`/hash audit over `cmd/ailang/prompts/` | same single `aver` hit; no missing mirror files (all 59 present) |
+| P13 | registry shape — `jq -r '[.versions[]\|keys[]]\|unique[]'` / `keys_unsorted\|join(",")` | entry keys are exactly `file,hash,description,created,tags,notes`, **in that order, for all 59**; top-level keys exactly `active,notes,schema_version,versions`; version keys are in **chronological, NOT alphabetical** order (`v0.16.6` last); file ends with `\n` |
+| P14 | `git ls-files 'eval_results/baselines/'` vs `…'*.json'` | 17,372 vs 17,343 — the 29 extras are `summary.jsonl` files; the `*.json` pathspec is depth-agnostic (git fnmatch), covering all 4/5/6-segment paths |
+
+**Gates newly proposed by this plan and measured green at base**: P1, P2, P3, P4. No proposed gate is red at base.
+
+### 2.3 BLOCKER — `aver` carries a stale hash at HEAD in BOTH registries
+
+```
+HASHMISMATCH aver exp=190bf4244a00bb0605d41ac01d4de415a6131a3a961aa6bca1689b23bc4d521d
+                  act=1f5c9654e39c411bcbedc35446ffa96c1d6dc8d7b9dd0fbec01b95ecf35f0157
+```
+
+`prompts/aver.md` and `cmd/ailang/prompts/aver.md` are byte-identical to each other (`1f5c9654…`);
+only the recorded hash is stale, in both registry files identically. Introduced by
+`0fcae6055 fix(eval): adopt upstream Aver prompt + enrich failures with aver check`.
+
+**Why it blocks M1 as written**: Q4 puts `aver` in the 39-entry `legacy` bucket; Q3 requires
+`freeze` to refuse when file bytes ≠ recorded hash; L3(b) makes such a frozen entry a violation.
+A literal M1 therefore either refuses to migrate or writes a frozen lie, and AC5's
+*"on unmodified post-migration `dev`, `--check` exits 0"* becomes unreachable. It also pre-breaks
+M3: once `internal/prompt.LoadPrompt` enforces frozen hashes, every `aver` eval hard-fails.
+Today the defect is invisible because `internal/prompt` never compares the hash (doc N-3) and
+`langreg/aver.go:33-37` has the same silent `(DefaultPrompt(), "default", nil)` fallback as
+`ailang.go`/`python.go` — a **third** instance of the N-4 pattern, which the doc does not list.
+
+**Resolution adopted (R-A)** — M1 **Task 0**: repair `aver`'s `hash` to `1f5c9654…` in both
+registries before migrating. This is the never-banked workflow the ruling explicitly permits:
+`aver` has **zero** corpus citations (P6 has no `aver` row), so under D-41(c) it is NEVER-BANKED
+and in-place editing with hash regeneration is legal. Freezing then locks the *current* bytes and
+breaks no provenance claim, and AC1's 19/39/1 is preserved exactly.
+Rejected: R-B (leave `aver` unfrozen) → 19/38/2, contradicts AC1.
+**Controller must confirm R-A.** If it declines, M1 cannot satisfy AC1 and AC5 simultaneously.
+
+Add `langreg/aver.go:33-37` to M3's fallback-removal list (a doc omission, not a plan deviation).
+
+---
+
+## 3. Constraints imposed by existing tests (M1 must not break these)
+
+Both live in `internal/eval_harness/prompt_loader_test.go` and are covered by gate B6.
+
+| Existing test | Constraint on M1 |
+|---|---|
+| `TestLoadPrompt_HashMismatch` (`:159` asserts `contains(err.Error(), "hash mismatch")`) | **The doc's Q5 never-banked message text — `hash for "v0.16.6" is stale.` — does NOT contain the substring `hash mismatch` and would turn this test red.** M1 MUST keep `hash mismatch for %q:` as the leading clause of the never-banked message and append the teaching lines after it. This satisfies both the existing test and AC3. |
+| `TestLoadPrompt_PlaceholderHash` (`:205` asserts an **unfrozen** `PLACEHOLDER` entry loads successfully) | Q6's refusal must be scoped to `Frozen != nil` only. A blanket PLACEHOLDER ban turns this red and would also break the documented dev workflow. This test *is* the control that keeps mutation 5's fix from over-tightening. |
+
+`TestAILANGPromptLoading` / `TestPromptDisambiguation` (V-H) load the active `v0.16.6`, which stays
+mutable with a valid hash — unaffected, as Conflict Surface 8 predicts.
+
+---
+
+## 4. AC id cross-check against the design doc (the doc WINS; these are doc-internal disagreements)
+
+| # | AC | Header tag in the doc's AC list | Milestones section says | Verdict |
+|---|---|---|---|---|
+| 1 | **AC8** | `(M3, mirror agreement)` | M2: *"Tests: AC4, AC5, second half of AC6, **AC8**, AC9's --check half"* | **REAL CONTRADICTION.** AC8 exercises `ailang prompt freeze --check`'s mirror `.md` comparison — that is L3(d), which the doc's own M2 description and its L3 table both place in M2. M3 touches only `internal/prompt` + `langreg` and adds nothing to `--check`. Two of three sites say M2. **This plan puts AC8 in M2** and flags the header tag as the defect. Controller to adjudicate. |
+| 2 | **AC6** | `(M2, frozen PLACEHOLDER ban)` | M1: *"first half of AC6"*; M2: *"second half of AC6"* | Labelling only. AC6's own text has two clauses — `LoadPrompt` refuses (loader → M1) and `--check` non-zero (CI → M2). Plan follows the split; header tag should read `(M1+M2)`. |
+| 3 | **AC9** | `(M2, mirror REGISTRY agreement)` | M1: *"AC9's jq-count/diff half"* | Labelling only. AC9's text has a migration half (counts on the mirror + empty `jq -S` diff → M1) and a tamper half (`--check` red → M2). Plan follows the split. |
+| 4 | **AC5** | `(M2, derivation audit)` | M1: *"`--check` (derivation + hash-integrity subset, i.e. **L3(a)**(b) callable locally)"* | **Coverage gap.** M1 *implements* L3(a) but no M1-assigned AC exercises it, so an M1-only iteration would ship the derivation untested. This plan **pulls AC5 into M1** (both halves). This adds coverage without contradicting the doc — AC5's own text is fully satisfiable by M1's code, and M2 re-runs it as a regression pin. |
+
+No other mismatches. `Testing Strategy`, the Mutation Table (rows 1,2,3,5,8,10 → M1) and the
+Enforcement-layer table are internally consistent with the milestone assignments used here.
+
+---
+
+## 5. M1 — the milestone to execute (detailed, literal)
+
+> Doc scope: *"`FrozenMarker` structs in both loaders; `ailang prompt freeze <version>` / `--migrate` /
+> `--check` (L3(a)(b)); every marker write to BOTH registry files; the migration commit (19/39/1);
+> the two-state error in `internal/eval_harness/prompt_loader.go`; frozen-PLACEHOLDER refusal."*
+
+### 5.1 Files
+
+**Create**
+| Path | Purpose | est. LOC |
+|---|---|---|
+| `internal/eval_harness/prompt_frozen.go` | `FrozenMarker`, `IsHexSHA256`, the three error constructors | 90 |
+| `internal/eval_harness/prompt_frozen_test.go` | AC2, AC3, AC6(loader half) | 200 |
+| `cmd/ailang/prompt_freeze.go` | `runPromptFreeze` — flag parsing, dispatch, exit codes, help | 130 |
+| `cmd/ailang/prompt_freeze_core.go` | ordered registry I/O, corpus scan, migration, L3(a)(b) check | 300 |
+| `cmd/ailang/prompt_freeze_test.go` | AC1, AC5, AC9(migration half) | 320 |
+
+**Modify**
+| Path | Change | est. LOC |
+|---|---|---|
+| `internal/eval_harness/prompt_loader.go` | `PromptVersion` gains `Frozen *FrozenMarker`; rewrite the `LoadPrompt` verification block (currently `:76-91`) | +18 / −12 |
+| `internal/prompt/loader.go` | `FrozenMarker` type + `VersionMetadata` gains `Frozen *FrozenMarker`. **Schema only — no enforcement in M1** (that is M3/L2) | +12 |
+| `internal/prompt/loader_test.go` | one round-trip test | +30 |
+| `cmd/ailang/prompt.go` | intercept the `freeze` subcommand before `promptFS.Parse`; add a `freeze` block to `printPromptHelp()` | +14 |
+| `prompts/versions.json` | Task 0 `aver` hash repair + 58 `frozen` markers (tool output) | generated |
+| `cmd/ailang/prompts/versions.json` | byte-identical copy of the above | generated |
+
+Size check: `prompt_loader.go` 189→~195, `prompt_loader_test.go` 570 (untouched — new tests go in the
+new file, deliberately, to stay clear of the 800-line gate), `prompt.go` 265→~279, `help.go`
+untouched (CLI docs are M2). All new files ≪ 800. **`make check-file-sizes` stays green.**
+
+`FrozenMarker` is declared **twice**, once per package, with identical JSON tags.
+`internal/prompt` must NOT import `internal/eval_harness` — `langreg` (inside `eval_harness`)
+imports `internal/prompt`, so the reverse edge is an import cycle.
+
+### 5.2 Task order
+
+**Task 0 — `aver` hash repair (blocker, §2.3).** Set `.versions.aver.hash` to
+`1f5c9654e39c411bcbedc35446ffa96c1d6dc8d7b9dd0fbec01b95ecf35f0157` in **both** registries.
+Nothing else in either file changes. Verify `shasum -a 256` of the two registries still match each
+other, and that the whole-registry audit (P11) now reports 0 mismatches.
+
+**Task 1 — `internal/eval_harness/prompt_frozen.go`.** Exactly these declarations:
+
+```go
+package eval_harness
+
+// FrozenMarker records that a prompt version's bytes are immutable because the version
+// has been used in at least one banked eval baseline. Decision D-41(c).
+// ABSENT (nil) means never-banked, i.e. mutable.
+type FrozenMarker struct {
+	At              string `json:"at"`               // YYYY-MM-DD
+	Reason          string `json:"reason"`           // "banked" | "legacy" | "manual"
+	EvidenceCount   int    `json:"evidence_count"`
+	EvidenceExample string `json:"evidence_example"` // "" for reason:"legacy"
+}
+
+// IsHexSHA256 reports whether s is exactly 64 lowercase hex characters.
+func IsHexSHA256(s string) bool
+
+// FrozenHashMismatchError builds the teaching error for a FROZEN version whose file
+// bytes no longer match its recorded hash. (Q5, mutation 1.)
+func FrozenHashMismatchError(versionID string, v PromptVersion, actualHash string) error
+
+// MutableHashMismatchError builds the teaching error for a NEVER-BANKED version with a
+// stale change-detector hash. MUST retain the substring "hash mismatch" (see plan §3).
+func MutableHashMismatchError(versionID string, v PromptVersion, actualHash string) error
+
+// FrozenUnenforceableHashError builds the refusal for a frozen version whose recorded
+// hash is not a 64-hex digest. (Q6, mutation 5.)
+func FrozenUnenforceableHashError(versionID string, v PromptVersion) error
+```
+
+Message templates — **the quoted literals are load-bearing; tests assert on them**:
+
+```go
+// FrozenHashMismatchError
+"prompt version %q is FROZEN: it is cited by %d banked baseline files under " +
+"eval_results/baselines/ (e.g. %s; frozen %s, reason: %s — decision D-41c). " +
+"Its bytes are immutable: editing %s in place would silently change what those " +
+"baselines measured.\n" +
+"To change the teaching prompt, create a NEW version instead:\n" +
+"  .claude/skills/prompt-manager/scripts/create_prompt_version.sh <new-id> %s \"<why>\"\n" +
+"(expected sha256 %s, got %s)"
+//  args: versionID, v.Frozen.EvidenceCount, v.Frozen.EvidenceExample, v.Frozen.At,
+//        v.Frozen.Reason, v.File, versionID, v.Hash, actualHash
+
+// MutableHashMismatchError  — leading clause preserved for TestLoadPrompt_HashMismatch (§3)
+"hash mismatch for %q: expected %s, got %s. This version is not yet banked, so " +
+"in-place editing is allowed (D-41c) — regenerate the change-detector hash:\n" +
+"  shasum -a 256 %s   # then update the \"hash\" field in prompts/versions.json"
+//  args: versionID, expectedPreview, actualPreview, v.File
+
+// FrozenUnenforceableHashError
+"prompt version %q is FROZEN but its recorded hash %q is not a 64-hex sha256: refuse " +
+"to load — a frozen version with an unenforceable hash is a freeze with no invariant " +
+"(D-41c, Q6). Restore the recorded hash from git history, or bump to a new version."
+```
+
+`expectedPreview`/`actualPreview` reuse the existing 16-char truncation from `prompt_loader.go:82-88`.
+
+**Task 2 — rewrite the verification block in `LoadPrompt`** (`internal/eval_harness/prompt_loader.go`,
+replacing lines 76-91). Exact structure and branch order:
+
+```go
+	if version.Frozen != nil {
+		if !IsHexSHA256(version.Hash) {
+			return "", FrozenUnenforceableHashError(versionID, version)   // Q6 / AC6(a)
+		}
+		if actual := computeSHA256(content); actual != version.Hash {
+			return "", FrozenHashMismatchError(versionID, version, actual) // Q5 / AC2
+		}
+		return string(content), nil
+	}
+	// never-banked: V-C semantics preserved exactly, message upgraded
+	if version.Hash != "PLACEHOLDER" {
+		if actual := computeSHA256(content); actual != version.Hash {
+			return "", MutableHashMismatchError(versionID, version, actual) // AC3
+		}
+	}
+	return string(content), nil
+```
+
+**Task 3 — `internal/prompt/loader.go` schema field.** Add the `FrozenMarker` type (same four
+fields, same JSON tags) directly above `VersionMetadata`, and one field to `VersionMetadata`:
+`Frozen *FrozenMarker \`json:"frozen,omitempty"\``. **Do not touch `LoadPrompt`** — enforcement is M3.
+
+**Task 4 — `cmd/ailang/prompt_freeze_core.go`.** Exactly these declarations:
+
+```go
+// registryPair is the two files every marker write must touch in lockstep (Q3, V-J).
+type registryPair struct{ Source, Mirror string } // "prompts/versions.json", "cmd/ailang/prompts/versions.json"
+
+// registryEntry mirrors one versions.json entry, field order matching the file (plan P13).
+type registryEntry struct {
+	File, Hash, Description, Created string
+	Tags                             []string
+	Notes                            string
+	Frozen                           *eval_harness.FrozenMarker
+}
+
+// orderedRegistry preserves version-key order so a migration diff shows ONLY added markers.
+type orderedRegistry struct {
+	SchemaVersion string
+	VersionKeys   []string            // chronological order as read from disk
+	Versions      map[string]*registryEntry
+	Active        string
+	Notes         []string
+}
+
+func loadOrderedRegistry(path string) (*orderedRegistry, error)
+func writeOrderedRegistry(path string, r *orderedRegistry) error
+
+type corpusEvidence struct {
+	Count   int
+	Example string // first tracked path, in git ls-files order
+}
+
+// scanCorpus derives banked(V) from `git ls-files 'eval_results/baselines/*.json'` (Q2).
+func scanCorpus(repoRoot string) (map[string]corpusEvidence, error)
+
+// corpusScanner is indirected so tests can inject a fixture corpus without a git repo.
+var corpusScanner = scanCorpus
+
+// migrateRegistries applies the Q4 split to BOTH files of the pair, writing them from ONE
+// in-memory registry so byte-identity is structural, not checked after the fact.
+// Returns (banked, legacy, mutable) counts.
+func migrateRegistries(repoRoot string, today string) (int, int, int, error)
+
+// freezeVersion writes a reason:"banked" marker for one version to BOTH files.
+func freezeVersion(repoRoot, versionID, today string) error
+
+// checkRegistries runs L3(a) (corpus derivation) + L3(b) (hash integrity) and returns
+// human-readable violations. Empty slice => green.
+func checkRegistries(repoRoot string) ([]string, error)
+```
+
+Behavioural requirements, each one load-bearing:
+
+- **`loadOrderedRegistry`** captures version-key order via a `json.Decoder` token stream over the
+  raw `versions` object (do **not** round-trip through `map[string]…` and re-marshal: Go sorts map
+  keys alphabetically and the file is chronological, P13 — that would produce a 59-entry reorder
+  diff and bury the actual change).
+- **`writeOrderedRegistry`** emits top-level keys in the order `schema_version, versions, active,
+  notes`; each entry's keys in the order `file, hash, description, created, tags, notes, frozen`;
+  2-space indent; **trailing newline**; `frozen` omitted when nil. Result on an unmigrated input
+  must be byte-identical to the input — **assert this in a test before trusting the writer.**
+- **`scanCorpus`** runs `git ls-files 'eval_results/baselines/*.json'` from `repoRoot` and decodes
+  only `prompt_version` from each file. Files without the field contribute nothing (Q2). Measured
+  1.87 s (P7).
+- **`migrateRegistries`** reads **`prompts/versions.json` only**, builds one migrated
+  `orderedRegistry`, then writes it to **both** paths. Rule per key `k` in `VersionKeys`:
+  - `k == r.Active` → leave `Frozen` nil.
+  - `corpus[k].Count > 0` → `{At: today, Reason: "banked", EvidenceCount: corpus[k].Count, EvidenceExample: corpus[k].Example}`.
+  - else → `{At: today, Reason: "legacy", EvidenceCount: 0, EvidenceExample: ""}`.
+  **Pre-flight refusals — write nothing and return an error if any of:** `r.Active` is `"latest"`
+  or not a registry key (the migration must not guess which entry stays mutable); any entry about
+  to be frozen has `!IsHexSHA256(hash)`; any entry about to be frozen has on-disk bytes ≠ hash
+  (Q3, "you may not freeze a lie" — this is the check `aver` trips before Task 0).
+  **Idempotent**: entries that already carry a `Frozen` marker are left untouched.
+- **`checkRegistries`** violations, each string naming the offending version id:
+  - L3(a) `corpus-evidenced but not frozen: <id> (<n> citations, e.g. <path>)`
+  - L3(b) `frozen version <id>: file bytes do not match recorded hash`
+  - L3(b) `frozen version <id>: recorded hash is not a 64-hex sha256 (unenforceable freeze)`
+  - mirror-registry parity `cmd/ailang/prompts/versions.json: entry <id> differs from source`
+  L3(c) merge-base immutability and L3(d) `.md` mirror bytes are **M2** — leave hooks, not code.
+
+**Task 5 — `cmd/ailang/prompt_freeze.go` + subcommand wiring.**
+
+`runPrompt` currently does `_ = promptFS.Parse(flag.Args()[1:])`. Go's `flag` **stops at the first
+non-flag argument**, so `ailang prompt freeze --check` would leave `--check` unparsed. Intercept
+*before* the FlagSet is built — insert at the top of `runPrompt()`:
+
+```go
+	sub := flag.Args()[1:]
+	if len(sub) > 0 && sub[0] == "freeze" {
+		runPromptFreeze(sub[1:])
+		return
+	}
+```
+
+```go
+// runPromptFreeze implements `ailang prompt freeze [<version>] [--migrate] [--check] [--repo DIR]`.
+// Exit codes: 0 green; 1 violations found (--check) ; 2 usage/IO error.
+func runPromptFreeze(args []string)
+```
+`--repo` defaults to the repo root discovered by walking up for `go.mod`/`.git`; it exists so the
+tests can point the command at a `t.TempDir()` fixture. Exactly one of `<version>`, `--migrate`,
+`--check` may be given. `--check` prints every violation to stderr, one per line, then exits 1.
+Add a `freeze` section to `printPromptHelp()`. **`cmd/ailang/help.go` is M2's** (CLI docs).
+
+**Task 6 — run the migration.**
+```
+go build -o /tmp/i291/ailang ./cmd/ailang        # rc must be 0
+/tmp/i291/ailang prompt freeze --migrate         # rc must be 0
+/tmp/i291/ailang prompt freeze --check           # rc must be 0
+```
+Then re-run `--migrate` and confirm both files are byte-identical to the previous run (idempotence).
+
+**Task 7 — tests** (§6).
+
+### 5.3 M1 acceptance criteria (closes doc AC1, AC2, AC3, AC5, AC6-loader-half, AC9-migration-half)
+
+Every command below was verified green-at-base in its baseline form (§2), or is new code.
+
+| id | Command | Expected | Doc AC |
+|---|---|---|---|
+| M1.1 | `test -z "$(gofmt -l internal/eval_harness cmd/ailang internal/prompt)"` | rc=0 | — (base P1=0) |
+| M1.2 | `go build ./cmd/ailang ./internal/eval_harness/... ./internal/prompt/...` | rc=0 | — (base P2=0) |
+| M1.3 | `go vet ./internal/eval_harness/... ./internal/prompt/ ./cmd/ailang/` | rc=0 | — (base B4/P3=0) |
+| M1.4 | `make check-file-sizes` | rc=0 | — (base B5=0) |
+| M1.5 | `go test ./internal/eval_harness/...` | rc=0 — **this is the §3 constraint gate**: `TestLoadPrompt_HashMismatch` and `TestLoadPrompt_PlaceholderHash` must still pass | — (base B6=0) |
+| M1.6 | `go test ./internal/prompt/` | rc=0 | — (base P4=0) |
+| M1.7 | `go test ./cmd/ailang/ -run 'TestAILANGPromptLoading\|TestPromptDisambiguation' -v > /tmp/o; grep -c -- '--- PASS: ' /tmp/o` | `2` | V-H pin (base P5=2) |
+| M1.8 **AC1** | `jq '[.versions[]\|select(.frozen.reason=="banked")]\|length' prompts/versions.json` / `…=="legacy"…` / `jq '[.versions\|to_entries[]\|select(.value\|has("frozen")\|not)]\|length'` / `jq -r '[.versions\|to_entries[]\|select(.value\|has("frozen")\|not)][0].key'` | `19` / `39` / `1` / `v0.16.6` | AC1 |
+| M1.9 **AC9a** | the same four jq commands against `cmd/ailang/prompts/versions.json` | `19` / `39` / `1` / `v0.16.6` | AC9 |
+| M1.10 **AC9a** | `diff <(jq -S .versions prompts/versions.json) <(jq -S .versions cmd/ailang/prompts/versions.json)` | rc=0, empty | AC9 |
+| M1.11 **AC5-green** | `/tmp/i291/ailang prompt freeze --check` on the migrated tree | rc=0, no output | AC5 |
+| M1.12 (§2.3) | `jq -r .versions.aver.hash prompts/versions.json` **equals** `shasum -a 256 prompts/aver.md \| cut -d' ' -f1` **equals** the same pair for the mirror | all `1f5c9654e39c…` | — |
+| M1.13 | whole-registry audit (P11 command) over **both** registries | **0** mismatches (base: 1, `aver`) | — |
+| M1.14 | `go test ./internal/eval_harness/ -run 'TestLoadPrompt_Frozen\|TestLoadPrompt_NeverBanked\|TestPromptRegistry_Frozen' -v > /tmp/o; grep -c -- '--- PASS: ' /tmp/o` | `5` | AC2, AC3, AC6a |
+| M1.15 | `go test ./cmd/ailang/ -run 'TestPromptFreeze\|TestRealRegistry' -v > /tmp/o; grep -c -- '--- PASS: ' /tmp/o` | `7` | AC1, AC5, AC9a |
+| M1.16 | `go test ./internal/prompt/ -run 'TestVersionMetadata_FrozenFieldRoundTrips' -v > /tmp/o; grep -c -- '--- PASS: ' /tmp/o` | `1` | schema |
+| **M1.X** | `go build ./...` | **NOT A GATE — rc=1 at base (B3). Any AC using it is broken on arrival.** | — |
+
+---
+
+## 6. M1 test plan — each test named, each mapped to the mutation it kills
+
+Naming is literal; the gates in §5.3 grep for these exact strings.
+
+### `internal/eval_harness/prompt_frozen_test.go`
+
+All fixtures use `t.TempDir()/prompts/{versions.json,<name>.md}` and `NewPromptLoader`, following
+the shape already in `prompt_loader_test.go:110-160`.
+**Fixture constant: `EvidenceCount = 4242`** — chosen so the asserted phrase cannot be produced by
+any other code path (see the justification column).
+
+| Test | Fixture | Assertions | Kills | Why the observable is downstream & unique |
+|---|---|---|---|---|
+| `TestLoadPrompt_FrozenTamperEmitsTeachingError` | one entry with `Frozen{At:"2026-08-27",Reason:"banked",EvidenceCount:4242,EvidenceExample:"eval_results/baselines/x/y.json"}`, correct 64-hex hash, then **append one byte** to the `.md` | `err != nil` **and** `err.Error()` contains ALL of: `is FROZEN`, the full phrase `cited by 4242 banked baseline files`, `create_prompt_version.sh` | **mutation 1** (freeze branch deleted) | Doc AC2's hollow-pass note: the pre-existing V-C check *also* errors on this input, so a bare-error assertion passes on unmodified code. The surviving message is `hash mismatch for … (file may have been modified)` — it can contain neither the word `FROZEN` nor the phrase `cited by 4242 banked baseline files` (the count is a fixture constant read from the marker, not derivable from the bytes; asserting the whole phrase rather than the bare token `4242` also rules out an accidental hex-preview substring match). |
+| `TestLoadPrompt_NeverBankedTamperRegenSucceeds` | entry with **no** marker; tamper the `.md` **and** rewrite `hash` to the new sha256 | `err == nil` **and** returned content `==` the tampered bytes exactly | **mutation 2** (inverted predicate: everything frozen) | A freeze-everything loader still recomputes and compares — it would *pass* a naive "error is nil" check only if it also allowed the edit. The content-equality clause makes the observable the *served bytes*, downstream of the branch. Doc AC3 first half. |
+| `TestLoadPrompt_NeverBankedStaleHashTeachesRegen` | entry with no marker; tamper the `.md`, leave `hash` stale | `err != nil` and message contains ALL of `hash mismatch` (§3 constraint), `not yet banked`, `in-place editing is allowed`, `shasum -a 256` | mutation 2 (second arm) | Doc AC3 second half. Unmodified code emits only `hash mismatch …` and fails the three teaching substrings. |
+| `TestLoadPrompt_FrozenPlaceholderRefused` | entry with a `Frozen` marker **and** `hash: "PLACEHOLDER"`; `.md` bytes arbitrary | `err != nil` and message contains `is FROZEN` and `unenforceable hash` | **mutation 5** (V-C skip retained for frozen) | Doc AC6 hollow-pass: under V-C semantics the load *succeeds*. The observable is a refusal carrying freeze-specific wording, producible only by the Q6 branch. |
+| `TestLoadPrompt_UnfrozenPlaceholderStillLoads` | entry with **no** marker and `hash: "PLACEHOLDER"` | `err == nil`, content matches file bytes | over-tightening of mutation 5's fix | **Mandatory control.** Without it, "refuse every PLACEHOLDER" also passes the previous row while breaking the documented never-banked workflow and `TestLoadPrompt_PlaceholderHash`. |
+| `TestPromptRegistry_FrozenFieldRoundTrips` | marshal a `PromptRegistry` with a marker, unmarshal | `Frozen` survives with all four fields; an entry with `Frozen == nil` marshals **without** a `frozen` key | schema regression | Cheap; pins `omitempty` so unmarked entries don't gain `"frozen": null` and corrupt AC1's `has("frozen")\|not` count. |
+
+### `cmd/ailang/prompt_freeze_test.go`
+
+All tests build a fixture repo under `t.TempDir()` (a `prompts/` + `cmd/ailang/prompts/` pair, 8
+entries) and inject the corpus by replacing `corpusScanner` — **no git repo, no network, no
+mutation of the real tree.**
+
+Fixture shape: 3 ids with corpus evidence (counts 210 / 38 / 1), 4 ids with none, 1 active id with
+none → expected split **3 banked / 4 legacy / 1 mutable**.
+
+| Test | Assertions | Kills | Why non-hollow |
+|---|---|---|---|
+| `TestPromptFreezeMigrate_SplitCounts` | after `migrateRegistries`, re-read the source registry: exactly 3 `reason:"banked"`, 4 `reason:"legacy"`, 1 with `Frozen == nil` and that one **is** the active id; and each banked entry's `EvidenceCount`/`EvidenceExample` equal the injected corpus values | **mutation 8** (legacy bucket omitted) | Doc AC1's hollow-pass logic, in fixture form: a corpus-only migration yields 3/0/5; a freeze-everything migration yields 0-mutable. Asserting the exact triple plus per-entry evidence rules out both, and the evidence fields can only come from the corpus scan. |
+| `TestPromptFreezeMigrate_WritesBothRegistries` | (a) the **mirror** file independently reports the same 3/4/1 split; (b) `jq`-equivalent deep-equality of the two `versions` objects; (c) mirror byte-length > 0 | **mutation 10** (source-only write) | Clause (b) **alone is hollow** — a migration that writes *neither* file also leaves them equal. Clause (a) is the load-bearing one: it asserts markers are *present in the mirror*, the file agent mode actually reads (V-J). |
+| `TestPromptFreezeMigrate_RefusesStaleHash` | fixture where one to-be-frozen entry's `.md` bytes ≠ its `hash` → `migrateRegistries` returns an error naming that id, **and both registry files are byte-unchanged** | Q3 "may not freeze a lie" | The byte-unchanged clause is what makes it non-hollow: an implementation that errors *after* a partial write passes an error-only assertion. This is the `aver` class (§2.3). |
+| `TestPromptFreezeMigrate_Idempotent` | run `migrateRegistries` twice; both files byte-identical after run 2; counts unchanged | re-freeze / marker churn | A second run must not bump `at` or recompute evidence, or the migration is not reproducible. |
+| `TestPromptFreezeCheck_GreenOnMigratedFixture` | `checkRegistries` on the just-migrated fixture returns **zero** violations | false-positive `--check` | Doc AC5 green half. Paired with the next row so "always green" and "always red" are both excluded. |
+| `TestPromptFreezeCheck_RedOnMissingMarker` | delete the `frozen` marker from the 210-citation id (leaving every hash self-consistent) → violations contains an entry naming that id **and** the substring `corpus-evidenced but not frozen`; and assert the returned slice has **length 1** | **mutation 3** (`--check` validates hashes only) | Doc AC5 hollow-pass: the input's hashes are all self-consistent by construction, so L3(b) stays green; only the corpus derivation can fire. The length-1 clause stops a "flag everything" mutation from passing. |
+| `TestRealRegistry_PostMigrationSplitCounts` | reads the **real** `../../prompts/versions.json` and `prompts/versions.json` (mirror): 19 banked / 39 legacy / 1 mutable, mutable id `v0.16.6`, both files' `versions` deep-equal, and `.versions.aver.hash` equals `sha256(prompts/aver.md)` | migration applied to the wrong tree; §2.3 regression | This is doc AC1 + AC9's jq half + M1.12 expressed as a `--- PASS` line, so the gate can use the `grep -c` form the brief mandates. Read-only; it never writes the real tree. |
+
+### `internal/prompt/loader_test.go`
+`TestVersionMetadata_FrozenFieldRoundTrips` — the marker survives unmarshal from a manifest
+containing `"frozen": {...}`, and an entry without one yields `Frozen == nil`. Pins the schema half
+of M3's dependency; **must not** assert any enforcement (M3 owns L2).
+
+---
+
+## 7. M2 — CI gate (follow-on iteration; independently landable on M1)
+
+**Files** — create `cmd/ailang/prompt_freeze_check_git.go` (L3(c) merge-base immutability, L3(d)
+`.md` mirror bytes) and `cmd/ailang/prompt_freeze_check_git_test.go`; modify
+`make/code-health.mk` (new `check-prompt-freeze` target), `make/ci.mk` (append
+`check-prompt-freeze` to the `ci` prerequisite list), `cmd/ailang/prompt_freeze_core.go` (one
+dispatch line in `checkRegistries`), `cmd/ailang/help.go`, `cmd/ailang/prompt.go` (help text),
+`.claude/skills/prompt-manager/scripts/create_prompt_version.sh` (one sentence in "Next steps"),
+`changelogs/v0.18-current.md`, `docs/docs/guides/evaluation.md`.
+
+**Tasks**: (1) `git merge-base HEAD origin/dev` + `git show <base>:prompts/versions.json` to
+diff frozen entries' `file`/`hash` and the frozen `.md` blobs — a frozen entry present at the
+merge-base whose `hash`, `file` or `.md` bytes changed is a violation naming `immutability`;
+(2) L3(d) `.md` mirror byte comparison for frozen ids; (3) Makefile wiring; (4) docs.
+
+**Closes**: AC4, AC5 (re-pin), AC6 second half, **AC8** (see §4 row 1 — the doc's AC header tags it
+M3, its milestone text and L3 table say M2), AC9 `--check` half.
+**Kills**: mutations 4, 9, and the `--check` arm of 3 and 5.
+**Tests** (each needs a scratch git repo built in the test, per the doc's Testing Strategy):
+`TestFreezeCheck_MergeBaseEditPlusRegenIsRed` (AC4 — the input is self-consistent at HEAD so
+L3(a)(b) both stay green; only the merge-base diff can fire),
+`TestFreezeCheck_FrozenPlaceholderIsRed` (AC6b), `TestFreezeCheck_MirrorMdDivergenceIsRed` (AC8 —
+assert the violation names the `cmd/ailang/prompts/…` path, not just the id),
+`TestFreezeCheck_MirrorRegistryDivergenceIsRed` (AC9 — the `.md` files are identical by
+construction, so AC8's instrument stays green; only the registry-entry comparison fires),
+`TestFreezeCheck_UnmodifiedTreeIsGreen` (the mandatory always-red control).
+**Gates**: M1.1-M1.7 plus `make check-prompt-freeze` rc=0 and `bash -n
+.claude/skills/prompt-manager/scripts/create_prompt_version.sh` rc=0.
+**Note**: `make ci` as a whole is *not* proposed as a gate — it was not baselined and includes
+long-running targets. Gate the new target only.
+
+## 8. M3 / M4 — outlines (follow-on iterations)
+
+**M3 — close the agent-mode hole.** Modify `internal/prompt/loader.go` (verify sha256 of the bytes
+actually read against `hash` **for frozen versions only**, on **both** the embedded and the disk
+path — `LoadPrompt` `:62-77`), reusing M1's error text; remove the silent
+`(DefaultPrompt(), "default", nil)` fallbacks in `langreg/ailang.go:32-38`,
+`langreg/python.go:31-39` **and `langreg/aver.go:33-37`** (the third instance, which the doc's N-4
+does not list — see §2.3). Closes AC7; kills mutations 6 and 7. Test
+`TestLoadSyntaxRef_FrozenMismatchIsLoudError` must deliver the tampered bytes **through the
+embedded FS** (mutation 7) and assert both `err != nil` **and** `versionUsed != "default"`
+(mutation 6 — the doc's AC7 hollow-pass note: today's code returns
+`(DefaultPrompt(), "default", nil)` on exactly this input). Highest-risk milestone: it converts a
+silent degradation into a hard abort on the path that runs most evals. **Prerequisite: `aver`'s
+hash must be correct (§2.3) or M3 breaks every aver eval on landing.**
+
+**M4 — bank-time byte evidence.** Add `PromptSHA256 string \`json:"prompt_sha256,omitempty"\`` at
+`cmd/ailang/eval_suite_manifest.go:77` and `:133`; populate from sha256 of the **fully evaluated
+prompt string immediately prior to model dispatch** at `cmd/ailang/eval_benchmark.go` (~`:165-180`,
+after the task description is appended) and `cmd/ailang/eval_benchmark_agent.go:315`; add
+`cmd/ailang/prompt_freeze_check_rows.go` for the merge-base-scoped row cross-check. Closes AC10,
+AC10(b), AC11; kills mutations 11 and 12. AC11's fixture must be **unfrozen + `PLACEHOLDER`** —
+the one state where bytes are served with no hash agreement — so that an implementation copying the
+registry `hash` writes the literal `"PLACEHOLDER"` and fails the 64-hex assertion. Safe per doc
+N-10 (no strict JSON decoders anywhere).
+
+## 9. File-overlap / bisectability audit (as requested)
+
+| File | M1 | M2 | M3 | M4 | Verdict |
+|---|---|---|---|---|---|
+| `internal/prompt/loader.go` | **type block only** (+12) | — | **`LoadPrompt` body** | — | **OVERLAP, mitigated.** The two hunks are disjoint (lines ~20-36 vs ~40-78). M1 must add the field and *nothing else* — no enforcement, no helper — or M3's diff stops being self-contained. |
+| `cmd/ailang/prompt_freeze_core.go` | creates | +1 dispatch line | — | +1 dispatch line | **OVERLAP, mitigated by splitting**: M2 and M4 put their check logic in **new** files (`prompt_freeze_check_git.go`, `prompt_freeze_check_rows.go`) and touch the core only to call them. Keeps each commit's diff readable and each milestone revertible. |
+| `internal/eval_harness/prompt_loader.go` | rewrites the verify block | — | — | possibly +1 exported hash helper | Minor. Prefer M4 reuse `ComputePromptHash`/add its own helper rather than editing this file. |
+| `cmd/ailang/prompt.go` | subcommand intercept + `printPromptHelp` | help text | — | — | Minor, adjacent hunks. |
+| `prompts/versions.json`, `cmd/ailang/prompts/versions.json` | **M1 exclusively** | fixtures only | fixtures only | fixtures only | Clean. The migration is one commit, one milestone. |
+| `cmd/ailang/help.go` | **untouched** (deliberate) | M2 | — | — | Clean. |
+| `make/ci.mk`, `make/code-health.mk` | — | M2 | — | — | Clean. |
+| `langreg/{ailang,python,aver}.go` | — | — | M3 | — | Clean. |
+| `cmd/ailang/eval_suite_manifest.go`, `eval_benchmark.go`, `eval_benchmark_agent.go` | — | — | — | M4 | Clean. |
+
+**No M1 file is also written by M2, M3 or M4 except `internal/prompt/loader.go` and
+`cmd/ailang/prompt_freeze_core.go`, both handled above.**
+
+## 10. Estimate
+
+Doc says 3.5-4 days for four milestones. This plan re-allocates: **M1 1.25 d** (the doc's ≤1 d does
+not budget the `aver` blocker, the order-preserving registry writer, or the two existing-test
+constraints in §3), M2 1 d, M3 1.25 d (highest risk), M4 1 d — total 4.5 d, of which **only M1
+(~800 LOC: ~420 impl / ~380 test) is executed this iteration**.
+```
+
+---
+
+---
+
+## Appendix A — planner's blocking finding (adjudicated by the controller)
+
+**`aver` has a stale registry hash at HEAD, in BOTH registries.** This is a live D-41-class incident already in the tree, and it makes M1-as-written produce a red `--check` on unmodified `dev`.
+
+```
+$ jq -r '.versions|to_entries[]|"\(.key) \(.value.file)"' prompts/versions.json \
+  | while read k f; do exp=$(jq -r --arg k "$k" '.versions[$k].hash' prompts/versions.json); \
+      act=$(shasum -a 256 "$f"|cut -d' ' -f1); [ "$exp" = "$act" ] || echo "HASHMISMATCH $k exp=$exp act=$act"; done
+HASHMISMATCH aver exp=190bf4244a00bb0605d41ac01d4de415a6131a3a961aa6bca1689b23bc4d521d act=1f5c9654e39c411bcbedc35446ffa96c1d6dc8d7b9dd0fbec01b95ecf35f0157
+```
+(58 of 59 clean = the positive control on the same instrument/scope. Mirror scan over `cmd/ailang/prompts/`: same single hit, `MIRROR-HASHMISMATCH aver`; the two `.md` files agree byte-for-byte at `1f5c9654…`, only the recorded hash is stale. Introduced by `0fcae6055 fix(eval): adopt upstream Aver prompt…`.)
+
+Why it blocks: Q4 puts `aver` in the 39-entry `legacy` bucket; Q3 says `freeze` "refuses if the version's current file bytes do not match its recorded hash (you may not freeze a lie)"; L3(b) makes a frozen entry with bytes ≠ hash a violation. So a literal M1 either **refuses to migrate** or **writes a frozen lie**, and AC5's "on unmodified post-migration `dev`, `--check` exits 0" is unreachable. It also pre-breaks M3: once `internal/prompt.LoadPrompt` enforces frozen hashes, every `aver` eval hard-fails.
+
+**Recommended resolution (R-A), used as the default in the plan below:** M1 Task 0 repairs `aver`'s hash to the disk sha256 in both registries *before* migrating. This is exactly the never-banked workflow the ruling permits — `aver` has **zero** corpus citations (`git ls-files 'eval_results/baselines/*.json' | xargs jq -r '…' | sort | uniq -c` → no `aver` row; 17,343 files, agrees with N-2/V-F exactly), so under D-41(c) it is NEVER-BANKED and in-place edit + hash regeneration is legal. Preserves AC1's 19/39/1 exactly. Rejected alternative R-B (leave `aver` unfrozen) yields 19/38/2 and contradicts AC1.
+
+---

--- a/design_docs/planned/m-prompt-version-freeze-on-first-bank.md
+++ b/design_docs/planned/m-prompt-version-freeze-on-first-bank.md
@@ -1,0 +1,648 @@
+# M-PROMPT-VERSION-FREEZE-ON-FIRST-BANK: Freeze a prompt version's bytes at first banked use
+
+**Status**: Planned
+**Target**: v0.34.x
+**Priority**: P1 (data-integrity — protects banked-baseline provenance, the substrate of every A/B and ELO claim)
+**Estimated**: 3.5–4 days (4 milestones, each ≤1 sprint-day, each independently landable)
+**Dependencies**: None
+**Author**: design-doc-creator role, mission iteration 291 (2026-08-27, worktree at `70f4e0660`)
+**Revision**: r2 — round-1 quorum verdict was **blocked** (3/3 reviewers present, three objections).
+This revision adds dual-registry freeze propagation (obj. 2), bank-time byte evidence with a
+declared trust-on-first-use residual for legacy rows (obj. 1), and the registry-intersection
+verification row (obj. 3). See the [Quorum revision log](#quorum-revision-log-round-1--r2).
+**Ruling implemented**: decision-ledger row **D-41**, answered by Mark 2026-08-27T07:26:21Z as
+option **(c)**: a prompt version is **MUTABLE UNTIL FIRST BANKED USE, then frozen**. The ruling is
+settled; this doc designs the mechanism only.
+
+---
+
+## Problem Statement
+
+`prompts/versions.json` (59 versions at `70f4e0660`) records a `hash` per version, and the
+eval harness verifies it at load time (`internal/eval_harness/prompt_loader.go:77-86`). But the
+registry has **no representation of lifecycle state at all** — zero of the 59 versions carry any
+`frozen` or `banked` field (V-A). So today the hash is simultaneously being used as two different
+things:
+
+1. A **change detector** for versions still under development — where regenerating it after an
+   in-place edit is legitimate (the workflow `create_prompt_version.sh` explicitly instructs:
+   "Update hash: shasum -a 256 ...").
+2. A **provenance invariant** for versions that appear in banked eval baselines — where an
+   in-place edit silently corrupts the meaning of every banked row that says `prompt_version: vX.Y.Z`.
+
+D-41(c) rules that these are two lifecycle **states** of one version, not one policy:
+
+- **NEVER-BANKED**: the `.md` file may be edited in place; the `hash` is a change detector,
+  legitimately regenerated on edit.
+- **BANKED** (used in ≥1 banked eval run): the bytes are **frozen**; the hash becomes a hard
+  invariant; a content change must bump to a new version id.
+
+Two facts make this urgent rather than theoretical:
+
+- **1,284 of 17,343 repo-tracked baseline files under `eval_results/baselines/` attribute
+  themselves to one of 18 distinct AILANG prompt-version ids** (plus 6,537 to `python`). Those
+  attributions are only meaningful while the named bytes are recoverable (V-F, re-derived
+  first-party below).
+- **The agent-mode eval path performs NO hash verification at all**, and on any prompt-load error
+  silently substitutes a hardcoded default prompt while banking `prompt_version: "default"`
+  (`internal/eval_harness/langreg/ailang.go:32-38` → `internal/prompt/loader.go`, which never
+  compares `Hash`). Even a perfect freeze record is unenforced on the path that runs most evals
+  today. This is a new first-party finding of this iteration (Verification Log rows N-3/N-4) and
+  is closed by Milestone 3.
+
+The mechanism is **prospective**: the active version `v0.16.6` has **zero** banked uses in the
+attributable corpus (V-F), so the in-place edit that opened D-41 was legitimate under the ruling —
+its only defect was the stale hash.
+
+---
+
+## Goals
+
+1. Make the BANKED/NEVER-BANKED state **representable** in the registry (schema addition), and
+   **recorded** for all 59 existing versions via one mechanical, verifiable migration — applied
+   to **BOTH** registry files: `prompts/versions.json` and its embedded-source mirror
+   `cmd/ailang/prompts/versions.json` (agent mode reads the embedded registry FIRST, V-J/N-5; a
+   marker present only in the source registry is invisible to every rig binary).
+2. Enforce frozen-bytes immutability at **four layers**: load time (standard-mode loader),
+   load time (agent-mode loader — currently unverified), **CI** (which alone can catch the
+   "edit the file AND regenerate the hash" bypass), and **bank-time byte evidence**
+   (`prompt_sha256` on new banked rows — the only layer that can catch a bytes-swap inside the
+   first-bank PR itself, Q7).
+3. Make the failure **teach**: the error a developer sees on editing a frozen prompt must state
+   why it is frozen, show the banked evidence, and name the bump command.
+4. Preserve the never-banked editing workflow byte-for-byte: `v0.16.6` (and future new versions)
+   stay editable in place with hash regeneration, exactly as today.
+
+## Non-Goals
+
+- No retroactive repair of historical attribution. The 9,522 tracked baselines with no
+  `prompt_version` field, and the fact that `python` has meant different bytes over time, are
+  permanent losses; freezing prevents recurrence, it does not reconstruct the past.
+- **No byte-fidelity guarantee for rows banked before M4 lands.** Rows that carry only a
+  `prompt_version` id (all 17,343 existing rows, and any row banked by a pre-M4 harness binary)
+  cannot prove WHICH bytes they measured; for those rows the first-bank commit is
+  trust-on-first-use. This residual is bounded, declared (Q7), and **closed-ended** (r3): it
+  covers only baseline files already present at the M4 cutoff commit. Every NEWLY ADDED row must
+  carry a valid 64-hex `prompt_sha256` or CI fails, so a stale pre-M4 binary cannot enlarge the
+  residual. Not silently implied away.
+- No change to the devtools prompt registry (`internal/devtoolsprompt/loader.go`, a separate
+  `versions.json`) in this doc — see Conflict Surface item 6 and Open Questions.
+- No general embedded-mirror sync checker for *unfrozen* versions (see Conflict Surface item 4).
+- No change to which runs get banked or how; this doc is about the registry, its loaders, and CI.
+
+---
+
+## Verification Log
+
+Rows **V-A … V-H** were measured first-party by the mission controller at commit `70f4e0660`
+(attribution: *verified by controller, iteration 291, commit 70f4e0660*). Rows **N-1 … N-8** were
+measured first-party by this role in the same worktree on 2026-08-27. Row N-2 is a deliberate
+re-derivation of V-F (load-bearing for Q2/Q4); it agreed exactly.
+
+| # | Claim | Command | Observed output | Source |
+|---|-------|---------|-----------------|--------|
+| V-A | 59 versions in `prompts/versions.json`; 0 carry any `frozen`/`banked` field | `jq -r '[.versions\|to_entries[]\|select(.value\|has("frozen") or has("banked"))]\|length' prompts/versions.json` (and `.versions\|length`) | `0` / `59` | controller |
+| V-B | Active version is `v0.16.6` | `jq -r .active prompts/versions.json` | `v0.16.6` | controller |
+| V-C | Hash verification is load-time only, at `internal/eval_harness/prompt_loader.go:77-86`, skipped when `Hash == "PLACEHOLDER"`; no other enforcement point | (controller code reading) | as stated | controller |
+| V-D | Banked results record `prompt_version` (`cmd/ailang/eval_suite_manifest.go:77`, `:133`; populated via `cmd/ailang/eval_benchmark.go:172` `loader.GetActiveVersionID()`) | (controller code reading) | as stated | controller |
+| V-E | Banked baselines are repo-tracked: 17,343 files under `eval_results/baselines/` (`.gitignore:92-93` negates the `eval_results/` ignore). Positive control: `git check-ignore -v bin/ailang` → `.gitignore:46:/bin` | `git ls-files 'eval_results/baselines/*.json' \| wc -l` | `17343` | controller |
+| V-F | Corpus distribution: 9,522 field-absent, 6,537 `python`, 18 distinct AILANG ids, **no v0.16.x at all** | (controller jq sweep) | as stated | controller |
+| V-G | Observatory SQLite `eval_baselines` (7 columns, 1,020 rows) has **no** `prompt_version` column — the tracked corpus is the only attributable bank | (controller schema read) | as stated | controller |
+| V-H | Tests that went red on the stale hash: `TestAILANGPromptLoading`, `TestPromptDisambiguation` (`cmd/ailang/eval_suite_prompt_test.go:34`, `:87`) | (controller) | as stated | controller |
+| V-I | **Registry∩corpus intersection holds exactly** (grounds the 19/39/1 migration split, Q4): registry keys 59; distinct corpus `prompt_version` values 19; corpus ids PRESENT in registry 19; MISSING 0 (including `v0.6.5`, the 1-citation id). Positive control: `python` in registry → `True`; negative control: `v9.9.9-nonexistent` in registry → `False`. Arithmetic: 19 banked + 39 legacy + 1 mutable = 59 | (controller set-intersection over `prompts/versions.json` keys × N-2 corpus values, both controls in the same run) | `present 19 / missing 0`; controls `True`/`False` | verified by controller, iteration 291, commit `70f4e0660` |
+| V-J | **Agent mode reads the EMBEDDED registry first**: `internal/prompt/loader.go:106-108` (`loadVersionsManifest`: `if embeddedPrompts != nil { fs.ReadFile(embeddedPrompts, "prompts/versions.json") }`), disk fallback only at `:120`; same embedded-first order for the `.md` read at `:62-74`. Mirror state today: `sha256 prompts/versions.json` = `97decb4d7dd3…ef06c99e` = `sha256 cmd/ailang/prompts/versions.json` — **byte-identical, no drift now; the hazard is prospective** | `shasum -a 256 prompts/versions.json cmd/ailang/prompts/versions.json` + code reading | identical digests `97decb4d…` | verified by controller, iteration 291, commit `70f4e0660` |
+| N-1 | **0 of 59** versions in `prompts/versions.json` have `hash == "PLACEHOLDER"`. Positive control, same command shape, same file: **59 of 59** hashes match `^[0-9a-f]{64}$` | `jq '[.versions\|to_entries[]\|select(.value.hash=="PLACEHOLDER")]\|length' prompts/versions.json` ; control `jq '[.versions\|to_entries[]\|select(.value.hash\|test("^[0-9a-f]{64}$"))]\|length'` | `0` ; control `59` | this role |
+| N-2 | Re-derivation of V-F over all 17,343 tracked files under `eval_results/baselines/`: `9522 ABSENT, 6537 python, 210 v0.3.21, 138 v0.5.0, 138 v0.4.8, 114 v0.6.2, 92 v0.6.6, 76 v0.4.1, 62 v0.4.7, 62 v0.11.4, 61 v0.7.4, 57 v0.9.0, 51 v0.12.1, 38×(v0.4.0,.2,.4,.5,.6), 32 v0.3.23, 1 v0.6.5` — sums to 17,343; **agrees exactly with V-F**. Also: neither `"default"` nor `"agent-prompt"` appears as a value | `git ls-files 'eval_results/baselines/*.json' \| xargs jq -r 'if has("prompt_version") then .prompt_version else "ABSENT" end' \| sort \| uniq -c \| sort -rn` | as quoted | this role |
+| N-3 | The agent-mode prompt loader (`internal/prompt/loader.go`, 209 lines) **never compares the hash**: the only occurrence of `Hash` in the file is the struct field at line 23. Positive control, same grep, the standard-mode loader in the same repo: `grep -c "Hash" internal/eval_harness/prompt_loader.go` → **8** (includes the comparison at :77-86) | `grep -n "Hash" internal/prompt/loader.go` ; control as stated | `23:	Hash string ...` (only) ; control `8` | this role |
+| N-4 | Agent mode attributes and falls back silently: `langreg/ailang.go:32-38` `LoadSyntaxRef` calls `promptpkg.LoadPromptWithVersion(version)` and on **any** error returns `(DefaultPrompt(), "default", nil)`; `langreg/python.go:31-39` has the identical pattern returning `("...", "default", nil)`. The result is banked via `result.PromptVersion` at `cmd/ailang/eval_benchmark_agent.go:315` (agent entry: `agent_runner_multi.go:182` → `GenerateAgentPromptsWithSystemPrompt`, `agent_prompt.go:404`) | `sed -n '29,38p' internal/eval_harness/langreg/ailang.go` (and python.go); `grep -n "PromptVersion" cmd/ailang/eval_benchmark_agent.go` | fallback branches as quoted; `:315 PromptVersion: result.PromptVersion` | this role |
+| N-5 | `internal/prompt/loader.go` reads the **embedded** copy first and falls back to disk (`LoadPrompt` lines 62-77; `loadVersionsManifest` likewise), so agent-mode bytes come from the binary's build-time snapshot of `cmd/ailang/prompts/` (embedded via `//go:embed all:prompts` at `cmd/ailang/main.go:21-22`), while the standard-mode loader reads **disk only** via `l.rootDir` (V-C) | `sed -n '60,80p' internal/prompt/loader.go` ; `grep -n "go:embed" cmd/ailang/main.go` | embedded-first branches as quoted; `21://go:embed all:prompts` | this role |
+| N-6 | The mirror `cmd/ailang/prompts/` currently agrees with `prompts/` for the active version (spot check) and contains 54 `v0*` files + its own `versions.json` | `diff <(shasum -a 256 prompts/v0.16.6.md) <(shasum -a 256 cmd/ailang/prompts/v0.16.6.md)` (hash fields only); `ls cmd/ailang/prompts \| grep -c '^v0'` | in sync; `54` | this role |
+| N-7 | **No Makefile involvement in prompt sync**: `grep -c "prompts" Makefile` → **0** occurrences of the string `prompts` anywhere in `Makefile`. Positive control, same instrument, same file: `grep -c "test" Makefile` → **21**. The mirror is maintained by manual copy (e.g. `.claude/rules/api-server.md:28` checklist "same (embedded copy)") | `grep -c "prompts" Makefile` ; control `grep -c "test" Makefile` | `0` ; control `21` | this role |
+| N-8 | `create_prompt_version.sh` (`.claude/skills/prompt-manager/scripts/`, 105 lines) computes the hash **at creation** (line ~72 `shasum -a 256`), writes the registry entry, sets `.active`, and its printed "Next steps" instruct a **manual hash update after editing** (step 3). It only ever creates NEW versions (errors if the id or file exists), so it never touches a frozen entry | `sed -n '1,105p' .claude/skills/prompt-manager/scripts/create_prompt_version.sh` | as quoted | this role |
+| N-9 | Version creation dates: `v0.16.6` created `2026-08-12`; `v0.16.5` (2026-08-07) carries the note "v0.16.5 remains served byte-identical for pinned eval baselines" — i.e. versions **without** corpus attribution are nevertheless relied upon as pinned (evidence for the legacy-freeze rule in Q2/Q4) | `jq -r '.versions["v0.16.6"], .versions["v0.16.5"].notes' prompts/versions.json` | as quoted | this role |
+| N-10 | **No baseline-JSON reader uses strict decoding**, so M4's additive `prompt_sha256` cannot break existing readers (grounds Conflict Surface item 10). `DisallowUnknownFields` occurs **0** times across `cmd/ internal/` and **0** repo-wide; the three named readers (`cmd/ailang/eval_elo.go`, `eval_saturation.go`, `eval_confidence.go`) are 0 each. Positive control per the reviewer's own prescription (`DisallowUnknownFields` is a `Decoder` method, not an `Unmarshal` option): `json.NewDecoder` occurs **10** times in `cmd/ailang/` and **122** repo-wide, so decoder usage exists and the instrument would have found a strict one | `grep -rn 'DisallowUnknownFields' --include='*.go' cmd/ internal/` with control `grep -rn 'json.NewDecoder' --include='*.go' cmd/ailang/` (scopes asserted with `test -d`) | `0` strict-decoder hits; controls `10` / `122` | verified by controller, iteration 291, commit `70f4e0660` |
+
+---
+
+## Design Questions — explicit answers
+
+### Q1. Where is "frozen" RECORDED?
+
+**Both: a recorded marker in `prompts/versions.json`, audited by a CI check that re-derives the
+predicate from the tracked corpus.**
+
+- **Recorded** (authoritative for enforcement): a `frozen` object on the version entry (schema
+  below). This is what both loaders and the developer-facing error read. *Cheap*: one JSON field,
+  zero extra I/O at load time — the loaders already parse this file.
+- **Derived** (auditor): CI recomputes `banked(V)` from the 17,343 tracked files under
+  `eval_results/baselines/` (one `git ls-files | xargs jq` pass, ~seconds; measured in N-2) and
+  fails if any corpus-evidenced version lacks a marker. *Honest*: the record cannot silently
+  drift below reality, because every PR re-checks it against the corpus that ships in the same
+  repo (V-E — the corpus being repo-tracked is what makes this possible; the observatory DB
+  cannot serve this role, V-G).
+
+A purely derived predicate was rejected because both loaders would need the 17k-file corpus at
+runtime (agent-mode loads happen on eval rigs from an embedded FS, with no corpus present). A
+purely recorded one was rejected because nothing would catch a marker that was never written.
+
+### Q2. What is the exact freeze predicate, given 9,522 attribution-less baselines?
+
+**Corpus predicate**: `banked(V)` ≡ at least one tracked file under `eval_results/baselines/`
+(scope: `git ls-files 'eval_results/baselines/*.json'`) has `.prompt_version == V`.
+
+An attribution-less baseline (9,522 of 17,343, N-2) **cannot count as evidence for any specific
+version** — it names none. So the corpus predicate errs toward **under-freezing**: a version that
+was really used before `prompt_version` was recorded stays mutable under the pure predicate.
+
+**That is the unsafe direction.** For reproducibility the fail-safe direction is
+**over-freezing**: the cost of a wrongly-frozen version is one version bump (~1 minute with the
+existing `create_prompt_version.sh`, N-8); the cost of a wrongly-mutable version is silent,
+later-undetectable corruption of banked provenance. Therefore the predicate is compensated at
+migration time (Q4) by a second freeze reason:
+
+- `reason: "banked"` — corpus-evidenced (the 18 AILANG ids + `python`, N-2).
+- `reason: "legacy"` — no corpus evidence, but created before this mechanism landed, when the
+  9,522 attribution-less rows were being banked; absence of evidence is not evidence of absence
+  here. N-9 shows this is not hypothetical: `v0.16.5` has zero corpus rows yet its own registry
+  note declares it "served byte-identical for pinned eval baselines".
+
+Going forward (post-migration), only `reason: "banked"` freezes are created, because every new
+banked row carries `prompt_version` (V-D) — the incompleteness is a property of the historical
+corpus, not of new data. Note this id-level predicate identifies **which version** was banked but
+not **which bytes**; the byte-level clause is added in Q7 (post-M4 rows also carry
+`prompt_sha256`, and the predicate then additionally requires agreement between the frozen hash
+and every byte-carrying row).
+
+### Q3. WHO freezes, and WHEN?
+
+**At PR time, by an explicit command, enforced by CI. The eval harness never writes the
+registry.**
+
+- New subcommand: `ailang prompt freeze <version>` — computes the corpus evidence at HEAD, writes
+  the `frozen` marker (with count + example path) to **BOTH registry files**
+  (`prompts/versions.json` AND `cmd/ailang/prompts/versions.json` — agent mode reads the embedded
+  registry first, V-J, so a single-registry write would leave every binary built from that tree
+  perceiving the version as never-banked and bypass M3's enforcement exactly on the eval rigs),
+  and refuses if the version's current file bytes do not match its recorded hash (you may not
+  freeze a lie).
+- `ailang prompt freeze --check` — the derivation audit (Q1) plus integrity checks; exits
+  non-zero with the list of violations. Wired into `make ci` via a new `check-prompt-freeze`
+  target (the Makefile currently references prompts nowhere, N-7, so this is additive).
+- **When**: a version becomes banked only when baseline JSONs naming it are committed under
+  `eval_results/baselines/` — and that is a repo event (a PR), regardless of which machine ran
+  the eval. This dissolves the harness-machine ≠ repo-machine problem: the rig banks locally, the
+  bank lands in the repo via the existing sync, and the first PR containing rows for version V
+  goes red on `--check` until someone runs `ailang prompt freeze V` in that PR.
+
+Bank-time freezing (harness writes the flag) was rejected: the harness often runs against an
+embedded snapshot on another machine (N-5), a write from there is unlandable, and V-G shows the
+only authoritative bank is the repo itself.
+
+### Q4. What happens to the versions already banked today?
+
+One mechanical migration, generated and verified by command, landed as a single commit in M1.
+
+Generator for the banked set (this is the same instrument as N-2):
+
+```bash
+git ls-files 'eval_results/baselines/*.json' \
+  | xargs jq -r 'select(has("prompt_version")) | .prompt_version' \
+  | sort | uniq -c | sort -rn
+```
+
+Migration rule, applied by `ailang prompt freeze --migrate`:
+
+| Set | Count (of 59 in `prompts/versions.json`) | Action |
+|-----|------------------------------------------|--------|
+| Corpus-evidenced: 18 AILANG ids + `python` (N-2) | 19 | `frozen` with `reason: "banked"`, `evidence_count` from the generator, `evidence_example` = first matching tracked path |
+| Everything else except the active version — 35 AILANG ids (incl. `v0.16.0`–`v0.16.5`) + `go`, `javascript`, `moonbit`, `aver` | 39 | `frozen` with `reason: "legacy"` (fail-safe direction, Q2; concrete justification N-9) |
+| `v0.16.6` (active, zero corpus evidence, V-F/V-B) | 1 | **left mutable** — the D-41 ruling itself classified its in-place edit as legitimate |
+
+19 + 39 + 1 = 59 (checks against V-A; and V-I verifies the intersection this split rests on —
+all 19 corpus-evidenced ids exist as registry keys, 0 missing, with positive/negative controls).
+The migration is applied to **BOTH** registry files (Q3/V-J); today they are byte-identical
+(V-J), so the dual write starts from an agreed base. Verifiable: after migration, `--check` must
+be green, and — against **each** of the two registry files —
+`jq '[.versions[]|select(.frozen.reason=="banked")]|length'` → 19,
+`...=="legacy"...` → 39, `[.versions|to_entries[]|select(.value|has("frozen")|not)]|length` → 1,
+plus `diff <(jq -S .versions prompts/versions.json) <(jq -S .versions cmd/ailang/prompts/versions.json)`
+→ empty.
+
+### Q5. What is the ERROR on editing a frozen prompt?
+
+Today (`prompt_loader.go:81-87`): `hash mismatch for "vX": expected …, got … (file may have been
+modified)` — it does not say whether the modification was legitimate, or what to do.
+
+After M1, the standard-mode loader distinguishes the two states:
+
+**Frozen** (hash mismatch, `frozen` marker present):
+
+```
+prompt version "v0.3.21" is FROZEN: it is cited by 210 banked baseline files under
+eval_results/baselines/ (e.g. eval_results/baselines/<example>.json; frozen 2026-08-27,
+reason: banked — decision D-41c). Its bytes are immutable: editing prompts/v0.3.21.md in
+place would silently change what those baselines measured.
+To change the teaching prompt, create a NEW version instead:
+  .claude/skills/prompt-manager/scripts/create_prompt_version.sh v0.3.22 v0.3.21 "<why>"
+(expected sha256 db0a593fd2a7…, got <actual>…)
+```
+
+**Never-banked** (hash mismatch, no marker):
+
+```
+hash for "v0.16.6" is stale. This version has no banked uses, so in-place editing is
+allowed (D-41c) — regenerate the change-detector hash:
+  shasum -a 256 prompts/v0.16.6.md   # then update the "hash" field in prompts/versions.json
+```
+
+M3 emits the same frozen-error text from the agent-mode loader (`internal/prompt`), so both eval
+modes teach identically. The `evidence_count`/`evidence_example` are read from the recorded
+marker (snapshot at freeze time), not recomputed at load — load-time cheapness per Q1.
+
+### Q6. Does the PLACEHOLDER escape hatch need closing for frozen versions?
+
+**Yes for frozen, no for never-banked — and it costs nothing today.** Measured (N-1): **0 of 59**
+versions in `prompts/versions.json` have `hash == "PLACEHOLDER"` (control: 59/59 are 64-hex). A
+frozen version with a PLACEHOLDER hash would be a freeze with no invariant, so:
+
+- Loaders: `frozen` marker present AND hash not `^[0-9a-f]{64}$` → hard error ("frozen version
+  with unenforceable hash — refuse to load"), instead of the V-C skip.
+- CI `--check`: same condition is a violation; `ailang prompt freeze` refuses to create such a
+  marker in the first place.
+- Never-banked versions keep the hatch exactly as in V-C (zero current users, but it is part of
+  the documented dev workflow and this doc's mandate is prospective enforcement, not workflow
+  removal).
+
+### Q7 (added in r2). Can the mechanism prove WHICH bytes a banked row measured?
+
+Round-1 review (gpt5-6-sol) identified a real hole: **L3(c) protects only versions already
+frozen at the merge-base.** In the first PR that banks rows for an unfrozen version, an author
+can run evals against bytes A, edit the prompt to bytes B, regenerate the registry hash, add the
+frozen marker, and commit all of it — every layer as designed in r1 sees self-consistent bytes B
+plus a marker and passes, yet the banked rows measured bytes A. Because rows record only a
+`prompt_version` **id**, no layer can tell which bytes were used. This strikes the core of
+D-41(c), which freezes "the bytes at first banked use".
+
+**Chosen direction: (A) — make the banked row carry the byte evidence — with the residual for
+legacy rows declared honestly rather than papered over.**
+
+Mechanism (Milestone 4):
+
+- **Bank-time**: new optional field `prompt_sha256` on the banked result/manifest schema
+  (alongside `prompt_version`, V-D sites: `cmd/ailang/eval_suite_manifest.go` and both mode
+  writers). It is the sha256 of the **bytes actually served** to the model — computed from the
+  **fully evaluated prompt string immediately prior to model dispatch (post-variable
+  substitution, if any)** — not merely the content the loader returned, and NOT copied from the
+  registry's `hash` field (the registry field
+  can be stale relative to served bytes; the D-41 incident was exactly that state).
+- **Predicate extension** (`ailang prompt freeze <V>` and `--check`): collect the distinct
+  `prompt_sha256` values among tracked rows citing V. If ≥1 row carries the field, ALL of them
+  must agree with each other AND with the registry hash of the frozen entry; any disagreement is
+  red. Replaying the reviewer's scenario: the banked rows carry `sha(A)`, the registry carries
+  `hash(B)` — `--check` goes red on the first-bank PR itself.
+- **Historical rows vs newly added rows — the legacy exception is defined by the MERGE-BASE, not
+  by field absence** (r3, gpt5-6-sol's round-2 `proposed_fix` applied verbatim). r2 defined the
+  exception as "row lacks the field", which silently treats *newly added, unverifiable* rows as
+  legacy and lets a stale-binary first-bank PR pass the integrity gate. Corrected: `--check` uses
+  the merge-base to distinguish historical rows from newly added ones — **field absence may warn
+  only for baseline files already present at the M4 cutoff commit, while every newly added banked
+  AILANG/control row must contain a valid 64-hex `prompt_sha256`. For any newly frozen version,
+  require at least one newly added row with byte evidence and require all newly added rows citing
+  it to agree with the frozen registry hash; otherwise fail CI.** So a row banked by a stale
+  pre-M4 binary and added in this PR is REJECTED rather than excused.
+- **Genuinely historical rows** (the 17,343 files present at the M4 cutoff commit, N-2): id-only
+  evidence, warning not failure; for those the first-bank commit is **trust-on-first-use**. This
+  is stated in Non-Goals and tracked as Open Question 4, and it is now a CLOSED set — it can
+  never grow, because every newly added row must carry byte evidence.
+
+Why (A) over (B) (declare-only): the ruling's subject is byte identity, and the evidence is
+available for free at bank time — the loaders already hold the served bytes (L1 already computes
+their sha256 for verification). Cost: one additive optional field on banked rows (old readers
+ignore unknown JSON fields, same tolerance argument as the registry schema), one cross-check in
+`--check`. It does nothing for the 9,522 attribution-less rows or the existing 1,284+6,537
+id-attributed rows — nothing can — which is precisely the residual that (B)'s honesty is applied
+to. An unearned guarantee would be worse than the gap; the doc therefore claims byte-fidelity
+**only** for post-M4 rows.
+
+---
+
+## Solution Design
+
+### Schema (versions.json `schema_version` 1.0 → 1.1)
+
+```jsonc
+"v0.3.21": {
+  "file": "prompts/v0.3.21.md",
+  "hash": "db0a593fd2a7…",            // unchanged meaning; becomes a HARD invariant when frozen
+  "frozen": {                          // ABSENT ⇒ never-banked ⇒ mutable
+    "at": "2026-08-27",
+    "reason": "banked",               // "banked" | "legacy" | "manual"
+    "evidence_count": 210,             // tracked files under eval_results/baselines/ citing this id, at freeze time
+    "evidence_example": "eval_results/baselines/<file>.json"   // "" for reason:"legacy"
+  },
+  ...
+}
+```
+
+Both loader structs (`internal/eval_harness/prompt_loader.go` `PromptVersion`,
+`internal/prompt/loader.go` `VersionMetadata`) gain `Frozen *FrozenMarker
+\`json:"frozen,omitempty"\``. Go's `json.Unmarshal` ignores unknown fields, so **binaries built
+before this change parse the new registry without error** — they simply do not enforce freezing;
+the enforcement floor for stale binaries is the CI gate.
+
+### Enforcement layers
+
+| Layer | Site | Catches | Cannot catch |
+|-------|------|---------|--------------|
+| L1 standard-mode load | `internal/eval_harness/prompt_loader.go` `LoadPrompt` (extends the existing V-C check) | file edited, hash not regenerated → **teaching frozen error** (Q5) | file edited AND hash regenerated |
+| L2 agent-mode load (M3) | `internal/prompt/loader.go` `LoadPrompt` — for **frozen** versions only, verify sha256 of the bytes actually read (embedded or disk) against `hash`; plus removal of the silent `DefaultPrompt`/`"default"` fallback in `langreg/ailang.go` and `langreg/python.go` (N-4) | same as L1, on the path that had **zero** verification (N-3); also stops `"default"` ever being banked as an attribution | same as L1 |
+| L3 CI (M2) | `ailang prompt freeze --check` via `make check-prompt-freeze`, in `make ci` | (a) corpus-evidenced version without marker; (b) frozen version whose file bytes ≠ hash, or hash not 64-hex; (c) **frozen-entry immutability vs merge-base**: for every version frozen at `origin/dev` merge-base, its `file`/`hash` fields and its `.md` bytes must be unchanged in the PR — this is the only layer that catches the edit+regen bypass; (d) mirror agreement for frozen ids, covering **BOTH** the `.md` bytes (`cmd/ailang/prompts/<file>` == `prompts/<file>`) **AND the mirror registry itself**: the frozen entry in `cmd/ailang/prompts/versions.json` (`file`, `hash`, `frozen`) must be identical to the source entry — the registry file is what carries the markers, and agent mode reads the embedded registry first (V-J), so a `.md`-only mirror check would leave the enforcement bits themselves free to drift (the mirror is manually synced, N-6/N-7/V-J) | runs only where CI runs — a rig with a stale binary and no CI is covered by L1/L2 at next load; and L3(c) alone cannot see a bytes-swap inside the first-bank PR (nothing frozen at merge-base) — that is L4's job |
+| L4 bank-time byte evidence (M4) | `prompt_sha256` of the **served bytes** written on every new banked row; `--check` requires all byte-carrying rows citing a frozen version to agree with each other and with the frozen hash (Q7) | the first-bank bytes-swap (rows measured bytes A, registry frozen at bytes B) — the only layer that can | **newly added** rows must carry a valid 64-hex `prompt_sha256` or CI fails (r3); the warning-not-failure path applies ONLY to baseline files already present at the M4 cutoff commit, a set that cannot grow — TOFU residual declared in Non-Goals |
+
+Note on L2 scope: hash verification in `internal/prompt` is applied **only to frozen versions**.
+The disk-fallback path exists to allow editing the active (mutable) version without rebuilding
+(loader comment, N-5); checking unfrozen versions there would break that workflow for no
+provenance gain.
+
+A useful emergent property: because L3(c) makes frozen disk bytes immutable on `dev`, every
+binary built after a version freezes embeds **identical** bytes for it — embedded-mirror drift
+becomes structurally impossible for frozen versions, without any sync tooling.
+
+---
+
+## Conflict Surface
+
+1. **PLACEHOLDER hatch (V-C)** — narrowed, not removed: banned for frozen versions (Q6), kept
+   for never-banked. Measured impact today: zero versions use it (N-1).
+2. **`active: "latest"` resolution** (`prompt_loader.go` `findLatestVersion`,
+   `internal/prompt` `"latest"` handling) — untouched. A frozen version MAY be active: freezing
+   blocks *edits*, not *use* (serving frozen bytes is exactly the point). The migration leaves
+   `active: "v0.16.6"` (a literal, V-B) mutable; nothing in the resolution path reads `frozen`.
+3. **Non-AILANG control entries** (`python`, `go`, `javascript`, `moonbit`, `aver`) — included in
+   the freeze. `python` has 6,537 banked citations (N-2) and is the control arm of the
+   local-vs-frontier thesis, so its comparability matters *more*, not less. Consequence: a future
+   `python.md` change requires a new key (convention: `python-v2`) **and** a one-line change in
+   `langreg/python.go:34`, which hardcodes `LoadPrompt("python")` (N-4). Historical `python`
+   attribution is already lossy (the bytes changed over the corpus's lifetime); that is
+   unrepairable and out of scope (Non-Goals).
+4. **Embedded mirror `cmd/ailang/prompts/`** — read FIRST by agent mode, **including the
+   registry file itself** (`loadVersionsManifest` embedded-first, V-J/N-5), maintained by manual
+   copy with no Makefile target (N-7). Consequences now designed in, not just noted: the
+   migration and every `freeze` write go to BOTH registries (Q3/Q4), and L3(d) checks frozen-id
+   agreement for `.md` bytes AND registry entries (a marker present only in
+   `prompts/versions.json` would leave every binary built from that tree blind to the freeze —
+   M3's enforcement bypassed exactly on the rigs). The two registry files are byte-identical
+   today (V-J), so both the dual write and the check start green. General mirror-sync checking
+   for mutable versions remains an open question (below).
+5. **Silent-fallback removal** (`langreg/ailang.go:35`, `langreg/python.go:35`) — behavior
+   change: an eval run whose prompt fails to load now **aborts loudly** instead of running with a
+   hardcoded default and banking `prompt_version: "default"`. N-2 shows no `"default"` rows exist
+   in the tracked corpus, so no existing data depends on the fallback; CLAUDE.md Principle 2
+   (no silent fallbacks on data-integrity paths) mandates the removal.
+6. **Devtools prompt registry** (`internal/devtoolsprompt/loader.go`, separate `versions.json`)
+   — deliberately untouched: different registry, different attribution field, and D-41 was opened
+   about the teaching-prompt registry. Flagged in Open Questions as a candidate for the same
+   mechanism.
+7. **`create_prompt_version.sh`** (N-8) — no functional change required: it only creates NEW
+   versions (never-banked by construction, id/file collision → error) and its manual
+   "update hash after edit" step remains legal exactly while the version is unbanked. M2 adds one
+   sentence to its printed "Next steps" naming the freeze rule, so the workflow teaches itself.
+8. **Existing tests (V-H)** — `TestAILANGPromptLoading` / `TestPromptDisambiguation` load the
+   active version, which stays mutable with a valid hash; they are unaffected. New tests are
+   added per the Mutation Table, not by editing these.
+9. **Stale binaries** — parse the new field harmlessly (unknown-field tolerance, Schema section)
+   but do not enforce; enforcement floor is CI (L3). This mirrors the repo's standing posture
+   that `~/go/bin/ailang` drifts by design.
+10. **Banked-result schema addition** (`prompt_sha256`, M4/Q7) — additive optional JSON field on
+   the manifest/result structs (V-D sites). Existing readers of baseline JSON (eval-elo,
+   eval-paired, dashboards) unmarshal into structs that ignore unknown fields, so old tooling is
+   unaffected; new `--check` logic treats field-absent rows as id-only evidence (warning, never
+   failure). No existing row is rewritten — re-banking history is prohibited by standing policy.
+
+---
+
+## Acceptance Criteria
+
+Each AC names its command and what would still pass if the claimed mechanism were absent
+(the "hollow-pass check").
+
+- **AC1 (M1, migration correctness)**: after the migration commit,
+  `jq '[.versions[]|select(.frozen.reason=="banked")]|length' prompts/versions.json` → `19`;
+  `…"legacy"…` → `39`; `jq '[.versions|to_entries[]|select(.value|has("frozen")|not)]|length'`
+  → `1` (and that one is `v0.16.6`). *Hollow-pass check*: a migration that marked everything
+  frozen would fail the third count; one that only marked corpus-evidenced ids would fail the
+  second.
+- **AC2 (M1, frozen teaching error)**: in a test fixture (or on a scratch copy of the repo —
+  never the working tree), append one byte to the frozen fixture's `.md`, then
+  `loader.LoadPrompt("<frozen-id>")` must return an error whose text contains ALL of: `FROZEN`,
+  the `evidence_count`, and `create_prompt_version.sh`. *Hollow-pass check*: the pre-existing
+  V-C hash check also errors on this input — asserting a bare error would pass without any
+  freeze code. The assertion is on the NEW message content, which only the frozen branch emits.
+- **AC3 (M1, mutability preserved)**: same fixture, a version WITHOUT a marker: tamper +
+  regenerate hash → `LoadPrompt` succeeds; tamper without regenerating → error containing
+  `not yet banked` / `in-place editing is allowed`. *Hollow-pass check*: a freeze-everything
+  mutation fails the first half; unchanged code fails the second half's message assertion.
+- **AC4 (M2, edit+regen bypass)**: on a branch, edit a frozen `.md` AND update its `hash` field
+  to the new sha256 → `ailang prompt freeze --check` (with merge-base = unmodified `dev`) exits
+  non-zero naming the version and `immutability`. *Hollow-pass check*: L3(b) alone (file-vs-hash
+  agreement) stays GREEN on this input — this AC is specifically the check that only the
+  merge-base comparison can fail, and it must be demonstrated red.
+- **AC5 (M2, derivation audit)**: on a branch, delete the `frozen` marker from `v0.3.21`
+  (210 corpus citations, N-2) → `--check` exits non-zero naming `v0.3.21` as corpus-evidenced
+  but unmarked. On unmodified post-migration `dev`, `--check` exits 0. *Hollow-pass check*: a
+  `--check` that only validated hashes would stay green on the deleted marker.
+- **AC6 (M2, frozen PLACEHOLDER ban)**: on a branch, set a frozen version's hash to
+  `"PLACEHOLDER"` → `--check` non-zero; and `LoadPrompt` on that fixture errors rather than
+  skipping. *Hollow-pass check*: under V-C semantics alone, PLACEHOLDER silently skips
+  verification and loads — that is the behavior this AC proves is gone for frozen entries.
+- **AC7 (M3, agent-mode hole closed)**: unit test with embedded FS pointed at a fixture whose
+  frozen `.md` bytes disagree with its manifest hash: `LoadSyntaxRef("ailang", ...)` (via
+  `langreg`) returns a non-nil error whose text contains `FROZEN`, and the returned
+  `versionUsed` is NOT `"default"`. *Hollow-pass check*: today's code returns
+  `(DefaultPrompt(), "default", nil)` on this exact input (N-4) — asserting only "no panic" or
+  "some prompt returned" would pass on unmodified code; the assertions are the error and the
+  absence of the `"default"` attribution.
+- **AC8 (M3, mirror agreement)**: on a branch, make `cmd/ailang/prompts/<frozen>.md` differ from
+  `prompts/<frozen>.md` → `--check` non-zero naming the mirror path. *Hollow-pass check*: no
+  current instrument sees this at all (N-7: no Makefile prompt tooling exists to catch it).
+- **AC9 (M2, mirror REGISTRY agreement)**: on a branch, leave every `.md` untouched and alter
+  ONLY the mirror registry — delete (or change the `hash` of) one frozen entry in
+  `cmd/ailang/prompts/versions.json` → `--check` non-zero naming
+  `cmd/ailang/prompts/versions.json` and the version id. Additionally, AC1's post-migration jq
+  counts (19/39/1) must hold against the MIRROR registry file too, and
+  `diff <(jq -S .versions prompts/versions.json) <(jq -S .versions cmd/ailang/prompts/versions.json)`
+  must be empty. *Hollow-pass check*: a `.md`-only mirror check (AC8's instrument) stays GREEN on
+  this input — the `.md` bytes are identical by construction; only a registry-entry comparison
+  can go red, and the registry file is the one that carries the freeze markers agent mode
+  actually reads (V-J).
+- **AC10 (M4, first-bank bytes-swap caught)**: fixture replaying the reviewer scenario — tracked
+  rows citing version V with `prompt_sha256 = sha(A)`, registry entry for V frozen with
+  `hash = sha(B)`, file bytes = B (self-consistent at HEAD, nothing frozen at merge-base) →
+  `--check` exits non-zero naming V and the byte disagreement. *Hollow-pass check*: L3(a)(b)(c)
+  ALL stay green on this input by construction (marker present, hash matches file, merge-base has
+  no frozen entry to diff) — this AC can only be turned red by the row-hash cross-check, which is
+  the mechanism under test.
+  **AC10(b) (r3, stale-binary fixture — gpt5-6-sol's round-2 `proposed_fix`)**: a NEWLY ADDED
+  baseline row (absent at merge-base) citing a newly frozen version and carrying NO
+  `prompt_sha256` → `--check` exits non-zero naming the row's path and `missing byte evidence`.
+  *Hollow-pass check*: under r2's field-absence rule this input was WARNED-and-passed, which is
+  exactly the bypass; and a `--check` that keyed on field absence alone rather than on merge-base
+  membership stays green on it. The historical arm must pass in the same test: an unchanged
+  pre-cutoff fieldless row warns and does not fail.
+- **AC11 (M4, served-bytes provenance)**: unit test on the bank path with a fixture registry
+  entry that is unfrozen with `hash: "PLACEHOLDER"` (the one state where the loader serves bytes
+  WITHOUT any hash agreement, V-C): the banked row's `prompt_sha256` must equal sha256 of the
+  **served file bytes**. *Hollow-pass check*: an implementation that copies the registry's `hash`
+  field instead of hashing the served content would write the literal `"PLACEHOLDER"` here —
+  the assertion on a real 64-hex digest of the fixture bytes can only be satisfied by hashing
+  what was actually served (this distinction is the D-41 incident class itself: registry field
+  stale relative to served bytes).
+
+None of these commands exists on unmodified `dev` today (the subcommand and tests are new), so no
+AC is red-on-dev in the G4 sense; AC1/AC5/AC9's green states are defined post-migration-commit
+and that ordering is explicit in M1/M2. No AC claims byte-fidelity for rows banked before M4
+(Non-Goals; Q7).
+
+---
+
+## Mutation Table
+
+| # | Mutation (introduced defect) | Killed by | Why the observable is downstream & unique |
+|---|------------------------------|-----------|-------------------------------------------|
+| 1 | L1 ignores the `frozen` field (freeze branch deleted) | AC2 | The asserted strings (`FROZEN`, evidence count, bump command) are emitted only by the frozen branch; the surviving V-C error cannot produce them |
+| 2 | L1 treats every version as frozen (inverted predicate) | AC3 | A frozen-everything loader rejects the legitimate tamper+regen edit of an unmarked version; AC3's success half fails |
+| 3 | `--check` skips corpus derivation (validates hashes only) | AC5 | The deleted-marker input has a self-consistent hash — only the derivation can turn it red |
+| 4 | `--check` compares file-vs-hash but not vs merge-base | AC4 | The edit+regen input is self-consistent at HEAD by construction; only the merge-base diff sees it |
+| 5 | Frozen + `PLACEHOLDER` still skips verification (V-C semantics retained) | AC6 | Load succeeding on a frozen placeholder is exactly the pre-change behavior; the AC asserts the refusal |
+| 6 | M3 hash check added but silent `"default"` fallback retained in `LoadSyntaxRef` | AC7 | The fallback converts the new error back into `(default-prompt, "default", nil)`; AC7 asserts on the returned error AND on `versionUsed != "default"` — a value only the fallback path produces |
+| 7 | M3 verifies the disk path but not the embedded path | AC7 | The AC7 fixture delivers the tampered bytes **via the embedded FS** (the path agent mode reads first, N-5) |
+| 8 | Migration writes `banked` markers but omits `legacy` | AC1 | The `39` count is asserted directly; a corpus-only migration yields 19/0/40 |
+| 9 | Mirror check dropped from `--check` | AC8 | No other layer reads `cmd/ailang/prompts/` bytes (N-3/N-7); only L3(d) can go red on that input |
+| 10 | Migration/`freeze` writes markers to `prompts/versions.json` only (mirror registry left unmarked) | AC9 | AC9's jq counts run against the MIRROR file and its `--check` input alters only the mirror registry; a source-only writer or a `.md`-only checker leaves both green — the registry-entry comparison is the sole observable that fires |
+| 11 | `--check` ignores `prompt_sha256` (or compares rows to each other but never to the frozen hash) | AC10 | AC10's fixture is green under every other sub-check by construction; only the row-hash-vs-frozen-hash cross-check can produce the asserted failure |
+| 12 | Bank path populates `prompt_sha256` from the registry `hash` field instead of hashing the served bytes | AC11 | The PLACEHOLDER fixture makes the copied value (`"PLACEHOLDER"`) and the true digest disjoint; the asserted 64-hex digest of the fixture bytes is producible only by hashing served content |
+
+---
+
+## Milestones
+
+### M1 — Schema, freeze command, migration, standard-mode teaching error (≤1 day) — **minimum viable ruling-compliance**
+
+`FrozenMarker` structs in both loaders; `ailang prompt freeze <version>` / `--migrate` /
+`--check` (derivation + hash-integrity subset, i.e. L3(a)(b) callable locally), with **every
+marker write going to BOTH registry files** (Q3/V-J); the migration commit (19/39/1 per Q4,
+applied to both registries, verified by V-I's intersection); the two-state error in
+`internal/eval_harness/prompt_loader.go` (Q5); frozen-PLACEHOLDER refusal in the same loader.
+Tests: AC1, AC2, AC3, first half of AC6, AC9's jq-count/diff half.
+This alone makes the D-41(c) state representable, recorded for all 59 versions **in both the
+registry agent mode reads and the one standard mode reads**, and enforced with a teaching error
+on the standard-mode path — everything else is hardening.
+
+### M2 — CI gate (≤1 day)
+
+`make check-prompt-freeze` target invoking `ailang prompt freeze --check` with the merge-base
+immutability check L3(c) and the mirror check L3(d) covering frozen `.md` bytes AND frozen
+entries of `cmd/ailang/prompts/versions.json` (the marker-carrying file, Q7/V-J); wire into
+`make ci`; the one-sentence freeze note in `create_prompt_version.sh`'s "Next steps"; CHANGELOG
++ `docs/docs/guides/evaluation.md` paragraph. Tests: AC4, AC5, second half of AC6, AC8, AC9's
+`--check` half.
+
+### M3 — Close the agent-mode verification hole (≤1 day)
+
+Frozen-hash verification in `internal/prompt.LoadPrompt` for both embedded and disk reads (L2);
+remove the silent `DefaultPrompt`/`"default"` fallbacks in `langreg/ailang.go` and
+`langreg/python.go` (Conflict Surface 5); same teaching error text as L1. Tests: AC7.
+Independently landable: it depends only on M1's schema field being present in the registry, which
+M1's dual-registry migration commit guarantees on `dev` (a source-only migration would make this
+milestone vacuous on rig binaries — the embedded registry would carry no markers, V-J).
+
+### M4 — Bank-time byte evidence (≤1 day)
+
+`prompt_sha256` (sha256 of the served bytes) written on every new banked row at the V-D sites for
+both modes; `--check` gains the row-hash cross-check (all byte-carrying rows citing a frozen
+version must agree with each other and with the frozen hash; zero byte-carrying rows → warning
+only). Closes the first-bank bytes-swap hole (Q7); the TOFU residual for pre-M4 rows is declared,
+not fixed. Tests: AC10, AC11. Independently landable after M1 (needs the marker schema for the
+cross-check; the bank-side field write itself has no dependency and starts accumulating evidence
+from the moment it lands).
+
+---
+
+## Testing Strategy
+
+- Unit tests live beside the loaders (`internal/eval_harness/prompt_loader_test.go`,
+  `internal/prompt/loader_test.go`, new `cmd/ailang` test for `freeze`/`--check`), using
+  `t.TempDir()` fixture registries — never the real `prompts/` tree (House rule: tests must not
+  mutate the shared working tree).
+- The `--check` tests drive the real binary logic against fixture git state (a scratch repo
+  created in the test), because L3(c) is meaningless without a merge-base to diff against.
+- M4's bank-path test (AC11) lives beside the result writers (V-D sites) and asserts on the
+  written JSON, the observable downstream of the mechanism, not on any intermediate variable.
+- V-H's existing tests are left untouched (Conflict Surface 8); per the testing policy
+  ("remove out-of-date tests"), nothing here obsoletes them — they test active-version loading,
+  which this design preserves.
+
+---
+
+## Axiom Compliance
+
+- **Principle 2 (no silent fallbacks)**: M3 removes two banked-attribution fallbacks (N-4);
+  frozen+PLACEHOLDER becomes a refusal, not a skip.
+- **Principle 3 (systemic fix)**: the audit found the same defect class (unverified prompt bytes)
+  on both eval paths and fixed the class (L1+L2+L3), not the incident.
+- **Fail-safe direction stated** (Q2): over-freeze, because the asymmetric cost is provenance
+  corruption.
+
+---
+
+## Open Questions
+
+1. **Devtools registry**: should `internal/devtoolsprompt`'s separate `versions.json` get the
+   same marker + gate once this lands? (Candidate follow-up; needs its own corpus-attribution
+   measurement first.)
+2. **General mirror sync**: L3(d) covers frozen ids only. A full `prompts/` ↔
+   `cmd/ailang/prompts/` sync check for mutable versions is cheap to add in the same script but
+   changes a long-standing manual workflow (N-7) — deferred to its own decision.
+3. **`reason: "manual"`**: reserved in the schema for a human choosing to freeze an unbanked
+   version (e.g. before a publicized comparison). No workflow ships it in M1–M4; the enum slot
+   exists so the schema does not need a second bump.
+4. **TOFU sunset (Q7 residual)**: with r3's merge-base cutoff the residual is already closed to
+   growth — newly added rows must carry byte evidence or CI fails — so the only remaining question
+   is when to retire the warning for the *historical* set entirely (i.e. re-bank or retire the
+   17,343 pre-cutoff files). That is a dated policy decision for the ledger, not a code change.
+
+---
+
+## Quorum revision log (round 1 → r2 → r3)
+
+Round-1 verdict: **blocked**, 3/3 external reviewers present (`absent_reviewers: []`).
+
+| Objection | Reviewer | Disposition in r2 |
+|-----------|----------|-------------------|
+| 1 — "L3(c) protects only versions frozen at merge-base; the first-bank PR can bank bytes A and freeze bytes B undetected" | gpt5-6-sol | **Accepted as a real hole.** Direction (A) chosen: bank-time `prompt_sha256` of the served bytes + `--check` cross-check (new Q7, L4, M4, AC10/AC11, mutation rows 11-12), with the residual for pre-M4 rows declared in Non-Goals and Open Question 4 rather than implied away |
+| 2 — "M1's migration writes only the source registry; agent mode reads the embedded registry first, so freeze markers never reach the rigs; L3(d) checked only `.md` files, not the marker-carrying registry" | gemini-3-1-pro | **Accepted, confirmed by controller measurement (V-J).** Migration and every `freeze` write now go to BOTH registry files (Q3/Q4, M1); L3(d) extended to frozen registry entries (M2); AC9 goes red on a mirror-registry-only divergence, with the hollow-pass note that a `.md`-only check stays green on that input; mutation row 10 |
+| 3 — "The 19/39/1 split is unverified: nobody checked the corpus ids exist as registry keys" | oc-glm-5-2 | **Refuted by controller measurement (V-I)**: intersection holds exactly (19 present, 0 missing, incl. `v0.6.5`; positive control `python` → True, negative control `v9.9.9-nonexistent` → False; 19+39+1=59). The missing verification ROW was a real doc defect and is now V-I; the design and AC1 are unchanged |
+
+### Round 2 → r3 (controller, narrow-refinement carve-out)
+
+Round-2 verdict: **blocked**, 3/3 external reviewers present (`absent_reviewers: []`), and
+`gemini-3-1-pro` **flipped to pass**. Both surviving objections carried a concrete
+reviewer-authored `proposed_fix` and neither disputed the design DIRECTION (one refines the L4
+predicate, one asks for a verification row), so the controller applied the ratified
+**narrow-refinement carve-out**: the reviewers' fix texts are applied VERBATIM, by the controller,
+without a third designer run. No controller-invented resolution; no objection overridden.
+
+| Objection | Reviewer | Disposition in r3 |
+|-----------|----------|-------------------|
+| "M4 does not guarantee byte evidence: the legacy exception is defined by field absence rather than by whether a row predates M4, so a stale-binary first-bank PR still passes" | gpt5-6-sol | **Accepted; fix applied verbatim.** `--check` now uses the MERGE-BASE to separate historical from newly added rows: field absence warns only for baseline files already present at the M4 cutoff commit; every newly added banked row must carry a valid 64-hex `prompt_sha256`; a newly frozen version requires ≥1 newly added row with byte evidence, all agreeing with the frozen registry hash, else CI fails. Q7, L4, Non-Goals, Open Question 4 and AC10 updated; new **AC10(b)** is the stale-binary fixture the reviewer asked for. The residual is now a CLOSED set that cannot grow |
+| "Conflict Surface item 10 (readers ignore unknown fields) is asserted bare with no verification row" | oc-glm-5-2 | **Refuted by controller measurement, and the requested row added verbatim as N-10.** `DisallowUnknownFields` = **0** across `cmd/ internal/` and 0 repo-wide; the three named readers are 0 each; the reviewer's own prescribed positive control (`json.NewDecoder`, since it is a `Decoder` method) fires at **10** in `cmd/ailang/` and **122** repo-wide. The non-breaking claim stands; the missing ROW was a real doc defect |
+| (non-blocking) "`prompt_sha256` should hash the fully evaluated string, not the loader's return" | gemini-3-1-pro (**pass**) | **Accepted anyway** — the sharpening is free and correct. Q7's bank-time bullet now reads "the fully evaluated prompt string immediately prior to model dispatch (post-variable substitution, if any)" |
+
+---
+
+## Related Documents
+
+- `design_docs/planned/m-contract-verification-coverage.md` — house-style sibling (structure model)
+- `design_docs/PROGRAM.md` — routing: this is harness/data-integrity work, not a core change
+- `.claude/skills/prompt-manager/` — the workflow this mechanism constrains
+- Decision ledger row D-41 (mission log, iteration 291) — the ruling

--- a/internal/eval_harness/prompt_frozen.go
+++ b/internal/eval_harness/prompt_frozen.go
@@ -1,0 +1,45 @@
+package eval_harness
+
+import "fmt"
+
+// FrozenMarker records that a prompt version's bytes are immutable because the version
+// has been used in at least one banked eval baseline. Decision D-41(c).
+// ABSENT (nil) means never-banked, i.e. mutable.
+type FrozenMarker struct {
+	At              string `json:"at"`
+	Reason          string `json:"reason"`
+	EvidenceCount   int    `json:"evidence_count"`
+	EvidenceExample string `json:"evidence_example"`
+}
+
+// IsHexSHA256 reports whether s is exactly 64 lowercase hex characters.
+func IsHexSHA256(s string) bool {
+	if len(s) != 64 {
+		return false
+	}
+	for _, c := range s {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func FrozenHashMismatchError(versionID string, v PromptVersion, actualHash string) error {
+	return fmt.Errorf("prompt version %q is FROZEN: it is cited by %d banked baseline files under eval_results/baselines/ (e.g. %s; frozen %s, reason: %s — decision D-41c). Its bytes are immutable: editing %s in place would silently change what those baselines measured.\nTo change the teaching prompt, create a NEW version instead:\n  .claude/skills/prompt-manager/scripts/create_prompt_version.sh <new-id> %s \"<why>\"\n(expected sha256 %s, got %s)", versionID, v.Frozen.EvidenceCount, v.Frozen.EvidenceExample, v.Frozen.At, v.Frozen.Reason, v.File, versionID, v.Hash, actualHash)
+}
+
+func MutableHashMismatchError(versionID string, v PromptVersion, actualHash string) error {
+	expectedPreview, actualPreview := v.Hash, actualHash
+	if len(expectedPreview) > 16 {
+		expectedPreview = expectedPreview[:16] + "..."
+	}
+	if len(actualPreview) > 16 {
+		actualPreview = actualPreview[:16] + "..."
+	}
+	return fmt.Errorf("hash mismatch for %q: expected %s, got %s. This version is not yet banked, so in-place editing is allowed (D-41c) — regenerate the change-detector hash:\n  shasum -a 256 %s   # then update the \"hash\" field in prompts/versions.json", versionID, expectedPreview, actualPreview, v.File)
+}
+
+func FrozenUnenforceableHashError(versionID string, v PromptVersion) error {
+	return fmt.Errorf("prompt version %q is FROZEN but its recorded hash %q is not a 64-hex sha256: refuse to load — a frozen version with an unenforceable hash is a freeze with no invariant (D-41c, Q6). Restore the recorded hash from git history, or bump to a new version.", versionID, v.Hash)
+}

--- a/internal/eval_harness/prompt_frozen_test.go
+++ b/internal/eval_harness/prompt_frozen_test.go
@@ -1,0 +1,99 @@
+package eval_harness
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func frozenFixture(t *testing.T, marker *FrozenMarker, hash string, content string) (*PromptLoader, string) {
+	t.Helper()
+	root := t.TempDir()
+	if hash == "" {
+		h := sha256.Sum256([]byte(content))
+		hash = hex.EncodeToString(h[:])
+	}
+	version := PromptVersion{File: "prompts/x.md", Hash: hash, Frozen: marker}
+	reg := PromptRegistry{Versions: map[string]PromptVersion{"x": version}, Active: "x"}
+	data, _ := json.Marshal(reg)
+	os.MkdirAll(filepath.Join(root, "prompts"), 0o755)
+	os.WriteFile(filepath.Join(root, "prompts", "x.md"), []byte(content), 0o644)
+	os.WriteFile(filepath.Join(root, "prompts", "versions.json"), data, 0o644)
+	loader, err := NewPromptLoader(filepath.Join(root, "prompts", "versions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return loader, filepath.Join(root, "prompts", "x.md")
+}
+
+func TestLoadPrompt_FrozenTamperEmitsTeachingError(t *testing.T) {
+	m := &FrozenMarker{At: "2026-08-27", Reason: "banked", EvidenceCount: 4242, EvidenceExample: "eval_results/baselines/x/y.json"}
+	l, path := frozenFixture(t, m, "", "original")
+	f, _ := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	f.WriteString("!")
+	f.Close()
+	_, err := l.LoadPrompt("x")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	for _, want := range []string{"is FROZEN", "cited by 4242 banked baseline files", "create_prompt_version.sh"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("missing %q: %v", want, err)
+		}
+	}
+}
+func TestLoadPrompt_NeverBankedTamperRegenSucceeds(t *testing.T) {
+	l, path := frozenFixture(t, nil, "", "new bytes")
+	got, err := l.LoadPrompt("x")
+	if err != nil || got != "new bytes" {
+		t.Fatalf("got %q, %v (%s)", got, err, path)
+	}
+}
+func TestLoadPrompt_NeverBankedStaleHashTeachesRegen(t *testing.T) {
+	l, path := frozenFixture(t, nil, "", "old")
+	os.WriteFile(path, []byte("new"), 0o644)
+	_, err := l.LoadPrompt("x")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	for _, want := range []string{"hash mismatch", "not yet banked", "in-place editing is allowed", "shasum -a 256"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("missing %q: %v", want, err)
+		}
+	}
+}
+func TestLoadPrompt_FrozenPlaceholderRefused(t *testing.T) {
+	l, _ := frozenFixture(t, &FrozenMarker{}, "PLACEHOLDER", "x")
+	_, err := l.LoadPrompt("x")
+	if err == nil || !strings.Contains(err.Error(), "is FROZEN") || !strings.Contains(err.Error(), "unenforceable hash") {
+		t.Fatalf("unexpected: %v", err)
+	}
+}
+func TestLoadPrompt_UnfrozenPlaceholderStillLoads(t *testing.T) {
+	l, _ := frozenFixture(t, nil, "PLACEHOLDER", "x")
+	got, err := l.LoadPrompt("x")
+	if err != nil || got != "x" {
+		t.Fatalf("got %q, %v", got, err)
+	}
+}
+func TestPromptRegistry_FrozenFieldRoundTrips(t *testing.T) {
+	r := PromptRegistry{Versions: map[string]PromptVersion{"f": {Frozen: &FrozenMarker{At: "a", Reason: "banked", EvidenceCount: 2, EvidenceExample: "e"}}, "m": {}}}
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got PromptRegistry
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Versions["f"].Frozen.EvidenceCount != 2 {
+		t.Fatalf("marker lost: %#v", got)
+	}
+	if strings.Contains(string(data), `"m":{"file":"","hash":"","description":"","created":"","tags":null,"notes":"","frozen"`) {
+		t.Fatalf("nil marker emitted: %s", data)
+	}
+}

--- a/internal/eval_harness/prompt_loader.go
+++ b/internal/eval_harness/prompt_loader.go
@@ -11,12 +11,13 @@ import (
 
 // PromptVersion represents metadata about a prompt version
 type PromptVersion struct {
-	File        string   `json:"file"`
-	Hash        string   `json:"hash"`
-	Description string   `json:"description"`
-	Created     string   `json:"created"`
-	Tags        []string `json:"tags"`
-	Notes       string   `json:"notes"`
+	File        string        `json:"file"`
+	Hash        string        `json:"hash"`
+	Description string        `json:"description"`
+	Created     string        `json:"created"`
+	Tags        []string      `json:"tags"`
+	Notes       string        `json:"notes"`
+	Frozen      *FrozenMarker `json:"frozen,omitempty"`
 }
 
 // PromptRegistry contains all registered prompt versions
@@ -73,21 +74,19 @@ func (l *PromptLoader) LoadPrompt(versionID string) (string, error) {
 		return "", fmt.Errorf("failed to read prompt %q: %w", version.File, err)
 	}
 
-	// Verify hash (skip if placeholder)
+	if version.Frozen != nil {
+		if !IsHexSHA256(version.Hash) {
+			return "", FrozenUnenforceableHashError(versionID, version)
+		}
+		if actual := computeSHA256(content); actual != version.Hash {
+			return "", FrozenHashMismatchError(versionID, version, actual)
+		}
+		return string(content), nil
+	}
+	// never-banked: the PLACEHOLDER development escape hatch remains available.
 	if version.Hash != "PLACEHOLDER" {
-		actualHash := computeSHA256(content)
-		if actualHash != version.Hash {
-			// Truncate hashes for error message (safely handle short hashes)
-			expectedPreview := version.Hash
-			if len(expectedPreview) > 16 {
-				expectedPreview = expectedPreview[:16] + "..."
-			}
-			actualPreview := actualHash
-			if len(actualPreview) > 16 {
-				actualPreview = actualPreview[:16] + "..."
-			}
-			return "", fmt.Errorf("hash mismatch for %q: expected %s, got %s (file may have been modified)",
-				versionID, expectedPreview, actualPreview)
+		if actual := computeSHA256(content); actual != version.Hash {
+			return "", MutableHashMismatchError(versionID, version, actual)
 		}
 	}
 

--- a/internal/prompt/loader.go
+++ b/internal/prompt/loader.go
@@ -17,14 +17,23 @@ func SetEmbeddedFS(efs fs.FS) {
 	embeddedPrompts = efs
 }
 
+// FrozenMarker records that a prompt version's bytes are immutable.
+type FrozenMarker struct {
+	At              string `json:"at"`
+	Reason          string `json:"reason"`
+	EvidenceCount   int    `json:"evidence_count"`
+	EvidenceExample string `json:"evidence_example"`
+}
+
 // VersionMetadata represents metadata for a prompt version
 type VersionMetadata struct {
-	File        string   `json:"file"`
-	Hash        string   `json:"hash"`
-	Description string   `json:"description"`
-	Created     string   `json:"created"`
-	Tags        []string `json:"tags"`
-	Notes       string   `json:"notes"`
+	File        string        `json:"file"`
+	Hash        string        `json:"hash"`
+	Description string        `json:"description"`
+	Created     string        `json:"created"`
+	Tags        []string      `json:"tags"`
+	Notes       string        `json:"notes"`
+	Frozen      *FrozenMarker `json:"frozen,omitempty"`
 }
 
 // VersionsManifest represents the versions.json file structure

--- a/internal/prompt/loader_test.go
+++ b/internal/prompt/loader_test.go
@@ -1,9 +1,24 @@
 package prompt
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
+
+func TestVersionMetadata_FrozenFieldRoundTrips(t *testing.T) {
+	var manifest VersionsManifest
+	err := json.Unmarshal([]byte(`{"versions":{"f":{"frozen":{"at":"2026-08-27","reason":"banked","evidence_count":7,"evidence_example":"x.json"}},"m":{}}}`), &manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.Versions["f"].Frozen == nil || manifest.Versions["f"].Frozen.EvidenceCount != 7 {
+		t.Fatalf("marker lost: %#v", manifest)
+	}
+	if manifest.Versions["m"].Frozen != nil {
+		t.Fatal("unmarked entry became frozen")
+	}
+}
 
 func TestLoadPrompt_ActiveVersion(t *testing.T) {
 	// Test loading with empty string (should use active version)

--- a/prompts/versions.json
+++ b/prompts/versions.json
@@ -10,7 +10,13 @@
         "baseline",
         "production"
       ],
-      "notes": "Original teaching prompt from v0.3.0 release. Comprehensive coverage of language features with clear syntax rules and examples."
+      "notes": "Original teaching prompt from v0.3.0 release. Comprehensive coverage of language features with clear syntax rules and examples.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.0-hints": {
       "file": "prompts/v0.3.0-hints.md",
@@ -21,7 +27,13 @@
         "experimental",
         "error-hints"
       ],
-      "notes": "Adds 6 common error pattern sections (PAR_001, TC_REC_001, TC_INT_001, EQ_001, CAP_001, MOD_001) with wrong/correct examples. Hypothesis: Explicit error warnings reduce first-attempt failures and improve repair success rate."
+      "notes": "Adds 6 common error pattern sections (PAR_001, TC_REC_001, TC_INT_001, EQ_001, CAP_001, MOD_001) with wrong/correct examples. Hypothesis: Explicit error warnings reduce first-attempt failures and improve repair success rate.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.2": {
       "file": "prompts/v0.3.2.md",
@@ -32,7 +44,13 @@
         "production",
         "planning"
       ],
-      "notes": "Adds proactive architecture planning with :propose and :scaffold commands. Includes plan schema, validation rules, and best practices. Teaches AI agents to validate architecture BEFORE coding. Derived from v0.3.0-hints with 24 validation error codes added."
+      "notes": "Adds proactive architecture planning with :propose and :scaffold commands. Includes plan schema, validation rules, and best practices. Teaches AI agents to validate architecture BEFORE coding. Derived from v0.3.0-hints with 24 validation error codes added.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.5": {
       "file": "prompts/v0.3.5.md",
@@ -42,7 +60,13 @@
       "tags": [
         "production"
       ],
-      "notes": "Adds support for: 1) Anonymous function syntax func(x) -> T { body }, 2) letrec keyword for recursive lambdas, 3) intToFloat/floatToInt builtins. Derived from v0.3.0 baseline."
+      "notes": "Adds support for: 1) Anonymous function syntax func(x) -> T { body }, 2) letrec keyword for recursive lambdas, 3) intToFloat/floatToInt builtins. Derived from v0.3.0 baseline.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.8": {
       "file": "prompts/v0.3.8.md",
@@ -52,7 +76,13 @@
       "tags": [
         "production"
       ],
-      "notes": "Major improvements: 1) std/prelude auto-imported (no more Ord/Eq imports needed), 2) Record update syntax {r | field: val}, 3) Multi-line ADTs with optional leading pipe, 4) Operator lowering fixes. 49.1% success rate (+10.5% from v0.3.7). All v0.3.5 features included."
+      "notes": "Major improvements: 1) std/prelude auto-imported (no more Ord/Eq imports needed), 2) Record update syntax {r | field: val}, 3) Multi-line ADTs with optional leading pipe, 4) Operator lowering fixes. 49.1% success rate (+10.5% from v0.3.7). All v0.3.5 features included.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.9": {
       "file": "prompts/v0.3.9.md",
@@ -62,7 +92,13 @@
       "tags": [
         "production"
       ],
-      "notes": "AI API integration features: 1) JSON encoding with std/json (encode, jo, ja, kv, js, jnum), 2) HTTP headers with httpRequest() and Result-based error handling, 3) NetError ADT (Transport, InvalidHeader, DisallowedHost, BodyTooLarge), 4) Verified with real Claude Haiku API call. All v0.3.8 features included."
+      "notes": "AI API integration features: 1) JSON encoding with std/json (encode, jo, ja, kv, js, jnum), 2) HTTP headers with httpRequest() and Result-based error handling, 3) NetError ADT (Transport, InvalidHeader, DisallowedHost, BodyTooLarge), 4) Verified with real Claude Haiku API call. All v0.3.8 features included.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.12": {
       "file": "prompts/v0.3.12.md",
@@ -72,7 +108,13 @@
       "tags": [
         "production"
       ],
-      "notes": "Recovery release restoring show() builtin (accidentally removed in v0.3.10). Prominent show() examples added to teach proper string conversion. All v0.3.9 features included. Testing hypothesis: Emphasizing show() will reduce syntax errors and improve AILANG success rates from 0% baseline."
+      "notes": "Recovery release restoring show() builtin (accidentally removed in v0.3.10). Prominent show() examples added to teach proper string conversion. All v0.3.9 features included. Testing hypothesis: Emphasizing show() will reduce syntax errors and improve AILANG success rates from 0% baseline.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.15": {
       "file": "prompts/v0.3.15.md",
@@ -84,7 +126,13 @@
         "latest",
         "vision-aligned"
       ],
-      "notes": "MAJOR upgrade addressing vision benchmark failures: 1) Effect system docs (~200 lines), 2) State threading patterns (~80 lines), 3) Canonical list operations (~120 lines). Targets: Effect 6%\u219270%, State 0%\u219260%, Canonical 0%\u219270%. Expected: 36.5%\u219270% AILANG success."
+      "notes": "MAJOR upgrade addressing vision benchmark failures: 1) Effect system docs (~200 lines), 2) State threading patterns (~80 lines), 3) Canonical list operations (~120 lines). Targets: Effect 6%\u219270%, State 0%\u219260%, Canonical 0%\u219270%. Expected: 36.5%\u219270% AILANG success.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.6": {
       "file": "prompts/v0.3.6.md",
@@ -95,7 +143,13 @@
         "experimental",
         "failed"
       ],
-      "notes": "FAILED: Two iterations showed 10% worse performance than v0.3.5. Longer prompts with anti-patterns and import checklists caused information overload. Conclusion: Prompt engineering is counter-productive; language changes (auto-import, record update syntax) are the solution."
+      "notes": "FAILED: Two iterations showed 10% worse performance than v0.3.5. Longer prompts with anti-patterns and import checklists caused information overload. Conclusion: Prompt engineering is counter-productive; language changes (auto-import, record update syntax) are the solution.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.2.0": {
       "file": "prompts/v0.2.0.md",
@@ -105,7 +159,13 @@
       "tags": [
         "historical"
       ],
-      "notes": "Pre-records, pre-recursion, pre-blocks. Kept for historical comparison."
+      "notes": "Pre-records, pre-recursion, pre-blocks. Kept for historical comparison.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "python": {
       "file": "prompts/python.md",
@@ -116,7 +176,13 @@
         "control",
         "python"
       ],
-      "notes": "Used for baseline comparison - how well do models do with Python vs AILANG?"
+      "notes": "Used for baseline comparison - how well do models do with Python vs AILANG?",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 6537,
+        "evidence_example": "eval_results/baselines/v0.11.2/agent/adt_option_python_claude-sonnet-4-5_1776087516.json"
+      }
     },
     "v0.3.16": {
       "file": "prompts/v0.3.16.md",
@@ -128,7 +194,13 @@
         "latest",
         "ai-first"
       ],
-      "notes": "Entry-module prelude: print builtin automatically available in modules with 'export func main' (no import needed). Libraries still explicit. AI-First DX: minimize syntactic entropy for benchmarks while keeping libraries explicit. All v0.3.15 features included."
+      "notes": "Entry-module prelude: print builtin automatically available in modules with 'export func main' (no import needed). Libraries still explicit. AI-First DX: minimize syntactic entropy for benchmarks while keeping libraries explicit. All v0.3.15 features included.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.17": {
       "file": "prompts/v0.3.17.md",
@@ -138,7 +210,13 @@
       "tags": [
         "production"
       ],
-      "notes": "Fix httpRequest documentation: remove false HTTP headers limitation and add httpRequest() examples"
+      "notes": "Fix httpRequest documentation: remove false HTTP headers limitation and add httpRequest() examples",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.18": {
       "file": "prompts/v0.3.18.md",
@@ -149,7 +227,13 @@
         "experimental",
         "failed"
       ],
-      "notes": "FAILED: Over-optimization (-59% tokens) collapsed success rate to 4.8%. Removed too many examples and context. See .claude/skills/prompt-manager/OPTIMIZATION_FAILURE_ANALYSIS.md"
+      "notes": "FAILED: Over-optimization (-59% tokens) collapsed success rate to 4.8%. Removed too many examples and context. See .claude/skills/prompt-manager/OPTIMIZATION_FAILURE_ANALYSIS.md",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.19": {
       "file": "prompts/v0.3.19.md",
@@ -161,7 +245,13 @@
         "latest",
         "optimized"
       ],
-      "notes": "SUCCESS: Phase 1 optimization (-2.5% tokens, 5189\u21925058 words). Added quick reference, condensed verbose sections, kept all 64 examples. Validated: 41.9% AILANG success rate. Conservative incremental approach proven effective."
+      "notes": "SUCCESS: Phase 1 optimization (-2.5% tokens, 5189\u21925058 words). Added quick reference, condensed verbose sections, kept all 64 examples. Validated: 41.9% AILANG success rate. Conservative incremental approach proven effective.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.20": {
       "file": "prompts/v0.3.20.md",
@@ -173,7 +263,13 @@
         "testing",
         "broken"
       ],
-      "notes": "BROKEN: Incorrect pattern matching syntax in Quick Reference (pipes before patterns). Caused -4.8% regression (40.0% \u2192 35.2%). Fixed in v0.3.21. Added testing features from v0.3.20: unit tests (test \"name\" = expr) and property-based tests (property \"name\" (x: type) = expr). Includes 100-case generation with automatic shrinking. Size: 5262 words (+4% from v0.3.19). Run with: ailang test file.ail"
+      "notes": "BROKEN: Incorrect pattern matching syntax in Quick Reference (pipes before patterns). Caused -4.8% regression (40.0% \u2192 35.2%). Fixed in v0.3.21. Added testing features from v0.3.20: unit tests (test \"name\" = expr) and property-based tests (property \"name\" (x: type) = expr). Includes 100-case generation with automatic shrinking. Size: 5262 words (+4% from v0.3.19). Run with: ailang test file.ail",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.21": {
       "file": "prompts/v0.3.21.md",
@@ -185,7 +281,13 @@
         "testing",
         "hotfix"
       ],
-      "notes": "CRITICAL HOTFIX: Fixed 3 syntax errors in v0.3.20: (1) Pattern matching (no pipes before patterns, commas between arms), (2) Import syntax (no quotes on module paths), (3) Tuple destructuring (use `match tuple { (x, y) => ... }` NOT `let (x, y) = tuple`). State threading examples corrected. All v0.3.20 testing features included. Expected: AILANG success 35.2% \u2192 40.0%+"
+      "notes": "CRITICAL HOTFIX: Fixed 3 syntax errors in v0.3.20: (1) Pattern matching (no pipes before patterns, commas between arms), (2) Import syntax (no quotes on module paths), (3) Tuple destructuring (use `match tuple { (x, y) => ... }` NOT `let (x, y) = tuple`). State threading examples corrected. All v0.3.20 testing features included. Expected: AILANG success 35.2% \u2192 40.0%+",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 210,
+        "evidence_example": "eval_results/baselines/v0.3.21-with-repair/adt_option_ailang_claude-haiku-4-5_1761578492.json"
+      }
     },
     "v0.3.22": {
       "file": "prompts/v0.3.22.md",
@@ -197,7 +299,13 @@
         "latest",
         "m-eval-http-fix"
       ],
-      "notes": "M-EVAL-HTTP-FIX Milestone 2: (1) Enhanced parser error messages for JavaScript/Python patterns (PAR014: const keyword, PAR015: bare assignment), (2) HTTP POST example moved from line 218 \u2192 line 107 (-51% position). Target: Reduce api_call_json failures from 75% by guiding AIs toward correct AILANG syntax earlier in prompt. All v0.3.21 testing features included."
+      "notes": "M-EVAL-HTTP-FIX Milestone 2: (1) Enhanced parser error messages for JavaScript/Python patterns (PAR014: const keyword, PAR015: bare assignment), (2) HTTP POST example moved from line 218 \u2192 line 107 (-51% position). Target: Reduce api_call_json failures from 75% by guiding AIs toward correct AILANG syntax earlier in prompt. All v0.3.21 testing features included.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.3.23": {
       "file": "prompts/v0.3.23.md",
@@ -208,7 +316,13 @@
         "production",
         "latest"
       ],
-      "notes": "Add note: print() auto-adds newline, don't concatenate \\n"
+      "notes": "Add note: print() auto-adds newline, don't concatenate \\n",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 32,
+        "evidence_example": "eval_results/baselines/v0.3.23/agent/fizzbuzz_ailang_claude-haiku-4-5_1761670751.json"
+      }
     },
     "v0.3.24": {
       "file": "prompts/v0.3.24.md",
@@ -219,7 +333,13 @@
         "production",
         "latest"
       ],
-      "notes": "Add zero-argument function call syntax documentation"
+      "notes": "Add zero-argument function call syntax documentation",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.4.0": {
       "file": "prompts/v0.4.0.md",
@@ -229,7 +349,13 @@
       "tags": [
         "production"
       ],
-      "notes": "Add Env effect, Net effect, and v0.4.0 features"
+      "notes": "Add Env effect, Net effect, and v0.4.0 features",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 38,
+        "evidence_example": "eval_results/baselines/v0.4.0/agent/deterministic_list_transform_ailang_claude-haiku-4-5_1761990967.json"
+      }
     },
     "v0.4.1": {
       "file": "prompts/v0.4.1.md",
@@ -240,7 +366,13 @@
         "production",
         "latest"
       ],
-      "notes": "Added syntactic sugar documentation: S-CONS (:: cons operator, expressions only), S-ARROWTYPE (-> function types), S-CALL0 (f() zero-arg calls, NOW WORKS at statement level!). IMPORTANT: :: sugar only works in expressions, NOT in patterns - use ::(h, t) in match. Includes --strict-syntax flag documentation. M-S-CALL0: Completed statement-level parsing for f() calls."
+      "notes": "Added syntactic sugar documentation: S-CONS (:: cons operator, expressions only), S-ARROWTYPE (-> function types), S-CALL0 (f() zero-arg calls, NOW WORKS at statement level!). IMPORTANT: :: sugar only works in expressions, NOT in patterns - use ::(h, t) in match. Includes --strict-syntax flag documentation. M-S-CALL0: Completed statement-level parsing for f() calls.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 76,
+        "evidence_example": "eval_results/baselines/v0.4.1/agent/deterministic_list_transform_ailang_claude-haiku-4-5_1762109126.json"
+      }
     },
     "v0.4.2": {
       "file": "prompts/v0.4.2.md",
@@ -251,7 +383,13 @@
         "production",
         "latest"
       ],
-      "notes": "Fix stdlib docs + remove Cons reference + clarify S-CONS limitation"
+      "notes": "Fix stdlib docs + remove Cons reference + clarify S-CONS limitation",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 38,
+        "evidence_example": "eval_results/baselines/v0.4.3/agent/deterministic_list_transform_ailang_claude-haiku-4-5_1762447321.json"
+      }
     },
     "v0.4.4": {
       "file": "prompts/v0.4.4.md",
@@ -262,7 +400,13 @@
         "production",
         "latest"
       ],
-      "notes": "Add S-CONS pattern sugar (x :: xs syntax)"
+      "notes": "Add S-CONS pattern sugar (x :: xs syntax)",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 38,
+        "evidence_example": "eval_results/baselines/v0.4.4/agent/deterministic_list_transform_ailang_claude-haiku-4-5_1763061148.json"
+      }
     },
     "v0.4.5": {
       "file": "prompts/v0.4.5.md",
@@ -273,7 +417,13 @@
         "production",
         "latest"
       ],
-      "notes": "Fix string concatenation (++) operator type inference"
+      "notes": "Fix string concatenation (++) operator type inference",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 38,
+        "evidence_example": "eval_results/baselines/v0.4.5/agent/deterministic_list_transform_ailang_claude-haiku-4-5_1763304852.json"
+      }
     },
     "v0.4.6": {
       "file": "prompts/v0.4.6.md",
@@ -284,7 +434,13 @@
         "production",
         "latest"
       ],
-      "notes": "Add teaching improvements: What NOT to have, multi-module, JSON, operators, effects emphasis, HTTP/Net capabilities"
+      "notes": "Add teaching improvements: What NOT to have, multi-module, JSON, operators, effects emphasis, HTTP/Net capabilities",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 38,
+        "evidence_example": "eval_results/baselines/v0.4.6/agent/deterministic_list_transform_ailang_claude-haiku-4-5_1763581870.json"
+      }
     },
     "v0.4.7": {
       "file": "prompts/v0.4.7.md",
@@ -295,7 +451,13 @@
         "production",
         "latest"
       ],
-      "notes": "Add inline tests documentation with cross-function deps (M-TESTING-DEPS)"
+      "notes": "Add inline tests documentation with cross-function deps (M-TESTING-DEPS)",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 62,
+        "evidence_example": "eval_results/baselines/v0.4.7/agent/deterministic_list_transform_ailang_claude-haiku-4-5_1764275585.json"
+      }
     },
     "v0.4.8": {
       "file": "prompts/v0.4.8.md",
@@ -306,7 +468,13 @@
         "production",
         "latest"
       ],
-      "notes": "Add mandatory template, stronger structure emphasis"
+      "notes": "Add mandatory template, stronger structure emphasis",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 138,
+        "evidence_example": "eval_results/baselines/v0.4.8/agent/adt_option_ailang_claude-haiku-4-5_1764418074.json"
+      }
     },
     "v0.4.10": {
       "file": "prompts/v0.4.10.md",
@@ -317,7 +485,13 @@
         "production",
         "latest"
       ],
-      "notes": "Add Array type with O(1) indexed access"
+      "notes": "Add Array type with O(1) indexed access",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.5.0": {
       "file": "prompts/v0.5.0.md",
@@ -328,7 +502,13 @@
         "production",
         "latest"
       ],
-      "notes": "Add AI effect for multi-provider AI oracle"
+      "notes": "Add AI effect for multi-provider AI oracle",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 138,
+        "evidence_example": "eval_results/baselines/v0.5.0/agent/adt_option_ailang_claude-haiku-4-5_1764697665.json"
+      }
     },
     "v0.5.2": {
       "file": "prompts/v0.5.2.md",
@@ -339,7 +519,13 @@
         "production",
         "latest"
       ],
-      "notes": "Add relaxed module matching (--relax-modules flag, AILANG_RELAX_MODULES env var)"
+      "notes": "Add relaxed module matching (--relax-modules flag, AILANG_RELAX_MODULES env var)",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.5.10": {
       "file": "prompts/v0.5.10.md",
@@ -350,7 +536,13 @@
         "production",
         "optimized"
       ],
-      "notes": "REWRITE v2: Added back critical sections lost in streamlining. Includes negative examples (\u274c WRONG / \u2705 RIGHT) for let/in scoping and curried function calls. Key sections: Block vs expression let bindings, curried function chaining, Option patterns, ADT state machine. 2,204 words (71% smaller than v0.4.4)."
+      "notes": "REWRITE v2: Added back critical sections lost in streamlining. Includes negative examples (\u274c WRONG / \u2705 RIGHT) for let/in scoping and curried function calls. Key sections: Block vs expression let bindings, curried function chaining, Option patterns, ADT state machine. 2,204 words (71% smaller than v0.4.4).",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.5.11": {
       "file": "prompts/v0.5.11.md",
@@ -362,7 +554,13 @@
         "semantic-caching",
         "embeddings"
       ],
-      "notes": "Major additions: (1) Semantic Caching Doctrine - SharedMem/SharedIndex as cognitive working memory, namespace conventions, canonical patterns (cache-or-compute, deduplication, multi-agent CAS). (2) Embeddings Doctrine - when/what/how to use neural embeddings for paraphrase detection, hybrid retrieval pattern. All v0.5.10 features included."
+      "notes": "Major additions: (1) Semantic Caching Doctrine - SharedMem/SharedIndex as cognitive working memory, namespace conventions, canonical patterns (cache-or-compute, deduplication, multi-agent CAS). (2) Embeddings Doctrine - when/what/how to use neural embeddings for paraphrase detection, hybrid retrieval pattern. All v0.5.10 features included.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.6.2": {
       "file": "prompts/v0.6.2.md",
@@ -374,7 +572,13 @@
         "record-patterns",
         "deriving-eq"
       ],
-      "notes": "Record pattern matching for destructuring records in match expressions. Syntax: {name}, {name: var}, {name, age}, {user: {name}} for nested patterns, {name, ...} for rest patterns. M-DX19: Auto-derive Eq for ADT types using `type Color = Red | Green | Blue deriving (Eq)` syntax. Enables == and != operators via structural equality comparison. All v0.5.11 features included."
+      "notes": "Record pattern matching for destructuring records in match expressions. Syntax: {name}, {name: var}, {name, age}, {user: {name}} for nested patterns, {name, ...} for rest patterns. M-DX19: Auto-derive Eq for ADT types using `type Color = Red | Green | Blue deriving (Eq)` syntax. Enables == and != operators via structural equality comparison. All v0.5.11 features included.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 114,
+        "evidence_example": "eval_results/baselines/v0.6.2/agent/adt_option_ailang_claude-haiku-4-5_1767366188.json"
+      }
     },
     "v0.6.3": {
       "file": "prompts/v0.6.3.md",
@@ -385,7 +589,13 @@
         "production",
         "stdlib-docs"
       ],
-      "notes": "AGENT DISCOVERABILITY: Added explicit documentation for std/math (floatToInt, intToFloat, floor, ceil, round) and expanded std/string (substring, contains, stringToInt, intToStr, floatToStr). Analysis of agent transcripts showed models were implementing their own broken versions of functions that already exist in stdlib but weren't documented in the prompt."
+      "notes": "AGENT DISCOVERABILITY: Added explicit documentation for std/math (floatToInt, intToFloat, floor, ceil, round) and expanded std/string (substring, contains, stringToInt, intToStr, floatToStr). Analysis of agent transcripts showed models were implementing their own broken versions of functions that already exist in stdlib but weren't documented in the prompt.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.6.4": {
       "file": "prompts/v0.6.4.md",
@@ -396,7 +606,13 @@
         "production",
         "json-helpers"
       ],
-      "notes": "JSON CONVENIENCE FUNCTIONS: Added getString, getNumber, getInt, getBool, getArray, getObject to std/json.ail. These combine get()+asX() to reduce nested Option matching from 4 levels to 2. Also added prominent import reminder warning to reduce 'forgot to import' errors. Target: json_parse benchmark turns <25 (down from 47 in v0.6.3)."
+      "notes": "JSON CONVENIENCE FUNCTIONS: Added getString, getNumber, getInt, getBool, getArray, getObject to std/json.ail. These combine get()+asX() to reduce nested Option matching from 4 levels to 2. Also added prominent import reminder warning to reduce 'forgot to import' errors. Target: json_parse benchmark turns <25 (down from 47 in v0.6.3).",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.6.5": {
       "file": "prompts/v0.6.5.md",
@@ -410,7 +626,13 @@
         "prelude-fix",
         "language-gaps"
       ],
-      "notes": "PRELUDE FIX: println is now in prelude (no import needed), print (no newline) requires import std/io (print). STDLIB GAPS (M-STDLIB-GAPS): Added std/list functions (nth, last, any, findIndex), std/string join and chars, JSON array extraction. LANGUAGE GAP WARNINGS (from agent analysis): Added letrec for recursive lambdas section, type annotations for HOFs section, expanded 'What AILANG Does NOT Have' table (tuple let-destructuring, lambda tuple syntax outside foldl, nested func syntax)."
+      "notes": "PRELUDE FIX: println is now in prelude (no import needed), print (no newline) requires import std/io (print). STDLIB GAPS (M-STDLIB-GAPS): Added std/list functions (nth, last, any, findIndex), std/string join and chars, JSON array extraction. LANGUAGE GAP WARNINGS (from agent analysis): Added letrec for recursive lambdas section, type annotations for HOFs section, expanded 'What AILANG Does NOT Have' table (tuple let-destructuring, lambda tuple syntax outside foldl, nested func syntax).",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 1,
+        "evidence_example": "eval_results/baselines/v0.6.5/agent/agent/config_file_parser_ailang_claude-haiku-4-5_1767632692.json"
+      }
     },
     "v0.6.6": {
       "file": "prompts/v0.6.6.md",
@@ -422,7 +644,13 @@
         "row-polymorphism",
         "width-subtyping"
       ],
-      "notes": "RECORD WIDTH SUBTYPING (M-GAP4): Added open record types for functions that accept extra fields. Syntax: {field: T | r} with explicit row variable, or {field: T, ...} sugar with fresh variable. Exact records (default) reject extra fields. Open records enable generic field extractors and flexible APIs."
+      "notes": "RECORD WIDTH SUBTYPING (M-GAP4): Added open record types for functions that accept extra fields. Syntax: {field: T | r} with explicit row variable, or {field: T, ...} sugar with fresh variable. Exact records (default) reject extra fields. Open records enable generic field extractors and flexible APIs.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 92,
+        "evidence_example": "eval_results/baselines/v0.7.0/agent/adt_option_ailang_claude-sonnet-4-5_1769088989.json"
+      }
     },
     "v0.7.0": {
       "file": "prompts/v0.7.0.md",
@@ -434,7 +662,13 @@
         "latest",
         "gap-analysis"
       ],
-      "notes": "Gap analysis integration from v0.6.2\u2192v0.7.0 eval comparison: (1) Strengthened block brace requirements with explicit examples, (2) Added import checklist reminder, (3) Enhanced JSON patterns with getString/getNumber examples. Target: Reduce AILANG eval failures from import errors and missing braces."
+      "notes": "Gap analysis integration from v0.6.2\u2192v0.7.0 eval comparison: (1) Strengthened block brace requirements with explicit examples, (2) Added import checklist reminder, (3) Enhanced JSON patterns with getString/getNumber examples. Target: Reduce AILANG eval failures from import errors and missing braces.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.7.3": {
       "file": "prompts/v0.7.3.md",
@@ -446,7 +680,13 @@
         "effectful-combinators",
         "structured-ai-output"
       ],
-      "notes": "Structured AI output: callJson (schema-enforced), callJsonSimple (no schema) for validated JSON responses from AI providers. All 4 providers wired (Gemini, OpenAI, Anthropic, Ollama). Effectful list combinators: mapE, filterE, foldlE, flatMapE, forEachE for effect-polymorphic HOFs. Pure flatMap added. Effect row variable syntax enabled."
+      "notes": "Structured AI output: callJson (schema-enforced), callJsonSimple (no schema) for validated JSON responses from AI providers. All 4 providers wired (Gemini, OpenAI, Anthropic, Ollama). Effectful list combinators: mapE, filterE, foldlE, flatMapE, forEachE for effect-polymorphic HOFs. Pure flatMap added. Effect row variable syntax enabled.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.7.4": {
       "file": "prompts/v0.7.4.md",
@@ -459,7 +699,13 @@
         "smt-verification",
         "contracts"
       ],
-      "notes": "Static contract verification: ailang verify command uses Z3 to mathematically prove requires/ensures contracts hold for ALL inputs. Covers decidable fragment (int/bool/enum ADTs, arithmetic, comparison, if/let/match). Shows counterexamples when violations found. Flags: --verbose (SMT-LIB), --json (machine-readable), --strict (fail on skipped). Replaced old --experimental-binop-shim requirement."
+      "notes": "Static contract verification: ailang verify command uses Z3 to mathematically prove requires/ensures contracts hold for ALL inputs. Covers decidable fragment (int/bool/enum ADTs, arithmetic, comparison, if/let/match). Shows counterexamples when violations found. Flags: --verbose (SMT-LIB), --json (machine-readable), --strict (fail on skipped). Replaced old --experimental-binop-shim requirement.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 61,
+        "evidence_example": "eval_results/baselines/v0.8.0/agent/adt_option_ailang_claude-sonnet-4-5_1771081134.json"
+      }
     },
     "v0.7.4-compact": {
       "file": "prompts/v0.7.4-compact.md",
@@ -470,7 +716,13 @@
         "production",
         "compact"
       ],
-      "notes": "Conservative 71% size reduction. Keeps: type system table, effect syntax, module syntax, contract syntax, critical gotchas. Removes: extended examples, design rationale, historical notes. For full reference: ailang prompt"
+      "notes": "Conservative 71% size reduction. Keeps: type system table, effect syntax, module syntax, contract syntax, critical gotchas. Removes: extended examples, design rationale, historical notes. For full reference: ailang prompt",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.8.0": {
       "file": "prompts/v0.8.0.md",
@@ -480,7 +732,13 @@
       "tags": [
         "production"
       ],
-      "notes": "Add getArgs/stdin docs, fix CLI args benchmark gap"
+      "notes": "Add getArgs/stdin docs, fix CLI args benchmark gap",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.8.1": {
       "file": "prompts/v0.8.1.md",
@@ -491,7 +749,13 @@
         "production",
         "latest"
       ],
-      "notes": "Contracts section rewritten with agent-centric framing (specify-implement-verify workflow). Updated all examples to use stdlib imports (std/string, std/list) instead of raw builtins. Moved contracts before Testing to reflect importance. Documents stdlib transparency in Z3 verification."
+      "notes": "Contracts section rewritten with agent-centric framing (specify-implement-verify workflow). Updated all examples to use stdlib imports (std/string, std/list) instead of raw builtins. Moved contracts before Testing to reflect importance. Documents stdlib transparency in Z3 verification.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.8.2": {
       "file": "prompts/v0.8.2.md",
@@ -502,7 +766,13 @@
         "production",
         "streaming-dx"
       ],
-      "notes": "M-STREAM-DX sprint: (1) Added zipWith to std/list docs, (2) Added std/bytes section (fromString, toString, toBase64, fromBase64, slice), (3) Added std/stream section (connect, transmit, transmitBinary, ssePost, withSSE, SSEData events), (4) Added newtype record field access docs (single-constructor ADT auto-unwrap), (5) Added show recommendation over intToStr/floatToStr for simple cases."
+      "notes": "M-STREAM-DX sprint: (1) Added zipWith to std/list docs, (2) Added std/bytes section (fromString, toString, toBase64, fromBase64, slice), (3) Added std/stream section (connect, transmit, transmitBinary, ssePost, withSSE, SSEData events), (4) Added newtype record field access docs (single-constructor ADT auto-unwrap), (5) Added show recommendation over intToStr/floatToStr for simple cases.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.9.0": {
       "file": "prompts/v0.9.0.md",
@@ -514,7 +784,13 @@
         "latest",
         "streaming"
       ],
-      "notes": "M-ASYNC-IO Phase 1+2: (1) Multi-source multiplexing (selectEvents, sourceOfConn, asyncReadStdinLines), (2) Subprocess stdout streaming (asyncExecProcess with SourceBytes events), (3) Correct StreamEvent ADT (11 variants including SourceText, SourceBytes), (4) Fixed return types to StreamErrorKind. All v0.8.2 features included."
+      "notes": "M-ASYNC-IO Phase 1+2: (1) Multi-source multiplexing (selectEvents, sourceOfConn, asyncReadStdinLines), (2) Subprocess stdout streaming (asyncExecProcess with SourceBytes events), (3) Correct StreamEvent ADT (11 variants including SourceText, SourceBytes), (4) Fixed return types to StreamErrorKind. All v0.8.2 features included.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 57,
+        "evidence_example": "eval_results/baselines/v0.11.2/agent/adt_option_ailang_claude-sonnet-4-5_1776087513.json"
+      }
     },
     "v0.11.4": {
       "file": "prompts/v0.11.4.md",
@@ -524,7 +800,13 @@
       "tags": [
         "production"
       ],
-      "notes": "Add v0.10.x + v0.11.x: short-circuit semantics, Map/iter/jwt/trace stdlib, parseFoldStep, bitwise ops, new string builtins, exit(), polymorphic comparison lambdas"
+      "notes": "Add v0.10.x + v0.11.x: short-circuit semantics, Map/iter/jwt/trace stdlib, parseFoldStep, bitwise ops, new string builtins, exit(), polymorphic comparison lambdas",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 62,
+        "evidence_example": "eval_results/baselines/v0.12.0/agent/adt_option_ailang_claude-sonnet-4-5_1776436817.json"
+      }
     },
     "v0.12.1": {
       "file": "prompts/v0.12.1.md",
@@ -536,7 +818,13 @@
         "latest",
         "string-interpolation"
       ],
-      "notes": "M-CONCAT-DISAMBIG Phase 1: Introduces \"${expr}\" interpolation as the idiomatic way to build strings. Desugars to concat_String(..., show(expr), ...) chains via Show type-class dispatch (show_String is identity). Supports nested braces, arbitrary expressions, and \\${ escape. ++ still works for strings today but will be restricted to lists only in v0.13.0 (Phase 2)."
+      "notes": "M-CONCAT-DISAMBIG Phase 1: Introduces \"${expr}\" interpolation as the idiomatic way to build strings. Desugars to concat_String(..., show(expr), ...) chains via Show type-class dispatch (show_String is identity). Supports nested braces, arbitrary expressions, and \\${ escape. ++ still works for strings today but will be restricted to lists only in v0.13.0 (Phase 2).",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "banked",
+        "evidence_count": 51,
+        "evidence_example": "eval_results/baselines/v0.13.0/agent/api_call_json_ailang_claude-sonnet-4-5_1776772769.json"
+      }
     },
     "go": {
       "file": "prompts/go.md",
@@ -547,7 +835,13 @@
         "control",
         "go"
       ],
-      "notes": "Used for Go vs AILANG baseline comparison in multi-language evals"
+      "notes": "Used for Go vs AILANG baseline comparison in multi-language evals",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "javascript": {
       "file": "prompts/javascript.md",
@@ -558,7 +852,13 @@
         "control",
         "javascript"
       ],
-      "notes": "Used for JavaScript vs AILANG baseline comparison in multi-language evals"
+      "notes": "Used for JavaScript vs AILANG baseline comparison in multi-language evals",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "moonbit": {
       "file": "prompts/moonbit.md",
@@ -570,11 +870,17 @@
         "moonbit",
         "three-camps"
       ],
-      "notes": "Closest ML-family peer to AILANG in the three-camps survey (verification camp via constrained sampling, MoonBitlang ICSE 2024). Targets apples-to-apples FP comparison on smoke + selected gap benchmarks. Built single-file `moon run` runner (no project scaffold needed)."
+      "notes": "Closest ML-family peer to AILANG in the three-camps survey (verification camp via constrained sampling, MoonBitlang ICSE 2024). Targets apples-to-apples FP comparison on smoke + selected gap benchmarks. Built single-file `moon run` runner (no project scaffold needed).",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "aver": {
       "file": "prompts/aver.md",
-      "hash": "190bf4244a00bb0605d41ac01d4de415a6131a3a961aa6bca1689b23bc4d521d",
+      "hash": "1f5c9654e39c411bcbedc35446ffa96c1d6dc8d7b9dd0fbec01b95ecf35f0157",
       "description": "Aver language teaching prompt for eval harness (M-THREE-CAMPS Verification-camp peer)",
       "created": "2026-05-21",
       "tags": [
@@ -583,7 +889,13 @@
         "three-camps",
         "verification"
       ],
-      "notes": "Verification-camp peer with verify blocks, decision blocks (ADRs in code), Lean 4 proof export. Indentation-based, match-only branching, namespaced constructors. Installed via `cargo install aver-lang` (aver-lang 0.21.0 verified). Single-file `aver run` mode."
+      "notes": "Verification-camp peer with verify blocks, decision blocks (ADRs in code), Lean 4 proof export. Indentation-based, match-only branching, namespaced constructors. Installed via `cargo install aver-lang` (aver-lang 0.21.0 verified). Single-file `aver run` mode.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.16.0": {
       "file": "prompts/v0.16.0.md",
@@ -596,7 +908,13 @@
         "labels",
         "m-taint-types"
       ],
-      "notes": "Adds Phase 1+2 IFC label syntax to the AILANG teaching prompt. Includes the inbox-injection worked example and the DECLASS rule. AI modes section added in M-AI-EFFECT-MODES (v0.15.0)."
+      "notes": "Adds Phase 1+2 IFC label syntax to the AILANG teaching prompt. Includes the inbox-injection worked example and the DECLASS rule. AI modes section added in M-AI-EFFECT-MODES (v0.15.0).",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.16.1": {
       "file": "prompts/v0.16.1.md",
@@ -607,7 +925,13 @@
         "production",
         "stdlib-coverage"
       ],
-      "notes": "Additive patch over v0.16.0 (no syntax changes). Closes ~50 stdlib documentation gaps surfaced by M-VERA-BENCH audit. Worst pre-fix offenders: std/clock (0/2 documented), std/datetime (1/22), std/math trig family (0/10), std/option helpers (3/6), std/result helpers (2/6). Token budget impact: ~600 extra tokens. Same hash discipline as prior versions."
+      "notes": "Additive patch over v0.16.0 (no syntax changes). Closes ~50 stdlib documentation gaps surfaced by M-VERA-BENCH audit. Worst pre-fix offenders: std/clock (0/2 documented), std/datetime (1/22), std/math trig family (0/10), std/option helpers (3/6), std/result helpers (2/6). Token budget impact: ~600 extra tokens. Same hash discipline as prior versions.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.16.2": {
       "file": "prompts/v0.16.2.md",
@@ -619,7 +943,13 @@
         "latest",
         "output-discipline"
       ],
-      "notes": "Active from v0.26.0 benchmark cycle. Additive patch over v0.16.1 (no syntax changes): adds an Output Discipline section instructing exact byte-for-byte stdout (no labels/prefixes/status lines). Validated by A/B on claude-opus-4-8 standard (14/24 -> 19/24; type_unify 1/3->3/3, mini_interpreter 2/3->3/3, csv_to_json 0/3->2/3; zero control regressions). Removes a verbosity grading tax that disproportionately hit frontier models. Full multi-model re-baseline deferred to the next release."
+      "notes": "Active from v0.26.0 benchmark cycle. Additive patch over v0.16.1 (no syntax changes): adds an Output Discipline section instructing exact byte-for-byte stdout (no labels/prefixes/status lines). Validated by A/B on claude-opus-4-8 standard (14/24 -> 19/24; type_unify 1/3->3/3, mini_interpreter 2/3->3/3, csv_to_json 0/3->2/3; zero control regressions). Removes a verbosity grading tax that disproportionately hit frontier models. Full multi-model re-baseline deferred to the next release.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.16.3": {
       "file": "prompts/v0.16.3.md",
@@ -630,7 +960,13 @@
         "production",
         "fmt-discoverability"
       ],
-      "notes": "Additive patch over v0.16.2 (no syntax changes, byte-identical prefix): appends a ~6-line Formatting section so agents can discover `ailang fmt`. Command-usage only (no code snippet) to avoid an `ailang check` verification surface. Activated as part of the fmt adoption rollout; v0.16.2 remains served byte-identical for pinned eval baselines."
+      "notes": "Additive patch over v0.16.2 (no syntax changes, byte-identical prefix): appends a ~6-line Formatting section so agents can discover `ailang fmt`. Command-usage only (no code snippet) to avoid an `ailang check` verification surface. Activated as part of the fmt adoption rollout; v0.16.2 remains served byte-identical for pinned eval baselines.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.16.4": {
       "file": "prompts/v0.16.4.md",
@@ -641,7 +977,13 @@
         "production",
         "dialect-alignment"
       ],
-      "notes": "Two fixes, both verified against the toolchain rather than assumed. (1) v0.16.3 taught that `letrec` with a `= ...` body is a PARSE ERROR; it type-checks AND runs correctly (verified with `ailang check` + `ailang run`) -- the claim went stale when M-SYNTAX-AI-FORGIVING R1 made an equation body a `;`-separated statement sequence. Teaching models to avoid valid syntax is the same failure class as `ailang fmt` contradicting the prompt. The section now states both forms work and recommends the block because that is what fmt emits. (2) `List[T]` -> `[T]` in 4 places (1 ailang block, 3 prose): `[T]` is taught 64 times and is what fmt emits, so `List[T]` was a spelling fmt would rewrite. Both parse to the identical TypeApp. v0.16.3 remains served byte-identical for pinned eval baselines."
+      "notes": "Two fixes, both verified against the toolchain rather than assumed. (1) v0.16.3 taught that `letrec` with a `= ...` body is a PARSE ERROR; it type-checks AND runs correctly (verified with `ailang check` + `ailang run`) -- the claim went stale when M-SYNTAX-AI-FORGIVING R1 made an equation body a `;`-separated statement sequence. Teaching models to avoid valid syntax is the same failure class as `ailang fmt` contradicting the prompt. The section now states both forms work and recommends the block because that is what fmt emits. (2) `List[T]` -> `[T]` in 4 places (1 ailang block, 3 prose): `[T]` is taught 64 times and is what fmt emits, so `List[T]` was a spelling fmt would rewrite. Both parse to the identical TypeApp. v0.16.3 remains served byte-identical for pinned eval baselines.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.16.5": {
       "file": "prompts/v0.16.5.md",
@@ -653,7 +995,13 @@
         "latest",
         "stdlib-discoverability"
       ],
-      "notes": "Prompted by issue #609, where a field agent reported a string's raw bytes were 'unreachable from AILANG' and asked for toInts. The reach claim was FALSE -- byteAt has shipped since v0.21.0 and was already taught in the bytes function list, and byteAt+length transcodes the reporter's exact Latin-1 payload correctly at HEAD (verified with ailang run before any change). What was actually missing was discoverability and shape. The common-imports line read `import std/bytes (fromString, toString, toBase64, fromBase64, length, slice)` -- not one byte-level function -- so an agent copying that canonical line saw a bytes module with no way into the bytes. The toInts entry also states explicitly that charCode/string indexing return U+FFFD for non-UTF-8 bytes and that fromString+toInts is the way through, because that specific wrong turn is what the report documented. v0.16.4 remains served byte-identical for pinned eval baselines."
+      "notes": "Prompted by issue #609, where a field agent reported a string's raw bytes were 'unreachable from AILANG' and asked for toInts. The reach claim was FALSE -- byteAt has shipped since v0.21.0 and was already taught in the bytes function list, and byteAt+length transcodes the reporter's exact Latin-1 payload correctly at HEAD (verified with ailang run before any change). What was actually missing was discoverability and shape. The common-imports line read `import std/bytes (fromString, toString, toBase64, fromBase64, length, slice)` -- not one byte-level function -- so an agent copying that canonical line saw a bytes module with no way into the bytes. The toInts entry also states explicitly that charCode/string indexing return U+FFFD for non-UTF-8 bytes and that fromString+toInts is the way through, because that specific wrong turn is what the report documented. v0.16.4 remains served byte-identical for pinned eval baselines.",
+      "frozen": {
+        "at": "2026-08-27",
+        "reason": "legacy",
+        "evidence_count": 0,
+        "evidence_example": ""
+      }
     },
     "v0.16.6": {
       "file": "prompts/v0.16.6.md",


### PR DESCRIPTION
Implements **milestone M1** of `m-prompt-version-freeze-on-first-bank`, the design doc for decision **D-41(c)** — Mark's ruling on issue 852 (`2026-08-27T07:26:21Z`, verbatim `D41 - C`): *a prompt version is MUTABLE UNTIL FIRST BANKED USE, then frozen.*

## The live defect this repairs

`prompts/versions.json` recorded a **stale hash for `aver`** in both registries, so the loader **failed outright** on it. Controller-verified before and after, same probe:

| | `aver` | `v0.16.6` | `python` | `v0.3.21` |
|---|---|---|---|---|
| before | **LOAD FAILS** (hash mismatch) | OK | OK | OK |
| after | OK | OK | OK | OK |

Whole-registry audit: **58 ok / 1 mismatched → 59 ok / 0 mismatched** (the 58 was the same-scope control). This is the same defect class that opened D-41 in the first place. `aver` has **0** banked baseline rows, so under (c) it is mutable and regenerating its change-detector hash is the authorized repair, not a version bump.

## What M1 ships

- `FrozenMarker` in both loaders, declared twice on purpose — `internal/prompt` must not import `internal/eval_harness` (`langreg` already depends the other way).
- **Two-state enforcement** in `internal/eval_harness/prompt_loader.go`: a frozen version gets a hard invariant plus a teaching error; a never-banked one keeps the change-detector and the `PLACEHOLDER` escape hatch.
- `ailang prompt freeze` / `--migrate` / `--check`, with an order-preserving registry writer.
- Migration marks all 59 versions: **19 banked, 39 legacy, 1 mutable** — the mutable one being `v0.16.6`, the *active* version, which has zero banked uses. Both registries end byte-identical (`933900660f7ab118…`).

M2 (CI gate), M3 (agent-mode hole), M4 (bank-time byte evidence) are planned and deliberately not started.

## Verification

Every gate re-run by the controller **outside the sandbox** — the executor's `rc=1` on `internal/eval_harness` was a sandbox loopback-bind denial, correctly labelled `UNINFORMATIVE` by the executor and `rc=0` (16.952s) outside it.

`gofmt` 0 · `go build` (3 scopes) 0 · `go vet` 0 · `go test ./internal/eval_harness/...` 0 · `go test ./internal/prompt/...` 0 · `make check-file-sizes` 0 · 15 `--- PASS` across the new tests. `go build ./...` is **red at base** on unmodified dev and was disqualified as a gate rather than chased.

**Mutation drill, anchored to the diff.** Both mutants asserted LANDED (sha256) and BUILDS `rc=0` *before* any test result was read, and both restored byte-identical by `cp`:

| mutant | result |
|---|---|
| neuter the frozen enforcement branch (`if false && …`) | exactly **2** FAILs, both frozen-specific |
| drop the `Frozen` field from `internal/prompt.VersionMetadata` (supporting hunk) | that package's **test build** fails — the only possible pin for a pure schema addition; the round-trip test asserts both arms |

## Provenance

Design doc quorum: r1 **blocked** (3 objections), r2 **blocked** (2, with `gemini-3-1-pro` flipping to pass), r3 applied the surviving reviewers' `proposed_fix` texts **verbatim** under the ratified narrow-refinement carve-out. `absent_reviewers: []` in both rounds. Two of the five objections were **refuted by controller measurement** rather than forwarded.

Designer lane `pi:ollama/kimi-k3:cloud` **failed** (`wall_timeout`, 0 files written); fell back to `claude:claude-fable-5` per rotation. Executor `codex:gpt-5.6-sol`; evaluator `sonnet` in its own worktree — generator≠judge holds on both axes.

Refs D-41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
