### PR TITLE
docker: add agent-pi-go so sprint-executor can follow the fleet onto pi

### DIFF
--- a/docker/Dockerfile.agent-pi-go
+++ b/docker/Dockerfile.agent-pi-go
@@ -1,0 +1,14 @@
+# AILANG Agent Executor — pi-go variant (pi coding agent + Go toolchain)
+#
+# M-EXECUTOR-VARIANTS. Added 2026-08-28 because pi became the fleet default
+# (opencode is our worst-measured harness) but every Go-capable image was built
+# on a different harness — agent-go (claude), agent-codex-go, agent-gemini-go,
+# agent-eval-go. sprint-executor needs the Go toolchain, so without this it was
+# the one agent that could not follow the fleet onto pi.
+ARG PROJECT
+FROM europe-west1-docker.pkg.dev/${PROJECT}/ailang/agent-pi:latest
+
+# Go toolchain — matches go.mod version in the ailang repo
+COPY --from=golang:1.26-bookworm /usr/local/go /usr/local/go
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOPATH="/home/ailang/go"


### PR DESCRIPTION
Four-line Dockerfile. `FROM agent-pi`, then the same `golang:1.26-bookworm` toolchain copy as `Dockerfile.agent-codex-go`.

## Why

pi became the fleet default (`ailang-multivac` `350dbf6`) because **opencode is our worst-measured harness in evals**. 31 of 34 agents switched over as config-only, since `ailang-agent-executor-pi` and `-pi-apikey` were already deployed.

`sprint-executor` could not follow. Every Go-capable image is built on a *different* harness:

| image | harness | Go |
|---|---|---|
| `agent-go` | claude | ✅ |
| `agent-codex-go` | codex | ✅ |
| `agent-gemini-go` | gemini | ✅ |
| `agent-eval-go` | eval | ✅ |
| `agent-pi` | pi | ❌ |

So this is the missing cell.

## Companion changes (ailang-multivac `266b610`)

- `cloudbuild-images.yaml`: `build-agent-pi-go`, `waitFor: build-agent-pi`, mirroring the codex-go cache shape. Family-tree comment updated — `agent-pi` is no longer "(no -go variant)".
- `terraform`: `agent_executor_pi_go` job, lifted from `agent_executor_codex_go`. Picks up `local.otlp_endpoint` automatically; all 17 OTLP sites verified correct afterwards. `terraform validate: Success`.

## Ordering

`sprint-executor` is **deliberately not repointed yet**. The image does not exist until a full build runs, and pointing an agent at a job that has not been created would break it on the next promote — the config-before-binary hazard that has already bitten twice today. It stays on codex/codex-go until `agent-pi-go` is built and `ailang-agent-executor-pi-go` is deployed.