### PR TITLE
feat(prompts): the freeze gate now checks every registry entry, not only frozen ones

### DIFF
--- a/.ailang/state/sprints/sprint_M-PROMPT-FREEZE-MIRROR-ALL-VERSIONS.json
+++ b/.ailang/state/sprints/sprint_M-PROMPT-FREEZE-MIRROR-ALL-VERSIONS.json
@@ -1,0 +1,307 @@
+{
+  "sprint_id": "M-PROMPT-FREEZE-MIRROR-ALL-VERSIONS",
+  "status": "planned",
+  "created": "2026-08-28",
+  "design_doc": "design_docs/planned/m-prompt-freeze-mirror-all-versions.md",
+  "sprint_plan": "design_docs/planned/m-prompt-freeze-mirror-all-versions-sprint-plan.md",
+  "risk_level": "low",
+  "milestone_count": 1,
+  "metadata": {
+    "mission": "v1",
+    "iteration": 297,
+    "planner_role": "sprint-planner",
+    "planner_lane": "opus fail-closed:planner-lane-field-missing",
+    "executor_lane": "codex:gpt-5.6-sol",
+    "executor_sandbox": "workspace-write",
+    "worktree": "/Users/voightkampff/dev/sunholo-data/.wt-iter297",
+    "worktree_head": "3d80bf91005a3c57042e0d6358373c4b4f005a4a",
+    "base_origin_dev": "0917693792d07c75ae0c4d233d2cc7e592fa9272",
+    "platform": "darwin/arm64",
+    "go_version": "go1.26.6 darwin/arm64",
+    "single_milestone_rationale": "checkRegistries signature change ([]string,error) -> ([]string,int,error) has 4 callers in one package (measured). Any split lands a non-compiling intermediate commit, i.e. a non-bisectable boundary. Splitting around it would create a milestone containing only a mechanical arity change with no behavior and no test.",
+    "gates_disqualified": [
+      "go build ./... is rc=1 AT BASE (cmd/wasm has no native main) and MUST NOT appear in any acceptance criterion"
+    ]
+  },
+  "velocity": {
+    "target_days": 1,
+    "estimated_hours": 6,
+    "estimated_production_loc": 46,
+    "estimated_test_loc": 174,
+    "commits_last_14_days_measured": 412,
+    "note": "Diff-size figures are the DESIGNER's estimate (doc Files-to-modify), carried forward unverified. The 412-commit figure is planner-measured (git log --since=14.days --oneline | wc -l) and is context only: per-sprint scope, not commit count, is the binding constraint on this mission."
+  },
+  "measured_baseline": {
+    "measured_by": "sprint-planner, first-party, this session",
+    "measured_at_head": "3d80bf91005a3c57042e0d6358373c4b4f005a4a",
+    "tree_state": "clean",
+    "gates": [
+      {"id": "G1", "command": "go build ./cmd/ailang/...", "rc_at_base": 0},
+      {"id": "G2", "command": "go vet ./cmd/ailang/...", "rc_at_base": 0},
+      {"id": "G3", "command": "test -z \"$(gofmt -l cmd/ailang)\"", "rc_at_base": 0},
+      {"id": "G4", "command": "go test ./cmd/ailang/ -run 'Freeze|Prompt' -count=1", "rc_at_base": 0, "note": "ok github.com/sunholo-data/ailang/cmd/ailang 2.367s"},
+      {"id": "G5", "command": "go run ./cmd/ailang prompt freeze --check", "rc_at_base": 0, "note": "STDOUT IS EMPTY at base (only the 'Observatory: 429MB' stderr log line) - this is what makes AC1's count-line assertion falsifiable"},
+      {"id": "G6", "command": "make check-prompt-freeze", "rc_at_base": 0}
+    ],
+    "toolchain_probes": [
+      {"claim": "-skip is supported", "command": "go test ./cmd/ailang/ -run 'Freeze|Prompt' -skip '^TestFreezeCheck_UnmodifiedTreeIsGreen$' -count=1", "rc": 0}
+    ],
+    "structural_facts": {
+      "source_registry_versions": 59,
+      "frozen_entries": 58,
+      "mutable_entries": ["v0.16.6"],
+      "active_entry": "v0.16.6",
+      "mirror_registry_versions": 59,
+      "source_md_files": 62,
+      "mirror_md_files": 62,
+      "v0166_hash_fresh_everywhere": "2a868106214d3a4fc94dcb5431560cebacbec05c1e1835a168b8dcb15f804b67 == source registry == mirror registry == shasum of prompts/v0.16.6.md == shasum of cmd/ailang/prompts/v0.16.6.md",
+      "expected_pristine_count_line": "checked 59 registry entries",
+      "checkRegistries_callers": [
+        "cmd/ailang/prompt_freeze.go:69",
+        "cmd/ailang/prompt_freeze_check_git_test.go:134",
+        "cmd/ailang/prompt_freeze_test.go:125",
+        "cmd/ailang/prompt_freeze_test.go:138"
+      ],
+      "imports_needed": "neither cmd/ailang/prompt_freeze_core.go nor cmd/ailang/prompt_freeze_check_git.go currently imports errors or io/fs; both need them. core.go already has crypto/sha256 and encoding/hex.",
+      "test_fixture_entry_count": 1,
+      "test_fixture_count_arithmetic": "newFreezeCheckRepo has ONE source entry v1.0.0 -> checked 1; with one mirror-only entry added -> checked MUST move to 2"
+    }
+  },
+  "doc_vs_plan_reconciliation": {
+    "doc_milestones_section_says": "AC1-AC8",
+    "doc_acceptance_criteria_table_contains": ["AC1","AC2","AC3","AC4","AC5","AC6","AC7","AC8","AC9","AC10"],
+    "plan_task_list_closes": ["AC1","AC2","AC3","AC4","AC5","AC6","AC7","AC8-REG","AC8-D","AC9","AC10"],
+    "divergence": "The doc's Milestones section string 'AC1-AC8' is stale r1 text that the r2 revision did not update. It is internal to the doc, not a scope ruling: the same milestone sentence also says 'all tests in the mutation table', and mutants M8/M9 name TestFreezeCheck_InvalidHashAndMissingSourceEmitsBoth and TestFreezeCheck_BothTreesDeletedEmitsBoth, whose fixtures ARE AC9 and AC10 verbatim.",
+    "ruling": "THE DOC WINS. The doc's own AC table and mutation table are the doc. The milestone closes AC1-AC10. No reviewed decision is overridden.",
+    "planner_amendments": [
+      "AC8 SPLIT into AC8-REG (regression guard, at its target state at base BY DESIGN, labelled as such) and AC8-D (the mirror-deletion rename, base string differs so it IS falsifiable). No criterion is weakened; the at-target-at-base half is no longer passed off as a progress gate."
+    ],
+    "acs_dropped": [],
+    "mutants_dropped": []
+  },
+  "features": [
+    {
+      "id": "T0_BASELINE_SMOKE",
+      "milestone": "M1",
+      "description": "Before touching anything, re-run G1-G6 and record every rc. All six must be 0.",
+      "estimated_hours": 0.33,
+      "files": [],
+      "dependencies": [],
+      "acceptance_criteria": [
+        "Six rc values recorded in the executor report, all 0.",
+        "If ANY is non-zero: STOP and escalate to the controller. The environment differs from the plan's measured baseline and every subsequent rc is uninterpretable. This is an environment escalation, NEVER a code fix.",
+        "This task is also the sandbox probe for risk R1 (TMPDIR / GOCACHE writability)."
+      ],
+      "passes": null
+    },
+    {
+      "id": "T1_T5_WIDEN_CHECKREGISTRIES",
+      "milestone": "M1",
+      "description": "Widen the per-entry loop in checkRegistries into the three INDEPENDENT arms of Solution Design section 1 (hash-enforceability, source-existence, source-bytes-vs-hash) carrying a state label; adjudicate missing source as violation S5 (rc=1) for fs.ErrNotExist only; add the mirror-only sweep emitting S10; add the checked counter incremented as the LAST statement of each visiting loop body; change the signature to ([]string, int, error); update all four callers; print 'checked %d registry entries' to stdout on every completed --check run.",
+      "estimated_loc": 34,
+      "estimated_hours": 1.67,
+      "files": [
+        "cmd/ailang/prompt_freeze_core.go",
+        "cmd/ailang/prompt_freeze.go",
+        "cmd/ailang/prompt_freeze_check_git_test.go",
+        "cmd/ailang/prompt_freeze_test.go"
+      ],
+      "dependencies": ["T0_BASELINE_SMOKE"],
+      "acceptance_criteria": [
+        "go build ./cmd/ailang/... rc=0 (base rc=0, measured).",
+        "go vet ./cmd/ailang/... rc=0 (base rc=0, measured).",
+        "test -z \"$(gofmt -l cmd/ailang)\" rc=0 (base rc=0, measured).",
+        "Frozen strings S1 and S3 stay BYTE-IDENTICAL: the '(unenforceable freeze)' suffix is preserved by a suffix switch on e.Frozen != nil, not by a duplicated branch.",
+        "The arm dependency set is EXACTLY the doc's section 3 table: hash-enforceable depends on nothing; source-existence depends on nothing; source-bytes-vs-hash depends on hashOK AND sourceExists. No other dependency is permitted.",
+        "Non-ErrNotExist read errors still return (nil, 0, err) so they remain rc=2.",
+        "checked is a PRODUCT of the per-entry work - incremented inside the visiting loop bodies, NEVER a len() computed beside the work. (This is r2 quorum objection 2; see risk R5.)",
+        "All four callers updated by name: prompt_freeze.go:69, prompt_freeze_check_git_test.go:134, prompt_freeze_test.go:125, prompt_freeze_test.go:138. Go is the enforcer: 3 results cannot be assigned to 2 variables, so a stale zero is impossible."
+      ],
+      "passes": null
+    },
+    {
+      "id": "T6_T8_WIDEN_MIRROR_AND_MIGRATE",
+      "milestone": "M1",
+      "description": "Widen the mirror loop in prompt_freeze_check_git.go (replace the Frozen==nil continue at line 51 with the state label; make mirror existence UNCONDITIONAL so a missing source cannot hide a missing/diverged mirror; emit S8 on fs.ErrNotExist; keep S6/S7 for divergence only; leave sameFrozenRegistryEntry dedupe as-is). Widen the migrateRegistries VALIDATION loop only.",
+      "estimated_loc": 12,
+      "estimated_hours": 0.75,
+      "files": [
+        "cmd/ailang/prompt_freeze_check_git.go",
+        "cmd/ailang/prompt_freeze_core.go"
+      ],
+      "dependencies": ["T1_T5_WIDEN_CHECKREGISTRIES"],
+      "acceptance_criteria": [
+        "DO NOT TOUCH prompt_freeze_check_git.go:28 - the merge-base loop's 'if baseEntry.Frozen == nil { continue }'. Merge-base IMMUTABILITY stays frozen-only (Non-Goals). The controller verifies line 28 is absent from the diff.",
+        "AC10's fixture emits BOTH S5 and S8 - mirror existence must not be gated on source existence.",
+        "migrateRegistries: the VALIDATION loop at prompt_freeze_core.go:251 drops 'id == r.Active || e.Frozen != nil'; the FREEZE-WRITING loop at :267 keeps BOTH skips unchanged, so migrate still never freezes the active entry.",
+        "go build / go vet / gofmt all still clean."
+      ],
+      "passes": null
+    },
+    {
+      "id": "T9_T10_TESTS",
+      "milestone": "M1",
+      "description": "Add 10 tests. Nine in prompt_freeze_check_git_test.go using newFreezeCheckRepo + writeFreezeCheckRegistries(..., frozen=false) for mutable fixtures: _MutablePlaceholderIsRed, _MutableSourceDivergenceIsRed, _SourceMissingIsViolationNotError (frozen + mutable sub-cases), _MutableMirrorDivergenceIsRed, _MirrorMissingIsRed (frozen + mutable), _MirrorOnlyEntryIsRed, _InvalidHashAndMissingSourceEmitsBoth, _BothTreesDeletedEmitsBoth, _CheckedCountMovesOnAddition. One in prompt_freeze_test.go: TestPromptFreezeMigrate_RefusesStaleActiveHash.",
+      "estimated_loc": 174,
+      "estimated_hours": 1.5,
+      "files": [
+        "cmd/ailang/prompt_freeze_check_git_test.go",
+        "cmd/ailang/prompt_freeze_test.go"
+      ],
+      "dependencies": ["T6_T8_WIDEN_MIRROR_AND_MIGRATE"],
+      "acceptance_criteria": [
+        "go test ./cmd/ailang/ -run 'Freeze|Prompt' -count=1 rc=0 (base rc=0, measured) with all 10 new tests present and running - verify with -v that none reports 'no tests to run'.",
+        "EVERY new test asserts BOTH the in-process checkRegistries violation slice (exact S-string via hasViolation) AND the helper-subprocess rc. Both are strictly downstream of the mechanism.",
+        "NO test seeds a verdict by raw fixture. Every test drives the REAL check path against a synthetic git repo. This is how the parent sprint's tests once stayed green while a writer did not exist.",
+        "rc semantics pinned: fs.ErrNotExist moves from the rc=2 bucket to the rc=1 bucket; every other error stays rc=2. _SourceMissingIsViolationNotError and _MirrorMissingIsRed exist specifically to pin that boundary.",
+        "PAUSE POINT: if this is not green, the sprint does NOT proceed to T11. A mutation matrix run against a red suite measures nothing."
+      ],
+      "passes": null
+    },
+    {
+      "id": "T11_MUTATION_MATRIX",
+      "milestone": "M1",
+      "description": "Run all 10 mutants (M1-M9 + M-ADD) under the mutation discipline. See the mutation_plan block of this file for the full matrix and the per-mutant protocol.",
+      "estimated_hours": 1.25,
+      "files": [],
+      "dependencies": ["T9_T10_TESTS"],
+      "acceptance_criteria": [
+        "Every mutant is the NEUTERING form 'if false && <cond>' (or the condition-WRAPPING form for M7/M8/M9). NO block is deleted, NO statement is deleted, NO import is removed - so 'the mutant does not compile' can never masquerade as 'the guard fired'.",
+        "Per mutant, BEFORE any test result is read: LANDED (shasum -a 256 differs from the pre-mutation value) AND BUILDS (go build ./cmd/ailang/... rc=0).",
+        "Per mutant, the actual failing-test set is ENUMERATED by running, not predicted, and a Criterion A or B verdict is recorded from that observation.",
+        "Criterion A (single-test): failing set is exactly {target} AND the inverse arm 'go test ./cmd/ailang/ -run Freeze|Prompt -skip ^<target>$ -count=1' returns rc=0. -skip support probed at base, rc=0.",
+        "Criterion B (broad blast): failing set has >1 member; Criterion A is unsatisfiable by construction. Required evidence is the enumerated set itself, plus (i) the target IS in the set and (ii) EVERY other member is explained by one sentence naming the shared code path. An unexplained member is a finding, not noise.",
+        "The planner's per-mutant 'prior' column is UNVERIFIED and carries no authority. If the observation contradicts the prior, the observation wins and the executor notes it.",
+        "RESTORE by cp from a pre-mutation backup, asserted byte-identical by sha256. NEVER 'git checkout -- <file>' and NEVER 'git stash' - the sprint's own uncommitted work lives in these exact files.",
+        "After the matrix, every touched file's sha256 equals its pre-mutation value."
+      ],
+      "passes": null
+    },
+    {
+      "id": "T12_T14_DOCS_AND_FINAL_GATES",
+      "milestone": "M1",
+      "description": "Update make/code-health.mk:184 help text to 'Check prompt registry integrity (all entries) + frozen immutability (CI gate)' (comment/help only; the recipe at :185 is unchanged). Add the CHANGELOG entry. Remove any .mutbak/ scratch. Re-run G1-G6.",
+      "estimated_loc": 8,
+      "estimated_hours": 0.5,
+      "files": ["make/code-health.mk", "CHANGELOG.md"],
+      "dependencies": ["T11_MUTATION_MATRIX"],
+      "acceptance_criteria": [
+        "G1-G6 all rc=0, each recorded.",
+        "make check-prompt-freeze rc=0 AND its stdout contains 'checked 59 registry entries'.",
+        "CHANGELOG records the 'checked N registry entries' stdout line as a behavior CHANGE, not merely a fix - base stdout is empty (measured).",
+        "No scratch directory (.mutbak/) is left in the worktree.",
+        "NO git add / commit / stash / checkout is performed by the executor. The controller builds the commit."
+      ],
+      "passes": null
+    }
+  ],
+  "acceptance_criteria": [
+    {"id": "AC1", "criterion": "Pristine stays green AND the count line appears", "command": "repo-root: make check-prompt-freeze ; probe: pristine --check", "rc_at_base_measured": 0, "base_note": "rc=0 AND STDOUT EMPTY - no count line exists at base", "required_post": "rc=0 and stdout contains 'checked 59 registry entries'", "falsifiable_at_base": "via the stdout half only; the rc half is a regression guard", "owner": "executor (repo-root half) + controller (probe half)"},
+    {"id": "AC2", "criterion": "Mutable source divergence refused", "command": "printf 'x' >> prompts/v0.16.6.md ; --check", "rc_at_base_measured": 0, "base_note": "THE HOLE", "required_post": "rc=1 containing 'mutable version v0.16.6: file bytes do not match recorded hash'", "falsifiable_at_base": "yes", "owner": "controller"},
+    {"id": "AC3", "criterion": "Mutable source deletion refused, named", "command": "rm prompts/v0.16.6.md ; --check", "rc_at_base_measured": 0, "base_note": "THE HOLE", "required_post": "rc=1 containing 'mutable version v0.16.6: prompt file missing at prompts/v0.16.6.md'", "falsifiable_at_base": "yes", "owner": "controller"},
+    {"id": "AC4", "criterion": "Mutable mirror divergence refused", "command": "printf 'x' >> cmd/ailang/prompts/v0.16.6.md ; --check", "rc_at_base_measured": 0, "base_note": "THE HOLE", "required_post": "rc=1 containing 'mutable version v0.16.6: mirror bytes differ at cmd/ailang/prompts/v0.16.6.md'", "falsifiable_at_base": "yes", "owner": "controller"},
+    {"id": "AC5", "criterion": "Mutable PLACEHOLDER refused", "command": "set v0.16.6 hash to PLACEHOLDER in BOTH registries ; --check", "rc_at_base_measured": 0, "base_note": "THE HOLE", "required_post": "rc=1 containing 'mutable version v0.16.6: recorded hash is not a 64-hex sha256 (unenforceable)'", "falsifiable_at_base": "yes", "owner": "controller"},
+    {"id": "AC6", "criterion": "Mirror-only entry refused AND counted", "command": "add v9.9.9-extra to the MIRROR registry only ; --check", "rc_at_base_measured": 0, "base_note": "THE HOLE; and no count line exists at base", "required_post": "rc=1 containing 'entry v9.9.9-extra missing from source registry' AND stdout reads 'checked 60 registry entries' (AC1 pins pristine at 59, so the 59->60 move is the assertion, not the verdict alone)", "falsifiable_at_base": "yes", "owner": "controller"},
+    {"id": "AC7", "criterion": "Missing FROZEN source is a named violation, not an abort", "command": "rm prompts/v0.3.21.md ; --check", "rc_at_base_measured": 2, "base_note": "stderr exactly 'open <root>/prompts/v0.3.21.md: no such file or directory' and NOTHING ELSE - the abort hides every other violation", "required_post": "rc=1 containing 'frozen version v0.3.21: prompt file missing at prompts/v0.3.21.md'", "falsifiable_at_base": "yes", "owner": "controller"},
+    {"id": "AC8-REG", "criterion": "REGRESSION GUARD - frozen source divergence and frozen mirror divergence stay byte-identical; existing tests keep passing", "command": "probe cells: printf 'x' >> prompts/v0.3.21.md ; printf 'x' >> cmd/ailang/prompts/v0.3.21.md ; repo-root: go test ./cmd/ailang/ -run 'Freeze|Prompt' -count=1", "rc_at_base_measured": 1, "base_note": "AC8a rc=1 with exactly the three frozen strings ('file bytes do not match recorded hash', 'immutability violation in prompts/v0.3.21.md bytes', 'mirror bytes differ at cmd/ailang/prompts/v0.3.21.md'); AC8b rc=1 with the mirror-differ string; test rc=0", "required_post": "identical rc and identical strings; test rc=0", "falsifiable_at_base": "NO - AT ITS TARGET STATE AT BASE BY DESIGN. Labelled a no-drift guard, NOT a progress gate. Retained because T1 rewrites the block producing S1/S3, so frozen-path string drift is a real risk of this diff (see risk R2).", "owner": "executor (test half) + controller (probe half)"},
+    {"id": "AC8-D", "criterion": "PROGRESS - frozen mirror DELETION is reported honestly (the S8 rename)", "command": "rm cmd/ailang/prompts/v0.3.21.md ; --check", "rc_at_base_measured": 1, "base_note": "rc=1 but with the MISLEADING string 'frozen version v0.3.21: mirror bytes differ at cmd/ailang/prompts/v0.3.21.md'", "required_post": "rc=1 CONTAINING 'frozen version v0.3.21: mirror file missing at cmd/ailang/prompts/v0.3.21.md' AND NOT containing 'mirror bytes differ at cmd/ailang/prompts/v0.3.21.md'", "falsifiable_at_base": "yes - via the negative half; the rc alone is unchanged, which is exactly why the NOT-contains clause is mandatory", "owner": "controller"},
+    {"id": "AC9", "criterion": "COMPOUND - invalid hash AND missing source emit BOTH named violations", "command": "set v0.16.6 hash to PLACEHOLDER in both registries AND rm prompts/v0.16.6.md ; --check", "rc_at_base_measured": 0, "base_note": "THE COMPOUND HOLE - neither S2 nor S5 fires", "required_post": "rc=1 with BOTH 'mutable version v0.16.6: recorded hash is not a 64-hex sha256 (unenforceable)' AND 'mutable version v0.16.6: prompt file missing at prompts/v0.16.6.md'", "falsifiable_at_base": "yes", "owner": "controller"},
+    {"id": "AC10", "criterion": "COMPOUND - source AND mirror both deleted emit BOTH named violations", "command": "rm prompts/v0.3.21.md cmd/ailang/prompts/v0.3.21.md ; --check", "rc_at_base_measured": 2, "base_note": "stderr names only the FIRST missing file; the mirror deletion is INVISIBLE", "required_post": "rc=1 with BOTH 'frozen version v0.3.21: prompt file missing at prompts/v0.3.21.md' AND 'frozen version v0.3.21: mirror file missing at cmd/ailang/prompts/v0.3.21.md'", "falsifiable_at_base": "yes", "owner": "controller"}
+  ],
+  "acceptance_criteria_provenance": {
+    "measured_by": "sprint-planner, first-party, this session - NOT transcribed from the design doc",
+    "probe_protocol": "/tmp/i297p/repo <- prompts/, cmd/ailang/prompts/, empty eval_results/baselines/ copied from the worktree; git init + one commit + git update-ref refs/remotes/origin/dev HEAD; tar --exclude .git snapshot restored before AND after every cell; probe binary 'go build -o /tmp/i297p/bin/ailang ./cmd/ailang'; invocation '/tmp/i297p/bin/ailang prompt freeze --check --repo /tmp/i297p/repo'",
+    "restore_control": "post-restore cell rc=0 - the restore is byte-faithful, so each cell's rc is attributable to that cell",
+    "positive_controls": "cells AC8-REG(a), AC8-REG(b) and AC8-D returned rc=1 with the exact frozen violation strings. Reds in the same instrument make the six rc=0 cells measurements of a hole, not a broken probe.",
+    "at_target_at_base_audit": "9 of 11 rows are falsifiable at base outright. AC1 is rc=0 at base and rc=0 after, falsifiable ONLY through its stdout half - which is why the stdout assertion is mandatory and not decorative. AC8-REG is at its target state at base by construction and is explicitly labelled a regression guard, not a progress gate."
+  },
+  "sandbox_split": {
+    "executor_constraints": "codex:gpt-5.6-sol under --sandbox workspace-write: cannot bind loopback sockets, cannot write outside the worktree",
+    "executor_gates": [
+      "G1 go build ./cmd/ailang/...",
+      "G2 go vet ./cmd/ailang/...",
+      "G3 gofmt -l cmd/ailang",
+      "G4 go test ./cmd/ailang/ -run 'Freeze|Prompt' -count=1 (harness writes to t.TempDir() under TMPDIR and runs git init THERE, not in the repo; go test also writes GOCACHE - T0 probes this before any edit)",
+      "G5 go run ./cmd/ailang prompt freeze --check (in-worktree, read-only git merge-base/show, no sockets)",
+      "G6 make check-prompt-freeze",
+      "T11 mutation matrix (edits and restores files INSIDE the worktree only)"
+    ],
+    "controller_gates": [
+      "AC1-AC10 probe-matrix cells: they construct a synthetic repo OUTSIDE the worktree (/tmp/i297p/repo) and run git init/commit/update-ref in it. Outside-worktree writes are NOT an executor obligation.",
+      "CI (.github/workflows/ci.yml:205): post-commit, needs network.",
+      "The commit itself."
+    ],
+    "note": "The Go tests of T9/T10 are the executor-side encoding of the probe matrix's coverage - which is why every AC row has a corresponding test row in the mutation plan. If the executor cannot satisfy an AC because it is a controller gate, that is not a failure; failing to have written the corresponding test IS."
+  },
+  "mutation_plan": {
+    "discipline": [
+      "NEUTERING FORM ONLY: 'if false && <cond>' (or the condition-WRAPPING form for M7/M8/M9). Never delete a block, a statement, or an import - with the block intact every import stays used, so 'the mutant does not compile' can never masquerade as 'the guard fired'.",
+      "LANDED before reading any test result: shasum -a 256 before and after MUST differ.",
+      "BUILDS before reading any test result: go build ./cmd/ailang/... rc=0.",
+      "RESTORE by cp from a pre-mutation backup, asserted byte-identical by sha256. NEVER 'git checkout -- <file>', NEVER 'git stash' - the sprint's own uncommitted work lives in these files. Keep backups at <worktree>/.mutbak/ if /tmp is not writable; delete in T12-T14.",
+      "ORDER: backup -> mutate -> LANDED -> BUILDS -> run -> record -> restore -> sha256-equality assert.",
+      "BLAST RADIUS IS MEASURED, NOT PREDICTED: run the mutant, enumerate the actual failing test names, then pick Criterion A or B from the observation."
+    ],
+    "criteria": {
+      "A_single_test": "failing set is exactly {target}; ADDITIONALLY the inverse arm 'go test ./cmd/ailang/ -run Freeze|Prompt -skip ^<target>$ -count=1' must be rc=0. This is the strongest evidence and is REQUIRED when the set is a singleton. -skip probed working at base (rc=0).",
+      "B_broad_blast": "failing set has >1 member; Criterion A is unsatisfiable BY CONSTRUCTION. Required evidence is the enumerated set itself plus (i) the target IS in the set and (ii) every other member explained by one sentence naming the shared code path. An unexplained member is a finding."
+    },
+    "mutants": [
+      {"id": "M1", "branch": "S2 mutable hash-enforceable", "mutation": "if false && !eval_harness.IsHexSHA256(e.Hash)", "test": "TestFreezeCheck_MutablePlaceholderIsRed", "observable": "violation containing 'unenforceable' AND rc 1->0; only this branch emits S2", "planner_prior_UNVERIFIED": "A"},
+      {"id": "M2", "branch": "S4 mutable bytes-vs-hash", "mutation": "if false && (hex.EncodeToString(sum[:]) != e.Hash) on a frozen=false fixture", "test": "TestFreezeCheck_MutableSourceDivergenceIsRed", "observable": "S4 string + rc; the frozen branch cannot fire on a frozen:false fixture", "planner_prior_UNVERIFIED": "A"},
+      {"id": "M3", "branch": "S5 missing source file", "mutation": "if false && errors.Is(srcErr, fs.ErrNotExist)", "test": "TestFreezeCheck_SourceMissingIsViolationNotError (frozen + mutable sub-cases)", "observable": "neutered -> the read error propagates -> checkRegistries returns err -> in-process t.Fatal path AND helper rc=2, not 1. The test asserts rc==1 AND the S5 string; both are produced only by the branch.", "planner_prior_UNVERIFIED": "A"},
+      {"id": "M4", "branch": "S7 mutable mirror divergence", "mutation": "if false && !bytes.Equal(sourceBytes, mirrorBytes)", "test": "TestFreezeCheck_MutableMirrorDivergenceIsRed", "observable": "S7 string + rc; no other arm reads mirror .md bytes", "planner_prior_UNVERIFIED": "B plausible - this is the SHARED S6/S7 comparison, so the existing frozen TestFreezeCheck_MirrorMdDivergenceIsRed may also go red. If so that is Criterion B with one explained member. MEASURE IT."},
+      {"id": "M5", "branch": "S8 mirror file missing", "mutation": "if false && errors.Is(mirrorErr, fs.ErrNotExist)", "test": "TestFreezeCheck_MirrorMissingIsRed (frozen + mutable)", "observable": "neutered -> falls to 'else if mirrorErr != nil -> return nil, err' -> rc=2, so the rc==1 assertion goes red for the reason it claims", "planner_prior_UNVERIFIED": "A"},
+      {"id": "M6", "branch": "S10 mirror-only entry", "mutation": "if false && (source.Versions[id] == nil)", "test": "TestFreezeCheck_MirrorOnlyEntryIsRed", "observable": "S10 string + rc; no other loop visits mirror-only keys", "planner_prior_UNVERIFIED": "B plausible - the same mutant also suppresses the checked++ inside that sweep, so TestFreezeCheck_CheckedCountMovesOnAddition is expected to go red too. Both members are targets of the same branch; enumerate and explain."},
+      {"id": "M7", "branch": "migrate validation widening", "mutation": "restore the skip as 'if false || id == r.Active { continue }' inside the VALIDATION loop only", "test": "TestPromptFreezeMigrate_RefusesStaleActiveHash (new)", "observable": "migrate's returned error is the direct product of the validation loop; with the skip restored, migrate succeeds and the error assertion fails", "planner_prior_UNVERIFIED": "A"},
+      {"id": "M8", "branch": "ARM INDEPENDENCE - source-existence must not depend on hash validity", "mutation": "wrap arm 2's emission as 'if hashOK && !sourceExists' (reintroduces round-1 masking; no block deleted, all imports stay used)", "test": "TestFreezeCheck_InvalidHashAndMissingSourceEmitsBoth (AC9 fixture: frozen=false, hash PLACEHOLDER, source absent)", "observable": "asserts BOTH S2 and S5; under the mutant only S2 is emitted -> red SPECIFICALLY on the S5 assertion", "planner_prior_UNVERIFIED": "A"},
+      {"id": "M9", "branch": "ARM INDEPENDENCE - mirror-existence must not depend on source existence", "mutation": "wrap the S8 emission as 'if sourceExists && errors.Is(mirrorErr, fs.ErrNotExist)'", "test": "TestFreezeCheck_BothTreesDeletedEmitsBoth (AC10 fixture: both .md removed)", "observable": "asserts BOTH S5 and S8; under the mutant only S5 is emitted -> red SPECIFICALLY on the S8 assertion", "planner_prior_UNVERIFIED": "A"},
+      {"id": "M-ADD", "branch": "enumerator completeness - an ADDITION, not a removal. Every removal proves the check FIRES; only an addition proves it LOOKS.", "mutation": "fixture-side: ADD v9.9.9-extra to the mirror registry of an otherwise-green fixture. NO production edit, so LANDED/BUILDS apply to the TEST file.", "test": "TestFreezeCheck_CheckedCountMovesOnAddition", "observable": "checked counts VISITS and is incremented inside the visiting body. Fixture arithmetic (planner-measured: newFreezeCheckRepo has ONE source entry): 1 source entry alone -> checked 1; with the mirror-only entry -> checked MUST move to 2 AND S10 must fire. An enumerator that never visits mirror-only keys contributes neither -> red ON THE COUNT, not merely on the verdict.", "planner_prior_UNVERIFIED": "A"}
+    ],
+    "observable_scope_note": "The checked count detects ENUMERATION BLINDNESS (an entry no loop visits). It structurally CANNOT detect a neutered arm inside a VISITED body - the entry is still visited and still counted. Those defects are killed by M1-M9. The two observables are deliberately complementary; both are asserted."
+  },
+  "day_by_day": [
+    {"band": "H0 0:00-0:20", "tasks": ["T0"], "exit": "six rc=0 recorded; any non-zero -> STOP + escalate"},
+    {"band": "H1 0:20-2:00", "tasks": ["T1","T2","T3","T4","T5"], "exit": "go build / go vet / gofmt clean. Freeze|Prompt tests MAY be red here - expected, T9 has not run."},
+    {"band": "H2 2:00-2:45", "tasks": ["T6","T7","T8"], "exit": "same three clean; diff touches prompt_freeze_check_git.go:49-72 and prompt_freeze_core.go:251-266 but NOT prompt_freeze_check_git.go:28"},
+    {"band": "H3 2:45-4:15", "tasks": ["T9","T10"], "exit": "go test ./cmd/ailang/ -run 'Freeze|Prompt' -count=1 rc=0 with all 10 new tests present and passing. PAUSE POINT."},
+    {"band": "H4 4:15-5:30", "tasks": ["T11"], "exit": "all 10 mutants: LANDED + BUILDS + enumerated failing set + Criterion A/B verdict + sha256-verified restore"},
+    {"band": "H5 5:30-6:00", "tasks": ["T12","T13","T14"], "exit": "G1-G6 all rc=0; .mutbak/ removed; report written"},
+    {"band": "post (controller)", "tasks": ["AC probe matrix","commit","CI"], "exit": "every AC row at its required post-state"}
+  ],
+  "risks": [
+    {"id": "R1", "risk": "Sandbox denies TMPDIR or GOCACHE writes, so go test / go build fail for environmental reasons and the executor misreads it as a code failure. The whole test harness builds repos in t.TempDir().", "likelihood": "low", "impact": "sprint-fatal if misdiagnosed", "mitigation": "T0 runs FIRST and is the probe. A T0 failure is an environment escalation to the controller, NEVER a code fix."},
+    {"id": "R2", "risk": "Frozen-path string drift. T1 rewrites the block producing S1 and S3; the '(unenforceable freeze)' vs '(unenforceable)' suffix is one if away from silently changing 58 entries' messages.", "likelihood": "medium", "impact": "high", "mitigation": "AC8-REG pins the frozen cells to byte-identical strings; TestFreezeCheck_FrozenPlaceholderIsRed and _MirrorMdDivergenceIsRed already assert them."},
+    {"id": "R3", "risk": "Accidentally widening merge-base immutability (the tempting 'just delete the Frozen guards' refactor), which would make the legitimate mutable edit+hash-regen workflow red.", "likelihood": "medium", "impact": "high", "mitigation": "T7 is an explicit do-not-touch task naming prompt_freeze_check_git.go:28; the controller verifies line 28 is absent from the diff."},
+    {"id": "R4", "risk": "Signature change leaves a caller behind, producing a non-compiling commit.", "likelihood": "low", "impact": "medium", "mitigation": "4 callers enumerated by name (planner-measured). Go is the enforcer: 3 results cannot be assigned to 2 variables, so this fails loudly at go build, never silently as a stale zero."},
+    {"id": "R5", "risk": "checked implemented as a len() beside the work instead of an in-body increment - exactly the r2 quorum objection - producing a count that is green while the enumerator is blind.", "likelihood": "medium", "impact": "high", "mitigation": "T3 states the constraint; M-ADD's kill condition is ON THE COUNT. NOTE: a len(source.VersionKeys)+len(mirrorOnly) implementation STILL PASSES M-ADD, so the code review MUST read the increment site. Flagged for the evaluator."},
+    {"id": "R6", "risk": "The 'checked N' stdout line breaks a consumer.", "likelihood": "low", "impact": "medium", "mitigation": "Designer inventory (V21, carried forward unverified) finds exactly one invocation, make/code-health.mk:185, which neither pipes nor parses stdout. Planner confirms base stdout is currently EMPTY (measured), so this IS a genuine behavior change - hence T13 records it in CHANGELOG as Changed, not merely Fixed."},
+    {"id": "R7", "risk": "Mutation restore via git checkout destroys the sprint's uncommitted work in the same files.", "likelihood": "low", "impact": "catastrophic", "mitigation": "Mutation discipline rule 4 forbids it explicitly; restore is cp + sha256 equality assert."},
+    {"id": "R8", "risk": "Committed PLACEHOLDER becomes a CI violation and breaks someone's flow.", "likelihood": "very low", "impact": "low", "mitigation": "Cost today is ZERO: 0 of 59 entries use PLACEHOLDER - the one mutable entry is 64-hex (measured), the 58 frozen were already banned. The loader's runtime hatch is untouched."},
+    {"id": "R9", "risk": "Existing TestPromptFreezeCheck_RedOnMissingMarker sets b1.Frozen = nil, making b1 MUTABLE and newly subject to all four widened arms; it asserts len(v) == 1.", "likelihood": "low", "impact": "medium", "mitigation": "freezeFixture writes fresh hashes and matching .md in both trees from one in-memory r (planner-measured), so the widened arms emit nothing for b1 and the count stays 1. Detected immediately by T9's test run if wrong."}
+  ],
+  "rollback": [
+    "PRE-MERGE: the controller simply does not commit. The worktree is discarded. There is no released artifact and no state written anywhere by this change.",
+    "POST-MERGE, gate too strict: revert the single commit. make check-prompt-freeze returns to frozen-only behavior. NO data is rolled back - the change reads files and returns an exit code; it writes nothing except one stdout line.",
+    "POST-MERGE, partial: to drop only the count observable, remove the fmt.Printf in prompt_freeze.go and revert the signature to ([]string, error). The four widened arms are independent of the count and stay.",
+    "WHAT ROLLBACK CANNOT UNDO: nothing. --migrate is not run by CI, freezeVersion is untouched, and no registry bytes are written by any code path this sprint modifies."
+  ],
+  "out_of_scope": [
+    "merge-base immutability widening (prompt_freeze_check_git.go:28) - Non-Goals",
+    "either loader (internal/prompt/loader.go, internal/eval_harness/prompt_loader.go)",
+    "registering the 3 unregistered .md files under prompts/",
+    "changing freezeVersion",
+    "any CI/Makefile WIRING change (the code-health.mk edit is help text only)",
+    "go build ./... - rc=1 at base for an unrelated reason (cmd/wasm has no native main)"
+  ],
+  "executor_prohibitions": [
+    "NO git add / git commit / git stash / git checkout / git reset - the controller builds the commit, and the sandbox cannot commit in a linked worktree anyway",
+    "NO writes outside the worktree",
+    "NO 'go build ./...' as a gate",
+    "NO deleting a block or an import to create a mutant"
+  ],
+  "discrepancies_found": [],
+  "github_issues": [],
+  "completed": null,
+  "evaluation": null
+}

--- a/changelogs/v0.32-current.md
+++ b/changelogs/v0.32-current.md
@@ -4,6 +4,15 @@
 
 ## [Unreleased]
 
+### Changed — prompt freeze integrity now covers every registry entry
+
+`ailang prompt freeze --check` now validates hash enforceability, source-file existence and bytes,
+mirror-file existence and bytes, and mirror-only registry entries for mutable as well as frozen
+prompt versions. Missing source and mirror files are named integrity violations instead of generic
+I/O aborts, including compound corruptions where both applicable violations are reported. Completed
+checks now print `checked N registry entries` to stdout so registry enumeration is observable, and
+`--migrate` refuses a stale active-entry hash before writing either registry.
+
 ### Fixed — an omitted OpenAI/OpenRouter `usage` block is now distinguishable from an all-zero one
 
 A provider failure can arrive on the wire as a *successful empty completion*: `finish_reason:"stop"`,

--- a/cmd/ailang/prompt_freeze.go
+++ b/cmd/ailang/prompt_freeze.go
@@ -66,7 +66,7 @@ func runPromptFreeze(args []string) {
 		return
 	}
 	if *check {
-		violations, err := checkRegistries(*repo)
+		violations, checked, err := checkRegistries(*repo)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(2)
@@ -74,6 +74,7 @@ func runPromptFreeze(args []string) {
 		for _, v := range violations {
 			fmt.Fprintln(os.Stderr, v)
 		}
+		fmt.Printf("checked %d registry entries\n", checked)
 		if len(violations) > 0 {
 			os.Exit(1)
 		}

--- a/cmd/ailang/prompt_freeze_check_git.go
+++ b/cmd/ailang/prompt_freeze_check_git.go
@@ -3,7 +3,9 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -38,6 +40,9 @@ func checkGitPromptFreezeInvariants(repoRoot string, source, mirror *orderedRegi
 			return nil, fmt.Errorf("git show merge-base prompt %s: %w", id, showErr)
 		}
 		currentBytes, readErr := os.ReadFile(filepath.Join(repoRoot, current.File))
+		if errors.Is(readErr, fs.ErrNotExist) {
+			continue
+		}
 		if readErr != nil {
 			return nil, readErr
 		}
@@ -48,8 +53,9 @@ func checkGitPromptFreezeInvariants(repoRoot string, source, mirror *orderedRegi
 
 	for _, id := range source.VersionKeys {
 		entry := source.Versions[id]
-		if entry.Frozen == nil {
-			continue
+		state := "mutable"
+		if entry.Frozen != nil {
+			state = "frozen"
 		}
 		mirrorEntry := mirror.Versions[id]
 		if !sameFrozenRegistryEntry(entry, mirrorEntry) {
@@ -62,12 +68,17 @@ func checkGitPromptFreezeInvariants(repoRoot string, source, mirror *orderedRegi
 		}
 		mirrorPath := filepath.Join("cmd", "ailang", entry.File)
 		sourceBytes, sourceErr := os.ReadFile(filepath.Join(repoRoot, entry.File))
-		mirrorBytes, mirrorErr := os.ReadFile(filepath.Join(repoRoot, mirrorPath))
-		if sourceErr != nil {
+		sourceExists := !errors.Is(sourceErr, fs.ErrNotExist)
+		if sourceExists && sourceErr != nil {
 			return nil, sourceErr
 		}
-		if mirrorErr != nil || !bytes.Equal(sourceBytes, mirrorBytes) {
-			violations = append(violations, fmt.Sprintf("frozen version %s: mirror bytes differ at %s", id, filepath.ToSlash(mirrorPath)))
+		mirrorBytes, mirrorErr := os.ReadFile(filepath.Join(repoRoot, mirrorPath))
+		if errors.Is(mirrorErr, fs.ErrNotExist) {
+			violations = append(violations, fmt.Sprintf("%s version %s: mirror file missing at %s", state, id, filepath.ToSlash(mirrorPath)))
+		} else if mirrorErr != nil {
+			return nil, mirrorErr
+		} else if sourceExists && !bytes.Equal(sourceBytes, mirrorBytes) {
+			violations = append(violations, fmt.Sprintf("%s version %s: mirror bytes differ at %s", state, id, filepath.ToSlash(mirrorPath)))
 		}
 	}
 	return violations, nil

--- a/cmd/ailang/prompt_freeze_check_git_test.go
+++ b/cmd/ailang/prompt_freeze_check_git_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -276,6 +277,29 @@ func runFreezeCheck(t *testing.T, root string) ([]string, int) {
 		t.Fatal(err)
 	}
 	return violations, rc
+}
+
+// TestFreezeCheck_CountLinePrintedToStdout pins the CLI wiring that PRINTS the
+// count, which is a different mechanism from the count itself.
+// TestFreezeCheck_CheckedCountMovesOnAddition pins checkRegistries' returned int;
+// it stays green if the command never prints it, because it never looks at stdout.
+// This arm reads the bytes the command actually emits, so it dies when the Printf
+// is removed. AC1's rc half is a regression guard (rc is 0 at base and after), so
+// this stdout line is AC1's only falsifiable half and it needs a killer in Go.
+func TestFreezeCheck_CountLinePrintedToStdout(t *testing.T) {
+	root := newFreezeCheckRepo(t)
+	cmd := exec.Command(os.Args[0], "-test.run=^TestFreezeCheckHelperProcess$")
+	cmd.Env = append(os.Environ(), "AILANG_FREEZE_CHECK_HELPER=1", "AILANG_FREEZE_CHECK_REPO="+root)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("green fixture must exit 0, got %v (stdout=%q)", err, stdout.String())
+	}
+	// The fixture registry holds exactly one entry, so the count is derivable and
+	// a wrong count fails as loudly as a missing line.
+	if want := "checked 1 registry entries"; !strings.Contains(stdout.String(), want) {
+		t.Fatalf("stdout must carry %q, got %q", want, stdout.String())
+	}
 }
 
 func hasViolation(violations []string, parts ...string) bool {

--- a/cmd/ailang/prompt_freeze_check_git_test.go
+++ b/cmd/ailang/prompt_freeze_check_git_test.go
@@ -65,6 +65,123 @@ func TestFreezeCheck_UnmodifiedTreeIsGreen(t *testing.T) {
 	}
 }
 
+func TestFreezeCheck_MutablePlaceholderIsRed(t *testing.T) {
+	root := newFreezeCheckRepo(t)
+	writeFreezeCheckRegistries(t, root, "PLACEHOLDER", "PLACEHOLDER", false)
+
+	violations, rc := runFreezeCheck(t, root)
+	if rc != 1 || !hasViolation(violations, "mutable version v1.0.0", "unenforceable") {
+		t.Fatalf("want mutable placeholder violation and rc 1, got rc=%d violations=%v", rc, violations)
+	}
+}
+
+func TestFreezeCheck_MutableSourceDivergenceIsRed(t *testing.T) {
+	root := newFreezeCheckRepo(t)
+	base := []byte("base prompt\n")
+	writeFreezeCheckRegistries(t, root, hashBytes(base), hashBytes(base), false)
+	writeFreezeCheckFile(t, root, "prompts/v1.0.0.md", []byte("changed source\n"))
+
+	violations, rc := runFreezeCheck(t, root)
+	if rc != 1 || !hasViolation(violations, "mutable version v1.0.0", "file bytes do not match recorded hash") {
+		t.Fatalf("want mutable source divergence and rc 1, got rc=%d violations=%v", rc, violations)
+	}
+}
+
+func TestFreezeCheck_SourceMissingIsViolationNotError(t *testing.T) {
+	for _, frozen := range []bool{true, false} {
+		t.Run(map[bool]string{true: "frozen", false: "mutable"}[frozen], func(t *testing.T) {
+			root := newFreezeCheckRepo(t)
+			base := []byte("base prompt\n")
+			writeFreezeCheckRegistries(t, root, hashBytes(base), hashBytes(base), frozen)
+			if err := os.Remove(filepath.Join(root, "prompts", "v1.0.0.md")); err != nil {
+				t.Fatal(err)
+			}
+			violations, rc := runFreezeCheck(t, root)
+			if rc != 1 || !hasViolation(violations, map[bool]string{true: "frozen", false: "mutable"}[frozen]+" version v1.0.0", "prompt file missing at prompts/v1.0.0.md") {
+				t.Fatalf("want named source-missing violation and rc 1, got rc=%d violations=%v", rc, violations)
+			}
+		})
+	}
+}
+
+func TestFreezeCheck_MutableMirrorDivergenceIsRed(t *testing.T) {
+	root := newFreezeCheckRepo(t)
+	base := []byte("base prompt\n")
+	writeFreezeCheckRegistries(t, root, hashBytes(base), hashBytes(base), false)
+	writeFreezeCheckFile(t, root, "cmd/ailang/prompts/v1.0.0.md", []byte("changed mirror\n"))
+
+	violations, rc := runFreezeCheck(t, root)
+	if rc != 1 || !hasViolation(violations, "mutable version v1.0.0", "mirror bytes differ at cmd/ailang/prompts/v1.0.0.md") {
+		t.Fatalf("want mutable mirror divergence and rc 1, got rc=%d violations=%v", rc, violations)
+	}
+}
+
+func TestFreezeCheck_MirrorMissingIsRed(t *testing.T) {
+	for _, frozen := range []bool{true, false} {
+		t.Run(map[bool]string{true: "frozen", false: "mutable"}[frozen], func(t *testing.T) {
+			root := newFreezeCheckRepo(t)
+			base := []byte("base prompt\n")
+			writeFreezeCheckRegistries(t, root, hashBytes(base), hashBytes(base), frozen)
+			if err := os.Remove(filepath.Join(root, "cmd", "ailang", "prompts", "v1.0.0.md")); err != nil {
+				t.Fatal(err)
+			}
+			violations, rc := runFreezeCheck(t, root)
+			if rc != 1 || !hasViolation(violations, map[bool]string{true: "frozen", false: "mutable"}[frozen]+" version v1.0.0", "mirror file missing at cmd/ailang/prompts/v1.0.0.md") {
+				t.Fatalf("want named mirror-missing violation and rc 1, got rc=%d violations=%v", rc, violations)
+			}
+		})
+	}
+}
+
+func TestFreezeCheck_MirrorOnlyEntryIsRed(t *testing.T) {
+	root := newFreezeCheckRepo(t)
+	addMirrorOnlyFreezeCheckEntry(t, root, "v9.9.9-extra")
+	violations, rc := runFreezeCheck(t, root)
+	if rc != 1 || !hasViolation(violations, "entry v9.9.9-extra missing from source registry") {
+		t.Fatalf("want mirror-only violation and rc 1, got rc=%d violations=%v", rc, violations)
+	}
+}
+
+func TestFreezeCheck_CheckedCountMovesOnAddition(t *testing.T) {
+	root := newFreezeCheckRepo(t)
+	addMirrorOnlyFreezeCheckEntry(t, root, "v9.9.9-extra")
+	oldScanner := corpusScanner
+	corpusScanner = func(string) (map[string]corpusEvidence, error) { return map[string]corpusEvidence{}, nil }
+	t.Cleanup(func() { corpusScanner = oldScanner })
+	violations, checked, err := checkRegistries(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checked != 2 || !hasViolation(violations, "entry v9.9.9-extra missing from source registry") {
+		t.Fatalf("want mirror-only addition counted (fixture 1 -> 2), got checked=%d violations=%v", checked, violations)
+	}
+}
+
+func TestFreezeCheck_InvalidHashAndMissingSourceEmitsBoth(t *testing.T) {
+	root := newFreezeCheckRepo(t)
+	writeFreezeCheckRegistries(t, root, "PLACEHOLDER", "PLACEHOLDER", false)
+	if err := os.Remove(filepath.Join(root, "prompts", "v1.0.0.md")); err != nil {
+		t.Fatal(err)
+	}
+	violations, rc := runFreezeCheck(t, root)
+	if rc != 1 || !hasViolation(violations, "mutable version v1.0.0", "unenforceable") || !hasViolation(violations, "mutable version v1.0.0", "prompt file missing") {
+		t.Fatalf("want both invalid-hash and missing-source violations, got rc=%d violations=%v", rc, violations)
+	}
+}
+
+func TestFreezeCheck_BothTreesDeletedEmitsBoth(t *testing.T) {
+	root := newFreezeCheckRepo(t)
+	for _, rel := range []string{"prompts/v1.0.0.md", "cmd/ailang/prompts/v1.0.0.md"} {
+		if err := os.Remove(filepath.Join(root, filepath.FromSlash(rel))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	violations, rc := runFreezeCheck(t, root)
+	if rc != 1 || !hasViolation(violations, "prompt file missing at prompts/v1.0.0.md") || !hasViolation(violations, "mirror file missing at cmd/ailang/prompts/v1.0.0.md") {
+		t.Fatalf("want both source- and mirror-missing violations, got rc=%d violations=%v", rc, violations)
+	}
+}
+
 func TestFreezeCheckHelperProcess(t *testing.T) {
 	if os.Getenv("AILANG_FREEZE_CHECK_HELPER") != "1" {
 		return
@@ -117,6 +234,20 @@ func writeFreezeCheckFile(t *testing.T, root, rel string, data []byte) {
 	}
 }
 
+func addMirrorOnlyFreezeCheckEntry(t *testing.T, root, id string) {
+	t.Helper()
+	path := filepath.Join(root, "cmd", "ailang", "prompts", "versions.json")
+	r, err := loadOrderedRegistry(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.VersionKeys = append(r.VersionKeys, id)
+	r.Versions[id] = &registryEntry{File: "prompts/" + id + ".md", Hash: strings.Repeat("a", 64)}
+	if err := writeOrderedRegistry(path, r); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func runFreezeCheckGit(t *testing.T, root string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)
@@ -131,7 +262,7 @@ func runFreezeCheck(t *testing.T, root string) ([]string, int) {
 	oldScanner := corpusScanner
 	corpusScanner = func(string) (map[string]corpusEvidence, error) { return map[string]corpusEvidence{}, nil }
 	t.Cleanup(func() { corpusScanner = oldScanner })
-	violations, err := checkRegistries(root)
+	violations, _, err := checkRegistries(root)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/ailang/prompt_freeze_core.go
+++ b/cmd/ailang/prompt_freeze_core.go
@@ -5,7 +5,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -250,9 +252,6 @@ func migrateRegistries(repoRoot, today string) (int, int, int, error) {
 	}
 	for _, id := range r.VersionKeys {
 		e := r.Versions[id]
-		if id == r.Active || e.Frozen != nil {
-			continue
-		}
 		if !eval_harness.IsHexSHA256(e.Hash) {
 			return 0, 0, 0, fmt.Errorf("%s: recorded hash is not enforceable", id)
 		}
@@ -332,21 +331,22 @@ func freezeVersion(repoRoot, versionID, today string) error {
 	return writeOrderedRegistry(pair.Mirror, r)
 }
 
-func checkRegistries(repoRoot string) ([]string, error) {
+func checkRegistries(repoRoot string) ([]string, int, error) {
 	pair := promptRegistryPair(repoRoot)
 	source, err := loadOrderedRegistry(pair.Source)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	mirror, err := loadOrderedRegistry(pair.Mirror)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	evidence, err := corpusScanner(repoRoot)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	var v []string
+	checked := 0
 	for id, ev := range evidence {
 		if e := source.Versions[id]; e != nil && e.Frozen == nil {
 			v = append(v, fmt.Sprintf("corpus-evidenced but not frozen: %s (%d citations, e.g. %s)", id, ev.Count, ev.Example))
@@ -354,13 +354,29 @@ func checkRegistries(repoRoot string) ([]string, error) {
 	}
 	for _, id := range source.VersionKeys {
 		e := source.Versions[id]
+		state := "mutable"
 		if e.Frozen != nil {
-			if !eval_harness.IsHexSHA256(e.Hash) {
-				v = append(v, fmt.Sprintf("frozen version %s: recorded hash is not a 64-hex sha256 (unenforceable freeze)", id))
-			} else if h, xerr := fileHash(filepath.Join(repoRoot, e.File)); xerr != nil {
-				return nil, xerr
-			} else if h != e.Hash {
-				v = append(v, fmt.Sprintf("frozen version %s: file bytes do not match recorded hash", id))
+			state = "frozen"
+		}
+		hashOK := eval_harness.IsHexSHA256(e.Hash)
+		if !hashOK {
+			suffix := "(unenforceable)"
+			if e.Frozen != nil {
+				suffix = "(unenforceable freeze)"
+			}
+			v = append(v, fmt.Sprintf("%s version %s: recorded hash is not a 64-hex sha256 %s", state, id, suffix))
+		}
+		sourceBytes, srcErr := os.ReadFile(filepath.Join(repoRoot, e.File))
+		sourceExists := !errors.Is(srcErr, fs.ErrNotExist)
+		if !sourceExists {
+			v = append(v, fmt.Sprintf("%s version %s: prompt file missing at %s", state, id, e.File))
+		} else if srcErr != nil {
+			return nil, 0, srcErr
+		}
+		if hashOK && sourceExists {
+			sum := sha256.Sum256(sourceBytes)
+			if hex.EncodeToString(sum[:]) != e.Hash {
+				v = append(v, fmt.Sprintf("%s version %s: file bytes do not match recorded hash", state, id))
 			}
 		}
 		a, _ := json.Marshal(e)
@@ -368,10 +384,17 @@ func checkRegistries(repoRoot string) ([]string, error) {
 		if !bytes.Equal(a, b) {
 			v = append(v, fmt.Sprintf("cmd/ailang/prompts/versions.json: entry %s differs from source", id))
 		}
+		checked++
+	}
+	for _, id := range mirror.VersionKeys {
+		if source.Versions[id] == nil {
+			v = append(v, fmt.Sprintf("cmd/ailang/prompts/versions.json: entry %s missing from source registry", id))
+			checked++
+		}
 	}
 	v, err = checkGitPromptFreezeInvariants(repoRoot, source, mirror, v)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	return v, nil
+	return v, checked, nil
 }

--- a/cmd/ailang/prompt_freeze_test.go
+++ b/cmd/ailang/prompt_freeze_test.go
@@ -108,6 +108,17 @@ func TestPromptFreezeMigrate_RefusesStaleHash(t *testing.T) {
 		t.Fatal("registry changed on refusal")
 	}
 }
+func TestPromptFreezeMigrate_RefusesStaleActiveHash(t *testing.T) {
+	root := freezeFixture(t)
+	p := filepath.Join(root, "prompts", "active.md")
+	if err := os.WriteFile(p, []byte("tampered"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, _, _, err := migrateRegistries(root, "2026-08-27")
+	if err == nil || !strings.Contains(err.Error(), "active") {
+		t.Fatalf("want stale active hash refusal, got %v", err)
+	}
+}
 func TestPromptFreezeMigrate_Idempotent(t *testing.T) {
 	root := freezeFixture(t)
 	migrateRegistries(root, "2026-08-27")
@@ -122,7 +133,7 @@ func TestPromptFreezeMigrate_Idempotent(t *testing.T) {
 func TestPromptFreezeCheck_GreenOnMigratedFixture(t *testing.T) {
 	root := freezeFixture(t)
 	migrateRegistries(root, "2026-08-27")
-	v, err := checkRegistries(root)
+	v, _, err := checkRegistries(root)
 	if err != nil || len(v) != 0 {
 		t.Fatalf("%v %v", v, err)
 	}
@@ -135,7 +146,7 @@ func TestPromptFreezeCheck_RedOnMissingMarker(t *testing.T) {
 	r.Versions["b1"].Frozen = nil
 	writeOrderedRegistry(pair.Source, r)
 	writeOrderedRegistry(pair.Mirror, r)
-	v, err := checkRegistries(root)
+	v, _, err := checkRegistries(root)
 	if err != nil || len(v) != 1 || !strings.Contains(v[0], "b1") || !strings.Contains(v[0], "corpus-evidenced but not frozen") {
 		t.Fatalf("%v %v", v, err)
 	}

--- a/design_docs/planned/m-prompt-freeze-mirror-all-versions-sprint-plan.md
+++ b/design_docs/planned/m-prompt-freeze-mirror-all-versions-sprint-plan.md
@@ -1,0 +1,426 @@
+# Sprint Plan — M-PROMPT-FREEZE-MIRROR-ALL-VERSIONS
+
+**Design doc**: [`design_docs/planned/m-prompt-freeze-mirror-all-versions.md`](m-prompt-freeze-mirror-all-versions.md) (r3, 467 lines)
+**Sprint ID**: `M-PROMPT-FREEZE-MIRROR-ALL-VERSIONS`
+**Planner**: sprint-planner role, V1 mission iteration 297, lane `opus` (Agent-tool planner)
+**Planned**: 2026-08-28
+**Worktree**: `/Users/voightkampff/dev/sunholo-data/.wt-iter297` @ `3d80bf91005a3c57042e0d6358373c4b4f005a4a` (design doc committed; tree clean)
+**Base**: origin/dev `0917693792d07c75ae0c4d233d2cc7e592fa9272`
+**Platform of all measurements below**: darwin/arm64, `go version go1.26.6 darwin/arm64`, module `go 1.26.6`
+**Executor lane**: `codex:gpt-5.6-sol` under `--sandbox workspace-write`
+**Milestones**: 1 · **Estimate**: 1 day (≤ 6h focused)
+
+---
+
+## 0. What this sprint changes, in one paragraph
+
+`make check-prompt-freeze` → `go run ./cmd/ailang prompt freeze --check` has three file-level
+arms, all gated on `Frozen != nil`. The registry holds 59 entries, 58 frozen and exactly one
+mutable — `v0.16.6`, which is also `active`, i.e. the prompt every agent reads. That one entry is
+therefore unchecked at the file level. This sprint widens **mirror byte-agreement**,
+**hash-vs-file-bytes**, **file existence** (as a named rc=1 violation, replacing an rc=2 abort) and
+**hash-enforceability** to ALL entries, adds a mirror-only-registry-entry violation and a
+`checked N registry entries` count observable, and widens the `--migrate` *validation* loop to
+match. **Merge-base IMMUTABILITY deliberately stays frozen-only** — mutable means editable, and the
+edit+hash-regen-in-one-commit workflow must stay green.
+
+---
+
+## 1. Measurement provenance — read this before trusting any number here
+
+Three tiers appear in this plan and are labelled inline:
+
+| Tier | Meaning |
+|------|---------|
+| **[P]** | **Planner-measured this session**, first-party, in the pristine worktree above. Command and rc recorded. |
+| **[C]** | Controller-measured and handed to the planner; the planner independently re-derived it (result agrees). |
+| **[D]** | **Designer-asserted only** (Verification Log V1–V22). Carried forward, NOT re-measured by the planner. Anything a milestone or AC rests on has been promoted to [P]. |
+
+**Rule honored: a value transcribed is not a measurement.** Every acceptance criterion in §6 rests
+on a [P] row. The [D] rows below are context, and no gate depends on one.
+
+### 1.1 Gate baseline — the six commands, re-measured [P]
+
+Run by the planner in `/Users/voightkampff/dev/sunholo-data/.wt-iter297` at `3d80bf910`, clean tree:
+
+| # | Command | rc at base |
+|---|---------|-----------|
+| G1 | `go build ./cmd/ailang/...` | **0** |
+| G2 | `go vet ./cmd/ailang/...` | **0** |
+| G3 | `test -z "$(gofmt -l cmd/ailang)"` | **0** |
+| G4 | `go test ./cmd/ailang/ -run 'Freeze\|Prompt' -count=1` | **0** (`ok … 2.367s`) |
+| G5 | `go run ./cmd/ailang prompt freeze --check` | **0**, **stdout empty** (only the `Observatory: 429MB` stderr log line) |
+| G6 | `make check-prompt-freeze` | **0** |
+
+**`go build ./...` is DISQUALIFIED as a gate** — it is rc=1 at base (`cmd/wasm` has no native
+`main`). It must not appear in any acceptance criterion, task, or CI-equivalence claim.
+
+**`-skip` support probed [P]**: `go test ./cmd/ailang/ -run 'Freeze|Prompt' -skip
+'^TestFreezeCheck_UnmodifiedTreeIsGreen$' -count=1` → rc=0. The inverse-arm criterion of §7 is
+therefore expressible on this toolchain.
+
+### 1.2 Structural facts re-derived by the planner [P]
+
+- Registry shape: source `versions.json` **59** versions, **58** frozen, **1** mutable =
+  `v0.16.6`; `.active` = `v0.16.6`; mirror registry also **59**; `prompts/*.md` = 62,
+  `cmd/ailang/prompts/*.md` = 62. → the pristine count observable must read **`checked 59`**.
+- `v0.16.6` hash is **fresh in both trees and both registries**:
+  source registry = mirror registry = `2a868106…f804b67` = `shasum -a 256 prompts/v0.16.6.md` =
+  `shasum -a 256 cmd/ailang/prompts/v0.16.6.md`. → AC1 is green *non-vacuously*; the widened arms
+  do not turn the real repo red.
+- `checkRegistries` call graph: **1 definition + 1 comment + 4 callers**, all `package main` in
+  `cmd/ailang` — `prompt_freeze.go:69`, `prompt_freeze_check_git_test.go:134`,
+  `prompt_freeze_test.go:125`, `prompt_freeze_test.go:138`. Agrees with [C] and with V20.
+  **Both test files are in scope**; Go rejects a 2-variable assignment from 3 results, so the
+  compiler enforces the update — a caller cannot silently take a stale zero.
+- Imports: `prompt_freeze_core.go` already imports `crypto/sha256`, `encoding/hex`, `bytes`,
+  `encoding/json`, `fmt`, `os`, `os/exec`, `path/filepath`, `strings`, `eval_harness`.
+  It does **not** import `errors` or `io/fs`. `prompt_freeze_check_git.go` imports `bytes`,
+  `encoding/json`, `fmt`, `os`, `os/exec`, `path/filepath`, `strings` — also **no** `errors`/`io/fs`.
+  Both new imports are required in both files. (Relevant to mutation discipline: the `if false &&
+  errors.Is(...)` form keeps them used.)
+- `orderedRegistry` exposes `VersionKeys []string` and `Versions map[string]*registryEntry`
+  (a **pointer** map, line 29) — the `source.Versions[id] == nil` sweep in Solution Design §1
+  compiles; the identical deref already ships at `prompt_freeze_core.go:351`.
+- Test harness: `newFreezeCheckRepo(t)` builds a synthetic git repo in `t.TempDir()` with **one**
+  entry `v1.0.0` (`active` = `v1.0.0`), `git init` → commit → `update-ref refs/remotes/origin/dev`
+  → `switch -c feature`. `writeFreezeCheckRegistries(t, root, sourceHash, mirrorHash, frozen bool)`
+  — the `frozen bool` parameter exists, so mutable fixtures need no new scaffolding.
+  `runFreezeCheck(t, root)` stubs `corpusScanner`, calls `checkRegistries` **in-process** and
+  `t.Fatal`s on a non-nil error, then re-execs `os.Args[0] -test.run=^TestFreezeCheckHelperProcess$`
+  with `AILANG_FREEZE_CHECK_HELPER=1` for the rc. `hasViolation(violations, parts...)` does
+  substring matching after `filepath.ToSlash`.
+  → **M-ADD arithmetic on this fixture: 1 source entry → `checked 1`; + one mirror-only entry →
+  `checked 2`.**
+- `migrateRegistries` validation loop (`prompt_freeze_core.go:251-266`) skips
+  `id == r.Active || e.Frozen != nil`; the freeze-writing loop at `:267` has the same skip. Only
+  the **validation** loop is widened (Solution Design §4).
+- `freezeFixture` (`prompt_freeze_test.go:14-44`) writes 8 entries with fresh
+  `sha256(content)` hashes and matching `.md` in **both** trees, and writes both registries from the
+  same in-memory `r` — so widening cannot make `TestPromptFreezeMigrate_*` or
+  `TestPromptFreezeCheck_GreenOnMigratedFixture` red.
+- `make/code-health.mk:184` help text is `## Check frozen prompt immutability and mirror agreement (CI gate)`.
+
+### 1.3 Carried forward from the designer without re-measurement [D]
+
+V2 (CI wiring: `make/ci.mk:11`, `.github/workflows/ci.yml:205`), V8 (`//go:embed all:prompts` is a
+directory glob), V9/V16 (loader behavior), V10 (`create_prompt_version.sh` path and content),
+V11 (3 unregistered `.md`), V12 (`eval_suite_manifest.go`), V21 (stdout consumers), V22
+(`freezeVersion` pre-write validation). None of these gates an AC; each is context.
+
+---
+
+## 2. Velocity and estimate
+
+- **Recent throughput [P]**: `git log --since=14.days --oneline | wc -l` → **412** commits in 14
+  days on this checkout's history. The mission runs a nightly design→plan→execute→evaluate loop,
+  so per-sprint scope, not commit count, is the binding constraint.
+- **Diff size (designer estimate, [D])**: ~+46/-16 production LOC over three files, ~+174 test LOC
+  over two files, 1 comment line in `make/code-health.mk`, 1 CHANGELOG entry.
+- **Estimate: 1 day / ≤ 6h.** Basis: all five touched files are ≤ 400 lines and were read
+  end-to-end this session; the fixture harness already has the `frozen bool` switch; the violation
+  strings are normative and pre-specified (S1–S11); and the six gates are already green at base, so
+  every red the executor sees is caused by the executor.
+- **Not a two-day sprint because**: no new package, no new dependency, no CI wiring change, no
+  schema change, no data migration.
+
+---
+
+## 3. Milestone structure — ONE milestone, and why
+
+The doc specifies a single milestone ("M1 — the whole change (≤1 day)"). The plan keeps it, for a
+reason that is a property of the change, not of its size:
+
+**The signature change `checkRegistries(repoRoot string) ([]string, error)` →
+`([]string, int, error)` is a compile-breaking edit with 4 callers in one package [P].** Any split
+that lands the core widening without simultaneously updating `prompt_freeze.go:69`,
+`prompt_freeze_check_git_test.go:134`, `prompt_freeze_test.go:125` and `:138` produces a
+**non-compiling intermediate commit** — i.e. a non-bisectable boundary. Splitting *around* that
+constraint (e.g. "signature + callers" as M1a) would create a milestone whose only content is a
+mechanical arity change with no behavior and no test — a boundary that proves nothing.
+
+So: one milestone, one commit, `go test ./cmd/ailang/ -run 'Freeze|Prompt' -count=1` green at its
+boundary.
+
+---
+
+## 4. Doc-vs-plan acceptance-criteria reconciliation (required section)
+
+**Doc's `## Milestones` section says**: "Solution Design §1-§5 + all tests in the mutation table +
+**AC1-AC8** + CHANGELOG."
+
+**Doc's `## Acceptance Criteria` table contains**: **AC1 … AC10** (AC9 and AC10 were added in the
+r2 revision in response to the `gpt5-6-sol` arm-independence objection).
+
+**Plan's milestone task list closes**: **AC1 … AC10**.
+
+**Divergence found, and it is internal to the doc**: the `## Milestones` string "AC1-AC8" is stale
+r1 text that the r2 revision did not update. It is not a scope ruling — the same milestone sentence
+says "**all tests in the mutation table**", and the mutation table's M8 / M9 rows name
+`TestFreezeCheck_InvalidHashAndMissingSourceEmitsBoth` and
+`TestFreezeCheck_BothTreesDeletedEmitsBoth`, whose fixtures **are** AC9 and AC10 verbatim. The
+milestone therefore already includes AC9/AC10 by way of the mutation table it incorporates.
+
+**Ruling**: the doc wins, and the doc's own AC table + mutation table are the doc. The milestone
+closes **AC1–AC10**. This is a stale-string reconciliation, not an override of a reviewed decision.
+The plan makes no other change to any AC. Second-order evidence: AC9/AC10 rest on V17/V18, which
+are r2 Verification-Log rows, and the r2 Quorum revision log records both as "pinned by new AC9/AC10
+plus independence mutants M8/M9".
+
+**Planner disagreements with the doc's ACs**: none on substance. One presentational repair, in §6:
+AC8 as written bundles a **regression** half (frozen cells 2–3 unchanged; existing tests pass) that
+is at its target state at base **by construction** with a **progress** half (cell 4's mirror-deletion
+rename) that is not. Bundled, AC8 reads as a criterion that half-cannot-fail. Split into
+**AC8-REG** and **AC8-Δ** with the base measurement stated for each; no criterion is weakened, and
+the at-target-at-base half is explicitly labelled as a regression guard rather than passed off as a
+progress gate.
+
+---
+
+## 5. Milestone M1 — task list
+
+Ordered. Every task is executable inside the worktree by a `workspace-write` sandbox. **No task
+performs a git write operation** — the controller builds the commit.
+
+| # | Task | Files | Done when |
+|---|------|-------|-----------|
+| T0 | **Baseline smoke** — re-run G1–G6 (§1.1) *before touching anything* and record rc. All six must be 0. | — | six rc=0 recorded in the executor report. **If any is non-zero, STOP and escalate** — the environment differs from the plan's baseline and every subsequent rc is uninterpretable (see Risk R1). |
+| T1 | Widen the per-entry loop in `checkRegistries` into the three **independent** arms of Solution Design §1 (hash-enforceability / source-existence / bytes-vs-hash), carrying the `state` label. Frozen strings S1/S3 stay **byte-identical** (the `(unenforceable freeze)` suffix is preserved by the `if e.Frozen != nil` suffix switch, not by a separate branch). | `cmd/ailang/prompt_freeze_core.go` | S1–S5 emitted per §1; arm dependencies exactly the §3 table and nothing more. |
+| T2 | Missing-source adjudication: `errors.Is(srcErr, fs.ErrNotExist)` → **violation S5 (rc=1)**; any other read error → `return nil, 0, srcErr` (rc=2, environmental). Add `errors` + `io/fs` imports. | same | AC3/AC7 fixture yields rc=1 with the named string, not an abort. |
+| T3 | Add the mirror-only sweep over `mirror.VersionKeys` emitting S10, and the `checked` counter — **incremented as the last statement of each visiting loop body**, never as a `len()` computed beside the work. Change the signature to `([]string, int, error)`. | same | `checked` is a product of the per-entry work (doc §1, r2 objection 2). |
+| T4 | Update **all four** callers for the new arity: `prompt_freeze.go:69`, `prompt_freeze_check_git_test.go:134`, `prompt_freeze_test.go:125`, `prompt_freeze_test.go:138`. | `prompt_freeze.go`, both test files | `go build ./cmd/ailang/...` rc=0 **and** `go vet ./cmd/ailang/...` rc=0. |
+| T5 | Print `checked %d registry entries\n` to **stdout** in `runPromptFreeze --check`, on every completed run, green or red. | `cmd/ailang/prompt_freeze.go` | AC1/AC6 stdout assertions satisfiable. Base stdout is empty [P], so this line is new. |
+| T6 | Widen the mirror loop: replace `if entry.Frozen == nil { continue }` (`prompt_freeze_check_git.go:51`) with the `state` label; make **mirror existence unconditional** (a missing source must not hide a missing/diverged mirror); emit S8 on `fs.ErrNotExist`; keep S6/S7 for divergence only. Leave the frozen-only `sameFrozenRegistryEntry` dedupe recheck exactly as-is. | `cmd/ailang/prompt_freeze_check_git.go` | S6/S7/S8 per §2; AC10 emits **both** S5 and S8. |
+| T7 | **Do NOT touch** the merge-base loop's `if baseEntry.Frozen == nil { continue }` at `prompt_freeze_check_git.go:28`. | — | `git diff` shows line 28 unchanged (controller verifies at commit time). |
+| T8 | Widen the `migrateRegistries` **validation** loop only: drop `id == r.Active \|\| e.Frozen != nil` from the loop at `:251`. The **freeze-writing** loop at `:267` keeps both skips. | `cmd/ailang/prompt_freeze_core.go` | migrate still never freezes `active`; `TestPromptFreezeMigrate_*` stay green. |
+| T9 | New tests, per the mutation table (§7), in `prompt_freeze_check_git_test.go` using `newFreezeCheckRepo` + `writeFreezeCheckRegistries(…, frozen=false)`: `_MutablePlaceholderIsRed`, `_MutableSourceDivergenceIsRed`, `_SourceMissingIsViolationNotError` (frozen + mutable sub-cases), `_MutableMirrorDivergenceIsRed`, `_MirrorMissingIsRed` (frozen + mutable), `_MirrorOnlyEntryIsRed`, `_InvalidHashAndMissingSourceEmitsBoth`, `_BothTreesDeletedEmitsBoth`, `_CheckedCountMovesOnAddition`. Each asserts the **in-process violation slice** (exact S-string via `hasViolation`) **and** the helper-subprocess rc. | `cmd/ailang/prompt_freeze_check_git_test.go` | `go test ./cmd/ailang/ -run 'Freeze\|Prompt' -count=1` rc=0. |
+| T10 | New migrate test `TestPromptFreezeMigrate_RefusesStaleActiveHash` extending `freezeFixture` (corrupt the `active` entry's file bytes after the fixture writes, so its recorded hash is stale) — `migrateRegistries` must return a non-nil error. | `cmd/ailang/prompt_freeze_test.go` | asserts the returned error, which is the direct product of the widened validation loop. |
+| T11 | **Run the mutation matrix** (§7) — all 10 mutants, each with its LANDED + BUILDS preconditions and byte-identical restore. Record per mutant: sha256 before/after/restored, build rc, the **enumerated** failing-test set, and the blast-radius verdict. | working copies only | §7's per-mutant criterion satisfied and recorded; tree byte-identical to pre-mutation state at the end (sha256 equality, per file). |
+| T12 | Update the `make/code-health.mk:184` help text from `Check frozen prompt immutability and mirror agreement (CI gate)` to `Check prompt registry integrity (all entries) + frozen immutability (CI gate)`. Comment/help only — the recipe line at `:185` is unchanged. | `make/code-health.mk` | `make check-prompt-freeze` still rc=0; `make help` renders. |
+| T13 | CHANGELOG entry under Unreleased → Fixed/Changed, naming the widened arms, the new S-strings, and the `checked N registry entries` stdout line as a behavior change. | `CHANGELOG.md` | present. |
+| T14 | **Final gate sweep**: re-run G1–G6 and record each rc. | — | all six rc=0. |
+
+**Explicitly out of scope** (Non-Goals — the executor must not do these): merge-base immutability
+widening; either loader (`internal/prompt/loader.go`, `internal/eval_harness/prompt_loader.go`);
+registering the 3 unregistered `.md` files; changing `freezeVersion`; any CI/Makefile **wiring**
+change; `go build ./...`.
+
+---
+
+## 6. Acceptance criteria — with planner-measured base rcs
+
+**Probe protocol used for every base measurement below [P]** (identical construction to the doc's,
+re-run first-party by the planner this session):
+`/tmp/i297p/repo` ← `prompts/`, `cmd/ailang/prompts/`, empty `eval_results/baselines/` copied from
+the worktree; `git init` + one commit + `git update-ref refs/remotes/origin/dev HEAD`; tar snapshot
+(`--exclude .git`) restored before **and** after every cell; probe binary
+`go build -o /tmp/i297p/bin/ailang ./cmd/ailang` from the worktree; invocation
+`/tmp/i297p/bin/ailang prompt freeze --check --repo /tmp/i297p/repo`. Post-restore control cell:
+**rc=0** — the restore is byte-faithful, so each cell's rc is attributable to that cell.
+
+**Positive controls in the same harness**: cells AC8a/AC8b/AC8c returned **rc=1 with the exact
+frozen violation strings**. Four reds in the same instrument make the six rc=0 cells measurements
+of a hole, not a broken probe.
+
+| # | Criterion | Command | **rc at base (planner-measured)** | Required post-change |
+|---|-----------|---------|-----------------------------------|----------------------|
+| AC1 | Pristine green **and the count line appears** | repo-root `make check-prompt-freeze`; probe pristine `--check` | **0**, and **stdout empty** — no count line exists at base | rc=0 **and** stdout contains `checked 59 registry entries`. *Falsifiable at base via the stdout half*; the rc half is a regression guard. |
+| AC2 | Mutable source divergence refused | `printf 'x' >> prompts/v0.16.6.md` → `--check` | **0** ← the hole | rc=1, contains `mutable version v0.16.6: file bytes do not match recorded hash` |
+| AC3 | Mutable source deletion refused, **named** | `rm prompts/v0.16.6.md` → `--check` | **0** ← the hole | rc=1, contains `mutable version v0.16.6: prompt file missing at prompts/v0.16.6.md` |
+| AC4 | Mutable mirror divergence refused | `printf 'x' >> cmd/ailang/prompts/v0.16.6.md` → `--check` | **0** ← the hole | rc=1, contains `mutable version v0.16.6: mirror bytes differ at cmd/ailang/prompts/v0.16.6.md` |
+| AC5 | Mutable `PLACEHOLDER` refused | set `v0.16.6` hash to `PLACEHOLDER` in **both** registries → `--check` | **0** ← the hole | rc=1, contains `mutable version v0.16.6: recorded hash is not a 64-hex sha256 (unenforceable)` |
+| AC6 | Mirror-only entry refused **and counted** | add `v9.9.9-extra` to the **mirror** registry only → `--check` | **0** ← the hole; and no count line exists at base | rc=1, contains `entry v9.9.9-extra missing from source registry`, **and** stdout reads `checked 60 registry entries` (AC1 pins pristine at 59, so the 59→60 move is the assertion, not the verdict alone) |
+| AC7 | Missing **frozen** source is a named violation, not an abort | `rm prompts/v0.3.21.md` → `--check` | **2**, stderr exactly `open /tmp/i297p/repo/prompts/v0.3.21.md: no such file or directory` and nothing else | rc=1, contains `frozen version v0.3.21: prompt file missing at prompts/v0.3.21.md` |
+| **AC8-REG** | **Regression guard — at target at base BY DESIGN.** Frozen source divergence and frozen mirror divergence stay byte-identical; existing tests keep passing | probe cells AC8a (`printf 'x' >> prompts/v0.3.21.md`) and AC8b (`printf 'x' >> cmd/ailang/prompts/v0.3.21.md`); repo-root `go test ./cmd/ailang/ -run 'Freeze\|Prompt' -count=1` | **AC8a rc=1** with exactly `frozen version v0.3.21: file bytes do not match recorded hash` + `frozen version v0.3.21: immutability violation in prompts/v0.3.21.md bytes` + `frozen version v0.3.21: mirror bytes differ at cmd/ailang/prompts/v0.3.21.md`; **AC8b rc=1** with `frozen version v0.3.21: mirror bytes differ at cmd/ailang/prompts/v0.3.21.md`; **test rc=0** | identical rc and identical strings; test rc=0. **This criterion cannot fail at base and is not claimed to — it is a no-drift guard, labelled as such.** |
+| **AC8-Δ** | **Progress — the mirror-deletion rename.** Frozen mirror deletion is reported honestly | `rm cmd/ailang/prompts/v0.3.21.md` → `--check` | **1**, with the *misleading* string `frozen version v0.3.21: mirror bytes differ at cmd/ailang/prompts/v0.3.21.md` | rc=1, containing `frozen version v0.3.21: mirror file missing at cmd/ailang/prompts/v0.3.21.md` and **NOT** containing `mirror bytes differ at cmd/ailang/prompts/v0.3.21.md`. *The negative half is what makes this falsifiable at base.* |
+| AC9 | **Compound**: invalid hash **and** missing source emit **both** named violations | set `v0.16.6` hash to `PLACEHOLDER` in both registries **and** `rm prompts/v0.16.6.md` → `--check` | **0** ← the compound hole | rc=1, stderr contains **both** `mutable version v0.16.6: recorded hash is not a 64-hex sha256 (unenforceable)` **and** `mutable version v0.16.6: prompt file missing at prompts/v0.16.6.md` |
+| AC10 | **Compound**: source **and** mirror both deleted emit **both** named violations | `rm prompts/v0.3.21.md cmd/ailang/prompts/v0.3.21.md` → `--check` | **2**, stderr names only the FIRST missing file; the mirror deletion is invisible | rc=1, stderr contains **both** `frozen version v0.3.21: prompt file missing at prompts/v0.3.21.md` **and** `frozen version v0.3.21: mirror file missing at cmd/ailang/prompts/v0.3.21.md` |
+
+**Audit of the "can this AC fail at base?" question, as required**: nine of eleven rows are
+falsifiable at base outright (AC2–AC7, AC8-Δ, AC9, AC10 differ from their required post-state in rc,
+string, or both). **AC1** is rc=0 at base and rc=0 after — falsifiable only through its stdout half,
+which is why the stdout assertion is mandatory and not decorative; without it AC1 would be a gate
+that cannot fail. **AC8-REG** is at its target state at base by construction and is labelled a
+regression guard, not a progress gate; it is retained because string drift on the frozen path is a
+real risk of this diff (T1 rewrites the block that produces S1/S3).
+
+### 6.1 Executor vs CONTROLLER split (sandbox reality)
+
+The executor lane is `codex:gpt-5.6-sol` under `--sandbox workspace-write`: **no loopback sockets,
+no writes outside the worktree.**
+
+| Gate | Owner | Why |
+|------|-------|-----|
+| G1 G2 G3 G4 G5 G6 (§1.1) | **Executor** | In-worktree; read-only git (`merge-base`, `show`); no sockets. G5/G6 shell out to `git` inside the worktree only. |
+| T9/T10 Go tests | **Executor** | The harness writes to `t.TempDir()` (under `TMPDIR`) and runs `git init` **in that temp dir** — not in the repo. `go test` also writes `GOCACHE`. This is the standing assumption of every Go sprint in this mission, and T0 probes it before any edit (Risk R1). |
+| T11 mutation matrix | **Executor** | Edits and restores files **inside the worktree** only; runs `go build` / `go test`. |
+| **AC1–AC10 probe-matrix cells** | **CONTROLLER** | They construct a synthetic repo **outside the worktree** (`/tmp/i297p/repo`) and run `git init` / `git commit` / `git update-ref` in it. Outside-worktree writes are not an executor obligation. |
+| **AC1 repo-root `make check-prompt-freeze` half** | **Executor** | In-worktree, read-only. |
+| CI (`.github/workflows/ci.yml:205`) | **CONTROLLER** | Post-commit; needs network. |
+
+**Consequence, stated plainly**: the executor's obligations are T0–T14 minus the probe matrix. The
+probe matrix is the controller's post-hoc confirmation, and the Go tests of T9/T10 are the
+executor-side encoding of the same coverage — which is why every AC row above has a corresponding
+test row in §7. **If the executor cannot satisfy an AC because it is a controller gate, that is not
+a failure; failing to have written the corresponding test IS.**
+
+---
+
+## 7. Mutation / refusal-branch test plan
+
+The deliverable's headline verb is **refuse**, so every refusal branch gets a mutant.
+
+### 7.1 Non-negotiable mutation discipline
+
+1. **Neutering form only.** `if false && <cond>` (or, for M7/M8/M9, the condition-**wrapping** form
+   given in the table). **Never delete a block, never delete a statement, never remove an import.**
+   Reason: with the block intact every import stays used, so "the mutant does not compile" can never
+   masquerade as "the guard fired".
+2. **LANDED check, before reading any test result.** `shasum -a 256 <file>` before and after the
+   edit **must differ**. A mutant that did not land makes the subsequent green meaningless.
+3. **BUILDS check, before reading any test result.** `go build ./cmd/ailang/...` **rc=0** under the
+   mutant. A compile failure is not a guard firing.
+4. **Restore by `cp` from a pre-mutation backup, verified by sha256 equality.**
+   **NEVER `git checkout -- <file>` and NEVER `git stash`** — the sprint's own uncommitted work
+   lives in these exact files, and a checkout would delete it. Suggested shape:
+   `cp cmd/ailang/prompt_freeze_core.go /tmp/i297mut/prompt_freeze_core.go.bak` before, then
+   `cp /tmp/i297mut/prompt_freeze_core.go.bak cmd/ailang/prompt_freeze_core.go` after, then assert
+   the sha256 equals the pre-mutation value. (Backups under `/tmp` are *reads* into the worktree on
+   restore; if the sandbox refuses `/tmp` writes, keep backups at `<worktree>/.mutbak/` — still no
+   git operation. Do not commit `.mutbak/`; delete it in T14.)
+5. **Order**: backup → mutate → LANDED → BUILDS → run → record → restore → sha256-equality assert.
+   All ten mutants restored before T12.
+
+### 7.2 Blast-radius classification — determined by RUNNING, not predicting
+
+Per mutant the executor must **run** `go test ./cmd/ailang/ -run 'Freeze|Prompt' -count=1` and
+**enumerate the actual failing test names** from the output. Then apply, per mutant:
+
+- **Criterion A — single-test (strongest).** The failing set is exactly `{target}`. The executor
+  must additionally run the **inverse arm**:
+  `go test ./cmd/ailang/ -run 'Freeze|Prompt' -skip '^<target>$' -count=1` → **rc must be 0**.
+  This proves the mutant is visible to that test and to no other. `-skip` is supported on this
+  toolchain [P].
+- **Criterion B — broad blast.** The failing set has >1 member. Criterion A is unsatisfiable *by
+  construction* here, so the required evidence is the **enumerated set itself**, plus: (i) the
+  target test **is in the set**, and (ii) **every other member is explained** by one sentence naming
+  the shared code path the mutant sits on. An unexplained member is a finding, not noise.
+
+**Which criterion applies is a measurement, not a prediction.** The "prior" column below is the
+planner's *unverified expectation* and carries no authority; the executor records the observed set
+and picks A or B from it. If the observation contradicts the prior, the observation wins and the
+executor notes it.
+
+### 7.3 The matrix
+
+| # | Refusal branch | Neutering mutation | Test that must go red | Downstream observable asserted | Criterion (planner prior — **unverified**) |
+|---|----------------|--------------------|-----------------------|-------------------------------|--------------------------------------------|
+| M1 | S2 mutable hash-enforceable | `if false && !eval_harness.IsHexSHA256(e.Hash)` | `TestFreezeCheck_MutablePlaceholderIsRed` | violation containing `unenforceable` **and** rc 1→0; only this branch emits S2 | A expected |
+| M2 | S4 mutable bytes-vs-hash | `if false && (hex.EncodeToString(sum[:]) != e.Hash)` on a `frozen=false` fixture | `TestFreezeCheck_MutableSourceDivergenceIsRed` | S4 string + rc; the frozen branch cannot fire on a `frozen:false` fixture | A expected |
+| M3 | S5 missing source file | `if false && errors.Is(srcErr, fs.ErrNotExist)` | `TestFreezeCheck_SourceMissingIsViolationNotError` (frozen + mutable sub-cases) | neutered → the read error propagates → `checkRegistries` returns `err` → in-process `t.Fatal` path **and** helper rc=**2**, not 1. The test asserts rc==1 **and** the S5 string; both are produced only by the branch | A expected |
+| M4 | S7 mutable mirror divergence | `if false && !bytes.Equal(sourceBytes, mirrorBytes)` | `TestFreezeCheck_MutableMirrorDivergenceIsRed` | S7 string + rc; no other arm reads mirror `.md` bytes | **B plausible** — this is the shared S6/S7 comparison, so `TestFreezeCheck_MirrorMdDivergenceIsRed` (existing, frozen) may also go red. If so that is Criterion B with one explained member. **Measure it.** |
+| M5 | S8 mirror file missing | `if false && errors.Is(mirrorErr, fs.ErrNotExist)` | `TestFreezeCheck_MirrorMissingIsRed` (frozen + mutable) | neutered → falls to `else if mirrorErr != nil → return nil, err` → rc=2, so the rc==1 assertion goes red for the reason it claims | A expected |
+| M6 | S10 mirror-only entry | `if false && (source.Versions[id] == nil)` | `TestFreezeCheck_MirrorOnlyEntryIsRed` | S10 string + rc; no other loop visits mirror-only keys | **B plausible** — the same mutant also suppresses the `checked++` inside that sweep, so `TestFreezeCheck_CheckedCountMovesOnAddition` is expected to go red too. Both members are targets of the same branch; enumerate and explain. |
+| M7 | migrate validation widening | restore the skip as `if false \|\| id == r.Active { continue }` inside the **validation** loop only | `TestPromptFreezeMigrate_RefusesStaleActiveHash` (new) | migrate's returned error is the direct product of the validation loop; with the skip restored, migrate succeeds and the error assertion fails | A expected |
+| M8 | **arm independence**: source-existence must not depend on hash validity | wrap arm 2's emission as `if hashOK && !sourceExists` (reintroduces r1 masking; no block deleted, all imports stay used) | `TestFreezeCheck_InvalidHashAndMissingSourceEmitsBoth` (AC9 fixture: `frozen=false`, hash `PLACEHOLDER`, source absent) | asserts **both** S2 and S5; under the mutant only S2 is emitted → red **specifically on the S5 assertion** | A expected |
+| M9 | **arm independence**: mirror-existence must not depend on source existence | wrap the S8 emission as `if sourceExists && errors.Is(mirrorErr, fs.ErrNotExist)` | `TestFreezeCheck_BothTreesDeletedEmitsBoth` (AC10 fixture: both `.md` removed) | asserts **both** S5 and S8; under the mutant only S5 is emitted → red **specifically on the S8 assertion** | A expected |
+| **M-ADD** | enumerator completeness — an **addition**, not a removal. Every removal proves the check FIRES; only an addition proves it **LOOKS** | fixture-side: ADD `v9.9.9-extra` to the mirror registry of an otherwise-green fixture. **No production edit**, so the LANDED/BUILDS preconditions apply to the *test* file | `TestFreezeCheck_CheckedCountMovesOnAddition` | `checked` counts **visits** and is incremented inside the visiting body (§1). Fixture arithmetic **[P]**: 1 source entry alone → `checked 1`; with the mirror-only entry → `checked` MUST move to **2** AND S10 must fire. An enumerator that never visits mirror-only keys contributes neither → red **on the count**, not merely on the verdict | A expected |
+
+**Honest scope of the two observables, restated so the executor does not conflate them**: the
+`checked` count detects **enumeration blindness** (an entry no loop visits). It structurally
+**cannot** detect a neutered arm inside a *visited* body — the entry is still visited and still
+counted. Those defects are killed by M1–M9. The observables are complementary; both are asserted.
+
+**Test-design constraint (carried from the doc, non-negotiable)**: every new test drives the REAL
+check path — the in-process `checkRegistries` **and** the `TestFreezeCheckHelperProcess` subprocess
+rc — against a synthetic git repo. **No test may seed a verdict by raw fixture**, which is how the
+parent sprint's tests once stayed green while a writer did not exist.
+
+---
+
+## 8. Day-by-day breakdown
+
+One day. Hour bands are guidance, not a contract; the ordering is the contract.
+
+| Band | Tasks | Exit condition |
+|------|-------|----------------|
+| **H0 — 0:00-0:20** | T0 | Six rc=0 recorded. Any non-zero → STOP + escalate. |
+| **H1 — 0:20-2:00** | T1, T2, T3, T4, T5 | `go build ./cmd/ailang/...` rc=0, `go vet ./cmd/ailang/...` rc=0, `gofmt -l cmd/ailang` empty. Existing `Freeze|Prompt` tests may be red here — expected, T9 has not run. |
+| **H2 — 2:00-2:45** | T6, T7, T8 | Same three rc=0. Diff touches `prompt_freeze_check_git.go:49-72` and `prompt_freeze_core.go:251-266` but **not** `prompt_freeze_check_git.go:28`. |
+| **H3 — 2:45-4:15** | T9, T10 | `go test ./cmd/ailang/ -run 'Freeze\|Prompt' -count=1` rc=0 with all 10 new tests present and passing. |
+| **H4 — 4:15-5:30** | T11 | All 10 mutants run, each with LANDED + BUILDS recorded, an enumerated failing set, a Criterion A or B verdict, and a sha256-verified restore. |
+| **H5 — 5:30-6:00** | T12, T13, T14 | G1–G6 all rc=0; `.mutbak/` removed; report written. |
+| **Post — controller** | AC1–AC10 probe matrix; commit; CI | Every AC row in §6 at its required post-state. |
+
+**Pause point**: after H3. If `go test` is not green at H3 the sprint does not proceed to mutation
+testing — a mutation matrix run against a red suite measures nothing.
+
+---
+
+## 9. Test plan (summary)
+
+- **Unit / integration**: `go test ./cmd/ailang/ -run 'Freeze|Prompt' -count=1` — 5 existing
+  `TestFreezeCheck_*` + the migrate/check tests in `prompt_freeze_test.go` + 10 new tests.
+  **rc=0 at base [P]**, so any red is caused by this sprint.
+- **String normativity**: S1–S11 in the doc's Solution Design table are **normative**. Frozen-path
+  strings S1/S3/S6/S9/S11 must stay byte-identical; S8 is the one deliberate rename. Assert with
+  `hasViolation(violations, parts...)` (substring after `ToSlash`), which already exists.
+- **rc semantics**: 0 green / 1 violations / 2 usage-or-IO error. The core behavioral change is that
+  **`fs.ErrNotExist` moves from the 2 bucket to the 1 bucket**; every other error stays at 2. Two
+  tests (`_SourceMissingIsViolationNotError`, `_MirrorMissingIsRed`) exist specifically to pin that
+  boundary, and their neutering mutants (M3, M5) both manifest as rc 1→2.
+- **Mutation**: §7, 10 mutants, LANDED+BUILDS gated, restore-by-cp.
+- **Whole-gate**: `make check-prompt-freeze` rc=0 at repo root, stdout containing
+  `checked 59 registry entries`.
+- **Probe matrix** (controller): all 11 cells of §6.
+- **Not run**: `go build ./...` — rc=1 at base for an unrelated reason [P].
+
+---
+
+## 10. Risks
+
+| # | Risk | Likelihood | Impact | Mitigation / detection |
+|---|------|-----------|--------|------------------------|
+| **R1** | **Sandbox denies `TMPDIR` or `GOCACHE` writes**, so `go test` / `go build` fail for environmental reasons and the executor misreads it as a code failure. The whole test harness builds repos in `t.TempDir()`. | Low (every prior Go sprint in this mission ran in this lane) | **Sprint-fatal if misdiagnosed** | **T0 runs first and is the probe.** All six gates rc=0 at base before a single edit. A T0 failure is an environment escalation to the controller, never a code fix. |
+| R2 | **Frozen-path string drift.** T1 rewrites the block that produces S1 and S3; the `(unenforceable freeze)` vs `(unenforceable)` suffix is one `if` away from silently changing 58 entries' messages. | Medium | High (breaks existing tests and any operator muscle memory) | AC8-REG pins cells AC8a/AC8b to byte-identical strings; `TestFreezeCheck_FrozenPlaceholderIsRed` and `_MirrorMdDivergenceIsRed` already assert them. |
+| R3 | **Accidentally widening merge-base immutability** (the tempting "just delete the Frozen guards" refactor), which would make the legitimate mutable edit+hash-regen workflow red. | Medium | High — breaks `create_prompt_version.sh`'s documented flow | T7 is an explicit do-not-touch task naming `prompt_freeze_check_git.go:28`; controller verifies line 28 is absent from the diff. |
+| R4 | **Signature change leaves a caller behind**, producing a non-compiling commit. | Low | Medium | 4 callers enumerated by name in T4 [P]; **Go is the enforcer** — 3 results cannot be assigned to 2 variables, so this fails loudly at `go build`, never silently as a stale zero. |
+| R5 | **`checked` implemented as a `len()` beside the work** instead of an in-body increment — this is exactly the r2 quorum objection, and it produces a count that is green while the enumerator is blind. | Medium (it is the easier implementation) | High — it silently voids AC6 and M-ADD | T3 states the constraint; M-ADD's kill condition is **on the count**; a `len(source.VersionKeys)+len(mirrorOnly)` implementation still passes M-ADD, so the **code review must read the increment site**. Flagged for the evaluator. |
+| R6 | **The `checked N` stdout line breaks a consumer.** | Low | Medium | Designer inventory [D, V21] finds exactly one invocation, `make/code-health.mk:185`, which neither pipes nor parses stdout. Planner confirms base stdout is currently **empty** [P], so this is a genuine behavior change — hence T13 records it in CHANGELOG as *Changed*, not merely *Fixed*. |
+| R7 | **Mutation restore via `git checkout`** destroys the sprint's uncommitted work in the same files. | Low but catastrophic | Sprint-fatal | §7.1 rule 4 forbids it explicitly; restore is `cp` + sha256 equality assert. |
+| R8 | **Committed `PLACEHOLDER` becomes a CI violation** (Solution Design §5) and breaks someone's flow. | Very low | Low | Cost today is **zero**: 0 of 59 entries use PLACEHOLDER — the one mutable entry is 64-hex [P], the 58 frozen were already banned. The loader's runtime hatch is untouched. |
+| R9 | Existing `TestPromptFreezeCheck_RedOnMissingMarker` sets `b1.Frozen = nil`, making `b1` **mutable** and newly subject to all four widened arms; it asserts `len(v) == 1`. | Low | Medium | `freezeFixture` writes fresh hashes and matching `.md` in both trees from one in-memory `r` [P], so the widened arms emit nothing for `b1` and the count stays 1. Detected immediately by T9's test run if wrong. |
+
+---
+
+## 11. Rollback
+
+The whole sprint is one commit touching six files, none of which is a schema, a migration, or a
+wire format.
+
+1. **Pre-merge**: the controller simply does not commit. The worktree is discarded; nothing else is
+   affected. There is no released artifact and no state written anywhere by this change.
+2. **Post-merge, gate too strict** (the realistic failure: some entry in a contributor's tree is red
+   for a reason we did not anticipate): revert the single commit. `make check-prompt-freeze`
+   returns to its current frozen-only behavior. **No data is rolled back** — the change reads files
+   and returns an exit code; it writes nothing except one stdout line.
+3. **Post-merge, partial rollback if only the count observable is unwanted**: remove the
+   `fmt.Printf("checked %d registry entries\n", n)` in `prompt_freeze.go` and revert the signature to
+   `([]string, error)`. The four widened arms are independent of the count and stay.
+4. **What rollback cannot undo**: nothing. `--migrate` is not run by CI, `freezeVersion` is
+   untouched, and no registry bytes are written by any code path this sprint modifies.
+
+---
+
+## 12. Definition of done
+
+- [ ] T0 recorded: G1–G6 all rc=0 **before** any edit.
+- [ ] T1–T8 landed; `go build ./cmd/ailang/...`, `go vet ./cmd/ailang/...`, `gofmt -l cmd/ailang`
+      all clean.
+- [ ] `prompt_freeze_check_git.go:28` (merge-base `Frozen == nil` skip) **unchanged**.
+- [ ] 10 new tests present; `go test ./cmd/ailang/ -run 'Freeze|Prompt' -count=1` rc=0.
+- [ ] All 10 mutants run with LANDED + BUILDS + enumerated failing set + Criterion A/B verdict +
+      sha256-verified restore; tree byte-identical afterwards.
+- [ ] `make/code-health.mk` help text updated; CHANGELOG entry written.
+- [ ] T14: G1–G6 all rc=0.
+- [ ] **Controller**: AC1–AC10 probe matrix at required post-state; commit; CI green.

--- a/design_docs/planned/m-prompt-freeze-mirror-all-versions.md
+++ b/design_docs/planned/m-prompt-freeze-mirror-all-versions.md
@@ -1,0 +1,467 @@
+# M-PROMPT-FREEZE-MIRROR-ALL-VERSIONS: `prompt freeze --check` must refuse divergence, deletion and unenforceable hashes for ALL registry entries, not only frozen ones
+
+**Status**: Planned
+**Target**: v0.34.x
+**Priority**: P1 (data-integrity — the one entry the gate cannot see is the active prompt every agent reads)
+**Estimated**: 1 day (single milestone)
+**Dependencies**: parent mechanism landed — `design_docs/planned/m-prompt-version-freeze-on-first-bank.md`, shipped via PR #937 (squash `445ccb550`)
+**Author**: design-doc-creator role, mission iteration 297 (2026-08-28), worktree at origin/dev = `0917693792d07c75ae0c4d233d2cc7e592fa9272`, darwin/arm64
+**Scope ruling**: the mission's queue-head decision was answered **EXTEND** — widen the file-level arms to all entries. This doc designs within that ruling; it does not re-open it.
+**Revision**: r2 — round-1 quorum verdict was **blocked** (3/3 reviewers present, two blocking
+objections, neither disputing the design direction). Both accepted: arm independence (no
+violation masking) and the checked-count observable made a product of the per-entry work. See
+the [Quorum revision log](#quorum-revision-log-round-1--r2).
+
+---
+
+## Problem Statement
+
+`make check-prompt-freeze` (CI gate, `make/code-health.mk:184`, member of `ci:` at `make/ci.mk:11`
+and an explicit step in `.github/workflows/ci.yml:205`) runs `ailang prompt freeze --check`. Its
+three file-level arms are ALL gated on `Frozen != nil`:
+
+1. `cmd/ailang/prompt_freeze_core.go` `checkRegistries`: hash-is-enforceable-sha256 and
+   file-bytes-vs-recorded-hash live inside `if e.Frozen != nil {` (line 357).
+2. `cmd/ailang/prompt_freeze_check_git.go:28` `if baseEntry.Frozen == nil { continue }` gates
+   merge-base immutability (correct — stays as-is, see Non-Goals).
+3. `cmd/ailang/prompt_freeze_check_git.go:51` `if entry.Frozen == nil { continue }` gates mirror
+   byte-agreement between `prompts/<x>.md` and `cmd/ailang/prompts/<x>.md`.
+
+The only all-entries check is the registry-vs-registry JSON entry comparison in `checkRegistries`
+(lines 366-370) — and it never opens a `.md` file, so it is structurally incapable of seeing file
+divergence, deletion, or a stale hash.
+
+The registry holds **59 versions, 58 frozen, exactly one mutable: `v0.16.6` — which is also the
+`active` entry** (V1). So the single entry the gate cannot see is the prompt every agent actually
+reads. Measured consequences (V4, V5): a diverged or deleted `prompts/v0.16.6.md`, a diverged
+mirror copy, or a `PLACEHOLDER` hash on the mutable entry all pass the gate at rc=0. Two
+amplifiers:
+
+- `cmd/ailang/main.go:21` is `//go:embed all:prompts`, a **directory** glob (V8) — a deleted
+  prompt file compiles clean; nothing at build time notices.
+- The enumerator iterates **source registry keys only**: an entry present only in the mirror
+  registry `cmd/ailang/prompts/versions.json` is invisible to every arm — measured rc=0 (V4 cell 8).
+
+Two adjacent defects surfaced by the same measurement: a **missing frozen source file** aborts the
+whole scan as a hard rc=2 error instead of a named rc=1 violation (V5 cell 11), hiding any other
+violations; and a mirror **deletion** is reported with the misleading text "mirror bytes differ"
+(V4 cell 4).
+
+---
+
+## Goals
+
+1. Every registry entry — frozen AND mutable — gets, at `--check` time:
+   (a) mirror byte-agreement (`prompts/<file>` vs `cmd/ailang/prompts/<file>`),
+   (b) recorded-hash vs actual source file bytes,
+   (c) file existence in both trees as a **named violation** (not a crash, not a silent pass),
+   (d) hash-is-enforceable-sha256.
+   The arms are **independent** (r2): for a given entry EVERY applicable violation is emitted —
+   one defect never masks another. The only permitted dependencies are the two byte-comparisons'
+   semantic prerequisites (Solution Design §3).
+2. The enumerator becomes auditable: mirror-only registry entries are a named violation, and
+   `--check` reports the **checked-entry count** so an addition the enumerator misses is
+   detectable by count, not only by verdict.
+3. All existing frozen-arm behavior and violation strings stay byte-identical except the one
+   deliberate rename (mirror deletion gets an honest "missing" message).
+
+## Non-Goals
+
+- **Merge-base IMMUTABILITY stays frozen-only.** The `if baseEntry.Frozen == nil { continue }` in
+  `checkGitPromptFreezeInvariants` is UNCHANGED. Mutable means editable — an edit+hash-regen in
+  the same commit is the legitimate workflow (`create_prompt_version.sh` step 3, V10) and must
+  stay green. The obvious "just delete the Frozen guards" refactor would break exactly this;
+  this doc widens three arms and deliberately not the fourth.
+- No change to either loader (`internal/eval_harness/prompt_loader.go` keeps its runtime
+  `PLACEHOLDER` hatch for mutable versions; `internal/prompt/loader.go` still performs no hash
+  verification — that is the parent doc's still-open M3, V9).
+- No registration of the 3 unregistered `.md` files under `prompts/` (V11) — enumeration stays
+  registry-driven; see Open Questions.
+- No change to `freezeVersion` (single-version freeze already validates its target).
+
+---
+
+## Verification Log
+
+All rows measured first-party by this role on **darwin/arm64**, in the clean worktree
+`/Users/voightkampff/dev/sunholo-data/.wt-iter297` at origin/dev =
+`0917693792d07c75ae0c4d233d2cc7e592fa9272`. Probe binary: `go build -o /tmp/i297bin/ailang
+./cmd/ailang` from this worktree (`--version` reports `AILANG dev` — no ldflags stamp; the binary
+is trusted **behaviorally** via the positive-control cells in V4, which reproduce the known frozen
+refusals). Synthetic probe repo for V4/V5: `/tmp/i297probe/repo` containing copies of `prompts/`,
+`cmd/ailang/prompts/` and an empty `eval_results/baselines/`; `git init` + one commit +
+`git update-ref refs/remotes/origin/dev HEAD`; a tar snapshot (`--exclude .git`) restored before
+each cell; invoked as `/tmp/i297bin/ailang prompt freeze --check --repo /tmp/i297probe/repo`.
+
+**Refuted hypothesis (kept per the hard gate — measure, don't reason):** the iteration controller
+initially inferred from reading `checkRegistries` alone that the mirror `.md` tree was never
+hashed for ANY entry. FALSE — the frozen-only mirror arm exists in the *other* file
+(`prompt_freeze_check_git.go:49-72`, violation text `"frozen version %s: mirror bytes differ at
+%s"` at line 70). I re-verified that arm by reading both files and by V4 cells 3-4 firing red.
+
+| # | Claim | Command | Observed output |
+|---|-------|---------|-----------------|
+| V1 | Registry shape: 59 versions, 58 frozen, 1 mutable = `v0.16.6` = `active`; mirror registry also 59; 62 `.md` files in each tree | `jq -r '.versions\|length' prompts/versions.json` ; `jq -r '[.versions\|to_entries[]\|select(.value\|has("frozen"))]\|length' …` ; `jq -r '[.versions\|to_entries[]\|select(.value\|has("frozen")\|not)\|.key]\|join(",")' …` ; `jq -r .active …` ; `ls prompts/*.md \| wc -l` ; `ls cmd/ailang/prompts/*.md \| wc -l` ; `jq -r '.versions\|length' cmd/ailang/prompts/versions.json` | `59` / `58` / `v0.16.6` / `v0.16.6` / `62` / `62` / `59` |
+| V2 | Gate wiring: make target + `ci:` membership + explicit CI step | `grep -n "check-prompt-freeze" make/code-health.mk make/ci.mk .github/workflows/ci.yml` | `make/code-health.mk:5` + `:184` (target = `go run ./cmd/ailang prompt freeze --check`), `make/ci.mk:11`, `.github/workflows/ci.yml:205: run: make check-prompt-freeze`; grep rc=0 |
+| V3 | The three file-level arms are gated on `Frozen != nil`; the registry-vs-registry compare is the only all-entries check and opens no `.md` | code read of `cmd/ailang/prompt_freeze_core.go:355-371` and `prompt_freeze_check_git.go:27-72` (full files read this session) | `if e.Frozen != nil {` guards hash-enforceable + bytes-vs-hash; `if baseEntry.Frozen == nil { continue }` (line 28); `if entry.Frozen == nil { continue }` (line 51); JSON compare at lines 366-370 uses `json.Marshal` only |
+| V4 | **The live matrix.** Cells, each restored from snapshot first: pristine; frozen `v0.3.21` source `.md` diverged; frozen mirror diverged; frozen mirror deleted; mutable `v0.16.6` source diverged; mutable source deleted; mutable mirror diverged; mirror-registry EXTRA entry (`v9.9.9-extra` added to mirror `versions.json` only); restored | probe-repo protocol above; divergence = `printf 'x' >> <file>`; extra entry via `jq '.versions["v9.9.9-extra"] = {"file":…,"hash":"PLACEHOLDER"}'` on the mirror registry only | `1 pristine rc=0` · `2 frozen-src-diverged rc=1` (`frozen version v0.3.21: file bytes do not match recorded hash` + `…immutability violation in prompts/v0.3.21.md bytes` + `…mirror bytes differ at cmd/ailang/prompts/v0.3.21.md`) · `3 frozen-mirror-diverged rc=1` · `4 frozen-mirror-deleted rc=1` (`frozen version v0.3.21: mirror bytes differ at cmd/ailang/prompts/v0.3.21.md` — the misleading text) · `5 mutable-src-diverged rc=0` **HOLE** · `6 mutable-src-deleted rc=0` **HOLE** · `7 mutable-mirror-diverged rc=0` **HOLE** · `8 mirror-registry-EXTRA-entry rc=0` **HOLE (new this iteration)** · `9 restored rc=0`. The four rc=1 cells in the same harness are the positive controls that make the four rc=0 cells measurements, not claims |
+| V5 | Two further cells: mutable entry with `hash="PLACEHOLDER"` in BOTH registries passes; a deleted **frozen source** file is a hard rc=2 abort, not a named violation | same protocol: `jq '.versions["v0.16.6"].hash = "PLACEHOLDER"'` applied to both registry files → run → restore; `rm prompts/v0.3.21.md` → run → restore → run | `CELL10 rc=0` **HOLE (arm d)** · `CELL11 rc=2`, stderr `open /tmp/i297probe/repo/prompts/v0.3.21.md: no such file or directory` · `CELL12 restored rc=0` (restore was byte-faithful) |
+| V6 | The mutable entry's recorded hash is currently FRESH in both trees and both registries agree — so widening arms (a)(b)(d) is green at base, not red | `jq -r '.versions["v0.16.6"].hash'` on both registries; `shasum -a 256 prompts/v0.16.6.md cmd/ailang/prompts/v0.16.6.md`; string compare | `reg=2a868106214d3a4fc94dcb5431560cebacbec05c1e1835a168b8dcb15f804b67`, `mirror_reg_same=yes`, `src_match=yes`, `mirror_match=yes` |
+| V7 | `make check-prompt-freeze` is rc=0 at base (pristine worktree, real repo) | `make check-prompt-freeze > /tmp/i297probe/mk.out 2>&1; printf 'rc=%s' "$?"` | `rc=0` |
+| V8 | The embed is a directory glob — a missing prompt compiles clean | `grep -n "go:embed" cmd/ailang/main.go` | `21://go:embed all:prompts` |
+| V9 | The agent-mode loader parses `Frozen` but performs **no** hash verification (parent M3 still open); and NO test references either loader error constructor by name | `grep -n "sha256\|Mismatch\|verify\|Verify" internal/prompt/loader.go` → empty. **Control, same instrument, same package**: the same grep over `internal/prompt/*.go` hits `fresh.go` at lines 17/162/184 (`crypto/sha256`, `sha256.Sum256`), so the instrument sees sha256 where it exists. `grep -rn "FrozenHashMismatchError\|MutableHashMismatchError" internal/ cmd/ --include='*_test.go'` → empty. **Control, same pattern, non-test files**: hits `internal/eval_harness/prompt_loader.go:89` and `prompt_frozen.go:32` | loader.go: no hits; fresh.go: sha256 hits; test grep: no hits; non-test grep: 2 hits |
+| V10 | `create_prompt_version.sh` lives at `.claude/skills/prompt-manager/scripts/` (NOT `scripts/` — the queue text's path is wrong), computes a real 64-hex hash at creation (line ~91-93), and its "Next steps" already instruct "Update hash" (line 129) and "Run make check-prompt-freeze before committing" (line 134) — so the widened gate matches the documented workflow | `ls scripts/create_prompt_version.sh` → `No such file or directory` with **control in the same call** `ls .claude/skills/prompt-manager/scripts/create_prompt_version.sh` → exists; `grep -n "hash\|freeze\|frozen" .claude/skills/prompt-manager/scripts/create_prompt_version.sh` | as stated; lines 91-93, 129, 134 |
+| V11 | Exactly 3 `.md` files under `prompts/` are referenced by no registry entry (docs, not prompt versions) | `comm -23 <(ls prompts/*.md \| sort) <(jq -r '.versions[].file' prompts/versions.json \| sort)` | `prompts/CHANGELOG_v0.3.15.md`, `prompts/feedback_gate_classifier.md`, `prompts/testing_guide_ai.md` |
+| V12 | `cmd/ailang/eval_suite_manifest.go` only *writes* `prompt_version` strings into manifests; it reads neither registry — no conflict with this change | `grep -n "prompt_version\|PromptVersion\|versions.json" cmd/ailang/eval_suite_manifest.go` | lines 77, 133, 205, 222 — all struct fields/assignments; zero `versions.json` hits |
+| V13 | `migrateRegistries`' pre-flight validation loop skips the active entry AND frozen entries (`if id == r.Active \|\| e.Frozen != nil { continue }`), so today `--migrate` would succeed on a tree where the widened `--check` is red | code read, `cmd/ailang/prompt_freeze_core.go:251-266` | as stated |
+| V14 | The migrate-test fixture writes FRESH hashes for every entry including `active`, so widening the migrate validation loop (Solution Design §4) does not break `TestPromptFreezeMigrate_*` | read of `freezeFixture` in `cmd/ailang/prompt_freeze_test.go:14-44` | fixture computes `sha256(content)` per entry incl. `"active"` and writes matching files to both trees |
+| V15 | The existing `--check` test harness builds a synthetic repo, drives `checkRegistries` in-process AND the rc via a helper subprocess, and has a `frozen bool` parameter on its registry writer — mutable fixtures are constructible without new scaffolding. Existing tests: `TestFreezeCheck_MergeBaseEditPlusRegenIsRed`, `_FrozenPlaceholderIsRed`, `_MirrorMdDivergenceIsRed` (divergence, not deletion — the deletion rename in §2 breaks no existing assertion), `_MirrorRegistryDivergenceIsRed`, `_UnmodifiedTreeIsGreen` | read of `cmd/ailang/prompt_freeze_check_git_test.go` (166 lines, full) | as stated; `writeFreezeCheckRegistries(t, root, sourceHash, mirrorHash, frozen bool)`; helper = `TestFreezeCheckHelperProcess` + `AILANG_FREEZE_CHECK_HELPER=1` |
+| V16 | The standard-mode loader ALREADY hash-verifies mutable versions at load time (`MutableHashMismatchError`) unless `hash == "PLACEHOLDER"` — the widened gate makes CI agree with the loader, not stricter than it (except for PLACEHOLDER, adjudicated in §5) | read of `internal/eval_harness/prompt_loader.go:76-93` | `if version.Frozen != nil {…}` / else `if version.Hash != "PLACEHOLDER" { … MutableHashMismatchError … }` |
+| V17 | **Compound hole (r2)**: a mutable entry with an INVALID hash AND a MISSING source file passes at base — neither S2 nor S5 fires | probe protocol: `jq '.versions["v0.16.6"].hash = "PLACEHOLDER"'` applied to BOTH registries + `rm prompts/v0.16.6.md` → `--check` → restore | `CELL13 rc=0`, no output beyond the Observatory log line |
+| V18 | **Compound abort (r2)**: a frozen entry with BOTH source and mirror `.md` deleted is a hard rc=2 abort naming only the FIRST missing file — the mirror deletion is invisible | `rm prompts/v0.3.21.md cmd/ailang/prompts/v0.3.21.md` → `--check` → restore → re-run restored control | `CELL14 rc=2`, stderr exactly one line: `open /tmp/i297probe/repo/prompts/v0.3.21.md: no such file or directory` (no mirror violation) · `CELL15 restored rc=0` |
+| V20 | **`checkRegistries` call graph (r3)**: 4 callers, all in `package main` under `cmd/ailang` — 1 production + 3 test; the r2 "Files to modify" list named only ONE of the two test files, so the objection found a real gap | `grep -rn "checkRegistries" --include='*.go' .` (rc=0), same-scope control `grep -rc "promptRegistryPair" --include='*.go' .` | 6 lines: def `prompt_freeze_core.go:335`; comment `prompt_freeze_check_git.go:56`; callers `prompt_freeze.go:69`, `prompt_freeze_check_git_test.go:134`, `prompt_freeze_test.go:125`, `prompt_freeze_test.go:138`. Control fires: `prompt_freeze_core.go:4`, `prompt_freeze_test.go:1` |
+| V21 | **`prompt freeze --check` stdout consumers (r3)**: exactly one, and it ignores stdout — so adding an unconditional count line breaks nothing | `grep -rn "freeze --check\|freeze\", \"--check\|check-prompt-freeze" --include='*.sh' --include='*.yml' --include='*.yaml' --include='*.mk' --include='Makefile' --include='*.go' .` (design_docs excluded) | `make/code-health.mk:185` is the sole invocation (`@go run … --check`, no pipe, no parse); reached from `.github/workflows/ci.yml:205` and `make/ci.mk:11`. Non-consumers: `help.go:285`, `prompt.go:154` (help strings) and `.claude`/`.agents` `create_prompt_version.sh:119,134` (a comment and an echo). **No consumer asserts on stdout or requires it empty** |
+| V22 | **`freezeVersion` pre-write validation (r3)**: the Non-Goals/Conflict-Surface claim is TRUE and is now measured rather than asserted | code read `cmd/ailang/prompt_freeze_core.go:298-333`; write-surface probe `sed -n '298,334p' … \| grep -c "WriteFile\|\.md"` with same-file control `grep -c writeOrderedRegistry …` | `:316` `!IsHexSHA256(e.Hash)` → error · `:319-322` `fileHash(...)` error propagated (covers a missing source file) · `:323` `actual != e.Hash` → error — **all three precede** the first write at `:329`. Write-surface probe = **0** (writes no `.md`), control = **5**. Writes both registries from the same `r` (`:329` source, `:332` mirror) |
+| V19 | `source.Versions[id] == nil` compiles: the registry map is a POINTER map, and the identical nil-deref pattern already ships in the same file (first-party re-derivation of the controller's measurement refuting gemini-3-1-pro's pass-note; no design change) | `sed -n '29p;351p' cmd/ailang/prompt_freeze_core.go` | `Versions      map[string]*registryEntry` · `if e := source.Versions[id]; e != nil && e.Frozen == nil {` |
+
+---
+
+## Solution Design
+
+One unified change: the file-level arms iterate **all** entries and carry a `state` label
+(`"frozen"` / `"mutable"`) in their violation strings; frozen-path strings stay byte-identical.
+The tests match on these exact strings, so they are normative:
+
+| # | Violation string (format) | Status |
+|---|---------------------------|--------|
+| S1 | `frozen version %s: recorded hash is not a 64-hex sha256 (unenforceable freeze)` | unchanged |
+| S2 | `mutable version %s: recorded hash is not a 64-hex sha256 (unenforceable)` | **new** |
+| S3 | `frozen version %s: file bytes do not match recorded hash` | unchanged |
+| S4 | `mutable version %s: file bytes do not match recorded hash` | **new** |
+| S5 | `frozen version %s: prompt file missing at %s` / `mutable version %s: prompt file missing at %s` | **new** (replaces the rc=2 abort, V5 cell 11) |
+| S6 | `frozen version %s: mirror bytes differ at %s` | unchanged (divergence only) |
+| S7 | `mutable version %s: mirror bytes differ at %s` | **new** |
+| S8 | `frozen version %s: mirror file missing at %s` / `mutable version %s: mirror file missing at %s` | **new** (deletion no longer reported as "differ"; no existing test asserts the deletion case, V15) |
+| S9 | `cmd/ailang/prompts/versions.json: entry %s differs from source` | unchanged (already all-entries; also fires when a source entry is absent from the mirror) |
+| S10 | `cmd/ailang/prompts/versions.json: entry %s missing from source registry` | **new** (mirror-only entries, V4 cell 8) |
+| S11 | `frozen version %s: immutability violation …` (both variants) | unchanged — frozen-only by design |
+
+### 1. `checkRegistries` (`cmd/ailang/prompt_freeze_core.go`) — widen the per-entry loop
+
+Replace the `if e.Frozen != nil { … }` block inside the `source.VersionKeys` loop with three
+**independent** arms (r2 — the round-1 draft chained them with `else if`, so one violation masked
+the others; V17 measures the compound state that masking cannot see):
+
+```go
+state := "mutable"
+if e.Frozen != nil {
+    state = "frozen"
+}
+// Arm 1 — hash enforceability. Unconditional.
+hashOK := eval_harness.IsHexSHA256(e.Hash)
+if !hashOK {
+    suffix := "(unenforceable)"
+    if e.Frozen != nil {
+        suffix = "(unenforceable freeze)" // preserves S1 byte-for-byte
+    }
+    v = append(v, fmt.Sprintf("%s version %s: recorded hash is not a 64-hex sha256 %s", state, id, suffix))
+}
+// Arm 2 — source existence. Unconditional; independent of arm 1.
+sourceBytes, srcErr := os.ReadFile(filepath.Join(repoRoot, e.File))
+sourceExists := !errors.Is(srcErr, fs.ErrNotExist)
+if !sourceExists {
+    v = append(v, fmt.Sprintf("%s version %s: prompt file missing at %s", state, id, e.File)) // S5
+} else if srcErr != nil {
+    return nil, 0, srcErr // environmental read errors (perms, I/O) stay hard errors
+}
+// Arm 3 — source bytes vs recorded hash. The ONLY conditional source arm, gated on
+// hashOK (without an enforceable hash there is no referent to compare against) and
+// sourceExists (without the file there are no bytes). Both dependencies are semantic
+// necessities, not sequencing accidents — nothing else may gate this arm.
+if hashOK && sourceExists {
+    sum := sha256.Sum256(sourceBytes)
+    if hex.EncodeToString(sum[:]) != e.Hash {
+        v = append(v, fmt.Sprintf("%s version %s: file bytes do not match recorded hash", state, id))
+    }
+}
+checked++ // LAST statement of the body: this entry's applicable arms have all run
+```
+
+(`fileHash` stays for the `--migrate`/`freezeVersion` paths; here the file is read once and
+hashed inline — `crypto/sha256` and `encoding/hex` are already imported in this file.)
+
+**Missing-file adjudication (scope item c):** a missing file becomes a **violation** (rc=1), not
+an `error` (rc=2), for `fs.ErrNotExist` specifically. Rationale: (i) a deleted prompt is exactly
+the corruption class this gate exists to name; (ii) the current `fileHash` error propagation
+aborts the scan at the first missing file and hides every other violation (V5 cell 11 shows one
+bare `open … no such file` line and nothing else); (iii) rc=1 vs rc=2 is the gate's documented
+contract (`prompt_freeze.go`: "0 green; 1 violations; 2 usage/IO error") — absence is a
+repo-state fact, not an IO accident. Environmental read errors (permissions, etc.) remain rc=2.
+
+**Enumerator audit (r2 — count is a PRODUCT of the per-entry work, never a `len()` computed
+beside it):** `checked` starts at 0 and is incremented exactly once per visited entry, as the
+last statement of the loop body that performs that entry's arms (see arm snippet above). The
+mirror-only sweep after the source loop does the same:
+
+```go
+for _, id := range mirror.VersionKeys {
+    if source.Versions[id] == nil { // pointer map; identical deref already ships (V19)
+        v = append(v, fmt.Sprintf("cmd/ailang/prompts/versions.json: entry %s missing from source registry", id)) // S10
+        checked++
+    }
+}
+```
+
+Keys present in both registries are counted once (the sweep counts only source-absent keys), so
+the arithmetic is order-independent and unambiguous: pristine real registry → `checked 59`; one
+mirror-only entry added → `checked 60`; the two-entry test fixture (1 source + 1 mirror-only) →
+`checked 2`. `checkRegistries` gains the count in its signature — `func checkRegistries(repoRoot
+string) ([]string, int, error)` — and `runPromptFreeze --check` prints
+`checked %d registry entries\n` to stdout on every completed run, green or red.
+
+**Honest scope of the count observable (r2):** because the increment lives inside the visiting
+body, an entry no loop visits contributes neither its violations nor its count — so the count
+detects **enumeration blindness** (the M-ADD case). It structurally CANNOT detect a neutered arm
+inside a visited body: the entry is still visited and still counted. Those defects are killed by
+the per-string mutants M1–M9. The two observables are complementary, and both are asserted
+(AC6, M-ADD vs AC2–AC5/AC9/AC10).
+
+### 2. Mirror arm (`cmd/ailang/prompt_freeze_check_git.go`, second loop) — widen and rename deletion
+
+Replace `if entry.Frozen == nil { continue }` with the state label; keep the frozen-only
+`sameFrozenRegistryEntry` dedupe recheck exactly as-is (it exists for independent callers and is
+already covered for all entries by S9 in `checkRegistries`). Body becomes (r2 — the round-1 draft
+`continue`d on a missing source BEFORE checking mirror existence, exactly the masking V18
+measures; mirror existence is now unconditional):
+
+```go
+sourceBytes, sourceErr := os.ReadFile(filepath.Join(repoRoot, entry.File))
+sourceExists := !errors.Is(sourceErr, fs.ErrNotExist)
+if sourceExists && sourceErr != nil {
+    return nil, sourceErr
+}
+// Mirror existence is checked UNCONDITIONALLY — a missing source must not hide a
+// missing or diverged mirror (V18). S5 for the missing source itself is emitted by
+// checkRegistries, not here; this loop never double-reports it.
+mirrorBytes, mirrorErr := os.ReadFile(filepath.Join(repoRoot, mirrorPath))
+if errors.Is(mirrorErr, fs.ErrNotExist) {
+    violations = append(violations, fmt.Sprintf("%s version %s: mirror file missing at %s", state, id, filepath.ToSlash(mirrorPath))) // S8
+} else if mirrorErr != nil {
+    return nil, mirrorErr
+} else if sourceExists && !bytes.Equal(sourceBytes, mirrorBytes) {
+    violations = append(violations, fmt.Sprintf("%s version %s: mirror bytes differ at %s", state, id, filepath.ToSlash(mirrorPath))) // S6/S7
+}
+```
+
+(The `else if` chain here switches on the mutually exclusive outcomes of ONE read — missing /
+error / readable — which is not arm-chaining; the independence requirement is across arms.)
+
+The merge-base loop above it (`if baseEntry.Frozen == nil { continue }`, line 28) is **not
+touched** (Non-Goals).
+
+### 3. Arm independence (r2 — quorum objection 1)
+
+The round-1 draft chained the arms and documented one masking corner as "acceptable". The quorum
+correctly rejected that: masking contradicts Goal 1(c), the stated motivation (the current rc=2
+abort already hides violations, V5 cell 11 / V18), and the no-silent-fallback axiom — and
+V17/V18 measure real compound states at base. The redesign makes the five questions independent;
+the COMPLETE dependency list, each one a semantic necessity:
+
+| Arm | Depends on | Why |
+|-----|------------|-----|
+| hash-enforceable (S1/S2) | nothing | — |
+| source existence (S5) | nothing | — |
+| source bytes vs hash (S3/S4) | hashOK ∧ sourceExists | no enforceable hash → no referent; no file → no bytes |
+| mirror existence (S8) | nothing | — |
+| mirror bytes agreement (S6/S7) | sourceExists ∧ mirrorExists | a byte comparison needs both operands |
+
+No other dependency is permitted. An entry in a compound bad state therefore emits EVERY
+applicable named violation: invalid hash + missing source → S2 **and** S5 (AC9); source and
+mirror both deleted → S5 **and** S8 (AC10).
+
+### 4. `--migrate` consistency (`migrateRegistries` pre-flight)
+
+Hazard adjudicated: today `--migrate`'s validation loop skips the active entry (V13), so it could
+succeed on a tree where the widened `--check` is red (stale active hash) — a gate that `--check`
+refuses but `--migrate` mints. Fix: the **validation** loop iterates ALL entries (drop
+`id == r.Active || e.Frozen != nil` from the validation loop only; frozen entries on a green tree
+match by definition, V6). The **freeze-writing** loop keeps both skips unchanged — migrate still
+never freezes the active entry. `TestPromptFreezeMigrate_*` fixtures already carry fresh hashes
+for every entry including `active` (V14), so no existing test breaks; `_RefusesStaleHash` keeps
+its meaning.
+
+### 5. PLACEHOLDER adjudication (scope item d)
+
+Widening hash-enforceability to mutable entries makes a committed `PLACEHOLDER` hash a CI
+violation (S2) while the standard-mode **loader** keeps honoring the hatch at runtime (V16,
+Non-Goals). Position: the hatch remains a *local, uncommitted* development convenience; a
+registry **committed to dev** must be enforceable, because the mirror/bytes arms are vacuous for
+an entry whose hash verifies nothing. Cost today: zero — 0 of 59 entries use PLACEHOLDER (V6
+shows the one mutable entry is 64-hex; the 58 frozen were already banned). `create_prompt_version.sh`
+never emits PLACEHOLDER (V10), so the scripted workflow is unaffected.
+
+### Files to modify
+
+- `cmd/ailang/prompt_freeze_core.go` — widen per-entry loop, S5 adjudication, mirror-only sweep,
+  count in signature (~+30/-10 LOC)
+- `cmd/ailang/prompt_freeze_check_git.go` — widen mirror loop, S8 (~+12/-6 LOC)
+- `cmd/ailang/prompt_freeze.go` — count printout, adapt to new `checkRegistries` signature (~+4 LOC)
+- `cmd/ailang/prompt_freeze_check_git_test.go` — new tests per the mutation table (~+170 LOC)
+- `cmd/ailang/prompt_freeze_test.go` — **REQUIRED, added r3 (quorum objection, `oc-glm-5-2`): it holds
+  TWO further in-process `checkRegistries` callers (`:125`, `:138`) that the signature change breaks.
+  The r2 list named only `prompt_freeze_check_git_test.go` and was incomplete — see V20** (~+4 LOC)
+- `make/code-health.mk` — comment only: target help text says "frozen prompt immutability"; update
+  to "prompt registry integrity (all entries) + frozen immutability" (1 line)
+- `CHANGELOG.md`
+
+---
+
+## Conflict Surface
+
+What else reads these registries/files, and why each survives the widening:
+
+| Surface | Reads | Verdict |
+|---------|-------|---------|
+| `internal/eval_harness/prompt_loader.go` | both trees via `rootDir`; already refuses stale mutable hashes at load (`MutableHashMismatchError`, V16) unless PLACEHOLDER | **Agrees.** The widened gate makes CI match the loader. The one divergence (PLACEHOLDER) is adjudicated in §5: loader hatch untouched, CI refuses committed placeholders |
+| `internal/prompt/loader.go` (agent mode) | embedded-first registry + `.md`; performs NO hash verification (V9) | **No conflict** — it never enforces, so it cannot disagree. Widened mirror agreement *helps* it: embedded bytes = source bytes for all entries once green |
+| `.claude/skills/prompt-manager/scripts/create_prompt_version.sh` (NOT `scripts/`, V10) | writes both registries + new `.md` in both trees, computes real hash at creation, already tells the user to run `make check-prompt-freeze` before committing | **Agrees.** The mutable edit→regen-hash workflow stays green when done in one commit, which is what its own step 3 + step 6 prescribe |
+| `cmd/ailang/eval_suite_manifest.go` | neither registry — only records `prompt_version` strings (V12) | **No conflict** |
+| `migrateRegistries` (`--migrate`) | validation loop currently skips active + frozen (V13) → could mint what `--check` refuses | **Real hazard; adjudicated** in Solution Design §4 (validate all, freeze-write unchanged; fixture already compatible, V14) |
+| `freezeVersion` (single-version path) | validates its own target's hash-enforceability and source-bytes-vs-hash before any write, and writes ONLY the two registry files (never a `.md`) — **measured r3, V22** | **No conflict** — it cannot mint a violation of any widened arm: the two hash arms are pre-validated, the two `.md` arms are untouched because it writes no `.md`, and registry-vs-registry agreement holds by construction because both registries are written from the same in-memory `r` |
+| Existing tests (V15) | exact violation strings + rc via helper subprocess | S1/S3/S6/S9/S11 unchanged; the only renamed case (mirror deletion → S8) has no existing assertion; `_UnmodifiedTreeIsGreen` stays green because the fixture writes fresh hashes and matching mirrors for its single entry regardless of the `frozen` flag |
+| **`checkRegistries` call graph (r3)** | the signature changes `([]string, error)` → `([]string, int, error)`; repo-wide inventory is **4 callers + 1 definition + 1 comment** (V20): production `prompt_freeze.go:69`; tests `prompt_freeze_check_git_test.go:134`, `prompt_freeze_test.go:125`, `prompt_freeze_test.go:138` | **Real gap, now closed.** All four callers are in `package main` in `cmd/ailang`; there is no external consumer, so the change cannot break another package. `prompt_freeze_test.go` is added to Files to modify. A caller ignoring the new `int` cannot silently receive a stale zero, because Go forbids assigning 3 results to 2 variables — the compiler is the enforcer |
+| **`prompt freeze --check` stdout consumers (r3)** | inventory across `*.sh`/`*.yml`/`*.mk`/`Makefile`/`*.go` (V21): the ONLY consumer is `make/code-health.mk:185` (`@go run ./cmd/ailang prompt freeze --check`), reached from `.github/workflows/ci.yml:205` and `make/ci.mk:11`. Remaining hits are help text (`help.go:285`, `prompt.go:154`) and shell comment/echo lines in both `create_prompt_version.sh` copies | **No conflict.** The recipe neither pipes nor parses stdout and asserts nothing about it — the exit code is the whole verdict. Nothing anywhere requires stdout to be empty, so the unconditional `checked N registry entries` line is safe |
+| CI / Makefile | invokes the same command | **No wiring change**; stdout gains one `checked N registry entries` line (safe — see the row above) |
+
+---
+
+## Acceptance Criteria
+
+Every command runs against the probe protocol of the Verification Log (same construction, same
+binary rebuild post-change) unless marked repo-root. **Base rc measured this iteration** is
+stated per AC; an AC already at its target state at base would be broken — none is.
+
+| # | Criterion | Command (probe repo unless noted) | rc at base (measured) | rc required post-change |
+|---|-----------|-----------------------------------|----------------------|------------------------|
+| AC1 | Pristine stays green, and the count line appears | repo-root: `make check-prompt-freeze`; probe: pristine `--check` | 0 (V7, V4 cell 1) | 0, stdout contains `checked 59 registry entries` (can fail: any widened arm misfiring on the real registry, or count wrong) |
+| AC2 | Mutable source divergence refused | `printf 'x' >> prompts/v0.16.6.md` → `--check` | **0** (V4 cell 5 — the hole) | 1, stderr contains `mutable version v0.16.6: file bytes do not match recorded hash` |
+| AC3 | Mutable source deletion refused, named | `rm prompts/v0.16.6.md` → `--check` | **0** (V4 cell 6) | 1, contains `mutable version v0.16.6: prompt file missing at prompts/v0.16.6.md` |
+| AC4 | Mutable mirror divergence refused | `printf 'x' >> cmd/ailang/prompts/v0.16.6.md` → `--check` | **0** (V4 cell 7) | 1, contains `mutable version v0.16.6: mirror bytes differ at cmd/ailang/prompts/v0.16.6.md` |
+| AC5 | Mutable PLACEHOLDER refused | set `v0.16.6` hash to `PLACEHOLDER` in BOTH registries → `--check` | **0** (V5 cell 10) | 1, contains `mutable version v0.16.6: recorded hash is not a 64-hex sha256 (unenforceable)` |
+| AC6 | Mirror-only entry refused AND counted | add `v9.9.9-extra` to mirror registry only → `--check` | **0**, and no count line exists at base (V4 cell 8) | 1, contains `entry v9.9.9-extra missing from source registry`, and stdout reads `checked 60 registry entries` — 59 source-visited + 1 mirror-only, each incremented inside its visiting loop body (§1); pristine prints `checked 59` (AC1), so the move 59→60 is the assertion, not the verdict alone |
+| AC7 | Missing FROZEN source is a named violation, not an abort | `rm prompts/v0.3.21.md` → `--check` | **2**, bare `open …: no such file` (V5 cell 11) | 1, contains `frozen version v0.3.21: prompt file missing at prompts/v0.3.21.md` |
+| AC8 | Frozen arms unchanged | V4 cells 2-4 re-run; `go test ./cmd/ailang -run 'TestFreezeCheck\|TestPromptFreeze'` at repo root | cells rc=1 with the strings quoted in V4 (positive controls) | identical rc; cells 2-3 identical strings; cell 4 now S8 (`frozen version v0.3.21: mirror file missing at cmd/ailang/prompts/v0.3.21.md`); existing tests pass (can fail: any accidental string drift) |
+| AC9 | **Compound (r2): invalid hash AND missing source emit BOTH named violations** | set `v0.16.6` hash to `PLACEHOLDER` in BOTH registries AND `rm prompts/v0.16.6.md` → `--check` | **0** (V17 cell 13 — the compound hole) | 1, stderr contains BOTH `mutable version v0.16.6: recorded hash is not a 64-hex sha256 (unenforceable)` AND `mutable version v0.16.6: prompt file missing at prompts/v0.16.6.md` |
+| AC10 | **Compound (r2): source AND mirror both deleted emit BOTH named violations** | `rm prompts/v0.3.21.md cmd/ailang/prompts/v0.3.21.md` → `--check` | **2**, only the first missing file named, mirror deletion invisible (V18 cell 14) | 1, stderr contains BOTH `frozen version v0.3.21: prompt file missing at prompts/v0.3.21.md` AND `frozen version v0.3.21: mirror file missing at cmd/ailang/prompts/v0.3.21.md` |
+
+---
+
+## Mutation / refusal-branch test plan
+
+The headline verb is "refuse", so every refusal branch gets one neutering mutation of the form
+`if false && <cond>` — or, for the r2 independence branches (M8/M9), a condition-WRAPPING mutant
+that reintroduces the round-1 masking dependency (never delete a block — every import stays
+used, so "mutant does not compile" can never masquerade as "guard fired"). All new tests use the existing harness
+(`newFreezeCheckRepo` + `writeFreezeCheckRegistries(…, frozen=false)` for mutable fixtures) and
+observe **both** the in-process `checkRegistries` violation slice and the helper-subprocess rc —
+both strictly downstream of the mechanism (the violation string is *produced by* the guarded
+`append`; no test asserts a value set alongside it).
+
+| # | Refusal branch | Neutering mutation | Test that must go red | Downstream observable |
+|---|----------------|--------------------|-----------------------|----------------------|
+| M1 | S2 mutable hash-enforceable | `if false && !eval_harness.IsHexSHA256(e.Hash)` | `TestFreezeCheck_MutablePlaceholderIsRed` (new) | violation containing `unenforceable` + rc 1→0; only this branch emits S2 |
+| M2 | S4 mutable bytes-vs-hash | `if false && (h != e.Hash)` (mutable-state fixture) | `TestFreezeCheck_MutableSourceDivergenceIsRed` (new) | S4 string + rc; the frozen branch cannot fire on a `frozen:false` fixture |
+| M3 | S5 missing source file | `if false && errors.Is(xerr, fs.ErrNotExist)` | `TestFreezeCheck_SourceMissingIsViolationNotError` (new; runs one frozen + one mutable sub-case) | with the branch neutered the read error propagates → `checkRegistries` returns `err` → in-process `t.Fatal` path + helper rc=2, not 1: the test asserts rc==1 AND the S5 string, both of which only the branch produces |
+| M4 | S7 mutable mirror divergence | `if false && !bytes.Equal(sourceBytes, mirrorBytes)` | `TestFreezeCheck_MutableMirrorDivergenceIsRed` (new) | S7 string + rc; no other arm reads mirror `.md` bytes (V3) |
+| M5 | S8 mirror file missing | `if false && errors.Is(mirrorErr, fs.ErrNotExist)` | `TestFreezeCheck_MirrorMissingIsRed` (new; frozen + mutable sub-cases) | S8 string; neutered → mirrorErr falls to the `bytes.Equal` arm with nil bytes? No — neutered branch falls through to `else if mirrorErr != nil → return err` → rc=2, so the rc==1 assertion goes red for the reason it claims |
+| M6 | S10 mirror-only entry | `if false && (source.Versions[id] == nil)` | `TestFreezeCheck_MirrorOnlyEntryIsRed` (new) | S10 string + rc; no other loop visits mirror-only keys (V3, V4 cell 8) |
+| M7 | migrate validation widening | restore `if id == r.Active` skip inside validation via `if false \|\| id == r.Active { continue }` | `TestPromptFreezeMigrate_RefusesStaleActiveHash` (new: fixture with stale `active` hash must make `migrateRegistries` return error) | migrate's returned error is the direct product of the validation loop; with the skip restored, migrate succeeds and the test's error assertion fails |
+| M8 | **arm independence (r2)**: source-existence must not depend on hash validity | wrap arm 2's emission as `if hashOK && !sourceExists` (reintroduces round-1's masking; no block deleted, all imports stay used) | `TestFreezeCheck_InvalidHashAndMissingSourceEmitsBoth` (new; AC9 fixture: `frozen=false`, hash `PLACEHOLDER`, source file absent) | the test asserts BOTH S2 and S5 in the violation slice; under the mutant only S2 is emitted, so the test goes red specifically on the S5 assertion — the string only arm 2 produces |
+| M9 | **arm independence (r2)**: mirror-existence must not depend on source existence | wrap the S8 emission as `if sourceExists && errors.Is(mirrorErr, fs.ErrNotExist)` | `TestFreezeCheck_BothTreesDeletedEmitsBoth` (new; AC10 fixture: both `.md` files removed) | asserts BOTH S5 and S8; under the mutant only S5 is emitted, red specifically on the S8 assertion — no other arm produces the mirror-missing string (V3) |
+| **M-ADD** | enumerator completeness (**addition**, not removal: every removal proves the check FIRES; only an addition proves it LOOKS) | fixture-side: ADD `v9.9.9-extra` to the mirror registry of an otherwise-green fixture | `TestFreezeCheck_CheckedCountMovesOnAddition` (new) | `checked` is incremented only inside the loop bodies that visit an entry (§1, r2) — it counts VISITS, never a `len()` computed beside the work. Fixture arithmetic: 1 source entry alone → count 1; with the mirror-only entry added → count MUST move to 2 AND S10 must fire. An implementation whose enumerator never visits mirror-only keys contributes neither the increment nor the violation → red **on the count**, not merely the verdict. Honest scope (r2): the count detects enumeration blindness only; a neutered arm inside a visited body leaves the count intact and is killed by M1–M9 — the two observables are deliberately complementary |
+
+Test-design constraint honored: every test drives the REAL check path (`checkRegistries` +
+helper subprocess) against synthetic git repos — no test seeds a verdict by raw fixture, which is
+how the parent sprint's tests once stayed green while a writer did not exist.
+
+---
+
+## Milestones
+
+### M1 — the whole change (≤1 day)
+
+Solution Design §1-§5 + all tests in the mutation table + AC1-AC8 + CHANGELOG. Single milestone:
+the diff is ~50 production LOC across three files already read end-to-end this iteration, and the
+test harness exists (V15).
+
+---
+
+## Testing Strategy
+
+- Extend `cmd/ailang/prompt_freeze_check_git_test.go` using `newFreezeCheckRepo` /
+  `writeFreezeCheckRegistries` (the `frozen bool` parameter already exists, V15); mutable
+  fixtures pass `frozen=false`. Migrate test extends `freezeFixture` in `prompt_freeze_test.go`.
+- Assert exact violation strings (they are normative, table S1-S11) via the in-process slice, and
+  rc via the existing `TestFreezeCheckHelperProcess` subprocess.
+- Run the V4/V5/V17/V18 probe matrix once by hand against the rebuilt binary before merging: all
+  five former rc=0 holes (cells 5, 6, 7, 8, 10) and the compound cell 13 must read rc=1; both
+  rc=2 aborts (cells 11, 14) must become rc=1 with every applicable violation named (cell 14:
+  both S5 and S8); cells 2-3 byte-identical; cell 4 = S8; pristine rc=0 with
+  `checked 59 registry entries`.
+- `make check-prompt-freeze` at repo root must stay rc=0 (AC1) — guaranteed non-vacuously by V6
+  (mutable hash fresh in both trees at base).
+
+---
+
+## Open Questions
+
+1. The 3 unregistered `.md` files under `prompts/` (V11) are invisible to a registry-driven
+   enumerator by construction. Should the gate also refuse *unregistered* files in the prompt
+   trees (a directory sweep), or are docs-alongside-prompts legitimate? Deferred — separate
+   decision, touches the prompt-manager workflow.
+2. Loader-side PLACEHOLDER hatch retirement (V16): with CI refusing committed placeholders (§5),
+   the runtime hatch protects only uncommitted local state. Retire it entirely? Parent doc Q6
+   deliberately kept it; not re-opened here.
+3. `MutableHashMismatchError` has no test referencing it (V9). The loader behavior predates this
+   doc; a loader-side test is cheap but belongs to the parent doc's test surface, not this gate's.
+
+---
+
+## Quorum revision log (round 1 → r2 → r3)
+
+Round-1 verdict: **blocked**, 3/3 reviewers present (no degrade). Neither blocking objection
+disputed the design direction; both were accepted without argument.
+
+| Objection | Reviewer | Disposition in r2 |
+|-----------|----------|-------------------|
+| "The proposed control flow silently suppresses independent integrity violations … an entry with an invalid hash and missing source, or with both source and mirror deleted, does not receive all applicable named violations" | gpt5-6-sol | **Accepted.** §1/§2 reworked into independent arms; the complete dependency list is now a table in §3 with each remaining dependency justified as a semantic necessity (only the two byte-comparisons are conditional). The round-1 §3 "corner case, stated deliberately" — which documented the masking as acceptable — is deleted. Both compound states were MEASURED at base (V17: rc=0, the compound hole; V18: rc=2 naming only the first missing file) and are pinned by new AC9/AC10 plus independence mutants M8/M9 |
+| "`checked` … is computed entirely outside the per-entry work … structurally decoupled from whether any entry's violation arms actually fire; AC6 and M-ADD assert a coverage property the count variable cannot deliver" | oc-glm-5-2 | **Accepted.** `checked` is now incremented exactly once per entry, as the last statement of the loop body that performs that entry's arms — never via `len()` beside the work (§1). Arithmetic restated unambiguously: pristine real registry 59 → mirror-only-added 60; test fixture 1 → 2. M-ADD's kill condition stays on the COUNT, and the doc now states the observable's honest scope: it detects enumeration blindness (unvisited entries), not neutered arms inside visited bodies — those belong to M1–M9; the observables are complementary |
+| (pass-note, not blocking) "`source.Versions[id] == nil` … if `source.Versions` is a map of structs, this will trigger a compilation error" | gemini-3-1-pro (pass) | **Refuted by controller measurement, re-derived first-party as V19**: `Versions map[string]*registryEntry` (`prompt_freeze_core.go:29`) is a pointer map, and the identical nil-deref already ships at line 351. No design change |
+
+
+### Round 2 → r3 (controller, narrow-refinement carve-out)
+
+Round-2 verdict: **blocked**, 3/3 reviewers present (`absent_reviewers` empty, no degrade). All
+three objections were **premise/completeness** objections about ONE surface — the call graph and
+consumers of the two interfaces this change touches. None disputed the design direction and each
+carried a concrete reviewer-authored fix, so the controller applied them under the
+narrow-refinement carve-out rather than spending a third designer run (the Fable diet's one-doc
+ceiling — authoring plus one protocol-mandated revision — was already reached). Per rule 3f the
+controller **measured** each premise rather than forwarding it; the fixes below are the
+measurements, not controller-invented resolutions.
+
+| Objection | Reviewer | Disposition in r3 |
+|-----------|----------|-------------------|
+| "The doc proposes changing `checkRegistries`' signature … but never verifies the call graph … if `prompt_freeze_test.go` or any other file calls `checkRegistries` directly … the list is incomplete and the signature change silently breaks compilation" | oc-glm-5-2 | **CONFIRMED by measurement — a real gap.** `prompt_freeze_test.go` holds two further in-process callers (`:125`, `:138`) and was absent from "Files to modify". Added, with the complete 4-caller inventory as **V20** and a new Conflict-Surface row. The reviewer's stale-zero worry is separately answered: Go rejects a 2-variable assignment from 3 results, so a caller cannot silently ignore the new `int` |
+| "…no repository-wide inventory of Go call sites or shell/CI consumers that may parse or require empty stdout" | gpt5-6-sol | **Inventory produced; the risk is REFUTED.** **V20** covers the Go call sites; **V21** covers the stdout consumers and finds exactly one invocation (`make/code-health.mk:185`), which neither pipes nor parses stdout — the exit code is the whole verdict. Every other hit is help text or a shell comment. Both are now Conflict-Surface rows. The reviewer was right that nobody had checked; checking clears it |
+| "…`freezeVersion` 'validates its own target's hash/bytes before writing' … is a load-bearing behavioral claim used to justify omitting `freezeVersion` from the widening scope, yet it entirely lacks a Verification Log entry" | gemini-3-1-pro | **CONFIRMED by measurement, and the row is now stronger than the claim it replaces.** **V22**: all three validations (`:316`, `:319-322`, `:323`) precede the first write at `:329`; and the write-surface probe shows `freezeVersion` writes **no `.md` at all** (0 hits, control 5), so it cannot mint a violation of the two byte-arms either, and writes both registries from one `r` so registry agreement holds by construction |
+
+---
+
+## Related Documents
+
+- **Parent**: `design_docs/planned/m-prompt-version-freeze-on-first-bank.md` — the freeze
+  mechanism this doc widens; its Q6/V-C define the PLACEHOLDER hatch, its L3 defines the gate.
+- **PR #937** (squash `445ccb550`) — landed the gate and its explicit CI step (V2).
+- `design_docs/PROGRAM.md` — routing: harness/data-integrity lane, not a core change.
+- `make/code-health.mk:184`, `.github/workflows/ci.yml:205` — the wiring under change-freeze here.

--- a/make/code-health.mk
+++ b/make/code-health.mk
@@ -181,7 +181,7 @@ check-autoclose: ## Refuse issue-closing phrases in docs-only commit/PR records 
 check-skills: ## Check .claude/skills/*/SKILL.md have name+description frontmatter (CI gate)
 	@bash scripts/check_skills.sh
 
-check-prompt-freeze: ## Check frozen prompt immutability and mirror agreement (CI gate)
+check-prompt-freeze: ## Check prompt registry integrity (all entries) + frozen immutability (CI gate)
 	@go run ./cmd/ailang prompt freeze --check
 
 check-pi-wire-budget: ## Assert the output budget pi ACTUALLY sends (real API call; NOT a CI gate)


### PR DESCRIPTION
## What

`ailang prompt freeze --check` had three file-level arms and **all three were gated on `Frozen != nil`**. The repo carries 59 registry entries — 58 frozen, and exactly **one mutable: `v0.16.6`, which is also `active`**. So the single entry the gate could not see at the file level was the prompt every agent actually reads.

This widens mirror byte-agreement, hash-vs-file-bytes, file existence and hash-enforceability to **every** entry. Merge-base **immutability** deliberately stays frozen-only — mutable means editable, and edit-plus-hash-regen in one commit is the legitimate workflow.

## The hole, measured before the change

Synthetic-repo probe, with the frozen arms as positive controls (which is what makes the zeros measurements rather than claims):

| cell | rc at base |
|---|---|
| frozen source diverged / mirror diverged / mirror deleted | **1** ← positive controls |
| mutable source diverged | **0** |
| mutable source deleted | **0** |
| mutable mirror diverged | **0** |
| mirror-registry-only entry | **0** (never visited) |
| mutable `PLACEHOLDER` hash | **0** |
| frozen source deleted | **2** — an abort that hid every other violation |

## What changed

- All four file-level arms apply to every entry, carrying a `mutable`/`frozen` state label. **Frozen violation strings are byte-preserved.**
- **The arms are independent.** An entry with an invalid hash *and* a missing source now emits both violations; the old `else if` chain emitted neither.
- A missing prompt file is a **named violation (rc=1)**, not an unnamed abort. Non-ENOENT read errors stay fatal.
- Mirror-registry-only entries are visited and refused.
- `--check` prints `checked N registry entries`. The counter is incremented as the **last statement inside each visiting loop body** — a count computed as a `len()` beside the work would pass the addition mutant while proving nothing.
- `--migrate`'s *validation* loop widens to match; its *freeze-writing* loop is unchanged, so migrate still never freezes `active`.

## Verification

**Nine gates, all rc=0, all run outside the executor sandbox** (darwin/arm64; ubuntu and windows legs unrun locally): build, vet, gofmt, the Freeze/Prompt tests, the full `cmd/ailang` package, `prompt freeze --check`, `check-prompt-freeze`, `check-changelog`, `check-file-sizes`. `go build ./...` is **rc=1 at base** (`cmd/wasm` has no native `main`) and was disqualified as a gate rather than shipped broken.

**Ten AC probes re-run first-party against a post-change ldflags-stamped binary.** Every criterion that was rc=0 or rc=2 at base is now rc=1 with its named string; the count observable moved **59 → 60** on a mirror-only entry; the restored control returned rc=0.

**Ten mutants**, each asserted LANDED by sha256 and BUILDS rc=0 *before* its result was read, each restored byte-identical: all killed — four by a sole-killer inverse arm, five by an enumerated failing set with every member explained, plus an **addition** mutant confirming the count observable moves (every removal mutant proves the check fires; only an addition proves it looks).

## Executor deviation, self-reported and adjudicated by measurement

To stop a deleted frozen source aborting, ENOENT from the merge-base loop's downstream read is now skipped, since the deletion has already been named. Checked in **both** arms: a frozen source that is *modified* rather than deleted still trips `immutability violation in prompts/v0.3.21.md bytes`. Strict, not a weakening. The frozen-only guard itself is untouched.

## Provenance

Design doc quorum: **blocked twice**, 3/3 external reviewers present both rounds, `absent_reviewers` empty. Round 1's two objections (violation masking; a `checked` count decoupled from the per-entry work) went back to the designer. Round 2's three were all premise objections about one surface and were adjudicated by controller measurement under the narrow-refinement carve-out — one **confirmed a real gap** (a second test file holds two more `checkRegistries` callers, absent from "Files to modify"), one **refuted** (no consumer of `--check` stdout exists), one **confirmed and documented** (`freezeVersion` writes no `.md`).

Follows #937, which landed the gate this widens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
