### PR TITLE
fix(telemetry): register the standard-mode OpenRouter session so its traces resolve to a chain

### DIFF
--- a/changelogs/v0.32-current.md
+++ b/changelogs/v0.32-current.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+### Fixed — standard eval OpenRouter traces resolve to their observatory chain
+
+Standard-mode evaluations now register their OpenRouter `session_id` (the eval chain ID)
+with the observatory session correlation store, allowing broadcast spans to resolve to the
+chain and stage that dispatched them. The telemetry write is best-effort and cannot fail an eval.
+
 ### Added — `std/string` gains total character accessors
 
 `charAt` was the only partial accessor in the stdlib that aborts instead of returning `Option`:

--- a/cmd/ailang/eval_benchmark.go
+++ b/cmd/ailang/eval_benchmark.go
@@ -110,6 +110,7 @@ func runSingleBenchmark(ctx context.Context, model, benchmarkID, lang, condition
 	// wire-identical to before.
 	if evalChain != nil {
 		agent.SetCorrelation(evalChain.ChainID, spec.ID, spec.Difficulty)
+		registerStandardEvalSession(ctx, evalChain, stageID, outputDir)
 	}
 
 	// Get runner with context for full telemetry hierarchy (TRACEPARENT + task ID)
@@ -344,4 +345,19 @@ func runSingleBenchmark(ctx context.Context, model, benchmarkID, lang, condition
 
 	benchSpan.SetStatus(codes.Ok, "benchmark passed")
 	return true, nil
+}
+
+// registerStandardEvalSession makes the OpenRouter session_id resolvable by the
+// observatory receiver. Session registration is telemetry-only and must never
+// prevent an evaluation from running.
+func registerStandardEvalSession(ctx context.Context, evalChain *EvalChainContext, stageID, workspace string) {
+	if evalChain == nil || stageID == "" {
+		return
+	}
+
+	_ = evalChain.Store.UpsertSessionWithCorrelation(ctx, evalChain.ChainID,
+		workspace, "", "eval-standard", &observatory.SessionCorrelation{
+			ChainID: evalChain.ChainID,
+			StageID: stageID,
+		})
 }

--- a/cmd/ailang/eval_benchmark_session_test.go
+++ b/cmd/ailang/eval_benchmark_session_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/observatory"
+)
+
+func TestRegisterStandardEvalSession_ResolvesOpenRouterSessionID(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "observatory.db")
+	store, err := observatory.OpenStore(dbPath)
+	if err != nil {
+		t.Fatalf("open observatory store: %v", err)
+	}
+	defer store.Close()
+
+	chain, err := store.CreateChain(ctx, &observatory.ChainCreateRequest{
+		SourceType:    observatory.ChainSourceEvalSuite,
+		SourceRef:     "standard-session-registration-test",
+		WorkspacePath: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("create eval chain: %v", err)
+	}
+	stage, err := store.CreateStage(ctx, &observatory.StageCreateRequest{
+		ChainID: chain.ID,
+		AgentID: "eval-standard:test-benchmark",
+	})
+	if err != nil {
+		t.Fatalf("create eval stage: %v", err)
+	}
+
+	registerStandardEvalSession(ctx, &EvalChainContext{Store: store, ChainID: chain.ID}, stage.ID, t.TempDir())
+
+	backend, err := observatory.NewSQLiteBackendFromPath(dbPath)
+	if err != nil {
+		t.Fatalf("open observatory resolver backend: %v", err)
+	}
+	defer backend.Close()
+	gotChainID, gotStageID := backend.LookupChainBySessionID(ctx, chain.ID)
+	if gotChainID != chain.ID || gotStageID != stage.ID {
+		t.Fatalf("LookupChainBySessionID(%q) = (%q, %q), want (%q, %q)",
+			chain.ID, gotChainID, gotStageID, chain.ID, stage.ID)
+	}
+}

--- a/cmd/ailang/eval_benchmark_session_wiring_test.go
+++ b/cmd/ailang/eval_benchmark_session_wiring_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// TestRegisterStandardEvalSession_IsWiredIntoDispatch pins the CALL SITE, not the
+// helper.
+//
+// TestRegisterStandardEvalSession_ResolvesOpenRouterSessionID calls
+// registerStandardEvalSession directly, so it proves the writer works and proves
+// nothing about whether anything invokes it. Measured: deleting the call from
+// runSingleBenchmark leaves that test — and the whole cmd/ailang suite — green.
+// That is the same defect this change exists to fix (M-MISSION-LOOP-UNIFIED-TELEMETRY
+// M1 shipped a resolver whose writer was never wired, and passed 5/5 of its own
+// acceptance criteria), so it is worth a gate of its own.
+//
+// runSingleBenchmark needs a live model call and cannot be exercised in a unit
+// test, so the reachable pin is structural: assert the call appears in that
+// function's body.
+func TestRegisterStandardEvalSession_IsWiredIntoDispatch(t *testing.T) {
+	const (
+		file    = "eval_benchmark.go"
+		caller  = "runSingleBenchmark"
+		callee  = "registerStandardEvalSession"
+		control = "SetCorrelation" // known-positive: must be found by the same walk
+	)
+
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, file, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+
+	var body *ast.BlockStmt
+	for _, decl := range parsed.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Name.Name == caller && fn.Body != nil {
+			body = fn.Body
+			break
+		}
+	}
+	if body == nil {
+		t.Fatalf("instrument failure: %s not found in %s", caller, file)
+	}
+
+	calls := map[string]int{}
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch fn := call.Fun.(type) {
+		case *ast.Ident:
+			calls[fn.Name]++
+		case *ast.SelectorExpr:
+			calls[fn.Sel.Name]++
+		}
+		return true
+	})
+
+	// Known-positive control: an empty walk must fail loudly rather than pass.
+	if calls[control] == 0 {
+		t.Fatalf("instrument failure: control %q not called in %s — the walk found nothing", control, caller)
+	}
+
+	if calls[callee] == 0 {
+		t.Fatalf("%s is never called from %s: the OpenRouter session_id is registered nowhere on the "+
+			"standard-mode path, so every Broadcast span it emits is unjoinable (control %q found %d times)",
+			callee, caller, control, calls[control])
+	}
+}


### PR DESCRIPTION
## What

`M-MISSION-LOOP-UNIFIED-TELEMETRY` M1 shipped the **read** side of the OpenRouter trace-join and never the **write** side — and passed 5/5 of its own acceptance criteria anyway, because all five seed the `sessions` table by raw `INSERT` and none exercises a dispatch path.

Standard-mode evals now register their OpenRouter `session_id` (which *is* the eval chain id) as a `sessions` row, so Broadcast spans resolve to the chain and stage that dispatched them.

## Why it was invisible

- `AIAgent.SetCorrelation(chainID, …)` sets `ai.Correlation.SessionID = chainID` (`ai_agent.go:289`)
- `openrouter/correlation.go:70` puts that on the wire as `session_id`
- `otlp_receiver.go:468` resolves it via `LookupChainBySessionID`, reading `sessions`
- agent mode registers that row (`eval_benchmark_agent.go:441`); **standard mode had zero such calls**

Measured before this change: sessions rows keyed by a chain id = **0**, against controls of **19262** sessions-with-chain-id-set and **18947** stages-with-session-id. Provider-side over a 72h window: **97** of **159** `LLM Generation` spans carried `session.id`, **0** resolved to a chain.

Registration is best-effort (it cannot fail an eval) and is skipped when `CreateStage` failed and `stageID` is empty.

## Two test arms, and why the second exists

| mutant | resolver arm | wiring arm |
|---|---|---|
| neuter the helper body | **rc=1** | rc=0 |
| delete the **call site** | rc=0 | **rc=1** |

Each mutant has exactly one sole killer. Both were asserted **LANDED** (sha256 differs) and **BUILDS** (`go build ./cmd/ailang/...` rc=0) before any result was read, and both files were restored **byte-identical**.

The second arm is the point. The first test calls the helper directly, so deleting the call from `runSingleBenchmark` left it *and the entire `cmd/ailang` suite* green — M1's own defect reproduced one layer down, and this repo's recurring *guard the helper, miss the call site* shape. `runSingleBenchmark` needs a live model call and is not unit-testable, so the reachable pin is an AST assertion over its body, carrying a known-positive control (`SetCorrelation`) that fails loudly if the walk finds nothing rather than passing vacuously.

## Gates

darwin/arm64, **outside** the sandbox, on a binary built with ldflags (`v0.34.0-118-gd5305fa79`, `--version` == `git describe`): `go build ./cmd/ailang/...`, `go build ./internal/observatory/...`, `go vet`, `go test ./internal/observatory/...`, `go test ./cmd/ailang/...` (fresh binary PATH-prepended — four test files shell out to a bare `ailang`), `gofmt -l cmd internal` — all **rc=0**.

The codex executor reported two of these red; both were `workspace-write` loopback bind denials, correctly labelled `UNINFORMATIVE UNDER SANDBOX`, and both are rc=0 outside it. No executor-reported gate was banked.

`go build ./...` is deliberately not a gate: it is rc=1 on untouched `dev` (`cmd/wasm`, `gen/main` have no native `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
