### PR TITLE
fix(ai): an absent OpenAI/OpenRouter usage block is now distinguishable from an all-zero one

### DIFF
--- a/changelogs/v0.32-current.md
+++ b/changelogs/v0.32-current.md
@@ -25,7 +25,6 @@ future guard is a legitimate tool call, which also carries `content:null` and *d
 Blast radius is wider than the report suggested: `internal/ai/ollama` builds an `openai` client against
 `<endpoint>/v1`, so every ollama tool-calling turn parses through this path too. Reported at issue #842.
 
-
 ### Added — `std/string` gains total character accessors
 
 `charAt` was the only partial accessor in the stdlib that aborts instead of returning `Option`:

--- a/changelogs/v0.32-current.md
+++ b/changelogs/v0.32-current.md
@@ -4,6 +4,28 @@
 
 ## [Unreleased]
 
+### Fixed — an omitted OpenAI/OpenRouter `usage` block is now distinguishable from an all-zero one
+
+A provider failure can arrive on the wire as a *successful empty completion*: `finish_reason:"stop"`,
+`"content":null`, and no `usage` key at all. `ParseChatStepResponse` returned no error, empty text,
+zero tool calls and zero tokens — indistinguishable from a model that legitimately said nothing.
+
+The reason no guard could be written for it was the representation: `ChatStepResponse.Usage` was a
+value type, so an absent `usage` key unmarshalled to the zero struct and `absent.Usage == allZero.Usage`
+was **true**. `Usage` is now `*ChatStepUsage`, so absence (nil) and present-but-all-zero (non-nil,
+zeroed) are finally different values.
+
+This is a representation change only — `ParseChatStepResponse` returns exactly what it returned before
+for every input, a nil `Usage` yielding the same zeros the zero struct did. Deciding a *policy* from the
+distinction is deliberately deferred: the Anthropic and Gemini paths do not share this parser and
+streaming usage delivery is opt-in on some providers, so a uniform guard would turn a legitimate empty
+completion into an error — the same defect pointed the other way. The standing negative control for any
+future guard is a legitimate tool call, which also carries `content:null` and *does* report usage.
+
+Blast radius is wider than the report suggested: `internal/ai/ollama` builds an `openai` client against
+`<endpoint>/v1`, so every ollama tool-calling turn parses through this path too. Reported at issue #842.
+
+
 ### Added — `std/string` gains total character accessors
 
 `charAt` was the only partial accessor in the stdlib that aborts instead of returning `Option`:

--- a/internal/ai/openai/step.go
+++ b/internal/ai/openai/step.go
@@ -297,7 +297,11 @@ type ChatStepResponse struct {
 	Object  string           `json:"object"`
 	Model   string           `json:"model"`
 	Choices []ChatStepChoice `json:"choices"`
-	Usage   ChatStepUsage    `json:"usage"`
+	// Usage is a pointer so an omitted usage key (nil) remains distinguishable
+	// from a present but all-zero usage block. A value field made that distinction
+	// inexpressible; deciding policy from it is deliberately future work tracked
+	// by row 6h step 2 and issue #842.
+	Usage *ChatStepUsage `json:"usage"`
 }
 
 // ChatStepChoice is one completion choice. Message.Content is RawMessage so
@@ -624,16 +628,20 @@ func ParseChatStepResponse(body []byte, requestedModel string) (*ai.Response, *a
 		model = requestedModel
 	}
 
+	usage := ChatStepUsage{}
+	if raw.Usage != nil {
+		usage = *raw.Usage
+	}
 	cacheRead := 0
-	if raw.Usage.PromptTokensDetails != nil {
-		cacheRead = raw.Usage.PromptTokensDetails.CachedTokens
+	if usage.PromptTokensDetails != nil {
+		cacheRead = usage.PromptTokensDetails.CachedTokens
 	}
 	return &ai.Response{
 		Text:                 text,
 		Reasoning:            reasoning,
-		InputTokens:          raw.Usage.PromptTokens,
-		OutputTokens:         raw.Usage.CompletionTokens,
-		TotalTokens:          raw.Usage.TotalTokens,
+		InputTokens:          usage.PromptTokens,
+		OutputTokens:         usage.CompletionTokens,
+		TotalTokens:          usage.TotalTokens,
 		CacheReadInputTokens: cacheRead,
 		Model:                model,
 		ToolCalls:            toolCalls,

--- a/internal/ai/openai/step_usage_absence_test.go
+++ b/internal/ai/openai/step_usage_absence_test.go
@@ -1,0 +1,114 @@
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestChatStepUsageAbsenceIsObservable(t *testing.T) {
+	const (
+		absentUsageBody = `{
+			"choices":[{"index":0,"message":{"role":"assistant","content":null},"finish_reason":"stop"}]
+		}`
+		presentUsageBody = `{
+			"choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":11,"completion_tokens":7,"total_tokens":18}
+		}`
+		toolCallBody = `{
+			"choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{}"}}]},"finish_reason":"tool_calls"}],
+			"usage":{"prompt_tokens":13,"completion_tokens":5,"total_tokens":18}
+		}`
+		zeroUsageBody = `{
+			"choices":[{"index":0,"message":{"role":"assistant","content":null},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}
+		}`
+	)
+
+	tests := []struct {
+		name       string
+		body       string
+		usageNil   bool
+		wantUsage  ChatStepUsage
+		checkUsage bool
+	}{
+		{
+			name:     "failing shape omits usage",
+			body:     absentUsageBody,
+			usageNil: true,
+		},
+		{
+			name:       "healthy completion reports usage",
+			body:       presentUsageBody,
+			wantUsage:  ChatStepUsage{PromptTokens: 11, CompletionTokens: 7, TotalTokens: 18},
+			checkUsage: true,
+		},
+		{
+			// A future policy must not use content:null as its signal: legitimate
+			// tool-call responses have null content and still report usage.
+			name:       "legitimate tool call reports usage",
+			body:       toolCallBody,
+			wantUsage:  ChatStepUsage{PromptTokens: 13, CompletionTokens: 5, TotalTokens: 18},
+			checkUsage: true,
+		},
+		{
+			name:       "present usage may be all zero",
+			body:       zeroUsageBody,
+			wantUsage:  ChatStepUsage{},
+			checkUsage: true,
+		},
+	}
+
+	parsed := make(map[string]ChatStepResponse, len(tests))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var raw ChatStepResponse
+			if err := json.Unmarshal([]byte(tt.body), &raw); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v", err)
+			}
+			parsed[tt.name] = raw
+
+			if tt.usageNil {
+				if raw.Usage != nil {
+					t.Fatalf("Usage = %#v, want nil", raw.Usage)
+				}
+				return
+			}
+			if raw.Usage == nil {
+				t.Fatal("Usage = nil, want present usage block")
+			}
+			if tt.checkUsage && *raw.Usage != tt.wantUsage {
+				t.Fatalf("Usage = %#v, want %#v", *raw.Usage, tt.wantUsage)
+			}
+		})
+	}
+
+	t.Run("omitted and present-zero usage are distinguishable", func(t *testing.T) {
+		absent := parsed["failing shape omits usage"]
+		presentZero := parsed["present usage may be all zero"]
+		if absent.Usage != nil || presentZero.Usage == nil {
+			t.Fatalf("usage presence collapsed: absent.Usage=%#v, presentZero.Usage=%#v", absent.Usage, presentZero.Usage)
+		}
+		if *presentZero.Usage != (ChatStepUsage{}) {
+			t.Fatalf("presentZero.Usage = %#v, want all-zero usage", *presentZero.Usage)
+		}
+	})
+
+	for _, tt := range []struct {
+		name string
+		body string
+	}{
+		{name: "omitted usage", body: absentUsageBody},
+		{name: "present zero usage", body: zeroUsageBody},
+	} {
+		t.Run("parser behavior unchanged with "+tt.name, func(t *testing.T) {
+			got, aiErr := ParseChatStepResponse([]byte(tt.body), "requested-model")
+			if aiErr != nil {
+				t.Fatalf("ParseChatStepResponse() error = %v", aiErr)
+			}
+			if got.Text != "" || len(got.ToolCalls) != 0 || got.InputTokens != 0 || got.OutputTokens != 0 || got.TotalTokens != 0 {
+				t.Fatalf("ParseChatStepResponse() = Text %q, %d tool calls, tokens (%d, %d, %d); want empty response with zero tokens",
+					got.Text, len(got.ToolCalls), got.InputTokens, got.OutputTokens, got.TotalTokens)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Motoko mission iteration 27 · queue row **6h** · reported at issue #842.

## The defect, and why no guard could be written for it

A provider failure arrives on the wire as a *successful empty completion* —
`finish_reason:"stop"`, `"content":null`, and **no `usage` key at all**.
`openai.ParseChatStepResponse` returns no error, empty text, zero tool calls, zero tokens.

The reason the reporter's suggested guard was not merely missing but **inexpressible**:
`ChatStepResponse.Usage` was a **value type**, so an omitted `usage` key unmarshals to the zero
struct and `absent.Usage == allZero.Usage` is `true`. `Usage` is now `*ChatStepUsage`.

**Representation only.** `ParseChatStepResponse` returns exactly what it returned before for every
input — a nil `Usage` yields the same zeros the zero struct did. Deciding a **policy** from the
distinction is deliberately deferred (row 6h step 2): the Anthropic and Gemini paths do not share
this parser and streaming usage delivery is opt-in on some providers, so a uniform guard would turn
a legitimate empty completion into an error — the same defect pointed the other way. The standing
negative control for any future guard is a legitimate tool call, which also carries `content:null`
and *does* report usage.

**Blast radius is wider than filed:** `internal/ai/ollama/step.go` builds an `openai` client against
`<endpoint>/v1`, so every ollama tool-calling turn parses through this path — the defect sits on our
own eval rig, where a masked provider failure is indistinguishable from a local model declining to act.

## Mutation drill — anchored to the diff hunk by hunk, not to the defect

Each mutant asserted **LANDED** (sha256), **BUILDS**, and **effect-verified against the gofmt-parsed
form rather than the file's bytes**; each restored from a `cp` backup and re-verified byte-identical.

| Mutant | Builds | Result |
|---|---|---|
| M1 break the `usage` json tag | yes | reds **2** top-level tests (new arms + pre-existing `TestStep_TextOnly_HappyPath`) — kill-set member, not sole killer |
| M2 nil no longer yields zero tokens | yes | **SOLE KILLER** of the new no-behaviour-change arm; inverse arm (`-skip` mine) **rc=0** |
| M3 neuter the deref guard | yes | reds **only** the PRE-EXISTING happy-path test — hunk pinned, but not by the new arms |
| M4 revert to the value type | **no** | compile error `raw.Usage != nil (mismatched types ChatStepUsage and untyped nil)`. Recorded as a **compile-time** arm, not a behavioural kill |

## Evaluation — round 1 PASS 94/100, ZERO blocking

The judge ran in its own worktree and **reproduced every controller claim**, then went past them:
it built a **16-case differential harness** across parent `d5305fa79` vs this branch — including
`usage:null`, `usage:[]`, `usage:"none"`, `usage:42`, negative tokens and malformed JSON — and found
the output **byte-identical in all 16**. That is stronger evidence for "no behaviour change" than
anything the controller produced.

**It also found a gap the controller's own drill missed, and it is recorded rather than papered over.**
`cacheRead = usage.PromptTokensDetails.CachedTokens` — inside this diff's second hunk — has **zero
killers**: mutating it to `+ 999` leaves openai, openrouter and ollama **all rc=0, 0 FAIL lines**.
Reproduced first-party. The apparent coverage is a mirage: `cache_usage_test.go` contains **0**
references to `ParseChatStepResponse` and **7** to `Generate`, a different code path that never
reaches this function. Per the standing rule that *a hunk with no killer is a finding, not a failure*,
this is **filed as motoko queue row 6m** rather than used to quietly widen this PR — the same
disposition iteration 24 gave its own zero-killer hunk (row 6i).

## Gates — re-run by the controller OUTSIDE the codex sandbox

`workspace-write` denies loopback binds and 15 of these test files bind sockets, so in-sandbox
verdicts for them are uninformative by construction. Run on **darwin/arm64** with a freshly built,
correctly ldflag-stamped binary on `PATH` (`v0.34.0-118-gd5305fa79-dirty`) — the system
`~/go/bin/ailang` was **43 commits adrift**, which is exactly how a stale binary reaches a suite
through a test's own shell-out:

- `go build ./internal/ai/...` rc=0 · `go vet ./internal/ai/...` rc=0
- `go test ./internal/ai/openai/... ./internal/ai/openrouter/... ./internal/ai/ollama/...` rc=0 / 0 / 0
- `gofmt -l internal/ai/openai/` empty · `make check-file-sizes` rc=0
- `make check-changelog` rc=0 · `make test-check-changelog` rc=0 (13 arms)
- judge additionally ran `golangci-lint run ./internal/ai/openai/...` → 0 issues

Windows and ubuntu matrix legs are unrun locally and read from CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
