### PR TITLE
feat(gitexec): one absolute-path git resolver, and a CI gate that can see the shape gofmt produces

### DIFF
--- a/.ailang/state/sprints/sprint_M-GIT-BINARY-RESOLUTION-SWEEP.json
+++ b/.ailang/state/sprints/sprint_M-GIT-BINARY-RESOLUTION-SWEEP.json
@@ -1,0 +1,213 @@
+{
+  "sprint_id": "M-GIT-BINARY-RESOLUTION-SWEEP",
+  "design_doc": "design_docs/planned/v0_35_0/m-git-binary-resolution-sweep.md",
+  "plan_path": "design_docs/planned/v0_35_0/m-git-binary-resolution-sweep-sprint-plan.md",
+  "created": "2026-08-28",
+  "iteration": 298,
+  "worktree": "/Users/voightkampff/dev/sunholo-data/.wt-iter298",
+  "branch": "sprint/iter298-git-exec-sweep",
+  "base_commit": "110bbb7c0",
+  "scope_note": "EXECUTE M1 ONLY this iteration, and land it as its own PR. M1 is independently executable and independently landable: it freezes the failure/caching contract, builds the go/ast enumerator and its CI gate, and converts only the 4 Sonar-flagged sites plus cmd/ailang/help.go. M2-M4 are bulk mechanical conversions against the contract M1 froze; they add no new decision, land as separate PRs later, and are safe to defer indefinitely because the M1 gate already prevents the class from growing. No M1 acceptance criterion references a post-M1 count.",
+  "github_issues": [],
+  "velocity": {
+    "target_loc_per_day": 200,
+    "estimated_total_loc": 1050,
+    "estimated_days": 4
+  },
+  "risk_level": "medium",
+  "status": "planned",
+  "measured_baselines": {
+    "note": "Measured on the pristine worktree at 110bbb7c0 during planning. rc values are the BASE rc, before any edit.",
+    "REJECTED_go_build_all": "go build ./... => rc=1 at base (cmd/wasm: 'function main is undeclared in the main package'). NOT an acceptance command. Use the narrowed form.",
+    "go_build_narrow": "go build ./internal/gitexec/... ./cmd/ailang/... ./internal/coordinator/... => rc=1 (gitexec absent)",
+    "go_test_gitexec": "go test ./internal/gitexec/... -count=1 => rc=1 (setup failed, no such package)",
+    "make_check_git_exec": "rc=2 (No rule to make target 'check-git-exec')",
+    "make_test_check_git_exec": "rc=2 (no such target)",
+    "bare_git_exec_sites": 93,
+    "bare_git_exec_sites_ast_arm": 93,
+    "bare_git_exec_files": 18,
+    "lookpath_git_outside_gitexec": 1,
+    "func_resolveGit_in_help_go": 1,
+    "grep_gitexec_in_changelog": 0,
+    "grep_make_check_git_exec_in_ci_yml": 0,
+    "grep_check_git_exec_in_ci_mk": 0,
+    "regression_gates_green_at_base": [
+      "go test ./cmd/ailang/... -count=1 => rc=0 (24.3s)",
+      "go test ./internal/coordinator/... ./internal/pkg/... ./internal/eval_harness/... -count=1 => rc=0",
+      "make check-boundaries => rc=0",
+      "make check-file-sizes => rc=0",
+      "make check-changelog => rc=0",
+      "gofmt -l cmd internal tools scripts => empty, rc=0",
+      "go vet ./cmd/ailang/... => rc=0"
+    ]
+  },
+  "ci_wiring": {
+    "make_ci_is_not_invoked_by_ci_yml": true,
+    "evidence": "grep -n 'run: make ' .github/workflows/ci.yml lists 31 targets; 'ci' is not among them. A target wired only into `make ci` does NOT run in CI.",
+    "code_health_mk": "make/code-health.mk — insert after line 162 (the `@bash scripts/check_boundaries.sh` recipe of the check-boundaries target at line 161): targets `check-git-exec` and `test-check-git-exec`, mirroring the check-tmpfile-hygiene / test-check-tmpfile-hygiene pair at lines 167-172.",
+    "ci_mk": "make/ci.mk line 11 — append `check-git-exec test-check-git-exec` to the `ci:` prerequisite list.",
+    "ci_yml": ".github/workflows/ci.yml — insert two steps after line 133 (`run: make check-boundaries`, under `- name: Check architecture boundaries` at line 132) and before line 135 (`- name: Verify install guide consistency`). Both land in the `test:` job (runs-on: ubuntu-latest, ci.yml:17-18), which runs `make install` at line 60 so Go tooling is available."
+  },
+  "changelog_target": "changelogs/v0.32-current.md under '## [Unreleased]'. Root CHANGELOG.md is INDEX-ONLY and `make check-changelog` (scripts/check_changelog.sh) fails on ANY heading other than '## Changelog Archives'.",
+  "features": [
+    {
+      "id": "M1_GITEXEC_CONTRACT_AND_GATE",
+      "description": "Create internal/gitexec (stdlib-only leaf: ErrUnresolvable, resolveWith test seam, mutex-guarded SUCCESS-ONLY cache, Path/Command/CommandContext with the deferred exec.Cmd.Err failure contract). Create the go/ast enumerator tools/check-git-exec (the doc's HID-6 commitment; bash cannot walk go/ast, and the doc omits this file from its file list). Create scripts/check_git_exec.sh (fixture anti-vacuity control -> AST enumeration -> per-file ratchet baseline -> LookPath positive invariant -> residual-class printout -> AST/regex cross-check scoped to the REAL TREE ONLY). Convert the 4 Sonar-flagged sites and migrate cmd/ailang/help.go off its private resolveGit/gitBinary. Wire the gate into make/code-health.mk, make/ci.mk:11, and TWO ci.yml steps. This milestone is independently landable as its own PR.",
+      "estimated_loc": 860,
+      "dependencies": [],
+      "files": [
+        "internal/gitexec/gitexec.go (NEW, ~130 LOC)",
+        "internal/gitexec/gitexec_test.go (NEW, ~230 LOC)",
+        "tools/check-git-exec/main.go (NEW, ~180 LOC) — go/ast enumerator; in tools/ NOT scripts/ because .golangci.yml sets exclude-dirs: scripts",
+        "tools/check-git-exec/main_test.go (NEW, ~200 LOC)",
+        "scripts/check_git_exec.sh (NEW, ~130 LOC)",
+        "scripts/test_check_git_exec.sh (NEW, ~200 LOC) — mirrors scripts/test_check_tmpfile_hygiene.sh incl. its ARMS_EXPECTED floor",
+        "scripts/testdata/git_exec_gate_positive.txt (NEW) — single-line AND multi-line exec.Command(\\n \"git\", ...) shapes; .txt so gofmt -l . and the sweep never see it",
+        "scripts/testdata/git_exec_gate_blindspot.txt (NEW) — variable-first-arg (g := \"git\") and bash -c shapes; NEGATIVE control, asserted count 0",
+        "scripts/git_exec_baseline.txt (NEW, 16 lines) — SEEDED BY FRESH MEASUREMENT after the 4 conversions; expected sum 89",
+        "cmd/ailang/prompt_freeze_check_git.go:82 (MODIFY, gitBytes)",
+        "cmd/ailang/prompt_freeze_core.go:194 (MODIFY, scanCorpus)",
+        "internal/coordinator/worktree.go:308 (MODIFY, repo-dir probe)",
+        "cmd/ailang/coordinator_cloud.go:459 (MODIFY, ahead-log probe)",
+        "cmd/ailang/help.go (MODIFY: delete resolveGit; replace gitBinary() body with a 3-line gitexec.Path() adapter mapping error -> \"\")",
+        "cmd/ailang/help_stale_test.go (MODIFY: resolveGit cases at 387-406 move to gitexec_test.go; 6 gitBinary() call sites at 223/230/240/243/367/427 keep compiling)",
+        "make/code-health.mk (MODIFY, +8 LOC after line 162)",
+        "make/ci.mk (MODIFY, line 11, +2 words)",
+        ".github/workflows/ci.yml (MODIFY, +6 LOC after line 133)",
+        "changelogs/v0.32-current.md (MODIFY, ~12 LOC under '## [Unreleased]')"
+      ],
+      "acceptance_criteria": [
+        "AC1 [base rc=1: 'pattern ./internal/gitexec/...: lstat: no such file or directory'] `go build ./internal/gitexec/... ./cmd/ailang/... ./internal/coordinator/...` => rc=0. NOTE: `go build ./...` is REJECTED as an acceptance command — it is rc=1 on the untouched tree (cmd/wasm has no native main).",
+        "AC2 [base rc=1, setup failed] `go test ./internal/gitexec/... -count=1` => rc=0",
+        "AC3 [base 93] AST enumerator total over cmd+internal (non-test) == 89, re-derived by measurement, not copied from this JSON",
+        "AC4 [base 1, cmd/ailang/help.go] `grep -rln 'LookPath(\"git\")' cmd internal --include='*.go' | grep -v '_test\\.go' | grep -cv '^internal/gitexec/'` == 0",
+        "AC5 [base rc=2, no such target] `make check-git-exec` => rc=0",
+        "AC6 [base rc=2, no such target] `make test-check-git-exec` => rc=0",
+        "AC7 [base 0] `grep -c 'make check-git-exec' .github/workflows/ci.yml` >= 1",
+        "AC8 [base 0] `grep -c 'make test-check-git-exec' .github/workflows/ci.yml` >= 1",
+        "AC9 [base 0] `grep -c 'check-git-exec' make/ci.mk` >= 1",
+        "AC10 [base 1] `grep -c 'func resolveGit' cmd/ailang/help.go` == 0",
+        "AC11 [base 0] `grep -c 'gitexec' changelogs/v0.32-current.md` >= 1 (root CHANGELOG.md must NOT be touched)",
+        "AC12 [base rc=2, no output] `make check-git-exec 2>&1 | grep -c 'variable first argument'` >= 1 — the gate names its residual classes in its OWN output every run (HID-6 clause 4)",
+        "AC13 anti-vacuity: with scripts/testdata/git_exec_gate_positive.txt moved aside, `bash scripts/check_git_exec.sh` => rc=2 and output contains 'INSTRUMENT BROKEN'. Green-when-fixture-missing is itself a failure.",
+        "AC14 mutation evidence for all 13 branches B1-B6 and G1-G7. Protocol per mutant, IN THIS ORDER: cp backup to /tmp (never `git checkout --`, the tree is uncommitted by construction); apply `if false && <cond>` (never delete a block — a non-compiling mutant makes red masquerade as the guard firing); assert the mutant LANDED (sha256 differs); assert the mutant BUILDS (`go build ./internal/gitexec/... ./cmd/ailang/...` rc=0, or `bash -n scripts/check_git_exec.sh` rc=0); ONLY THEN run the named test and require rc!=0; restore from backup and require rc=0.",
+        "AC15 [base: both arms 93, per-file diff empty] AST arm and regex arm both report 89 over cmd+internal with an empty per-file diff; a disagreement is a gate FAILURE — scoped to the REAL TREE ONLY, never to the fixtures (see contradiction 1)",
+        "REGRESSION GATES (rc=0 at base AND after; NOT acceptance criteria, they cannot fail for the right reason): `go test ./cmd/ailang/... -count=1`; `go test ./internal/coordinator/... ./internal/pkg/... ./internal/eval_harness/... -count=1`; `make check-boundaries`; `make check-file-sizes`; `make check-changelog`; `gofmt -l cmd internal tools scripts` empty; `go vet ./cmd/ailang/...`",
+        "NOT FALSIFIABLE FROM THE BRANCH, deliberately excluded: the SonarCloud metric. Sonar re-analyses only on a merged push and its leak period is defined against previous_version=v0.33.2, so 'the 4 flagged go:S4036 issues are resolved' is a post-merge observation, not an acceptance criterion. The rating is NOT asserted to reach A: the resolver's own LookPath is expected to keep one finding (follow-up M-GIT-RESOLVER-S4036-CLOSURE)."
+      ],
+      "test_plan": [
+        "B1 look() errors -> refuse | TestResolveWith_LookError | kills mutant `if false && err != nil`",
+        "B2 relative path -> refuse | TestResolveWith_RelativeRefused (\"git\" and \"./git\") | kills `if false && !filepath.IsAbs(p)`",
+        "B3 failed resolve -> Cmd.Err | TestCommand_DeferredError, asserting error identity from Run(), not from construction | kills `if false && resolveErr != nil` at the Cmd.Err assignment",
+        "B4 success -> Cmd.Path is absolute | TestCommand_UsesAbsolutePath (+ cancelled ctx aborts CommandContext) | kills `Path: \"git\"` bare-literal swap (which BUILDS)",
+        "B5 success IS cached | TestPath_CachesSuccess (look invoked exactly once across two Path() calls) | kills `if false && err == nil { cached = p }`",
+        "B6 failure is NOT cached (HID-3) | TestPath_DoesNotCacheFailure (first Path fails, second re-invokes look and succeeds) | kills the named mutation 'cache the failure too'",
+        "G1 fixture missing -> exit 2 | self-test S2 | kills `if false && [ ! -f \"$POSITIVE_FIXTURE\" ]`",
+        "G2 fixture yields 0 matches -> exit 2 | self-test S2b | kills `if false && [ \"$FIXTURE_COUNT\" -eq 0 ]`",
+        "G3 file above baseline -> exit 1 naming file:line | self-test S3 | kills `if false && [ \"$n\" -gt \"$base\" ]`",
+        "G4 file below baseline -> exit 1 'tighten the baseline' | self-test S4 | kills `if false && [ \"$n\" -lt \"$base\" ]`",
+        "G5 file with matches absent from baseline -> exit 1 | self-test S3b | kills `if false && [ -z \"$base\" ]`",
+        "G6 LookPath(\"git\") outside internal/gitexec -> exit 1 | self-test S5 | kills `if false && [ \"$LOOKPATH_OUTSIDE\" -gt 0 ]`",
+        "G7 AST vs regex disagree on the real tree -> exit 1 | self-test S6 (plant a multi-line git site in a temp tree copy) | kills `if false && [ \"$AST_TOTAL\" -ne \"$RX_TOTAL\" ]`",
+        "E1 ADDITION ARM (the load-bearing one): temp tree count N; copy the MULTI-LINE fixture in as .go; count == N+1 | kills a regression of the enumerator to line-oriented grep. A removal-only test proves a check FIRES; only this addition proves it LOOKS.",
+        "E2 blind-spot fixture (g := \"git\"; exec.Command(g,...) and bash -c \"git status\") adds EXACTLY 0 | kills a silent widening that leaves the declared residual list stale",
+        "E3 exec.Command(\"git-lfs\",...) and exec.Command(\"gitfoo\") add 0 | kills prefix matching instead of strconv.Unquote(lit) == \"git\"",
+        "E4 exec.CommandContext(ctx, \"git\", ...) counted at arg index 1; a \"git\" at arg 2 is not | kills an off-by-one in the arg index",
+        "E5 fixture named x_test.go adds 0; THE SAME BYTES renamed x.go add 1 | kills a vacuous _test.go exclusion (one that matches nothing rather than filtering by suffix)",
+        "E6 a file with a Go syntax error -> exit 2 naming the file | kills a silent skip of unparseable files (the planning prototype had exactly this hole)"
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": "Plan-time design refinements to the doc, each justified in section 6 of the sprint plan: R1 gitBinary() survives as a 3-line gitexec.Path() adapter (the doc says delete, but deleting removes the only site mapping a resolution error to the \"\" that gitHead/gitDirty read as 'undeterminable -> SHOW the warning'); R2 the AST/regex cross-check runs over the real tree only, because the doc's HID-6 clauses 2 and 3 contradict each other (measured: the multi-line fixture makes AST=1, regex=0); R3 internal/gitexec is NOT excluded from the exec enumeration (it never calls exec.Command(\"git\",...), so the exclusion is a hiding place, not a necessity); R4 an unparseable .go file is exit 2, not a skip; R5 the variable-first-arg fixture is a NEGATIVE control asserted at 0, and the multi-line fixture carries the count-moves-by-addition requirement; R6 the enumerator lives in tools/ because .golangci.yml excludes scripts/ from make lint."
+    },
+    {
+      "id": "M2_COORDINATOR_SWEEP",
+      "description": "Mechanical conversion of the remaining 42 internal/coordinator sites to gitexec.Command / gitexec.CommandContext, preserving each site's cmd.Dir vs -C convention verbatim. No new decision; the contract is frozen by M1. Lands as its own PR after M1. Five sites in this repo already discard the error (_ = cmd.Run(): daemon_tasks_exec_run.go:461,463; worktree.go:239; and coordinator_browse.go:87,240 in M3) — conversion PRESERVES that silent swallow, which the design explicitly does not fix.",
+      "estimated_loc": 90,
+      "dependencies": ["M1_GITEXEC_CONTRACT_AND_GATE"],
+      "files": [
+        "internal/coordinator/worktree.go (15 remaining)",
+        "internal/coordinator/merge.go (8)",
+        "internal/coordinator/approval_processor.go (6)",
+        "internal/coordinator/artifact_discovery.go (5)",
+        "internal/coordinator/daemon_tasks_exec_run.go (4)",
+        "internal/coordinator/daemon_tasks_worktrees.go (3)",
+        "internal/coordinator/observatory_sync.go (1)",
+        "scripts/git_exec_baseline.txt (ratchet 89 -> 47)",
+        "changelogs/v0.32-current.md"
+      ],
+      "acceptance_criteria": [
+        "[base at M2 start: 89] AST enumerator total over cmd+internal == 47, re-derived by measurement",
+        "[base at M2 start: rc=1 'tighten the baseline'] `make check-git-exec` => rc=0 with the ratcheted baseline (the below-baseline branch G4 makes an unratcheted baseline fail loudly, so this AC IS falsifiable at M2's own base)",
+        "[base 0 -> >=1] `grep -c 'gitexec' internal/coordinator/merge.go` >= 1",
+        "REGRESSION GATE (rc=0 before and after): `go test ./internal/coordinator/... -count=1`"
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": "NOT executed in iteration 298. Deferred by design; the M1 gate already prevents the class from growing while this waits."
+    },
+    {
+      "id": "M3_CMD_AILANG_SWEEP",
+      "description": "Mechanical conversion of the remaining 41 cmd/ailang sites. No new decision. Lands as its own PR after M2.",
+      "estimated_loc": 85,
+      "dependencies": ["M2_COORDINATOR_SWEEP"],
+      "files": [
+        "cmd/ailang/coordinator_cloud.go (14 remaining)",
+        "cmd/ailang/coordinator_browse.go (11)",
+        "cmd/ailang/chains_diff.go (4)",
+        "cmd/ailang/coordinator_inspect.go (4)",
+        "cmd/ailang/messages_send.go (3)",
+        "cmd/ailang/coordinator_utils.go (3)",
+        "cmd/ailang/coordinator_cloud_github.go (2)",
+        "scripts/git_exec_baseline.txt (ratchet 47 -> 6)",
+        "changelogs/v0.32-current.md"
+      ],
+      "acceptance_criteria": [
+        "[base at M3 start: 47] AST enumerator total over cmd+internal == 6, re-derived by measurement",
+        "[base at M3 start: rc=1 'tighten the baseline'] `make check-git-exec` => rc=0 with the ratcheted baseline",
+        "[base at M3 start: 7 files under cmd/ailang in the baseline] the baseline contains ZERO cmd/ailang entries",
+        "REGRESSION GATE (rc=0 before and after): `go test ./cmd/ailang/... -count=1`"
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": "NOT executed in iteration 298."
+    },
+    {
+      "id": "M4_TOOLS_LAYER_SWEEP",
+      "description": "Convert the last 6 sites in the tools layer, ratchet the baseline to 0, and turn on the standing positive invariant (exactly one exec.LookPath(\"git\") in the repo, inside internal/gitexec/). The fixture control (AC13) is what keeps the now-empty gate non-vacuous forever after.",
+      "estimated_loc": 15,
+      "dependencies": ["M3_CMD_AILANG_SWEEP"],
+      "files": [
+        "internal/pkg/gitcache.go (5)",
+        "internal/eval_harness/gemini_evaluator_bridge.go (1)",
+        "scripts/git_exec_baseline.txt (ratchet 6 -> 0; asserts emptiness)",
+        "changelogs/v0.32-current.md"
+      ],
+      "acceptance_criteria": [
+        "[base at M4 start: 6] AST enumerator total over cmd+internal == 0, re-derived by measurement",
+        "[base at M4 start: rc=1 'tighten the baseline'] `make check-git-exec` => rc=0 on an EMPTY baseline",
+        "[falsifiable anti-vacuity on an empty gate] with the positive fixture moved aside, `bash scripts/check_git_exec.sh` => rc=2 'INSTRUMENT BROKEN'. An empty enumeration must never be green on its own.",
+        "[base 1 in internal/gitexec] exactly one exec.LookPath(\"git\") repo-wide and it is inside internal/gitexec/ — enforced by the gate, not only asserted",
+        "REGRESSION GATE (rc=0 before and after): `go test ./internal/pkg/... ./internal/eval_harness/... -count=1`"
+      ],
+      "passes": null,
+      "started": null,
+      "completed": null,
+      "notes": "NOT executed in iteration 298."
+    }
+  ],
+  "contradictions_found_at_plan_time": [
+    "The doc's HID-6 clauses 2 and 3 are mutually inconsistent: clause 2 makes an AST/regex disagreement a gate FAILURE, clause 3 ships a fixture designed to make them disagree. Measured on such a fixture: AST=1, regex=0. Resolved by scoping the cross-check to cmd/ + internal/.",
+    "The doc's 'Files to Modify/Create' omits the Go file HID-6 requires. It lists scripts/check_git_exec.sh (~120 LOC bash) as the enumerator, but bash cannot walk go/ast. tools/check-git-exec/main.go + main_test.go (~380 LOC) are missing from the doc's file list and LOC estimate.",
+    "Excluding internal/gitexec/ from the exec enumeration (doc, gate step 2) is unnecessary AND a hole: gitexec calls exec.Command(absPath, ...), never exec.Command(\"git\", ...), so the exclusion only creates a directory where a bare site can hide. Only the LookPath invariant needs that scoping.",
+    "V17 CONFIRMED by a stronger, independent instrument: a real go/ast enumerator built during planning returns 93 with a per-file diff against the regex of exactly ZERO. The doc used a whitespace-collapsing python regex; an AST walk is a genuinely independent arm and it agrees.",
+    "exec.Cmd.Err was doc-verified (go doc) but not behaviour-verified. Verified during planning on go1.26.6: (&exec.Cmd{Path:\"\", Err: wrapped}).Run() and .Output() both return the wrapped error and satisfy errors.Is. The failure contract is sound.",
+    "A .go fixture would break make fmt-check: it runs `gofmt -l .` repo-wide and gofmt does NOT skip testdata/. Fixtures must stay .txt; go/parser.ParseFile accepts source bytes regardless of extension, so this costs nothing.",
+    ".golangci.yml sets exclude-dirs: [..., scripts]. A Go enumerator under scripts/ would escape make lint silently. Hence tools/.",
+    "The doc's instruction to delete gitBinary() is under-specified: deleting it removes the only site mapping a resolution error to the \"\" that gitHead/gitDirty treat as 'undeterminable -> show the warning'. Kept as a 3-line adapter; resolveGit's deletion is the falsifiable part (AC10).",
+    "9 of the 18 sweep files changed between the doc's original base e38c0c493 and 999d4c1dd, so every count must be re-derived at execution time. Re-derived at plan time: still 93 across 18 files, per-file distribution unchanged."
+  ]
+}

--- a/.ailang/state/sprints/sprint_M-GIT-BINARY-RESOLUTION-SWEEP.json
+++ b/.ailang/state/sprints/sprint_M-GIT-BINARY-RESOLUTION-SWEEP.json
@@ -15,7 +15,7 @@
     "estimated_days": 4
   },
   "risk_level": "medium",
-  "status": "planned",
+  "status": "in_progress",
   "measured_baselines": {
     "note": "Measured on the pristine worktree at 110bbb7c0 during planning. rc values are the BASE rc, before any edit.",
     "REJECTED_go_build_all": "go build ./... => rc=1 at base (cmd/wasm: 'function main is undeclared in the main package'). NOT an acceptance command. Use the narrowed form.",
@@ -116,10 +116,10 @@
         "E5 fixture named x_test.go adds 0; THE SAME BYTES renamed x.go add 1 | kills a vacuous _test.go exclusion (one that matches nothing rather than filtering by suffix)",
         "E6 a file with a Go syntax error -> exit 2 naming the file | kills a silent skip of unparseable files (the planning prototype had exactly this hole)"
       ],
-      "passes": null,
-      "started": null,
-      "completed": null,
-      "notes": "Plan-time design refinements to the doc, each justified in section 6 of the sprint plan: R1 gitBinary() survives as a 3-line gitexec.Path() adapter (the doc says delete, but deleting removes the only site mapping a resolution error to the \"\" that gitHead/gitDirty read as 'undeterminable -> SHOW the warning'); R2 the AST/regex cross-check runs over the real tree only, because the doc's HID-6 clauses 2 and 3 contradict each other (measured: the multi-line fixture makes AST=1, regex=0); R3 internal/gitexec is NOT excluded from the exec enumeration (it never calls exec.Command(\"git\",...), so the exclusion is a hiding place, not a necessity); R4 an unparseable .go file is exit 2, not a skip; R5 the variable-first-arg fixture is a NEGATIVE control asserted at 0, and the multi-line fixture carries the count-moves-by-addition requirement; R6 the enumerator lives in tools/ because .golangci.yml excludes scripts/ from make lint."
+      "passes": true,
+      "started": "2026-08-28T09:12:00+02:00",
+      "completed": "2026-08-28T09:30:00+02:00",
+      "notes": "M1 complete: added the success-only cached absolute git resolver, AST enumerator and ratcheting CI gate, converted exactly the four flagged calls, migrated help.go, wired two CI steps, and seeded the freshly measured 89-site baseline. All B1-B6/G1-G7 neutering mutants and the E1 multi-line addition mutant were build-verified and killed by their named arms. M2-M4 remain intentionally unexecuted."
     },
     {
       "id": "M2_COORDINATOR_SWEEP",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,12 @@ jobs:
     - name: Check architecture boundaries
       run: make check-boundaries
 
+    - name: Check git exec sites
+      run: make check-git-exec
+
+    - name: Git exec gate self-test
+      run: make test-check-git-exec
+
     - name: Verify install guide consistency
       run: make verify-install-guide
 

--- a/changelogs/v0.32-current.md
+++ b/changelogs/v0.32-current.md
@@ -4,6 +4,13 @@
 
 ## [Unreleased]
 
+### Changed — git subprocesses begin migrating to one absolute-path resolver
+
+Added the concurrency-safe `internal/gitexec` resolver, which caches successful resolution but
+retries after failure, and migrated the four Sonar-flagged calls plus the stale-binary probe.
+A new AST-based CI ratchet inventories the remaining bare-name calls, checks its own fixtures,
+and reports the intentionally uncovered variable, shell, syscall, and non-Go classes.
+
 ### Changed — prompt freeze integrity now covers every registry entry
 
 `ailang prompt freeze --check` now validates hash enforceability, source-file existence and bytes,

--- a/cmd/ailang/coordinator_cloud.go
+++ b/cmd/ailang/coordinator_cloud.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sunholo-data/ailang/internal/executor"
+	"github.com/sunholo-data/ailang/internal/gitexec"
 	// Import to trigger init() registration — same as local coordinator (provider_executor.go)
 	_ "github.com/sunholo-data/ailang/internal/executor/claude"
 	_ "github.com/sunholo-data/ailang/internal/executor/managed_agents"
@@ -459,7 +460,7 @@ func executeCloudTask(ctx context.Context, taskID, agentID, repoURL, baseBranch,
 	// no-op cloud task left an orphan branch behind and logged a failure for
 	// doing exactly the right thing. Compare against the clone point instead.
 	if newBranch {
-		aheadCmd := exec.CommandContext(ctx, "git", "-C", workDir, "log", clonePoint+"..HEAD", "--oneline")
+		aheadCmd := gitexec.CommandContext(ctx, "-C", workDir, "log", clonePoint+"..HEAD", "--oneline")
 		if aheadOut, aheadErr := aheadCmd.Output(); aheadErr == nil && len(strings.TrimSpace(string(aheadOut))) == 0 {
 			fmt.Println("execute-job: no commits to push (agent made no changes) — not creating branch or PR")
 			changedFiles := discoverChangedFilesFromCommit(workDir, clonePoint)

--- a/cmd/ailang/help.go
+++ b/cmd/ailang/help.go
@@ -8,8 +8,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
+
+	"github.com/sunholo-data/ailang/internal/gitexec"
 )
 
 // staleCheckDirs are the source directories the staleness heuristic samples.
@@ -158,33 +159,14 @@ func isFullSHA(s string) bool {
 	return true
 }
 
-var (
-	gitPathOnce sync.Once
-	gitPath     string
-)
-
-// resolveGit returns an ABSOLUTE path to git, or "" if look cannot produce one.
-//
-// Requiring an absolute result is deliberate: this check runs on an ordinary
-// `ailang` invocation, so it must not execute whatever a relative or writable
-// PATH entry happens to call "git". An empty result makes both probes report
-// undeterminable, which SHOWS the warning rather than suppressing it — a
-// failure here costs a spurious warning, never a silenced real one.
-func resolveGit(look func() (string, error)) string {
-	p, err := look()
+// gitBinary maps resolution failure to "", preserving the stale check's
+// undeterminable -> show the warning behavior.
+func gitBinary() string {
+	p, err := gitexec.Path()
 	if err != nil {
 		return ""
 	}
-	if !filepath.IsAbs(p) {
-		return ""
-	}
 	return p
-}
-
-// gitBinary resolves git once per process.
-func gitBinary() string {
-	gitPathOnce.Do(func() { gitPath = resolveGit(func() (string, error) { return exec.LookPath("git") }) })
-	return gitPath
 }
 
 // gitHead returns the HEAD sha of the checkout at dir, running the git at the

--- a/cmd/ailang/help_stale_test.go
+++ b/cmd/ailang/help_stale_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -370,43 +369,6 @@ func TestGitBinaryIsAbsolute(t *testing.T) {
 	}
 	if !filepath.IsAbs(got) {
 		t.Fatalf("git resolved to %q, which is not an absolute path", got)
-	}
-}
-
-// TestResolveGitRefusesAnythingNotAbsolute drives the real resolver, not a
-// re-implementation of its predicate, across every way it can fail. The
-// positive arm is what stops the refusals passing vacuously.
-func TestResolveGitRefusesAnythingNotAbsolute(t *testing.T) {
-	// Derive the absolute path at runtime rather than writing a POSIX literal:
-	// filepath.IsAbs("/usr/bin/git") is FALSE on windows, which needs a volume
-	// name, so a hardcoded path would red for the platform and not for the code.
-	absGit := filepath.Join(t.TempDir(), "git")
-	if !filepath.IsAbs(absGit) {
-		t.Fatalf("instrument failure: %q must be absolute on this platform", absGit)
-	}
-	if got := resolveGit(func() (string, error) { return absGit, nil }); got != absGit {
-		t.Fatalf("an absolute path must be accepted; got %q", got)
-	}
-	for _, tc := range []struct {
-		why  string
-		path string
-		err  error
-	}{
-		{"git is not on PATH at all", "", exec.ErrNotFound},
-		{"lookup errored but still returned a usable-looking path", "ERRPATH", exec.ErrNotFound},
-		{"git resolved to a RELATIVE path", "bin/git", nil},
-		{"git resolved to a bare name", "git", nil},
-		{"git resolved to a CWD-relative path", "./git", nil},
-	} {
-		t.Run(tc.why, func(t *testing.T) {
-			path := tc.path
-			if path == "ERRPATH" {
-				path = absGit // absolute AND erroring: only the error may refuse it
-			}
-			if got := resolveGit(func() (string, error) { return path, tc.err }); got != "" {
-				t.Fatalf("must refuse %q (%s); got %q", tc.path, tc.why, got)
-			}
-		})
 	}
 }
 

--- a/cmd/ailang/prompt_freeze_check_git.go
+++ b/cmd/ailang/prompt_freeze_check_git.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/sunholo-data/ailang/internal/gitexec"
 )
 
 func checkGitPromptFreezeInvariants(repoRoot string, source, mirror *orderedRegistry, violations []string) ([]string, error) {
@@ -90,7 +91,7 @@ func gitOutput(repoRoot string, args ...string) (string, error) {
 }
 
 func gitBytes(repoRoot string, args ...string) ([]byte, error) {
-	cmd := exec.Command("git", args...)
+	cmd := gitexec.Command(args...)
 	cmd.Dir = repoRoot
 	out, err := cmd.Output()
 	if err != nil {

--- a/cmd/ailang/prompt_freeze_core.go
+++ b/cmd/ailang/prompt_freeze_core.go
@@ -9,11 +9,11 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/sunholo-data/ailang/internal/eval_harness"
+	"github.com/sunholo-data/ailang/internal/gitexec"
 )
 
 type registryPair struct{ Source, Mirror string }
@@ -193,7 +193,7 @@ type corpusEvidence struct {
 }
 
 func scanCorpus(repoRoot string) (map[string]corpusEvidence, error) {
-	cmd := exec.Command("git", "ls-files", "eval_results/baselines/*.json")
+	cmd := gitexec.Command("ls-files", "eval_results/baselines/*.json")
 	cmd.Dir = repoRoot
 	out, err := cmd.Output()
 	if err != nil {

--- a/design_docs/planned/v0_35_0/m-git-binary-resolution-sweep-sprint-plan.md
+++ b/design_docs/planned/v0_35_0/m-git-binary-resolution-sweep-sprint-plan.md
@@ -1,0 +1,393 @@
+# Sprint Plan: M-GIT-BINARY-RESOLUTION-SWEEP
+
+**Design doc**: [m-git-binary-resolution-sweep.md](m-git-binary-resolution-sweep.md) (quorum-refined, 666 lines)
+**Target**: v0.35.0
+**Planned at**: 2026-08-28, iteration 298
+**Base**: `sprint/iter298-git-exec-sweep` @ `110bbb7c0` (origin/dev `999d4c1dd` + the design-doc commit)
+**Risk**: M1 medium (new shared package + new CI gate + new AST machinery), M2-M4 low (mechanical)
+
+---
+
+## 0. Scope discipline — READ FIRST
+
+This plan covers all four milestones, but **only M1 is scheduled for execution in this
+iteration, and M1 is designed to be independently executable and independently landable as
+its own PR.**
+
+M1 is the milestone that matters. It fixes the *contract* (failure semantics, caching
+semantics, absolute-path refusal), builds the *instrument* (the AST enumerator and its CI
+gate), and converts only the 4 Sonar-flagged sites plus `cmd/ailang/help.go`. Everything in
+M1 is either new machinery or a 2-line mechanical conversion of a site whose error handling
+already consumes `Run`/`Output`.
+
+M2-M4 are **bulk conversions against a contract M1 froze**. They add no new decision, no new
+package, no new gate. They ratchet a baseline file downward, 42 sites then 41 then 6. They
+land later, each as its own PR, and each is safe to defer indefinitely because the M1 gate
+already prevents the class from *growing* while they wait.
+
+**M1 landing criterion**: the branch is mergeable on its own when every AC in §3.5 holds.
+Nothing in M2-M4 is a prerequisite for merging M1, and no AC in M1 references a post-M1
+count.
+
+---
+
+## 1. Velocity and sizing
+
+Recent comparable work in this repo (gate-shaped sprints): `M-ARCH-BOUNDARIES`
+(`scripts/check_boundaries.sh` + make target + ci.yml step, ~260 LOC, 1.5d),
+`check_tmpfile_hygiene` + its 11-arm self-test, `check_protocol_closure` + self-test. All
+three landed as script+target+ci-step+self-test bundles. M1 is the same shape plus a new Go
+package and a new Go AST tool, so it is the largest of the family.
+
+| Milestone | Impl LOC | Test LOC | Est. |
+|---|---|---|---|
+| M1 | ~430 | ~430 | 1.5d |
+| M2 | ~90 (42 sites x ~2 lines) | 0 new (existing coordinator tests) | 1d |
+| M3 | ~85 (41 sites) | 0 new | 1d |
+| M4 | ~15 (6 sites) | 0 new | 0.5d |
+
+---
+
+## 2. Measured facts this plan is built on
+
+Every number below was **re-measured on the pristine tree at `110bbb7c0`** during planning,
+not copied from the design doc. Where a measurement contradicts the doc it is called out in
+§6.
+
+| Fact | Command | Observed |
+|---|---|---|
+| Bare-name git exec sites, non-test, regex | `grep -rEn 'exec\.Command(Context)?\([^)"]*"git"' cmd internal --include='*.go' \| grep -v '_test\.go' \| wc -l` | **93** across **18** files |
+| Same, narrow regex | `... -E 'exec\.Command(Context)?\((ctx, )?"git"' ...` | **93**, `diff` vs wide = empty |
+| Same, **go/ast** prototype (built during planning) | walk `*ast.CallExpr`, `exec.Command` arg 0 / `exec.CommandContext` arg 1, `strconv.Unquote == "git"` | **93** (cmd 44 + internal 49), **per-file diff vs regex = EMPTY** |
+| `Command` vs `CommandContext` split | grep on the site list | 70 / 23 (= 93) |
+| `LookPath("git")` non-test | `grep -rn 'LookPath("git")' cmd internal --include='*.go' \| grep -v '_test\.go'` | 1 hit: `cmd/ailang/help.go:186` |
+| `gitBinary(` refs in `help_stale_test.go` | grep | 6 (lines 223, 230, 240, 243, 367, 427); plus `resolveGit` at 387, 406 and `exec.ErrNotFound` at 395, 396 |
+| Boundary policed sets | `grep -n 'CORE_PKGS\|DASHBOARD_PKGS\|CORE_SURFACE_PKGS' scripts/check_boundaries.sh` | `CORE_PKGS=(parser types eval core elaborate effects builtins lexer ast pipeline runtime link iface)`, `DASHBOARD_PKGS=(server coordinator observatory messaging)`, `CORE_SURFACE_PKGS=(parser types core elaborate pipeline)` — **`gitexec` is in none** |
+| `exec.Cmd.Err` deferred contract | standalone Go probe on go1.26.6: `(&exec.Cmd{Path:"", Args:[...], Err: fmt.Errorf("gitexec: %w: no", sentinel)}).Run()` | `Run` returns the wrapped error, `errors.Is(err, sentinel) == true`; same for `.Output()`. **Behaviourally verified, not doc-verified** |
+| Go / module | `head -3 go.mod; go version` | `go 1.26.6`, `go1.26.6 darwin/arm64` |
+| Linters enabled | `.golangci.yml` | `govet ineffassign staticcheck unused misspell` — **no gosec**, so no G204 interference. `exclude-dirs` includes `scripts` |
+| Formatting scope | `make fmt-check` | `gofmt -l .` — **repo-wide, testdata included**. This is why gate fixtures must be `.txt`, never `.go` (§6.7) |
+
+### 2.1 Per-file baseline this sprint will seed (post-M1)
+
+M1 converts 4 sites: `prompt_freeze_check_git.go` 1→0, `prompt_freeze_core.go` 1→0,
+`worktree.go` 16→15, `coordinator_cloud.go` 15→14. `help.go` holds **zero** bare sites (its
+git calls are variable-first-arg, `help.go:204,222`), so the help.go migration does not move
+the count. Residual = **89 across 16 files**. The executor MUST re-derive this by measurement
+at execution time and use the measured value; the table below is the expected result, and a
+disagreement is a signal to stop and investigate, not to edit the table.
+
+```
+internal/coordinator/worktree.go 15
+cmd/ailang/coordinator_cloud.go 14
+cmd/ailang/coordinator_browse.go 11
+internal/coordinator/merge.go 8
+internal/coordinator/approval_processor.go 6
+internal/pkg/gitcache.go 5
+internal/coordinator/artifact_discovery.go 5
+internal/coordinator/daemon_tasks_exec_run.go 4
+cmd/ailang/coordinator_inspect.go 4
+cmd/ailang/chains_diff.go 4
+internal/coordinator/daemon_tasks_worktrees.go 3
+cmd/ailang/messages_send.go 3
+cmd/ailang/coordinator_utils.go 3
+cmd/ailang/coordinator_cloud_github.go 2
+internal/eval_harness/gemini_evaluator_bridge.go 1
+internal/coordinator/observatory_sync.go 1
+```
+Sum = 89.
+
+---
+
+## 3. M1 — helper + flagged sites + gate (1.5d, THIS ITERATION)
+
+### 3.1 Task breakdown
+
+| # | Task | Files | LOC |
+|---|---|---|---|
+| T1 | `internal/gitexec` package: `ErrUnresolvable`, `resolveWith` seam, mutex-guarded **success-only** cache, `Path()`, `Command()`, `CommandContext()` | `internal/gitexec/gitexec.go` (NEW) | ~130 |
+| T2 | Refusal-branch + caching tests (B1-B6, §3.3) | `internal/gitexec/gitexec_test.go` (NEW) | ~230 |
+| T3 | **go/ast enumerator** (the doc's HID-6 commitment; bash cannot do this) | `tools/check-git-exec/main.go` (NEW) | ~180 |
+| T4 | Enumerator unit tests, incl. the ADDITION arms E1-E6 | `tools/check-git-exec/main_test.go` (NEW) | ~200 |
+| T5 | Gate driver: fixture control → enumerate → ratchet → LookPath invariant → residual print | `scripts/check_git_exec.sh` (NEW) | ~130 |
+| T6 | Gate fixtures | `scripts/testdata/git_exec_gate_positive.txt` (NEW), `scripts/testdata/git_exec_gate_blindspot.txt` (NEW) | ~40 |
+| T7 | Baseline, **seeded by fresh measurement after T8** | `scripts/git_exec_baseline.txt` (NEW) | 16 lines |
+| T8 | Convert the 4 flagged sites (2-line diffs, conventions preserved verbatim) | `cmd/ailang/prompt_freeze_check_git.go:82`, `cmd/ailang/prompt_freeze_core.go:194`, `internal/coordinator/worktree.go:308`, `cmd/ailang/coordinator_cloud.go:459` | ~10 |
+| T9 | help.go migration: delete `resolveGit`, replace `gitBinary()` body with a `gitexec.Path()` adapter mapping error→`""` | `cmd/ailang/help.go` | ~-25/+8 |
+| T10 | Rewrite `help_stale_test.go` against the new seam (drop `resolveGit` cases → they move to `gitexec_test.go`; keep the 6 `gitBinary()` call sites working) | `cmd/ailang/help_stale_test.go` | ~-45/+10 |
+| T11 | Gate bash self-test (mirrors `scripts/test_check_tmpfile_hygiene.sh` idiom, incl. `ARMS_EXPECTED` floor) | `scripts/test_check_git_exec.sh` (NEW) | ~200 |
+| T12 | Make targets + `ci:` aggregate + **two** ci.yml steps (§3.4) | `make/code-health.mk`, `make/ci.mk`, `.github/workflows/ci.yml` | ~14 |
+| T13 | Changelog entry | `changelogs/v0.32-current.md` (NOT root `CHANGELOG.md` — see §3.4) | ~12 |
+| T14 | Run the mutation protocol (§3.3) and record evidence in the sprint log | — | — |
+
+### 3.2 Design refinements this plan makes to the doc (all justified in §6)
+
+- **R1 — `gitBinary()` is kept as a 3-line adapter, not deleted.** The doc says "delete both".
+  `resolveGit` genuinely moves to `gitexec` and is deleted from `help.go`. But the doc's own
+  rationale requires *somewhere* in `help.go` that maps `gitexec.Path()`'s error to `""` so
+  `gitHead`/`gitDirty` keep their "undeterminable → SHOW the warning" semantics. Keeping
+  `gitBinary()` as that one mapping site localises the semantics, keeps 6 test call sites
+  compiling, and is the minimal diff. `resolveGit`'s deletion is the falsifiable part and is
+  asserted by AC9.
+- **R2 — the AST/regex cross-check runs over the REAL TREE ONLY, never over the fixtures.**
+  Measured during planning: on a fixture holding a multi-line `exec.Command(\n"git", …)` the
+  AST arm returns 1 and the regex arm returns 0. The doc's HID-6 clause 2 ("a disagreement
+  between them is a gate FAILURE") and clause 3 (ship a multi-line fixture) contradict each
+  other if the cross-check is applied to the fixture. Scope the cross-check to `cmd/` +
+  `internal/`, where both arms measure 93 today and 89 after M1.
+- **R3 — `internal/gitexec/` is NOT excluded from the exec enumeration.** The doc excludes it.
+  It does not need to be: `gitexec` never calls `exec.Command("git", …)` (it calls
+  `exec.Command(absPath, …)`), so excluding it only creates a directory where a bare site
+  could hide. Only the **`LookPath("git")` invariant** is scoped to `internal/gitexec/`.
+- **R4 — an unparseable `.go` file is a gate FAILURE (exit 2), not a skip.** The prototype
+  built during planning printed to stderr and continued; that is a silent hole (a syntax-broken
+  file hides every site in it). The shipped enumerator must exit 2 naming the file.
+- **R5 — the variable-first-arg fixture is a NEGATIVE control with an asserted count of 0**,
+  not a positive that moves the count. An AST enumerator keyed on a `"git"` *string literal*
+  cannot see `g := "git"; exec.Command(g, …)` — that is the design's own declared residual
+  (HID-6 clause 4). Asserting it stays 0 makes the declared residual falsifiable: if someone
+  later adds dataflow, the test fails and forces the residual list to be updated. The
+  **count-moves-by-addition** requirement is carried by the multi-line fixture (E1), which
+  moves the count by exactly +1.
+- **R6 — the AST enumerator lives in `tools/`, not `scripts/`.** `.golangci.yml` sets
+  `exclude-dirs: [..., scripts]`, so a Go program under `scripts/` would silently escape
+  `make lint`. `tools/` already holds nine `package main` Go tools with tests
+  (`tools/gen-error-codes/main_test.go` is the precedent).
+
+### 3.3 Test plan and mutation protocol
+
+Every refusal branch M1 adds gets one test AND one **neutering** mutation of the form
+`if false && <cond>` — never a deletion, because a deleted block can fail to COMPILE and that
+red masquerades as the guard firing. Protocol per mutant, in this order:
+
+1. `cp <file> /tmp/m1-backup/<file>` (restore from this backup — **never** `git checkout --`,
+   the tree is uncommitted by construction).
+2. Apply the mutation.
+3. **Assert the mutant LANDED**: `sha256sum` before ≠ after, and `grep -c 'if false &&' <file>` moved.
+4. **Assert the mutant BUILDS**: `go build ./internal/gitexec/... ./cmd/ailang/...` rc=0 (Go tool)
+   or `bash -n scripts/check_git_exec.sh` rc=0 (bash gate). **Only then** read a test result.
+5. Run the named test; require rc≠0.
+6. Restore from backup; re-run; require rc=0.
+
+| # | Branch / property | Test | Neutering mutation the test must kill |
+|---|---|---|---|
+| B1 | `look()` errors → refuse | `TestResolveWith_LookError` : `resolveWith(fail)` returns err with `errors.Is(_, ErrUnresolvable)` | `if false && err != nil` in the error check |
+| B2 | `look()` returns a relative path → refuse | `TestResolveWith_RelativeRefused` : `"git"` and `"./git"` both refused | `if false && !filepath.IsAbs(p)` |
+| B3 | failed resolve → `Cmd.Err` carries it | `TestCommand_DeferredError` : build a Cmd under an injected failing resolver, assert the error identity comes back from **`Run()`**, not from construction | `if false && resolveErr != nil` at the `Cmd.Err` assignment |
+| B4 | success path → `Cmd.Path` is the absolute path | `TestCommand_UsesAbsolutePath` : `resolveWith(-> "/abs/git")`, assert `cmd.Path == "/abs/git"` and `cmd.Args[0] == "/abs/git"`; `CommandContext` honours a cancelled ctx | swap the assignment to the bare literal `Path: "git"` (builds; B4's absolute assertion kills it) |
+| B5 | success IS cached | `TestPath_CachesSuccess` : two `Path()` calls, `look` invoked exactly once | guard the cache store: `if false && err == nil { cached = p }` |
+| B6 | failure is NOT cached (HID-3) | `TestPath_DoesNotCacheFailure` : first `Path()` fails, second `Path()` re-invokes `look` and returns a later success | **"cache the failure too"** — store the error in the cache slot on failure; the second call returns the stale error without re-invoking `look` |
+| G1 | fixture missing → exit 2 "INSTRUMENT BROKEN" | self-test S2 | `if false && [ ! -f "$POSITIVE_FIXTURE" ]` |
+| G2 | fixture yields 0 matches → exit 2 | self-test S2b (fixture present but emptied) | `if false && [ "$FIXTURE_COUNT" -eq 0 ]` |
+| G3 | a file above its baseline count → exit 1, names file:line | self-test S3 | `if false && [ "$n" -gt "$base" ]` |
+| G4 | a file below its baseline count → exit 1 "tighten the baseline" | self-test S4 | `if false && [ "$n" -lt "$base" ]` |
+| G5 | a file with matches absent from the baseline → exit 1 | self-test S3b (new file) | `if false && [ -z "$base" ]` |
+| G6 | `LookPath("git")` outside `internal/gitexec/` → exit 1 | self-test S5 | `if false && [ "$LOOKPATH_OUTSIDE" -gt 0 ]` |
+| G7 | AST vs regex disagree **on the real tree** → exit 1 | self-test S6 (plant a multi-line git site in a temp tree copy: AST sees it, regex does not) | `if false && [ "$AST_TOTAL" -ne "$RX_TOTAL" ]` |
+
+Enumerator unit tests (`tools/check-git-exec/main_test.go`), all **addition** arms:
+
+| # | Arm | Kills |
+|---|---|---|
+| E1 | temp tree count = N; copy in the multi-line fixture as `.go`; count = **N+1** | "enumerator is line-oriented" — i.e. a regression to `grep`. This is the ADDITION arm; a removal-only test would still pass under it |
+| E2 | blind-spot fixture (`g := "git"` + `bash -c "git status"`) adds **exactly 0** | a silent widening of the enumerator that leaves the declared residual list stale |
+| E3 | `exec.Command("git-lfs", …)` and `exec.Command("gitfoo")` add 0 | prefix-matching instead of `strconv.Unquote(lit) == "git"` |
+| E4 | `exec.CommandContext(ctx, "git", …)` counted at arg index **1**; a `"git"` in arg 2 is not | an off-by-one in the arg index |
+| E5 | fixture named `x_test.go` adds 0; the **same bytes** renamed `x.go` add 1 | a `_test.go` exclusion that is vacuous (matches nothing) rather than suffix-based |
+| E6 | a file with a Go syntax error → **exit 2**, naming the file | R4: silent skip of unparseable files |
+
+Bash self-test (`scripts/test_check_git_exec.sh`) carries an `ARMS_EXPECTED` floor exactly as
+`scripts/test_check_tmpfile_hygiene.sh:9` does, so a self-test that stops running arms fails
+loudly instead of reporting green.
+
+### 3.4 CI wiring — derived from the repo, not from memory
+
+**`make ci` is NOT invoked anywhere in `.github/workflows/ci.yml`.** Verified:
+`grep -n 'run: make ' .github/workflows/ci.yml` lists 31 individual targets and `ci` is not
+among them. A target wired only into `make ci` **does not run in CI**. Both edits are
+therefore required:
+
+1. **`make/code-health.mk`** — add beside `check-boundaries` (currently line 161-162, exactly):
+   ```
+   check-boundaries: ## Check architecture layer boundaries (CI gate)
+   	@bash scripts/check_boundaries.sh
+   ```
+   Insert after line 162:
+   ```
+   check-git-exec: ## Refuse bare-name git exec sites outside internal/gitexec (CI gate)
+   	@bash scripts/check_git_exec.sh
+
+   test-check-git-exec: ## Run the git-exec gate's own self-test (bash 3.2)
+   	@/bin/bash scripts/test_check_git_exec.sh
+   	@/bin/bash -n scripts/check_git_exec.sh
+   	@go test ./tools/check-git-exec/... -count=1
+   ```
+   (the `bash -n` + self-test pairing mirrors `test-check-tmpfile-hygiene` at
+   `make/code-health.mk:170-172`.)
+
+2. **`make/ci.mk` line 11** — append `check-git-exec test-check-git-exec` to the `ci:`
+   prerequisite list. The line currently reads (truncated):
+   ```
+   ci: deps fmt-check vet lint test test-nightly-classifier test-coverage-badge test-lowering verify-no-shim ... check-tmpfile-hygiene test-check-autoclose test-check-changelog test-check-protocol-closure test-check-tmpfile-hygiene check-prompt-freeze ## Run full CI verification, including workflow gates
+   ```
+
+3. **`.github/workflows/ci.yml`** — the boundary step is exactly:
+   ```
+   132:    - name: Check architecture boundaries
+   133:      run: make check-boundaries
+   ```
+   Insert **after line 133** (before `- name: Verify install guide consistency` at line 135):
+   ```yaml
+       - name: Check git exec sites
+         run: make check-git-exec
+
+       - name: Git exec gate self-test
+         run: make test-check-git-exec
+   ```
+   These land in the `test:` job (`runs-on: ubuntu-latest`, ci.yml:17-18), which has Go set up
+   and runs `make install` at line 60, so `go test ./tools/...` is available.
+
+**Changelog**: `make check-changelog` runs `scripts/check_changelog.sh`, whose rule is
+structural — the root `CHANGELOG.md` may contain **exactly one heading**, the archive table's
+(`## Changelog Archives`); *any* other heading is release-note content and fails the gate.
+Verified at base: `make check-changelog` rc=0, printing
+`✓ CHANGELOG.md is index-only and links changelogs/v0.32-current.md`, and
+`grep -n '^#' CHANGELOG.md` returns exactly two lines (`# AILANG Changelog`,
+`## Changelog Archives`). **The M1 entry goes under `## [Unreleased]` in
+`changelogs/v0.32-current.md`. Do not touch root `CHANGELOG.md`.**
+
+### 3.5 Acceptance criteria, each with its **measured base rc**
+
+Measured on the pristine worktree at `110bbb7c0` before any edit. Falsifiability column
+answers: *what would this still pass under, if the claim were false?*
+
+| # | Acceptance command | Base (measured) | Required after M1 | Falsifiable? |
+|---|---|---|---|---|
+| AC1 | `go build ./internal/gitexec/... ./cmd/ailang/... ./internal/coordinator/...` | **rc=1** (`pattern ./internal/gitexec/...: lstat: no such file or directory`) | rc=0 | YES — red at base for the right reason (package absent) |
+| AC2 | `go test ./internal/gitexec/... -count=1` | **rc=1** (setup failed, no such package) | rc=0 | YES |
+| AC3 | AST enumerator total over `cmd internal` = **89** (via `make check-git-exec` output, or the tool directly) | **93** | 89 | YES |
+| AC4 | `grep -rln 'LookPath("git")' cmd internal --include='*.go' \| grep -v '_test\.go' \| grep -cv '^internal/gitexec/'` | **1** (`cmd/ailang/help.go`) | **0** | YES |
+| AC5 | `make check-git-exec` | **rc=2** (`No rule to make target 'check-git-exec'`) | rc=0 | YES |
+| AC6 | `make test-check-git-exec` | **rc=2** (no such target) | rc=0 | YES |
+| AC7 | `grep -c 'make check-git-exec' .github/workflows/ci.yml` | **0** (rc=1) | `>= 1` | YES |
+| AC8 | `grep -c 'make test-check-git-exec' .github/workflows/ci.yml` | **0** (rc=1) | `>= 1` | YES |
+| AC9 | `grep -c 'check-git-exec' make/ci.mk` | **0** (rc=1) | `>= 1` | YES |
+| AC10 | `grep -c 'func resolveGit' cmd/ailang/help.go` | **1** | **0** | YES |
+| AC11 | `grep -c 'gitexec' changelogs/v0.32-current.md` | **0** (rc=1) | `>= 1` | YES |
+| AC12 | `make check-git-exec 2>&1 \| grep -c 'variable first argument'` (residual classes printed every run — HID-6 cl.4) | **rc=2**, no output | `>= 1` | YES |
+| AC13 | Gate anti-vacuity: `mv scripts/testdata/git_exec_gate_positive.txt /tmp/ && bash scripts/check_git_exec.sh; rc=$?` | n/a (no fixture, no gate) | **rc=2**, output contains `INSTRUMENT BROKEN` | YES |
+| AC14 | Mutation evidence: for each of B1-B6 and G1-G7, the mutant (a) has a different sha256 from the backup, (b) **builds** (`go build …` rc=0 / `bash -n …` rc=0), and (c) the named test returns rc≠0; restoring gives rc=0 | n/a | all 13 pass | YES by construction |
+| AC15 | AST arm and regex arm agree on `cmd internal` (both 89) | both **93** (per-file `diff` = empty, verified) | both 89, diff empty | YES (89 ≠ 93) |
+| **REGRESSION GATES — rc=0 at base AND after. NOT acceptance criteria; they cannot fail for the right reason.** |
+| R-a | `go test ./cmd/ailang/... -count=1` | rc=0 (24.3s) | rc=0 | no |
+| R-b | `go test ./internal/coordinator/... ./internal/pkg/... ./internal/eval_harness/... -count=1` | rc=0 | rc=0 | no |
+| R-c | `make check-boundaries` | rc=0 | rc=0 | no |
+| R-d | `make check-file-sizes` | rc=0 | rc=0 | no |
+| R-e | `make check-changelog` | rc=0 | rc=0 | no (AC11 is its falsifiable partner) |
+| R-f | `gofmt -l cmd internal tools scripts` | empty, rc=0 | empty | no |
+| R-g | `go vet ./cmd/ailang/...` | rc=0 | rc=0 | no |
+| **REJECTED — already red on the untouched tree; would measure the repo, not the change** |
+| X-1 | `go build ./...` | **rc=1**: `# github.com/sunholo-data/ailang/cmd/wasm` / `runtime.main_main·f: function main is undeclared in the main package` | — | **REJECTED**. Use AC1's narrowed form |
+
+### 3.6 M1 risks
+
+| Risk | Mitigation |
+|---|---|
+| `go run`/`go test` in the gate slows CI | `tools/check-git-exec` is stdlib-only and tiny; the `test:` job already runs 31 make targets. If it matters, the gate can `go build -o` once into `$TMPDIR` |
+| The gate's ratchet blocks unrelated PRs that legitimately add a git call | That is the point (HID-6). The escape hatch is an explicit, reviewed edit to `scripts/git_exec_baseline.txt`, which is exactly the audit trail wanted |
+| `help_stale_test.go` rewrite loses coverage | The `resolveGit` cases (lines 387-406) move to `gitexec_test.go` as B1/B2 and are strengthened there with mutants; net coverage goes up, not down |
+| Concurrent-session collision | Re-verified at plan time: none of the 4 flagged files nor `help.go` is under active edit; the tree is clean at `110bbb7c0` |
+
+---
+
+## 4. M2-M4 — mechanical conversions (NOT this iteration)
+
+Each is its own PR, each ratchets `scripts/git_exec_baseline.txt` downward, each adds **no**
+new decision. The contract is frozen by M1; the only per-site work is replacing
+`exec.Command("git", args…)` with `gitexec.Command(args…)` and
+`exec.CommandContext(ctx, "git", args…)` with `gitexec.CommandContext(ctx, args…)`,
+preserving each site's `cmd.Dir` vs `-C` convention verbatim.
+
+### M2 — `internal/coordinator` (1d, 42 sites, 7 files)
+`worktree.go` 15, `merge.go` 8, `approval_processor.go` 6, `artifact_discovery.go` 5,
+`daemon_tasks_exec_run.go` 4, `daemon_tasks_worktrees.go` 3, `observatory_sync.go` 1.
+Acceptance: baseline sum = **47** (89 − 42, re-derived); `make check-git-exec` rc=0;
+`go test ./internal/coordinator/... -count=1` rc=0 (base rc=0, regression gate).
+Note: 5 sites here and in M3 already discard the error (`_ = cmd.Run()`,
+`daemon_tasks_exec_run.go:461,463`, `coordinator_browse.go:87,240`, `worktree.go:239`).
+Conversion **preserves** that silent swallow; the design explicitly does not fix them.
+
+### M3 — `cmd/ailang` (1d, 41 sites, 7 files)
+`coordinator_cloud.go` 14, `coordinator_browse.go` 11, `chains_diff.go` 4,
+`coordinator_inspect.go` 4, `messages_send.go` 3, `coordinator_utils.go` 3,
+`coordinator_cloud_github.go` 2.
+Acceptance: baseline sum = **6**; `go test ./cmd/ailang/... -count=1` rc=0.
+
+### M4 — tools layer (0.5d, 6 sites, 2 files)
+`internal/pkg/gitcache.go` 5, `internal/eval_harness/gemini_evaluator_bridge.go` 1.
+Acceptance: baseline sum = **0**; the baseline file asserts emptiness; the positive
+invariant (exactly one `LookPath("git")`, inside `internal/gitexec/`) is the standing gate
+thereafter, kept non-vacuous forever by the fixture control (AC13).
+
+---
+
+## 5. Success metrics
+
+- M1: 93 → 89 bare sites; 1 → 1 `LookPath("git")` but **relocated** into `internal/gitexec/`;
+  gate live in CI as two ci.yml steps; 13 mutants killed.
+- M4: 0 bare sites; residual classes (variable first argument, dataflow/aliasing, shell
+  strings, `syscall.Exec`, non-Go surfaces) printed by the gate on every run and **not**
+  claimed as covered.
+- Sonar: the 4 flagged new-code `go:S4036` issues stop invoking `exec.Command("git", …)`.
+  The rating is **not** asserted to reach A — the resolver's own `LookPath` is expected to
+  keep one finding, tracked as `M-GIT-RESOLVER-S4036-CLOSURE`.
+
+---
+
+## 6. Contradictions and staleness found while measuring
+
+Reported because a refutation is the useful output, not agreement.
+
+1. **The doc's HID-6 clauses 2 and 3 are mutually inconsistent as written.** Clause 2 makes
+   an AST/regex disagreement a gate FAILURE; clause 3 ships a fixture *designed* to make them
+   disagree. Measured: on such a fixture the AST arm returns **1** and the regex arm returns
+   **0**. Resolved by R2 — the cross-check is scoped to `cmd/` + `internal/` only.
+2. **The doc never lists the Go file that HID-6 requires.** "Files to Modify/Create" has
+   `scripts/check_git_exec.sh` (~120 LOC bash) as the enumerator, but bash cannot walk
+   `go/ast`. `tools/check-git-exec/main.go` + `main_test.go` (~380 LOC) are missing from the
+   doc's file list and from its LOC estimate. Added as T3/T4.
+3. **Excluding `internal/gitexec/` from the exec enumeration (doc, gate step 2) is both
+   unnecessary and a hole.** `gitexec` calls `exec.Command(absPath, …)`, never
+   `exec.Command("git", …)`, so it would never be flagged; the exclusion only creates a
+   directory where a bare site can hide. Only the `LookPath` invariant needs that scoping (R3).
+4. **The doc's V17 multi-line premise is CONFIRMED, and now confirmed by a second, stronger
+   instrument.** A real `go/ast` enumerator built during planning returns **93** with a
+   **per-file diff against the regex of exactly zero**. The doc's V17 used a whitespace-collapsing
+   python regex; an AST walk is a genuinely independent arm and it agrees. The blind spot is
+   prospective, as the doc says.
+5. **`exec.Cmd.Err` was doc-verified (`go doc`) but not behaviour-verified.** Verified during
+   planning on go1.26.6 that `(&exec.Cmd{Path:"", Err: wrapped}).Run()` and `.Output()` both
+   return the wrapped error and satisfy `errors.Is`. The failure contract is sound.
+6. **`worktree.go` now holds 16 git sites, not the doc's implied 16-via-"15 more".** Consistent,
+   but the executor must re-measure: 9 of the 18 sweep files changed between the doc's original
+   base `e38c0c493` and `999d4c1dd`.
+7. **A `.go` fixture would break `make fmt-check`.** `fmt-check` runs `gofmt -l .` repo-wide and
+   `gofmt` does **not** skip `testdata/`. Fixtures must stay `.txt`; `go/parser.ParseFile`
+   accepts source by bytes regardless of extension, so this costs nothing (R6 rationale).
+8. **`.golangci.yml` excludes `scripts/`.** A Go enumerator placed under `scripts/` would escape
+   `make lint` silently. Hence `tools/` (R6).
+9. **The doc's `gitBinary` deletion is under-specified** — deleting it removes the only place
+   that maps a resolution error to the `""` that `gitHead`/`gitDirty` treat as "undeterminable →
+   show the warning". Kept as a 3-line adapter (R1).
+
+### Acceptance criteria that could NOT be made falsifiable
+
+- **R-a … R-g** (§3.5): the seven regression gates. All are rc=0 at base and required rc=0
+  after, so none can fail *for the right reason*; they are listed as regression gates, not as
+  acceptance criteria. `make check-changelog` (R-e) is the one with a falsifiable partner
+  (AC11, `grep -c 'gitexec' changelogs/v0.32-current.md`: 0 → ≥1).
+- **The Sonar success metric.** SonarCloud only re-analyses on a merged push and its leak
+  period is defined against `previous_version = v0.33.2`, so "the 4 flagged issues are
+  resolved" cannot be asserted from the branch at all. It is deliberately excluded from §3.5
+  and recorded as a post-merge observation.
+- **`go build ./...`** (X-1): rejected outright, already rc=1 at base.

--- a/design_docs/planned/v0_35_0/m-git-binary-resolution-sweep.md
+++ b/design_docs/planned/v0_35_0/m-git-binary-resolution-sweep.md
@@ -1,4 +1,4 @@
-# M-GIT-BINARY-RESOLUTION-SWEEP: One Absolute-Path Git Resolver for All 92 Exec Sites
+# M-GIT-BINARY-RESOLUTION-SWEEP: One Absolute-Path Git Resolver for All 93 Exec Sites
 
 **Status**: Planned
 **Target**: v0.35.0
@@ -18,10 +18,10 @@ resolve `git` through whatever `PATH` happens to contain at run time (Verificati
 
 Those 4 sites are not special. They are merely the 4 members of an identical class that were
 *touched inside the new-code period* (`previous_version = v0.33.2`, 2026-08-26). The full class
-is **92 bare-name git exec sites** across `cmd/ailang` (43), `internal/coordinator` (43),
+is **93 bare-name git exec sites** across `cmd/ailang` (44), `internal/coordinator` (43),
 `internal/pkg` (5), and `internal/eval_harness` (1) — and **zero** Go files outside `cmd/` and
 `internal/` contain any (V2, V9, V13). Fixing only the flagged 4 would turn the gate green while
-leaving 88 identical sites in place: gate-satisfying, not a fix. Per the mission's standing rule
+leaving 89 identical sites in place: gate-satisfying, not a fix. Per the mission's standing rule
 (3n(d)), a new-code gate hit is *evidence about the unswept class*, never a threshold to satisfy.
 
 Meanwhile, the repo already contains the correct pattern — and uses it exactly once.
@@ -33,32 +33,53 @@ consumer count outside its own file is **zero** (V3). The knowledge exists; the 
 share it does not.
 
 **Current State:**
-- 92 bare-name git exec sites, 0 of which route through the existing resolver (V2, V3)
-- 4 of 92 visible to Sonar's new-code gate; 88 invisible because they are old (V1 vs V2)
+- 93 bare-name git exec sites, 0 of which route through the existing resolver (V2, V3)
+- 4 of 93 visible to Sonar's new-code gate; 89 invisible because they are old (V1 vs V2)
 - The one hardened resolver is trapped in `package main` (`cmd/ailang/help.go:173,185`) (V3, V4)
 - No CI gate prevents new bare-name git exec sites from being added (no such check exists in
   `make/*.mk` or `scripts/` — V7 shows the boundary gate; nothing polices exec sites)
 
 **Impact:**
-- Security posture: every one of the 92 sites executes whatever `PATH` resolves `git` to,
-  in daemons (coordinator), eval harnesses, and CLI paths. Severity is MINOR per Sonar, but
-  the class is broad and includes long-running privileged-ish processes (worktree management,
-  cloud task execution).
+- Security posture (current state): every one of the 93 sites executes whatever `PATH`
+  resolves `git` to, in daemons (coordinator), eval harnesses, and CLI paths. Severity is
+  MINOR per Sonar, but the class is broad and includes long-running privileged-ish processes
+  (worktree management, cloud task execution). **What this sweep delivers** (and what it does
+  not): it eliminates **relative-path and empty-PATH-entry** resolution and reduces 93
+  independent resolution points to ONE auditable one. It does **NOT** validate that the
+  resolved directory is unwriteable, and it does **NOT** defend against replacement of the
+  binary after resolution (TOCTOU) — both are explicitly non-properties of this design
+  (HID-5), because `exec.LookPath` returning an absolute path is the only property the
+  resolver enforces (V4).
 - Process: the Sonar gate stays red on `new_security_rating` until the flagged sites change,
-  and *any* future PR touching one of the 88 old sites re-flags it — a slow drip of
+  and *any* future PR touching one of the 89 old sites re-flags it — a slow drip of
   one-off "fix the flagged line" patches unless the class is closed once.
 
 ## Goals
 
-**Primary Goal:** Every git execution in the repo goes through one shared absolute-path
-resolver, and CI makes a new bare-name git exec site a build failure.
+**Primary Goal:** Every *direct Go `os/exec` git execution with a literal `"git"` command
+name* goes through one shared absolute-path resolver, and CI makes a new such site a build
+failure.
+
+**The narrowing in that sentence is load-bearing and was added under the round-2 carve-out**
+(HID-6), because `gpt5-6-sol` correctly objected that the original wording — "every git
+execution in the repo" — is wider than any static gate can enforce, so CI could report zero
+while prohibited executions remained. What the gate CANNOT see is enumerated in the Conflict
+Surface and printed by the gate on every run: a variable first argument, dataflow/aliasing, a
+shell string (`bash -c "… git …"`), `syscall.Exec`, and every non-Go surface (scripts,
+Makefiles, launchd plists). Those are named residual classes with their own owners — not
+coverage this design claims.
 
 **Success Metrics:**
-- Bare-name git exec sites (non-test): 92 → 0 by end of M4, with the residual count stated
-  explicitly at each milestone (88 after M1, 46 after M2, 6 after M3, 0 after M4)
+- Bare-name git exec sites (non-test): 93 → 0 by end of M4, with the residual stated at each
+  milestone. Residuals are **derived at execution time**, not hardcoded: the gate baseline is
+  SEEDED FROM A FRESH MEASUREMENT the moment M1 lands, so the numbers below are illustrative
+  of the ratchet's shape, not a contract (see "CI gate"). At HEAD they are 89 after M1, 47
+  after M2, 6 after M3, 0 after M4.
 - `LookPath("git")` call sites repo-wide: exactly 1, inside the new shared package (V6 shows 1 today, in `help.go`; it moves)
-- Sonar `go:S4036` open issues in the class: 4 → 0 flagged sites converted (the resolver's own
-  single `LookPath` may attract one residual finding — see "Sonar interaction")
+- Sonar `go:S4036`: the 4 flagged NEW-CODE sites are converted to route through `gitexec`.
+  The resolver's own single `LookPath` is EXPECTED to keep `go:S4036` present on that one
+  auditable site; the rating is NOT claimed to reach A. Closing that residual is a named,
+  separate follow-up, not something this sweep asserts away (see "Sonar interaction", HID-5).
 - CI gate `make check-git-exec` exists, runs in ci.yml, and fails loudly on an empty
   enumeration (anti-vacuity fixture)
 
@@ -66,20 +87,114 @@ resolver, and CI makes a new bare-name git exec site a build failure.
 
 | Decision | Why High Impact | Chosen By | Deadline | Change Cost |
 |----------|-----------------|-----------|----------|-------------|
-| Failure contract: deferred error via `exec.Cmd.Err` (os/exec's own Go 1.19+ contract), **no** bare-`"git"` fallback, **no** panic | Dictates the shape of all 92 conversions and the UX for a user without git | agent (this doc) | design | high after M2 starts |
+| Failure contract: deferred error via `exec.Cmd.Err` (os/exec's own Go 1.19+ contract), **no** bare-`"git"` fallback, **no** panic | Dictates the shape of all 93 conversions and the UX for a user without git | agent (this doc) | design | high after M2 starts |
+| Caching contract: **cache SUCCESS only**; a failed resolution is re-attempted on the next call | A once-per-process failure cache would permanently break all 43 coordinator git tasks after one early miss (HID-3) | agent (this doc) | design | low |
 | Helper location: new stdlib-only leaf package `internal/gitexec` | Must be importable by `package main` AND `internal/{coordinator,pkg,eval_harness}` without violating layer rules | agent (this doc) | design | med |
 | CI gate is a per-file baseline **ratchet** (fails on increase AND on untightened decrease) with a known-positive anti-vacuity fixture | A count-only or vacuously-green gate lets the class recur silently | agent (this doc) | design | low |
-| Milestone split with explicit residuals (4 → then 42 → 40 → 6) | Prevents the doc being read as claiming full coverage at M1 | agent (this doc) | design | low |
+| Milestone split with explicit residuals (4 → then 42 → 41 → 6), **derived by re-measurement at execution time**, not hardcoded | Prevents the doc being read as claiming full coverage at M1, and prevents a stale hardcoded baseline from rotting the moment anyone adds a site | agent (this doc) | design | low |
+| Security model: **(i) absolute-only** (chosen) vs (ii) absolute + directory-writability check | Determines whether S4036 is actually closed or merely centralised (HID-5) | agent (this doc) | design | med |
 
-No design-freeze items: every decision above is agent-resolvable, preserves today's observable
-failure behavior for users, and touches no cost/KPI/banked-data semantics.
+No design-freeze items: every decision above is agent-resolvable and touches no
+cost/KPI/banked-data semantics. The caching contract (HID-3) *changes* one observable
+behaviour for the better rather than merely preserving it: today every one of the 93 sites
+re-resolves git per call; after, the success path resolves once per process while the
+failure path keeps today's per-call re-resolution, so a long-lived process recovers if git
+appears on PATH after startup — the recovery behaviour is preserved exactly, and the success
+path is strictly cheaper. The security model (HID-5) is scoped to what the resolver
+actually enforces.
+
+**HID-3 — Caching contract: success only.** The previous draft cached resolution success
+AND failure in a `sync.Once`, which is a demonstrable regression for the coordinator daemon
+(43 of the 93 sites live in `internal/coordinator`, the long-lived process): if git is absent
+at daemon startup but appears on PATH later, today every site re-resolves per call and the
+daemon recovers on its next git call; a cached failure would make all 43 sites fail
+permanently without a daemon restart. This revision caches **success only**. The cache is a
+mutex-guarded string (not `sync.Once`, which is wrong for a retryable op): it stays empty
+until a resolution succeeds, and on failure it is left empty so the next `Path()` re-resolves.
+A mutex (rather than `sync.Once`) is required because the coordinator calls git from multiple
+goroutines. Cost accepted: a **permanently**-missing git means one `LookPath("git")` per
+`Path()` call instead of one per process. That path is only hot on a genuinely broken
+environment (git never present), and each call is a cheap PATH walk that immediately returns
+the same `ErrUnresolvable`-wrapped error the site already handles today — this is exactly the
+per-call cost every one of the 93 sites already pays in the status quo, so the failure path
+costs no more than today, and the success path is strictly cheaper. The caching test inverts
+the old contract accordingly (Testing Strategy).
+
+**HID-5 — Security model: absolute-only (i).** The previous draft claimed the resolver
+"must not execute whatever a relative **or writable** PATH entry happens to call git" and
+dispositioned the remaining Sonar `go:S4036` finding as reviewed-safe. That claim is not
+enforced: the resolver checks `filepath.IsAbs(p)` and nothing else (V4) — it does not stat
+the resolved directory, check ownership, or check write permission, and `exec.LookPath` can
+return `/tmp/bin/git` from a writable PATH directory. The binary or its directory can also
+be swapped after resolution (TOCTOU). This design therefore chooses **(i) absolute-only**:
+it narrows the claim to the property actually delivered (refuse relative/empty-PATH results,
+centralise to one auditable site) and deletes the unearned "reviewed-safe" disposition. The
+cost of choosing (ii) — an added `stat` + directory-writability check on the resolved parent
+dir — is that it can refuse on a maintainer's own laptop, because Homebrew's
+`/usr/local/bin` (and `/opt/homebrew/bin`) are commonly group-writable; option (ii) would
+therefore make `ailang`/the coordinator fail git tasks on the exact machine where the
+developer most needs them. That consequence would be *discovered* not *designed* under (ii),
+so (i) is chosen here and the residual S4036 finding is left as an explicit, named follow-up
+(`M-GIT-RESOLVER-S4036-CLOSURE`) rather than closed by assertion.
+
+## Quorum Verification (revision pass)
+
+**Round 1 — BLOCKED.** Quorum ran 3/3 reviewers present (gpt5-6-sol, gemini-3-1-pro,
+oc-glm-5-2), 0 absent, all three REJECTED. One-line objections and this revision's response:
+
+- **gpt5-6-sol — security claim over-stated** (CONFIRMED): the resolver enforces only
+  `filepath.IsAbs`, so it cannot claim to guarantee unwriteable directories nor defend
+  TOCTOU, and the "reviewed-safe" S4036 disposition was unearned. → Rewrote the security
+  posture (Impact), the Success Metric, the Sonar interaction, added HID-5 choosing
+  absolute-only, removed "or writable" from the planned doc comment, and replaced
+  "reviewed-safe" with a named follow-up (`M-GIT-RESOLVER-S4036-CLOSURE`).
+- **oc-glm-5-2 — failure-caching regression** (CONFIRMED): a process-wide cache that stores
+  resolution failure permanently breaks all 43 coordinator git tasks after one early miss
+  without a daemon restart. → Added HID-3 (cache success only, mutex-guarded), changed the
+  `Path()` contract, bound the per-call cost, and inverted the caching test.
+- **gemini-3-1-pro — unverified error-text consumers** (REFUTED by measurement): claimed the
+  88-site error-handling sweep risked silent breakage on string-matching
+  `executable file not found`. Repo-wide grep at HEAD finds **0** producers of that concern
+  and the typed `exec.ErrNotFound` sentinel is confined to out-of-scope files; recorded in
+  V14–V15. No design change; the contract requirement is now stated explicitly.
+
+Additionally re-derived every count at HEAD `999d4c1dd` (the doc's base `e38c0c493` was
+stale): **93** sites (was 92), and made milestone residuals derived-by-measurement rather
+than hardcoded. See V14–V16.
+
+**Round 2 — BLOCKED, and the objections LOCALISED onto one surface.** 3/3 reviewers present,
+0 absent. `gemini-3-1-pro` **flipped to PASS** (its round-1 objection was answered by
+measurement). The two survivors are both about the CI gate's **enumerator**, and neither
+disputes the design direction — so the mission skill's **narrow-refinement carve-out**
+applies, and the controller made a bounded round-2 revision applying the reviewers' own
+fixes verbatim rather than buying a third designer round:
+
+- **gpt5-6-sol** — "It then makes AST-based detection only a 'SHOULD,' allowing M4 and CI to
+  report zero while prohibited git executions remain." → **HID-6**: the enumerator MUST be
+  `go/ast`-based (committed, not executor discretion); the regex is demoted to an optional
+  cross-check whose disagreement is a gate FAILURE; and the **Primary Goal is narrowed** to
+  the class a static gate can actually enforce, with every residual class named and printed
+  by the gate on every run.
+- **oc-glm-5-2** — "A CI gate with a known blind spot for the exact shape it exists to catch
+  does not satisfy its stated primary goal; punting the fix to the executor makes the design
+  incomplete." → same HID-6, plus an **anti-vacuity-by-ADDITION** requirement: the gate ships
+  a multi-line and a variable-first-arg fixture and self-tests that its COUNT MOVES when they
+  are present. A removal proves a check fires; only an addition proves it looks.
+
+**One shared premise in both objections was REFUTED by controller measurement (V17), and it
+changes the urgency without changing the fix.** Both read `internal/eval_harness/watchdog.go:57`
+as an existing git site the regex misses. It is `exec.Command("bash", "-c", …)` — not git —
+exactly as V12 already recorded. A multi-line-aware enumeration over 1,254 non-test Go files
+returns **93**, byte-identical to the single-line count, with an EMPTY differing-file list. So
+there is nothing to recover today and nothing to stop a `gofmt`-wrapped git call being invisible
+tomorrow: the blind spot is **prospective, not present**, and HID-6 closes it prospectively.
 
 **Quorum trigger analysis** (per design-doc-creator checklist): trigger 1 (freeze items) — no.
 Trigger 2 (overrides shared machinery) — no: it *creates* shared machinery and converts callers;
 `scripts/check_boundaries.sh` is reused as a pattern, not modified. Trigger 3 (cost/KPI/schema)
 — no. Trigger 4 (external-system premises) — **arguably yes**: the problem statement leans on
 SonarCloud's leak-period semantics (`sinceLeakPeriod=true`, an API whose sibling parameter
-`inNewCodePeriod` is silently ignored — V1's control). The design's *substance* (92 sites, the
+`inNewCodePeriod` is silently ignored — V1's control). The design's *substance* (93 sites, the
 resolver, the gate) is verifiable entirely in-repo. Recommendation: run `ailang design-quorum`
 before planning, since this is an unattended-loop doc.
 
@@ -116,12 +231,14 @@ package gitexec
 
 // ErrUnresolvable is returned (wrapped) whenever git cannot be resolved to an
 // ABSOLUTE path. Requiring an absolute result is deliberate: callers must not
-// execute whatever a relative or writable PATH entry happens to call "git".
+// execute whatever a relative PATH entry happens to call "git".
 var ErrUnresolvable = errors.New("git is not resolvable to an absolute path")
 
 // Path returns the process-wide cached absolute path to git, or an error
-// wrapping ErrUnresolvable. Resolution runs once per process (sync.Once),
-// caching success AND failure.
+// wrapping ErrUnresolvable. Only SUCCESS is cached (HID-3): on a failed
+// resolution the cache stays empty and the next call re-resolves, so a
+// long-lived process recovers if git appears on PATH after startup. The cache
+// is a mutex-guarded string, safe under concurrent use from many goroutines.
 func Path() (string, error)
 
 // Command returns an *exec.Cmd for the resolved absolute git path.
@@ -143,7 +260,7 @@ func resolveWith(look func() (string, error)) (string, error)
 - **Chosen: deferred error via `Cmd.Err`.** On resolution failure, `gitexec.Command` returns a
   `*exec.Cmd` with `Err` set to `fmt.Errorf("gitexec: %w: %v", ErrUnresolvable, cause)`;
   `Run`/`Output` return that error. This mirrors what `os/exec` itself already does when
-  `exec.Command("git", ...)` cannot find git — so **every one of the 92 call sites keeps its
+  `exec.Command("git", ...)` cannot find git — so **every one of the 93 call sites keeps its
   existing error-handling control flow unchanged**. A user whose git is genuinely not on PATH
   sees the same failure point as today (the `Run`/`Output` error path), with a *sharper*
   message: today `exec: "git": executable file not found in $PATH`; after,
@@ -151,14 +268,14 @@ func resolveWith(look func() (string, error)) (string, error)
   No new failure mode, no behavioral cliff, and `errors.Is(err, gitexec.ErrUnresolvable)` is
   available to any site that wants to special-case it.
 - **Rejected: `(cmd, err)` two-value return.** Correct but forces a second error check at all
-  92 sites *before* the existing `Run`/`Output` check — roughly doubling the diff and creating
-  92 opportunities for a careless `_ =` swallow. The deferred contract achieves the same
+  93 sites *before* the existing `Run`/`Output` check — roughly doubling the diff and creating
+  93 opportunities for a careless `_ =` swallow. The deferred contract achieves the same
   loudness through the error path every site already has — **except at the sites that already
   discard it**, and there are at least five: `internal/coordinator/daemon_tasks_exec_run.go:461,463`,
   `cmd/ailang/coordinator_browse.go:87,240`, and `internal/coordinator/worktree.go:239`
   (`_ = cmd.Run()`, "Ignore errors"). Those keep today's silent-swallow behaviour after
   conversion — this design neither improves nor worsens them, and the claim of uniform
-  improved diagnostics across "every one of the 92" does **not** hold for them. They are a
+  improved diagnostics across "every one of the 93" does **not** hold for them. They are a
   pre-existing class, listed here rather than fixed, so no reader mistakes conversion for
   diagnosis.
 - **Rejected: fallback to bare `"git"` on resolution failure.** This is a silent fallback in
@@ -207,7 +324,7 @@ V7) + a ci.yml step after "Check architecture boundaries" (ci.yml:133, V7) + mem
 2. **Enumerate** bare-name git exec sites over all `*.go` under the repo root, excluding
    `_test.go`, `vendor/`, and `internal/gitexec/` (the one sanctioned site), with the regex
    `exec\.Command(Context)?\([^)"]*"git"` (validated in this doc: narrow and wide variants
-   agree at 92 with zero diff — V2; nothing exists outside cmd/ and internal/ — V13).
+   agree at 93 with zero diff — V2; nothing exists outside cmd/ and internal/ — V13).
 3. **Compare against a per-file baseline** (`scripts/git_exec_baseline.txt`, `path count`
    lines). Failure conditions, all loud: (a) a file with matches that is absent from the
    baseline; (b) a count above baseline for any file; (c) **a count below baseline** — the
@@ -242,23 +359,68 @@ V7) + a ci.yml step after "Check architecture boundaries" (ci.yml:133, V7) + mem
   shape and missed that it is *also* a multi-line call, which is exactly how a blind spot
   hides: the site was looked at, through the wrong lens). `gofmt` produces this shape
   naturally as soon as an argument list grows, so a future `git` call is more likely to be
-  invisible the longer it is. **Mitigation for the sprint:** the gate SHOULD join logical
-  lines before matching (`gofmt`-normalise, or match over `go/ast` rather than text) — and if
-  the executor keeps the textual form, this limitation must be restated in the gate's own
-  output, not only here.
+  invisible the longer it is.
+
+  **DECIDED — HID-6 (controller, round-2 carve-out): the enumerator MUST be AST-based, and
+  this is a committed design decision, not executor discretion.** Round 2 blocked on exactly
+  this clause being a `SHOULD`, from two reviewers independently:
+
+  > **gpt5-6-sol:** "It then makes AST-based detection only a 'SHOULD,' allowing M4 and CI to
+  > report zero while prohibited git executions remain."
+  >
+  > **oc-glm-5-2:** "The proposed mitigation ('the gate SHOULD join logical lines before
+  > matching') is a SHOULD, not a committed design decision, leaving it to executor
+  > discretion. A CI gate with a known blind spot for the exact shape it exists to catch does
+  > not satisfy its stated primary goal; punting the fix to the executor makes the design
+  > incomplete."
+
+  Both are right about the `SHOULD`, and both are wrong about one premise, which the
+  controller measured at HEAD `999d4c1dd` rather than forwarding (V17): they read
+  `watchdog.go:57` as an existing **git** site the regex misses. It is not — it is
+  `exec.Command("bash", "-c", …)`, which is what V12 already said. **A multi-line-aware
+  enumeration finds exactly 93 sites, byte-identical to the single-line count, with ZERO
+  files where joining logical lines finds more.** So the blind spot is **prospective, not
+  present**: there is nothing to recover today, and nothing to stop a `gofmt`-wrapped git
+  call being invisible tomorrow. That distinction changes the urgency and not the fix — a
+  gate whose whole job is to make a class unable to grow must be able to see the shape the
+  formatter produces.
+
+  **The committed contract, replacing the `SHOULD`:**
+  1. `scripts/check_git_exec.sh` enumerates over **`go/ast`** — parse each non-test `.go`
+     file under `cmd/` and `internal/`, walk `*ast.CallExpr`, and flag a call whose function
+     resolves to `exec.Command`/`exec.CommandContext` with a `"git"` string literal in the
+     command-name position. Physical line breaks are then irrelevant by construction, which
+     is what makes this complete for the Go/literal class rather than complete-by-inspection.
+  2. The line-oriented regex MAY be retained only as a cross-check. If both run, a
+     **disagreement between them is a gate FAILURE**, not a warning — that difference is the
+     only cheap signal that one enumerator has gone blind.
+  3. **Anti-vacuity by ADDITION, not only by removal** (this repo's rule 3a(i-e): a removal
+     proves a check FIRES, only an addition proves it LOOKS). The gate ships a fixture
+     containing a **multi-line** `exec.Command(\n "git", …)` and a **variable-first-arg**
+     shape, and a self-test asserting the enumerator's COUNT MOVES when the fixture is
+     present. A gate that flags the fixture-missing case green is itself a failure (exit 2,
+     loud), as the existing anti-vacuity requirement already states.
+  4. The residual classes below — variable first argument, dataflow/aliasing, shell strings,
+     `syscall.Exec`, and every non-Go surface — are **NOT** closed by the AST enumerator and
+     the gate must say so **in its own output**, every run, not only in this document.
+     Accordingly the Primary Goal is scoped to what the gate can actually enforce (see the
+     Goals section), because a goal stated wider than its instrument is the defect
+     gpt5-6-sol named: CI reporting zero while prohibited executions remain.
 - `syscall.Exec`, execution of scripts under `tools/` or launchd plists that themselves call
   git, and any non-Go surface (shell scripts, Makefiles). These are different classes with
   different owners; the gate is honest about only policing direct Go `os/exec` use of `"git"`.
 
 **Sonar interaction:** converting the 4 flagged sites resolves the 4 `go:S4036` issues
 (the flagged lines stop invoking `exec.Command("git", ...)`). The resolver's own single
-`LookPath("git")` may attract one residual S4036 finding; if it does, it is marked reviewed-safe
-via the `sonarcloud-triage` flow with a justification pointing at this doc — a per-site
-disposition on the one auditable site, **not** a repo-wide rule suppression.
+`LookPath("git")` is **expected** to keep one `go:S4036` finding present on that auditable
+site (HID-5 chooses absolute-only, which does not validate unwriteability). This revision does
+**not** disposition that residual as reviewed-safe: closing it is a named, separate follow-up
+(`M-GIT-RESOLVER-S4036-CLOSURE`), and this sweep does not claim the security rating reaches A.
 
 ### Implementation Plan
 
-**M1 — helper + flagged sites + gate (1.5d).** Residual after M1: **88 bare sites remain.**
+**M1 — helper + flagged sites + gate (1.5d).** Residual after M1: **89 bare sites remain**
+(derived: 93 − 4 flagged).
 - Create `internal/gitexec` (resolver, `Path`, `Command`, `CommandContext`, test seam).
 - Convert the 4 Sonar-flagged sites: `cmd/ailang/prompt_freeze_check_git.go:82` (`gitBytes`),
   `cmd/ailang/prompt_freeze_core.go:194` (`scanCorpus`), `internal/coordinator/worktree.go:308`
@@ -267,19 +429,19 @@ disposition on the one auditable site, **not** a repo-wide rule suppression.
   (site bodies read at V8's companion reads; see V1 for the flagged list).
 - Migrate `cmd/ailang/help.go` off its private `resolveGit`/`gitBinary` (delete both; rewrite
   `help_stale_test.go` accordingly).
-- Land `scripts/check_git_exec.sh` + make target + ci.yml step, baseline seeded at the
-  measured post-M1 per-file counts (sum = 88).
-- Refusal-branch tests + neutering mutations (below).
+- Land `scripts/check_git_exec.sh` + make target + ci.yml step, baseline **seeded by a fresh
+  measurement** of the post-M1 per-file counts (sum = 89 at HEAD), not hardcoded.
+- Refusal-branch tests + neutering mutations + the inverted caching test (below).
 
 **M2 — `internal/coordinator` sweep (1d).** Converts the remaining 42 coordinator sites
 (`worktree.go` 15 more, `merge.go` 8, `approval_processor.go` 6, `artifact_discovery.go` 5,
 `daemon_tasks_exec_run.go` 4, `daemon_tasks_worktrees.go` 3, `observatory_sync.go` 1 — V9).
-Baseline ratchets 88 → **46 remain.**
+Baseline ratchets → **47 remain** (derived: 89 − 42).
 
-**M3 — `cmd/ailang` sweep (1d).** Converts the remaining 40 cmd sites (`coordinator_cloud.go`
+**M3 — `cmd/ailang` sweep (1d).** Converts the remaining 41 cmd sites (`coordinator_cloud.go`
 14 more, `coordinator_browse.go` 11, `chains_diff.go` 4, `coordinator_inspect.go` 4,
-`messages_send.go` 3, `coordinator_utils.go` 3, `coordinator_cloud_github.go` 1 — V9).
-Baseline ratchets 46 → **6 remain.**
+`messages_send.go` 3, `coordinator_utils.go` 3, `coordinator_cloud_github.go` 2 — V9).
+Baseline ratchets → **6 remain** (derived: 47 − 41).
 
 **M4 — tools layer sweep (0.5d).** Converts `internal/pkg/gitcache.go` (5) and
 `internal/eval_harness/gemini_evaluator_bridge.go` (1). Baseline ratchets 6 → **0**; the
@@ -302,7 +464,8 @@ to a follow-up commit after that session lands, and say so in the sprint log.
 - `internal/gitexec/gitexec.go` — NEW (~120 LOC): resolver, ErrUnresolvable, Path/Command/CommandContext, test seam
 - `internal/gitexec/gitexec_test.go` — NEW (~200 LOC): refusal-branch tests + mutation protocol comments
 - `scripts/check_git_exec.sh` — NEW (~120 LOC): gate with anti-vacuity fixture + ratchet baseline
-- `scripts/git_exec_baseline.txt` — NEW: per-file allowed counts (seeded at 88, ratchets to 0)
+- `scripts/git_exec_baseline.txt` — NEW: per-file allowed counts (**seeded from a fresh
+  measurement** at M1 landing — sum 89 at HEAD — then ratcheted to 0)
 - `scripts/testdata/git_exec_gate_positive.txt` — NEW: known-positive fixture for the instrument check
 - `make/code-health.mk` — MODIFY (+6 LOC): `check-git-exec` target beside `check-boundaries` (V7)
 - `make/ci.mk` — MODIFY (+1 word): add `check-git-exec` to the `ci:` aggregate (line 11 — V7)
@@ -316,7 +479,7 @@ to a follow-up commit after that session lands, and say so in the sprint log.
 ## Conflict Surface
 
 This design touches no parser/lexer/typechecker/codegen path, so the mandatory trigger does
-not fire; the section is included because the sweep's blast radius is wide (18 files, 92
+not fire; the section is included because the sweep's blast radius is wide (18 files, 93
 sites) and the honest answer is not "no conflicts".
 
 ### Positions touched
@@ -357,8 +520,14 @@ path: `internal/gitexec/` is the only directory allowed to name `"git"` in an ex
   corner executes the relative git; after, the site's error path fires with `ErrUnresolvable`.
   This is the point of the design.
 - Error text at failing sites changes from `exec: "git": executable file not found in $PATH`
-  to the wrapped `gitexec: ...` form. Anything parsing that string would break — no in-repo
-  code matches on it (checked while reading the 4 flagged sites; none inspect error text).
+  to the wrapped `gitexec: ...` form. Anything parsing that string would break — measured
+  repo-wide, nothing does (V14, with its known-positive control). Separately, the new package
+  returns a typed `gitexec.ErrUnresolvable` rather than `exec.ErrNotFound`, so any **future**
+  caller that wants to detect "is git missing" must test `errors.Is(err, gitexec.ErrUnresolvable)`
+  instead. No current caller needs to change: the typed-sentinel enumeration (V15) shows the
+  only production consumer of `exec.ErrNotFound` is `internal/effects/process.go` (std
+  `process.exec`), which resolves an arbitrary user-supplied binary — not git — and is outside
+  this sweep's scope. This is stated as a measured contract, not an assurance.
 
 ## Testing Strategy
 
@@ -376,9 +545,16 @@ it fails under its paired mutant.
 | B3 | `Command`/`CommandContext` after failed resolve → returned Cmd carries `Err`; `Run` fails with `errors.Is(_, ErrUnresolvable)` | run a Cmd built under an injected failing resolver; assert error identity from `Run()`, not just construction | `if false && resolveErr != nil` at the `Cmd.Err` assignment |
 | B4 | Success path → `Cmd.Path` is the absolute resolved path; `Args[0]` sane; context honored for `CommandContext` | `resolveWith(-> "/abs/git", nil)`; assert `cmd.Path == "/abs/git"` and a cancelled context aborts `Run` | swap the assignment to the bare literal: `Path: "git"` (builds; B4's absolute-path assertion kills it) |
 
-Plus one **caching** test (not a refusal branch): the `look` func is invoked exactly once
-across two `Path()` calls, including when the first call *failed* — failure is cached too, and
-the test asserts the second call returns the same error without re-invoking `look`.
+Plus two **caching** tests (not refusal branches), enforcing HID-3:
+
+- **Success is cached.** Two consecutive `Path()` calls that both succeed invoke `look`
+  exactly once — the second call returns the cached path without re-resolving.
+- **Failure is NOT cached (falsifiable arm).** This arm inverts the old contract: a first
+  `Path()` that FAILS must leave the cache empty, so a second `Path()` call re-invokes `look`
+  and returns whatever the environment now resolves to (e.g. a later success). The named
+  mutation that kills it is **"cache the failure too"** — store the error in the cache slot on
+  failure — under which the second call returns the stale error without re-invoking `look`,
+  failing the assertion. This is the daemon-recovery behaviour the design preserves (HID-3).
 
 ### Gate self-tests
 - Instrument test: run the script against a tree copy with the fixture removed from the
@@ -399,50 +575,70 @@ the test asserts the second call returns the same error without re-invoking `loo
   use of `"git"` (stated as enumerator blind spots above).
 - Repo-wide suppression of Sonar rule `go:S4036` — per-site disposition on the single
   sanctioned resolver only.
-- Vendoring or shelling to a pinned git version; PATH is still *read* once at resolve time —
-  the change is that its result must be absolute and is resolved at one auditable site.
+- Vendoring or shelling to a pinned git version; PATH is still *read* at resolve time —
+  once on the success path (cached) and per call on the failure path (HID-3) — and the
+  change is that its result must be absolute and is resolved at one auditable site.
 
 ## Success Criteria
 
 - [ ] M1: `internal/gitexec` exists; the 4 Sonar-flagged sites and `help.go` route through it;
-      refusal-branch tests pass and each documented mutant is killed; `make check-git-exec`
-      runs in CI with baseline sum = **88** — the doc and the baseline both state that
-      **88 bare sites remain** (this criterion is unmeetable by a doc claiming full coverage)
-- [ ] M2: coordinator sweep done; baseline sum = **46 remaining**
-- [ ] M3: cmd/ailang sweep done; baseline sum = **6 remaining**
+      refusal-branch tests pass and each documented mutant is killed; the caching tests enforce
+      HID-3 (success cached, failure re-resolved); `make check-git-exec` runs in CI with a
+      baseline **seeded by fresh measurement** (sum 89 at HEAD) — the baseline, not this doc,
+      is the contract, and both state that **89 bare sites remain**
+- [ ] M2: coordinator sweep done; baseline sum = **47 remaining** (derived)
+- [ ] M3: cmd/ailang sweep done; baseline sum = **6 remaining** (derived)
 - [ ] M4: baseline sum = **0**; positive invariant (exactly 1 `LookPath("git")`, in
       `internal/gitexec/`) enforced by the gate
 - [ ] Gate anti-vacuity verified: fixture-missing run exits 2 (loud), never green
-- [ ] Sonar: 4 `go:S4036` new-code issues no longer attach to the converted lines; any
-      residual finding on the resolver is dispositioned per-site with a justification
+- [ ] Sonar: the 4 flagged NEW-CODE `go:S4036` sites are converted (their lines stop invoking
+      `exec.Command("git", ...)`). The rating is NOT asserted to reach A: the resolver's single
+      `LookPath` is expected to keep S4036 present, and that residual is a named follow-up
+      (`M-GIT-RESOLVER-S4036-CLOSURE`), not a disposition this sweep makes
 - [ ] All tests passing; CHANGELOG updated per milestone; no edits to the six
       concurrent-session files
 
 ## Verification Log
 
-Every "the codebase currently does X" claim above is backed by a row here. Commands were run
-at `e38c0c493` (origin/dev) from the repo root on 2026-08-27. Empty/negative results carry a
-same-call, same-path known-positive control.
+Every "the codebase currently does X" claim above is backed by a row here. This revision
+re-derived all counts at HEAD `999d4c1dd` (origin/dev, 2026-08-28); the original draft was
+measured at `e38c0c493` (2026-08-27). Empty/negative results carry a same-call, same-path
+known-positive control.
 
 | # | Claim | Command | Observed |
 |---|-------|---------|----------|
 | V1 | Exactly 4 new-code `go:S4036` issues, at the 4 named sites; leak-period narrows (instrument works) | `curl -s "https://sonarcloud.io/api/issues/search?componentKeys=sunholo-data_ailang&sinceLeakPeriod=true&rules=go:S4036&ps=50"` piped to python; controls: same query without `rules` (`&ps=1`) and without `sinceLeakPeriod` | `total: 4` — `prompt_freeze_check_git.go:82`, `prompt_freeze_core.go:194`, `worktree.go:308`, `coordinator_cloud.go:459`, all MINOR/OPEN. Controls: `leak: 19`, `all: 2404` (the leak-period filter demonstrably narrows; `inNewCodePeriod` is the known-broken parameter, not used) |
-| V2 | 92 bare-name git exec sites (non-test) in cmd+internal; regex not under-matching | narrow `grep -rn --include='*.go' -E 'exec\.Command(Context)?\((ctx, )?"git"' cmd internal \| grep -v '_test.go' \| wc -l`; wide `[^)"]*"git"` variant; `diff` of sorted outputs; control incl. tests | narrow = **92**, wide = **92**, diff = empty; control including `_test.go` = 108 (≥ 92, instrument sees positives); known-positive control `grep -n 'exec.Command' cmd/ailang/prompt_freeze_check_git.go` → line 82 |
+| V2 | 93 bare-name git exec sites (non-test) in cmd+internal; regex not under-matching | narrow `grep -rn --include='*.go' -E 'exec\.Command(Context)?\((ctx, )?"git"' cmd internal \| grep -v '_test\.go' \| wc -l`; wide `[^)"]*"git"` variant; `diff` of sorted outputs; control incl. tests | narrow = **93**, wide = **93**, diff = empty; control including `_test.go` = 113 (≥ 93, instrument sees positives); known-positive control `grep -n 'exec.Command' cmd/ailang/prompt_freeze_check_git.go` → line 82 |
 | V3 | The existing resolver has zero consumers outside its own file (+ its tests) | `grep -rn --include='*.go' 'gitBinary(' cmd internal` | Hits only in `cmd/ailang/help.go` (:41, :185 def) and `cmd/ailang/help_stale_test.go` (6 refs) |
 | V4 | `resolveGit`/`gitBinary` exist at help.go:173/185, require ABSOLUTE, `""` = show-warning semantics | `sed -n '160,220p' cmd/ailang/help.go` | Doc comment: "must not execute whatever a relative or writable PATH entry happens to call \"git\"… empty result makes both probes report undeterminable, which SHOWS the warning"; `sync.Once` cache confirmed |
 | V5 | No existing package could host this (negative-existence) | `ls internal \| grep -i 'git\|osutil\|executil'` with control `ls internal \| grep -c 'coordinator'` | grep exit=1 (no match); control = 1 (the pipeline finds known packages) |
 | V6 | Exactly one `LookPath("git")` in the repo (non-test) | `grep -rn --include='*.go' 'LookPath("git")' cmd internal \| grep -v '_test.go'` | Single hit: `cmd/ailang/help.go:186` (this is also the positive control for the pattern) |
 | V7 | Boundary gate = fixed name-set rules; `check-boundaries` lives in make/code-health.mk:161, aggregate in make/ci.mk:11, CI step at ci.yml:133; `gitexec` in no policed set | `make -n check-boundaries`; `grep -rn 'check-boundaries' make/*.mk`; `sed -n '128,138p' .github/workflows/ci.yml`; `sed -n '1,80p' scripts/check_boundaries.sh` | `bash scripts/check_boundaries.sh`; `make/code-health.mk:161`, `make/ci.mk:11`; ci.yml step "Check architecture boundaries"; CORE_PKGS/DASHBOARD_PKGS/CORE_SURFACE_PKGS arrays contain fixed names, none is `gitexec` |
 | V8 | The six concurrent-session files contain ZERO git exec sites | `grep -n -E 'exec\.Command(Context)?\([^)"]*"git"' cmd/ailang/docs.go cmd/ailang/prompt.go cmd/ailang/verify.go internal/prompt/loader.go` with control `grep -c <same pattern> cmd/ailang/prompt_freeze_check_git.go` | exit=1 (no matches); control = 1 (same regex, known positive). The two non-Go files (`std/string.ail`, `prompts/versions.json`) are outside `--include='*.go'` scope by construction |
-| V9 | Per-file distribution: cmd 43, coordinator 43, pkg 5, eval_harness 1; 69 `Command` + 23 `CommandContext` | `grep -rc --include='*.go' -E '<wide pattern>' cmd internal \| grep -v ':0$' \| grep -v '_test.go'`; per-package `cut -d/ -f1-2 \| sort \| uniq -c`; split greps | 18 files, counts as listed in Implementation Plan; 43+43+5+1 = 92 ✓; 69+23 = 92 ✓ |
+| V9 | Per-file distribution: cmd 44, coordinator 43, pkg 5, eval_harness 1; 70 `Command` + 23 `CommandContext` | `grep -rc --include='*.go' -E '<wide pattern>' cmd internal \| grep -v ':0$' \| grep -v '_test\.go'`; per-package `cut -d/ -f1-2 \| sort \| uniq -c`; split greps | 18 files, counts as listed in Implementation Plan; 44+43+5+1 = 93 ✓; 70+23 = 93 ✓ |
 | V10 | Go 1.26.6; `exec.Cmd.Err` exists (deferred-error contract available) | `head -5 go.mod`; `go doc os/exec.Cmd.Err` | `go 1.26.6`; `Err error  // LookPath error, if any.` |
 | V11 | Variable-first-arg git exec shapes exist (enumerator blind spot is real) | `grep -n 'exec.CommandContext(ctx, git,' cmd/ailang/help.go` | Hits at help.go:204 and :222 (first arg is the variable `git`) |
 | V12 | A `bash -c` exec site exists (shell-string blind spot is real); it is out of the git class | `grep -rn --include='*.go' -E '"(sh\|bash)", "-c"' cmd internal \| grep -v '_test.go'`; then read the site | Single hit `internal/eval_harness/watchdog.go:57`; site body is process-tree cleanup, no git invocation |
-| V13 | ZERO git exec sites outside cmd/ and internal/ (negative + control) | root grep with `--exclude-dir={cmd,internal,vendor,node_modules,.git}`; control: same root grep including cmd+internal | exit=1 (none outside); control = **92** exactly (instrument sees the known positives through the identical invocation) |
+| V13 | ZERO git exec sites outside cmd/ and internal/ (negative + control) | root grep with `--exclude-dir={cmd,internal,vendor,node_modules,.git}`; control: same root grep including cmd+internal | exit=1 (none outside); control = **93** exactly (instrument sees the known positives through the identical invocation) |
 
 **Not reproduced from the commissioning brief:** the brief estimated "roughly 95" sites; the
-measured count is **92** (V2, cross-checked three ways: narrow regex, wide regex, root-wide
-control). All other commissioned facts reproduced exactly.
+measured count was **92** at the original base and is **93** at HEAD `999d4c1dd` (V2,
+cross-checked three ways: narrow regex, wide regex, root-wide control) — a single new bare
+git site was added between the two bases. 9 of the 18 sweep files changed since `e38c0c493`
+(`cmd/ailang/coordinator_cloud.go`, `docs.go`, `prompt.go`, `prompt_freeze_check_git.go`,
+`prompt_freeze_core.go`, `verify.go`, `internal/coordinator/daemon_tasks_exec_run.go`,
+`internal/prompt/loader.go`, `std/string.ail`), which is why counts must be re-derived at
+execution time and the gate baseline is seeded by measurement, not hardcoded.
+
+## Additional Verification (revision pass, at HEAD `999d4c1dd`)
+
+| # | Claim | Command | Observed |
+|---|-------|---------|----------|
+| V14 | No Go code in cmd/ or internal/ string-matches os/exec's not-found error text (negative + control) | `grep -rn "executable file not found" cmd internal --include='*.go' \| grep -v '_test\.go'`; then `grep -rniE 'strings\.(Contains|HasPrefix|HasSuffix)\([^)]*(not found in \$PATH|executable file not found|exec: )' cmd internal --include='*.go'`; known-positive control `grep -rniE 'strings\.(Contains|HasPrefix|HasSuffix)\(' cmd internal --include='*.go' \| wc -l` | Literal-text grep: 0 hits, rc=1. Matcher grep: 0 hits, rc=1. **Control = 2918** — the instrument demonstrably fires on `strings.Contains/HasPrefix/HasSuffix` usage, so a 0 here is a real absence, not a blind instrument. Supports the "no in-repo code parses the old error text" claim (What deliberately changes) |
+| V15 | Typed-sentinel `exec.ErrNotFound` is confined to out-of-sweep files; the only production consumer is not git | `grep -rn "exec.ErrNotFound" cmd internal --include='*.go'` | 7 hits: `cmd/ailang/help_stale_test.go:395,396` (test; M1 rewrites this file anyway), `internal/notify/macos_test.go:73,99,100,153` (test; terminal-notifier/osascript, not git), `internal/effects/process.go:197` (**PRODUCTION**: `errors.Is(err, exec.ErrNotFound)`). Cross-check: `grep -c '"git"' internal/effects/process.go` → **0** — that consumer is std `process.exec`, resolving an arbitrary user-supplied binary (line 123), NOT git, and no sweep milestone touches it. So no current caller of the git path needs to change; future callers must test `gitexec.ErrUnresolvable` |
+| V16 | Resolver enforces only `filepath.IsAbs` (basis for HID-5) | `sed -n '173,181p' cmd/ailang/help.go` | `resolveGit` returns `""` on `look()` error OR `if !filepath.IsAbs(p) { return "" }` — an absolute-path check and **nothing else**; no `stat`, no ownership check, no write-permission check. Doc comment reads "must not execute whatever a relative or writable PATH entry happens to call git" (the "writable" half is not enforced — the basis for removing it from the planned comment). `sync.Once` cache confirmed at help.go:186 |
+
+| V17 | The multi-line enumerator blind spot is PROSPECTIVE, not present: a multi-line-aware count equals the single-line count exactly, and the site both round-2 reviewers cited as an existing miss is not a git call | Single-line arm: `grep -rEn 'exec\.Command(Context)?\((ctx, )?"git"' cmd internal --include='*.go' \| grep -v '_test\.go' \| wc -l`. Multi-line arm: a python3 walk of all non-test `.go` files under `cmd/`+`internal/` collapsing whitespace (`re.sub(r'\s+',' ',src)`) before matching `exec\.Command(Context)?\(\s*(?:<ident>\s*,\s*)?"git"`, printing every file where the joined count exceeds the single-line count. Then `sed -n '50,62p' internal/eval_harness/watchdog.go` | Single-line **93**; multi-line-aware **93** over **1254** files scanned; the differing-file list is **EMPTY**. `watchdog.go:57` reads `exec.Command("bash", "-c", …)` — multi-line, and NOT git, exactly as V12 states. So both round-2 objections are correct that the `SHOULD` was not a commitment (fixed as HID-6) and incorrect that a git site is being missed today. Measured by the controller at HEAD `999d4c1dd` under the round-2 narrow-refinement carve-out, per this repo's rule 3f (measure a premise objection, never forward it) |
 
 ## Related Documents
 
@@ -464,7 +660,7 @@ resolution or an exec-hardening sweep — nearest neighbours, each distinct:
 
 | Day | Work |
 |-----|------|
-| 1–1.5 | M1: gitexec package, 4 flagged sites, help.go migration, tests+mutants, gate landed (baseline 88) |
-| 2.5 | M2: coordinator sweep (baseline → 46) |
-| 3.5 | M3: cmd/ailang sweep (baseline → 6) |
+| 1–1.5 | M1: gitexec package, 4 flagged sites, help.go migration, tests+mutants, gate landed (baseline seeded from measurement: 89 at HEAD) |
+| 2.5 | M2: coordinator sweep (baseline → 47, derived) |
+| 3.5 | M3: cmd/ailang sweep (baseline → 6, derived) |
 | 4 | M4: pkg + eval_harness sweep (baseline → 0), positive invariant on, CHANGELOG |

--- a/design_docs/planned/v0_35_0/m-git-binary-resolution-sweep.md
+++ b/design_docs/planned/v0_35_0/m-git-binary-resolution-sweep.md
@@ -391,9 +391,21 @@ V7) + a ci.yml step after "Check architecture boundaries" (ci.yml:133, V7) + mem
      resolves to `exec.Command`/`exec.CommandContext` with a `"git"` string literal in the
      command-name position. Physical line breaks are then irrelevant by construction, which
      is what makes this complete for the Go/literal class rather than complete-by-inspection.
-  2. The line-oriented regex MAY be retained only as a cross-check. If both run, a
-     **disagreement between them is a gate FAILURE**, not a warning — that difference is the
-     only cheap signal that one enumerator has gone blind.
+  2. The line-oriented regex MAY be retained only as a cross-check, **scoped to the REAL
+     TREE (`cmd/` + `internal/`) and to nothing else**. Within that scope a **disagreement
+     between the two arms is a gate FAILURE**, not a warning — that difference is the only
+     cheap signal that one enumerator has gone blind. Today the two arms agree exactly
+     (both **93**, per-file diff empty — V17, and independently re-derived by the sprint
+     planner with a real `go/ast` walker), which is what makes equality a usable invariant.
+
+     **The scoping in clause 2 is load-bearing, and its absence was a defect in this
+     document's first draft of HID-6** (found by the sprint planner, reproduced by the
+     controller before acting). Clause 2 as originally written said only "a disagreement
+     between them is a gate FAILURE", with no scope — and clause 3 requires shipping a
+     fixture whose entire purpose is to make the two arms disagree. Measured on exactly that
+     fixture: regex arm **0**, AST arm **1**. So the two clauses were jointly unsatisfiable,
+     and an executor implementing both literally would have produced a gate that fails on its
+     own test fixture. The fixtures are enumerator INPUTS, never cross-check inputs.
   3. **Anti-vacuity by ADDITION, not only by removal** (this repo's rule 3a(i-e): a removal
      proves a check FIRES, only an addition proves it LOOKS). The gate ships a fixture
      containing a **multi-line** `exec.Command(\n "git", …)` and a **variable-first-arg**

--- a/internal/coordinator/worktree.go
+++ b/internal/coordinator/worktree.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/sunholo-data/ailang/internal/gitexec"
 )
 
 // ErrWorktreeLimitReached is returned when no worktrees are available.
@@ -305,7 +307,7 @@ func validateRepoDir(repoDir string) error {
 	if !info.IsDir() {
 		return fmt.Errorf("worktree repo dir %q is not a directory", repoDir)
 	}
-	if err := exec.Command("git", "-C", repoDir, "rev-parse", "--git-dir").Run(); err != nil {
+	if err := gitexec.Command("-C", repoDir, "rev-parse", "--git-dir").Run(); err != nil {
 		return fmt.Errorf("worktree repo dir %q is not a git repository: %w", repoDir, err)
 	}
 	return nil

--- a/internal/gitexec/gitexec.go
+++ b/internal/gitexec/gitexec.go
@@ -1,0 +1,63 @@
+// Package gitexec resolves and executes git by absolute path.
+package gitexec
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"sync"
+)
+
+var ErrUnresolvable = errors.New("git is not resolvable to an absolute path")
+
+var (
+	cacheMu   sync.Mutex
+	cachedGit string
+	lookPath  = func() (string, error) { return exec.LookPath("git") }
+)
+
+func resolveWith(look func() (string, error)) (string, error) {
+	p, err := look()
+	if err != nil {
+		return "", fmt.Errorf("gitexec: %w: %v", ErrUnresolvable, err)
+	}
+	if !filepath.IsAbs(p) {
+		return "", fmt.Errorf("gitexec: %w: lookup returned %q", ErrUnresolvable, p)
+	}
+	return p, nil
+}
+
+// Path returns a process-wide cached absolute git path. Only success is cached.
+func Path() (string, error) {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+	if cachedGit != "" {
+		return cachedGit, nil
+	}
+	p, err := resolveWith(lookPath)
+	if err == nil {
+		cachedGit = p
+	}
+	return p, err
+}
+
+func commandWith(ctx context.Context, resolve func() (string, error), args ...string) *exec.Cmd {
+	p, resolveErr := resolve()
+	cmd := exec.CommandContext(ctx, p, args...)
+	if resolveErr != nil {
+		cmd.Err = resolveErr
+	}
+	return cmd
+}
+
+// Command returns a git command whose resolution failure is deferred through Cmd.Err.
+func Command(args ...string) *exec.Cmd {
+	return commandWith(context.Background(), Path, args...)
+}
+
+// CommandContext is Command with a context.
+func CommandContext(ctx context.Context, args ...string) *exec.Cmd {
+	return commandWith(ctx, Path, args...)
+}

--- a/internal/gitexec/gitexec_test.go
+++ b/internal/gitexec/gitexec_test.go
@@ -3,10 +3,33 @@ package gitexec
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
+
+// fakeGit creates a real, executable-looking git at a temp path and returns it.
+//
+// The name is platform-dependent on purpose. On Windows os/exec resolves an
+// absolute path through lookExtensions, which consults PATHEXT and REFUSES a
+// suffix-less file at exec.Command time — so a bare "git" makes Cmd.Err
+// "executable file not found in %PATH%" and any later assertion about WHY the
+// command failed is testing the fixture instead of the code. The file must also
+// actually exist for the same reason.
+func fakeGit(t *testing.T) string {
+	t.Helper()
+	name := "git"
+	if runtime.GOOS == "windows" {
+		name = "git.exe"
+	}
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, nil, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
 
 func resetForTest(t *testing.T, look func() (string, error)) {
 	t.Helper()
@@ -47,7 +70,7 @@ func TestCommand_DeferredError(t *testing.T) {
 }
 
 func TestCommand_UsesAbsolutePath(t *testing.T) {
-	p := filepath.Join(t.TempDir(), "git")
+	p := fakeGit(t)
 	cmd := commandWith(context.Background(), func() (string, error) { return p, nil }, "status")
 	if cmd.Path != p || cmd.Args[0] != p {
 		t.Fatalf("Path/Args = %q/%q, want %q", cmd.Path, cmd.Args[0], p)

--- a/internal/gitexec/gitexec_test.go
+++ b/internal/gitexec/gitexec_test.go
@@ -1,0 +1,95 @@
+package gitexec
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func resetForTest(t *testing.T, look func() (string, error)) {
+	t.Helper()
+	cacheMu.Lock()
+	oldLook, oldCache := lookPath, cachedGit
+	lookPath, cachedGit = look, ""
+	cacheMu.Unlock()
+	t.Cleanup(func() {
+		cacheMu.Lock()
+		lookPath, cachedGit = oldLook, oldCache
+		cacheMu.Unlock()
+	})
+}
+
+func TestResolveWith_LookError(t *testing.T) {
+	abs := filepath.Join(t.TempDir(), "git")
+	_, err := resolveWith(func() (string, error) { return abs, exec.ErrNotFound })
+	if !errors.Is(err, ErrUnresolvable) {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestResolveWith_RelativeRefused(t *testing.T) {
+	for _, p := range []string{"git", "./git"} {
+		_, err := resolveWith(func() (string, error) { return p, nil })
+		if !errors.Is(err, ErrUnresolvable) {
+			t.Fatalf("%q: got %v", p, err)
+		}
+	}
+}
+
+func TestCommand_DeferredError(t *testing.T) {
+	want := errors.New("resolution failed")
+	cmd := commandWith(context.Background(), func() (string, error) { return "", want }, "status")
+	if err := cmd.Run(); !errors.Is(err, want) {
+		t.Fatalf("Run error = %v", err)
+	}
+}
+
+func TestCommand_UsesAbsolutePath(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "git")
+	cmd := commandWith(context.Background(), func() (string, error) { return p, nil }, "status")
+	if cmd.Path != p || cmd.Args[0] != p {
+		t.Fatalf("Path/Args = %q/%q, want %q", cmd.Path, cmd.Args[0], p)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cmd = commandWith(ctx, func() (string, error) { return p, nil })
+	if err := cmd.Run(); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled Run error = %v", err)
+	}
+}
+
+func TestPath_CachesSuccess(t *testing.T) {
+	p, calls := filepath.Join(t.TempDir(), "git"), 0
+	resetForTest(t, func() (string, error) { calls++; return p, nil })
+	if _, err := Path(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Path(); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("lookup calls = %d, want 1", calls)
+	}
+}
+
+func TestPath_DoesNotCacheFailure(t *testing.T) {
+	p, calls := filepath.Join(t.TempDir(), "git"), 0
+	resetForTest(t, func() (string, error) {
+		calls++
+		if calls == 1 {
+			return "", exec.ErrNotFound
+		}
+		return p, nil
+	})
+	if _, err := Path(); !errors.Is(err, ErrUnresolvable) {
+		t.Fatalf("first error = %v", err)
+	}
+	if got, err := Path(); err != nil || got != p {
+		t.Fatalf("second = %q, %v", got, err)
+	}
+	if calls != 2 {
+		t.Fatalf("lookup calls = %d, want 2", calls)
+	}
+}

--- a/make/ci.mk
+++ b/make/ci.mk
@@ -8,7 +8,7 @@
 all: test build ## Run tests and build
 
 # CI verification
-ci: deps fmt-check vet lint test test-nightly-classifier test-coverage-badge test-lowering verify-no-shim verify-examples verify-examples-toplevel verify-stdlib verify-stdlib-selftest verify-examples-gate-selftest verify-mcp-tools verify-install-guide check-boundaries check-changelog check-file-sizes check-golden-drift check-protocol-closure check-skills check-tmpfile-hygiene test-check-autoclose test-check-changelog test-check-protocol-closure test-check-tmpfile-hygiene check-prompt-freeze ## Run full CI verification, including workflow gates
+ci: deps fmt-check vet lint test test-nightly-classifier test-coverage-badge test-lowering verify-no-shim verify-examples verify-examples-toplevel verify-stdlib verify-stdlib-selftest verify-examples-gate-selftest verify-mcp-tools verify-install-guide check-boundaries check-git-exec test-check-git-exec check-changelog check-file-sizes check-golden-drift check-protocol-closure check-skills check-tmpfile-hygiene test-check-autoclose test-check-changelog test-check-protocol-closure test-check-tmpfile-hygiene check-prompt-freeze ## Run full CI verification, including workflow gates
 	@echo "$(GREEN)$(CHECKMARK) CI verification complete$(RESET)"
 
 ci-strict: deps fmt-check vet lint test test-coverage-badge verify-lowering test-lowering test-builtin-freeze test-operator-assertions test-imports test-recursion test-iface-determinism verify-examples verify-examples-toplevel verify-mcp-tools verify-install-guide ## Extended CI with A2 milestone gates

--- a/make/code-health.mk
+++ b/make/code-health.mk
@@ -161,6 +161,14 @@ check-file-sizes: ## Check for files >800 lines (CI gate)
 check-boundaries: ## Check architecture layer boundaries (CI gate)
 	@bash scripts/check_boundaries.sh
 
+check-git-exec: ## Refuse bare-name git exec sites outside internal/gitexec (CI gate)
+	@bash scripts/check_git_exec.sh
+
+test-check-git-exec: ## Run the git-exec gate's own self-test (bash 3.2)
+	@/bin/bash scripts/test_check_git_exec.sh
+	@/bin/bash -n scripts/check_git_exec.sh
+	@go test ./tools/check-git-exec/... -count=1
+
 check-protocol-closure: ## Check serveapi protocol/facade build closures (CI gate)
 	@/bin/bash scripts/check_protocol_closure.sh
 

--- a/scripts/check_git_exec.sh
+++ b/scripts/check_git_exec.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -u
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+SCAN_ROOT=${GIT_EXEC_ROOT:-$REPO_ROOT}
+BASELINE=${GIT_EXEC_BASELINE:-$REPO_ROOT/scripts/git_exec_baseline.txt}
+POSITIVE_FIXTURE=${GIT_EXEC_POSITIVE_FIXTURE:-$REPO_ROOT/scripts/testdata/git_exec_gate_positive.txt}
+TOOL=${GIT_EXEC_TOOL:-$REPO_ROOT/tools/check-git-exec}
+TMP_DIR=$(mktemp -d) || exit 2
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+broken() { printf 'INSTRUMENT BROKEN (%s): %s\n' "$1" "$2" >&2; exit 2; }
+
+if [ ! -f "$POSITIVE_FIXTURE" ]; then
+	broken G1 "positive fixture missing: $POSITIVE_FIXTURE"
+fi
+mkdir -p "$TMP_DIR/fixture"
+cp "$POSITIVE_FIXTURE" "$TMP_DIR/fixture/positive.go" || broken G2 "cannot copy positive fixture"
+go run "$TOOL" --root "$TMP_DIR" fixture >"$TMP_DIR/fixture.out" 2>"$TMP_DIR/fixture.err" || broken G2 "fixture enumeration failed: $(cat "$TMP_DIR/fixture.err")"
+FIXTURE_COUNT=$(awk '$1=="TOTAL" {print $2}' "$TMP_DIR/fixture.out")
+if [ "${FIXTURE_COUNT:-0}" -eq 0 ]; then
+	broken G2 "positive fixture yielded zero matches"
+fi
+
+[ -d "$SCAN_ROOT/cmd" ] || broken G0 "missing cmd/ under $SCAN_ROOT"
+[ -d "$SCAN_ROOT/internal" ] || broken G0 "missing internal/ under $SCAN_ROOT"
+[ -f "$BASELINE" ] || broken G0 "missing baseline: $BASELINE"
+go run "$TOOL" --root "$SCAN_ROOT" cmd internal >"$TMP_DIR/ast.out" 2>"$TMP_DIR/ast.err" || broken G0 "tree enumeration failed: $(cat "$TMP_DIR/ast.err")"
+AST_TOTAL=$(awk '$1=="TOTAL" {print $2}' "$TMP_DIR/ast.out")
+
+FAILED=0
+while read -r tag file n; do
+	[ "$tag" = COUNT ] || continue
+	base=$(awk -v f="$file" '$1==f {print $2}' "$BASELINE")
+	if [ -z "$base" ]; then
+		printf 'git exec site absent from baseline: %s (%s)\n' "$file" "$n" >&2; FAILED=1; continue
+	fi
+	if [ "$n" -gt "$base" ]; then
+		printf 'git exec count increased: %s actual=%s baseline=%s\n' "$file" "$n" "$base" >&2; grep "^SITE $file:" "$TMP_DIR/ast.out" >&2; FAILED=1
+	fi
+	if [ "$n" -lt "$base" ]; then
+		printf 'git exec count decreased: tighten the baseline for %s (actual=%s baseline=%s)\n' "$file" "$n" "$base" >&2; FAILED=1
+	fi
+done <"$TMP_DIR/ast.out"
+while read -r file base; do
+	[ -n "$file" ] || continue
+	n=$(awk -v f="$file" '$1=="COUNT" && $2==f {print $3}' "$TMP_DIR/ast.out")
+	if [ -z "$n" ] && [ "$base" -ne 0 ]; then
+		printf 'git exec count decreased: tighten the baseline for %s (actual=0 baseline=%s)\n' "$file" "$base" >&2; FAILED=1
+	fi
+done <"$BASELINE"
+
+LOOKPATH_ALL=$(grep -R -n -F 'exec.LookPath("git")' "$SCAN_ROOT/cmd" "$SCAN_ROOT/internal" --include='*.go' | grep -v '_test.go:' || true)
+LOOKPATH_TOTAL=$(printf '%s\n' "$LOOKPATH_ALL" | awk 'NF {n++} END {print n+0}')
+LOOKPATH_OUTSIDE=$(printf '%s\n' "$LOOKPATH_ALL" | grep -v '/internal/gitexec/' | awk 'NF {n++} END {print n+0}')
+if [ "$LOOKPATH_OUTSIDE" -gt 0 ]; then
+	printf 'LookPath("git") outside internal/gitexec:\n%s\n' "$LOOKPATH_ALL" >&2; FAILED=1
+fi
+if [ "$LOOKPATH_TOTAL" -ne 1 ]; then
+	printf 'expected exactly one LookPath("git"), found %s\n' "$LOOKPATH_TOTAL" >&2; FAILED=1
+fi
+
+RX_TOTAL=$(grep -R -h -E 'exec\.Command(Context)?\([^)"]*"git"' "$SCAN_ROOT/cmd" "$SCAN_ROOT/internal" --include='*.go' --exclude='*_test.go' | wc -l | tr -d ' ')
+if [ "$AST_TOTAL" -ne "$RX_TOTAL" ]; then
+	printf 'AST/regex disagreement on real tree: AST=%s regex=%s\n' "$AST_TOTAL" "$RX_TOTAL" >&2; FAILED=1
+fi
+
+printf 'git exec AST total: %s; regex total: %s; fixture total: %s\n' "$AST_TOTAL" "$RX_TOTAL" "$FIXTURE_COUNT"
+printf 'Residual classes (not covered): variable first argument; dataflow/aliasing; shell strings; syscall.Exec; non-Go surfaces. Test files are excluded.\n'
+[ "$FAILED" -eq 0 ] || exit 1
+printf 'git exec gate: OK\n'

--- a/scripts/check_git_exec.sh
+++ b/scripts/check_git_exec.sh
@@ -50,9 +50,16 @@ while read -r file base; do
 	fi
 done <"$BASELINE"
 
-LOOKPATH_ALL=$(grep -R -n -F 'exec.LookPath("git")' "$SCAN_ROOT/cmd" "$SCAN_ROOT/internal" --include='*.go' | grep -v '_test.go:' || true)
-LOOKPATH_TOTAL=$(printf '%s\n' "$LOOKPATH_ALL" | awk 'NF {n++} END {print n+0}')
-LOOKPATH_OUTSIDE=$(printf '%s\n' "$LOOKPATH_ALL" | grep -v '/internal/gitexec/' | awk 'NF {n++} END {print n+0}')
+# AST-based, for the same reason the exec.Command enumeration is (HID-6): a
+# line-oriented matcher cannot see a gofmt-canonical multi-line call, nor an
+# aliased os/exec import. Both evasions were demonstrated against the previous
+# grep form by the iteration-298 evaluator and reproduced by the controller.
+LOOKPATH_ALL=$(sed -n 's/^LOOKPATH //p' "$TMP_DIR/ast.out")
+LOOKPATH_TOTAL=$(sed -n 's/^LOOKPATH_TOTAL //p' "$TMP_DIR/ast.out" | head -1)
+case "$LOOKPATH_TOTAL" in ''|*[!0-9]*)
+	printf 'INSTRUMENT BROKEN: enumerator emitted no LOOKPATH_TOTAL\n' >&2; exit 2 ;;
+esac
+LOOKPATH_OUTSIDE=$(printf '%s\n' "$LOOKPATH_ALL" | grep -v '^internal/gitexec/' | awk 'NF {n++} END {print n+0}')
 if [ "$LOOKPATH_OUTSIDE" -gt 0 ]; then
 	printf 'LookPath("git") outside internal/gitexec:\n%s\n' "$LOOKPATH_ALL" >&2; FAILED=1
 fi
@@ -66,6 +73,6 @@ if [ "$AST_TOTAL" -ne "$RX_TOTAL" ]; then
 fi
 
 printf 'git exec AST total: %s; regex total: %s; fixture total: %s\n' "$AST_TOTAL" "$RX_TOTAL" "$FIXTURE_COUNT"
-printf 'Residual classes (not covered): variable first argument; dataflow/aliasing; shell strings; syscall.Exec; non-Go surfaces. Test files are excluded.\n'
+printf 'Residual classes (not covered): command name via a variable or constant (dataflow); dot-imports of os/exec; shell strings; syscall.Exec; non-Go surfaces. Test files are excluded. Aliased os/exec imports and multi-line calls ARE covered: both arms resolve through the AST and the import declarations.\n'
 [ "$FAILED" -eq 0 ] || exit 1
 printf 'git exec gate: OK\n'

--- a/scripts/git_exec_baseline.txt
+++ b/scripts/git_exec_baseline.txt
@@ -1,0 +1,16 @@
+cmd/ailang/chains_diff.go 4
+cmd/ailang/coordinator_browse.go 11
+cmd/ailang/coordinator_cloud.go 14
+cmd/ailang/coordinator_cloud_github.go 2
+cmd/ailang/coordinator_inspect.go 4
+cmd/ailang/coordinator_utils.go 3
+cmd/ailang/messages_send.go 3
+internal/coordinator/approval_processor.go 6
+internal/coordinator/artifact_discovery.go 5
+internal/coordinator/daemon_tasks_exec_run.go 4
+internal/coordinator/daemon_tasks_worktrees.go 3
+internal/coordinator/merge.go 8
+internal/coordinator/observatory_sync.go 1
+internal/coordinator/worktree.go 15
+internal/eval_harness/gemini_evaluator_bridge.go 1
+internal/pkg/gitcache.go 5

--- a/scripts/test_check_git_exec.sh
+++ b/scripts/test_check_git_exec.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -u
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+GATE="$REPO_ROOT/scripts/check_git_exec.sh"
+TMP_DIR=$(mktemp -d) || exit 2
+trap 'rm -rf "$TMP_DIR"' EXIT
+FAILED=0; ARMS_RUN=0; ARMS_EXPECTED=8
+pass(){ ARMS_RUN=$((ARMS_RUN+1)); printf '  PASS — %s\n' "$1"; }
+fail(){ ARMS_RUN=$((ARMS_RUN+1)); FAILED=1; printf '  FAIL — %s\n' "$1"; }
+mkroot(){ mkdir -p "$1/cmd" "$1/internal/gitexec"; printf 'package main\n' >"$1/cmd/main.go"; printf 'package gitexec\nimport "os/exec"\nfunc p(){ _,_=exec.LookPath("git") }\n' >"$1/internal/gitexec/gitexec.go"; }
+baseline(){ : >"$1"; }
+run(){ GIT_EXEC_ROOT="$1" GIT_EXEC_BASELINE="$2" GIT_EXEC_POSITIVE_FIXTURE="$3" bash "$GATE" >"$TMP_DIR/out" 2>&1; RC=$?; OUT=$(cat "$TMP_DIR/out"); }
+
+R="$TMP_DIR/real"; mkroot "$R"; B="$TMP_DIR/base"; baseline "$B"; P="$REPO_ROOT/scripts/testdata/git_exec_gate_positive.txt"
+run "$R" "$B" "$P"; [ "$RC" -eq 0 ] && pass S1 || fail "S1 real control rc=$RC: $OUT"
+run "$R" "$B" "$TMP_DIR/missing"; [ "$RC" -eq 2 ] && printf '%s' "$OUT" | grep -q 'G1' && pass S2 || fail "S2 missing fixture: $OUT"
+printf 'package fixture\n' >"$TMP_DIR/empty.txt"; run "$R" "$B" "$TMP_DIR/empty.txt"; [ "$RC" -eq 2 ] && printf '%s' "$OUT" | grep -q 'G2' && pass S2b || fail "S2b empty fixture: $OUT"
+printf 'package main\nimport "os/exec"\nfunc f(){exec.Command("git")}\n' >"$R/cmd/add.go"; run "$R" "$B" "$P"; [ "$RC" -eq 1 ] && printf '%s' "$OUT" | grep -q 'absent from baseline' && pass S3b || fail "S3b absent baseline: $OUT"
+printf 'cmd/add.go 0\n' >"$B"; run "$R" "$B" "$P"; [ "$RC" -eq 1 ] && printf '%s' "$OUT" | grep -q 'count increased' && pass S3 || fail "S3 increase: $OUT"
+printf 'cmd/add.go 2\n' >"$B"; run "$R" "$B" "$P"; [ "$RC" -eq 1 ] && printf '%s' "$OUT" | grep -q 'tighten the baseline' && pass S4 || fail "S4 decrease: $OUT"
+printf 'cmd/add.go 1\n' >"$B"; printf 'package main\nimport "os/exec"\nfunc p(){_,_=exec.LookPath("git")}\n' >"$R/cmd/look.go"; run "$R" "$B" "$P"; [ "$RC" -eq 1 ] && printf '%s' "$OUT" | grep -q 'outside internal/gitexec' && pass S5 || fail "S5 LookPath: $OUT"
+rm "$R/cmd/look.go"; printf 'package main\nimport "os/exec"\nfunc g(){exec.Command(\n"git")}\n' >"$R/cmd/multi.go"; printf 'cmd/add.go 1\ncmd/multi.go 1\n' >"$B"; run "$R" "$B" "$P"; [ "$RC" -eq 1 ] && printf '%s' "$OUT" | grep -q 'AST/regex disagreement' && pass S6 || fail "S6 cross-check: $OUT"
+
+[ "$ARMS_RUN" -eq "$ARMS_EXPECTED" ] || { FAILED=1; printf '  FAIL — %s of %s arms ran\n' "$ARMS_RUN" "$ARMS_EXPECTED"; }
+[ "$FAILED" -eq 0 ] && { printf 'git exec gate self-test: OK (%s arms)\n' "$ARMS_RUN"; exit 0; }
+printf 'git exec gate self-test: FAILED\n'; exit 1

--- a/scripts/testdata/git_exec_gate_blindspot.txt
+++ b/scripts/testdata/git_exec_gate_blindspot.txt
@@ -1,0 +1,9 @@
+package fixture
+
+import "os/exec"
+
+func blindspots() {
+	git := "git"
+	exec.Command(git, "status")
+	exec.Command("bash", "-c", "git status")
+}

--- a/scripts/testdata/git_exec_gate_positive.txt
+++ b/scripts/testdata/git_exec_gate_positive.txt
@@ -1,0 +1,11 @@
+package fixture
+
+import "os/exec"
+
+func singleLine() { exec.Command("git", "status") }
+
+func multiLine() {
+	exec.Command(
+		"git", "status",
+	)
+}

--- a/tools/check-git-exec/main.go
+++ b/tools/check-git-exec/main.go
@@ -18,10 +18,58 @@ type finding struct {
 	Line int
 }
 
-func enumerate(root string, paths []string) ([]finding, error) {
-	var out []finding
+// execNames returns the set of identifiers that refer to package os/exec in f.
+//
+// Resolving through the import declarations rather than matching the literal
+// identifier "exec" is what makes an aliased import (`import exe "os/exec"`)
+// visible. A name-only check is evaded by one keystroke, and the evasion is
+// gofmt-canonical, so nothing else in the toolchain would surface it.
+func execNames(f *ast.File) map[string]bool {
+	names := map[string]bool{}
+	for _, imp := range f.Imports {
+		p, err := strconv.Unquote(imp.Path.Value)
+		if err != nil || p != "os/exec" {
+			continue
+		}
+		switch {
+		case imp.Name == nil:
+			names["exec"] = true
+		case imp.Name.Name == "." || imp.Name.Name == "_":
+			// A dot-import puts Command/LookPath in file scope unqualified and a
+			// blank import cannot call anything. Neither is matchable by the
+			// selector walk below; both are declared residuals, not silent passes.
+		default:
+			names[imp.Name.Name] = true
+		}
+	}
+	return names
+}
+
+// gitLiteralAt reports whether call's argument at idx is the string literal "git".
+func gitLiteralAt(call *ast.CallExpr, idx int) bool {
+	if len(call.Args) <= idx {
+		return false
+	}
+	lit, ok := call.Args[idx].(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return false
+	}
+	v, err := strconv.Unquote(lit.Value)
+	return err == nil && v == "git"
+}
+
+// enumerate walks every non-test .go file under root/paths and returns, per
+// AST rather than per line, the bare-name git exec sites and the LookPath("git")
+// sites.
+//
+// Both are AST-based for the same reason (design HID-6): grep is line-anchored,
+// and gofmt wraps an argument list as soon as it grows or a comment anchors it,
+// so a line-oriented matcher cannot see the shape the formatter itself produces.
+// The LookPath arm was line-oriented until the iteration-298 evaluator planted a
+// gofmt-canonical multi-line duplicate resolver and the gate reported OK.
+func enumerate(root string, paths []string) (cmds []finding, lookPaths []finding, err error) {
 	for _, base := range paths {
-		err := filepath.Walk(filepath.Join(root, base), func(path string, info os.FileInfo, err error) error {
+		walkErr := filepath.Walk(filepath.Join(root, base), func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return err
 			}
@@ -35,10 +83,16 @@ func enumerate(root string, paths []string) ([]finding, error) {
 				return nil
 			}
 			fset := token.NewFileSet()
-			f, err := parser.ParseFile(fset, path, nil, 0)
+			f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
 			if err != nil {
 				return fmt.Errorf("parse %s: %w", path, err)
 			}
+			names := execNames(f)
+			if len(names) == 0 {
+				return nil
+			}
+			rel, _ := filepath.Rel(root, path)
+			rel = filepath.ToSlash(rel)
 			ast.Inspect(f, func(n ast.Node) bool {
 				call, ok := n.(*ast.CallExpr)
 				if !ok {
@@ -49,43 +103,44 @@ func enumerate(root string, paths []string) ([]finding, error) {
 					return true
 				}
 				id, ok := sel.X.(*ast.Ident)
-				if !ok || id.Name != "exec" {
+				if !ok || !names[id.Name] {
 					return true
 				}
-				idx := 0
-				if sel.Sel.Name == "CommandContext" {
-					idx = 1
-				} else if sel.Sel.Name != "Command" {
-					return true
+				line := fset.Position(call.Pos()).Line
+				switch sel.Sel.Name {
+				case "Command":
+					if gitLiteralAt(call, 0) {
+						cmds = append(cmds, finding{rel, line})
+					}
+				case "CommandContext":
+					if gitLiteralAt(call, 1) {
+						cmds = append(cmds, finding{rel, line})
+					}
+				case "LookPath":
+					if gitLiteralAt(call, 0) {
+						lookPaths = append(lookPaths, finding{rel, line})
+					}
 				}
-				if len(call.Args) <= idx {
-					return true
-				}
-				lit, ok := call.Args[idx].(*ast.BasicLit)
-				if !ok || lit.Kind != token.STRING {
-					return true
-				}
-				v, err := strconv.Unquote(lit.Value)
-				if err != nil || v != "git" {
-					return true
-				}
-				rel, _ := filepath.Rel(root, path)
-				out = append(out, finding{filepath.ToSlash(rel), fset.Position(call.Pos()).Line})
 				return true
 			})
 			return nil
 		})
-		if err != nil {
-			return nil, err
+		if walkErr != nil {
+			return nil, nil, walkErr
 		}
 	}
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].File == out[j].File {
-			return out[i].Line < out[j].Line
+	sortFindings(cmds)
+	sortFindings(lookPaths)
+	return cmds, lookPaths, nil
+}
+
+func sortFindings(fs []finding) {
+	sort.Slice(fs, func(i, j int) bool {
+		if fs[i].File == fs[j].File {
+			return fs[i].Line < fs[j].Line
 		}
-		return out[i].File < out[j].File
+		return fs[i].File < fs[j].File
 	})
-	return out, nil
 }
 
 func main() {
@@ -95,13 +150,13 @@ func main() {
 	if len(paths) == 0 {
 		paths = []string{"cmd", "internal"}
 	}
-	fs, err := enumerate(*root, paths)
+	cmds, lookPaths, err := enumerate(*root, paths)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(2)
 	}
 	counts := map[string]int{}
-	for _, f := range fs {
+	for _, f := range cmds {
 		counts[f.File]++
 		fmt.Printf("SITE %s:%d\n", f.File, f.Line)
 	}
@@ -113,5 +168,9 @@ func main() {
 	for _, f := range files {
 		fmt.Printf("COUNT %s %d\n", f, counts[f])
 	}
-	fmt.Printf("TOTAL %d\n", len(fs))
+	fmt.Printf("TOTAL %d\n", len(cmds))
+	for _, f := range lookPaths {
+		fmt.Printf("LOOKPATH %s:%d\n", f.File, f.Line)
+	}
+	fmt.Printf("LOOKPATH_TOTAL %d\n", len(lookPaths))
 }

--- a/tools/check-git-exec/main.go
+++ b/tools/check-git-exec/main.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type finding struct {
+	File string
+	Line int
+}
+
+func enumerate(root string, paths []string) ([]finding, error) {
+	var out []finding
+	for _, base := range paths {
+		err := filepath.Walk(filepath.Join(root, base), func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				if info.Name() == "vendor" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, path, nil, 0)
+			if err != nil {
+				return fmt.Errorf("parse %s: %w", path, err)
+			}
+			ast.Inspect(f, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				id, ok := sel.X.(*ast.Ident)
+				if !ok || id.Name != "exec" {
+					return true
+				}
+				idx := 0
+				if sel.Sel.Name == "CommandContext" {
+					idx = 1
+				} else if sel.Sel.Name != "Command" {
+					return true
+				}
+				if len(call.Args) <= idx {
+					return true
+				}
+				lit, ok := call.Args[idx].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					return true
+				}
+				v, err := strconv.Unquote(lit.Value)
+				if err != nil || v != "git" {
+					return true
+				}
+				rel, _ := filepath.Rel(root, path)
+				out = append(out, finding{filepath.ToSlash(rel), fset.Position(call.Pos()).Line})
+				return true
+			})
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].File == out[j].File {
+			return out[i].Line < out[j].Line
+		}
+		return out[i].File < out[j].File
+	})
+	return out, nil
+}
+
+func main() {
+	root := flag.String("root", ".", "repository root")
+	flag.Parse()
+	paths := flag.Args()
+	if len(paths) == 0 {
+		paths = []string{"cmd", "internal"}
+	}
+	fs, err := enumerate(*root, paths)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	counts := map[string]int{}
+	for _, f := range fs {
+		counts[f.File]++
+		fmt.Printf("SITE %s:%d\n", f.File, f.Line)
+	}
+	files := make([]string, 0, len(counts))
+	for f := range counts {
+		files = append(files, f)
+	}
+	sort.Strings(files)
+	for _, f := range files {
+		fmt.Printf("COUNT %s %d\n", f, counts[f])
+	}
+	fmt.Printf("TOTAL %d\n", len(fs))
+}

--- a/tools/check-git-exec/main_test.go
+++ b/tools/check-git-exec/main_test.go
@@ -21,17 +21,17 @@ func write(t *testing.T, dir, name, src string) {
 func TestEnumerator_AdditionAndBlindspots(t *testing.T) {
 	d := t.TempDir()
 	write(t, d, "cmd/base.go", "package p\nimport \"os/exec\"\nfunc f(){ exec.Command(\"git\", \"status\") }\n")
-	fs, err := enumerate(d, []string{"cmd"})
+	fs, _, err := enumerate(d, []string{"cmd"})
 	if err != nil || len(fs) != 1 {
 		t.Fatalf("base = %v, %v", fs, err)
 	}
 	write(t, d, "cmd/multi.go", "package p\nimport \"os/exec\"\nfunc f(){ exec.Command(\n\"git\", \"status\") }\n")
-	fs, err = enumerate(d, []string{"cmd"})
+	fs, _, err = enumerate(d, []string{"cmd"})
 	if err != nil || len(fs) != 2 {
 		t.Fatalf("addition count = %d, %v", len(fs), err)
 	}
 	write(t, d, "cmd/blind.go", "package p\nimport \"os/exec\"\nfunc f(){ g:=\"git\"; exec.Command(g); exec.Command(\"bash\",\"-c\",\"git status\") }\n")
-	fs, err = enumerate(d, []string{"cmd"})
+	fs, _, err = enumerate(d, []string{"cmd"})
 	if err != nil || len(fs) != 2 {
 		t.Fatalf("blindspots added findings: %d, %v", len(fs), err)
 	}
@@ -51,7 +51,7 @@ func TestEnumerator_CommittedFixtures(t *testing.T) {
 			t.Fatal(err)
 		}
 		write(t, d, filepath.Join("cmd", tc.name+".go"), string(data))
-		fs, err := enumerate(d, []string{"cmd"})
+		fs, _, err := enumerate(d, []string{"cmd"})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -67,7 +67,7 @@ func TestEnumerator_CommittedFixtures(t *testing.T) {
 func TestEnumerator_ExactNamesAndArgumentPositions(t *testing.T) {
 	d := t.TempDir()
 	write(t, d, "cmd/x.go", "package p\nimport (\"context\"; \"os/exec\")\nfunc f(ctx context.Context){ exec.Command(\"git-lfs\"); exec.Command(\"gitfoo\"); exec.Command(\"echo\",\"git\"); exec.CommandContext(ctx,\"git\"); exec.CommandContext(ctx,\"echo\",\"git\") }\n")
-	fs, err := enumerate(d, []string{"cmd"})
+	fs, _, err := enumerate(d, []string{"cmd"})
 	if err != nil || len(fs) != 1 {
 		t.Fatalf("findings = %v, %v", fs, err)
 	}
@@ -77,12 +77,12 @@ func TestEnumerator_ExcludesTests(t *testing.T) {
 	d := t.TempDir()
 	src := "package p\nimport \"os/exec\"\nfunc f(){exec.Command(\"git\")}\n"
 	write(t, d, "cmd/x_test.go", src)
-	fs, err := enumerate(d, []string{"cmd"})
+	fs, _, err := enumerate(d, []string{"cmd"})
 	if err != nil || len(fs) != 0 {
 		t.Fatalf("test file = %v, %v", fs, err)
 	}
 	write(t, d, "cmd/x.go", src)
-	fs, err = enumerate(d, []string{"cmd"})
+	fs, _, err = enumerate(d, []string{"cmd"})
 	if err != nil || len(fs) != 1 {
 		t.Fatalf("go file = %v, %v", fs, err)
 	}
@@ -91,8 +91,45 @@ func TestEnumerator_ExcludesTests(t *testing.T) {
 func TestEnumerator_ParseErrorNamesFile(t *testing.T) {
 	d := t.TempDir()
 	write(t, d, "cmd/bad.go", "package p\nfunc (")
-	_, err := enumerate(d, []string{"cmd"})
+	_, _, err := enumerate(d, []string{"cmd"})
 	if err == nil || !strings.Contains(err.Error(), "bad.go") {
 		t.Fatalf("error = %v", err)
+	}
+}
+
+// TestEnumerator_LookPathIsASTBased pins the iteration-298 evaluator's BLOCKING
+// finding. The LookPath invariant used to be a line-anchored grep, while the
+// exec.Command enumeration was AST-based for the express reason that grep cannot
+// see the shape gofmt produces (design HID-6). That reasoning was never applied
+// to the sibling check inside the same gate, so a gofmt-canonical multi-line
+// duplicate resolver — and an aliased os/exec import — both passed with rc=0.
+//
+// Every arm below is gofmt-canonical: none is a shape `make fmt-check` would
+// reformat away. The last arm asserts a DECLARED residual (dataflow through a
+// constant), so the known miss is pinned deliberately rather than left silent.
+func TestEnumerator_LookPathIsASTBased(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want int
+	}{
+		{"single line", "package p\n\nimport \"os/exec\"\n\nfunc f() { _, _ = exec.LookPath(\"git\") }\n", 1},
+		{"multi line", "package p\n\nimport \"os/exec\"\n\nfunc f() {\n\t_, _ = exec.LookPath(\n\t\t\"git\")\n}\n", 1},
+		{"aliased import", "package p\n\nimport exe \"os/exec\"\n\nfunc f() { _, _ = exe.LookPath(\"git\") }\n", 1},
+		{"not git", "package p\n\nimport \"os/exec\"\n\nfunc f() { _, _ = exec.LookPath(\"hg\") }\n", 0},
+		{"declared residual: constant not literal", "package p\n\nimport \"os/exec\"\n\nconst n = \"git\"\n\nfunc f() { _, _ = exec.LookPath(n) }\n", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := t.TempDir()
+			write(t, d, "cmd/x.go", tc.src)
+			_, lp, err := enumerate(d, []string{"cmd"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(lp) != tc.want {
+				t.Fatalf("LookPath findings = %d, want %d (%v)", len(lp), tc.want, lp)
+			}
+		})
 	}
 }

--- a/tools/check-git-exec/main_test.go
+++ b/tools/check-git-exec/main_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func write(t *testing.T, dir, name, src string) {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnumerator_AdditionAndBlindspots(t *testing.T) {
+	d := t.TempDir()
+	write(t, d, "cmd/base.go", "package p\nimport \"os/exec\"\nfunc f(){ exec.Command(\"git\", \"status\") }\n")
+	fs, err := enumerate(d, []string{"cmd"})
+	if err != nil || len(fs) != 1 {
+		t.Fatalf("base = %v, %v", fs, err)
+	}
+	write(t, d, "cmd/multi.go", "package p\nimport \"os/exec\"\nfunc f(){ exec.Command(\n\"git\", \"status\") }\n")
+	fs, err = enumerate(d, []string{"cmd"})
+	if err != nil || len(fs) != 2 {
+		t.Fatalf("addition count = %d, %v", len(fs), err)
+	}
+	write(t, d, "cmd/blind.go", "package p\nimport \"os/exec\"\nfunc f(){ g:=\"git\"; exec.Command(g); exec.Command(\"bash\",\"-c\",\"git status\") }\n")
+	fs, err = enumerate(d, []string{"cmd"})
+	if err != nil || len(fs) != 2 {
+		t.Fatalf("blindspots added findings: %d, %v", len(fs), err)
+	}
+}
+
+func TestEnumerator_CommittedFixtures(t *testing.T) {
+	d := t.TempDir()
+	for _, tc := range []struct {
+		name string
+		want int
+	}{
+		{"git_exec_gate_positive.txt", 2},
+		{"git_exec_gate_blindspot.txt", 0},
+	} {
+		data, err := os.ReadFile(filepath.Join("..", "..", "scripts", "testdata", tc.name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		write(t, d, filepath.Join("cmd", tc.name+".go"), string(data))
+		fs, err := enumerate(d, []string{"cmd"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(fs) != tc.want {
+			t.Fatalf("%s findings = %d, want %d", tc.name, len(fs), tc.want)
+		}
+		if err := os.RemoveAll(filepath.Join(d, "cmd")); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestEnumerator_ExactNamesAndArgumentPositions(t *testing.T) {
+	d := t.TempDir()
+	write(t, d, "cmd/x.go", "package p\nimport (\"context\"; \"os/exec\")\nfunc f(ctx context.Context){ exec.Command(\"git-lfs\"); exec.Command(\"gitfoo\"); exec.Command(\"echo\",\"git\"); exec.CommandContext(ctx,\"git\"); exec.CommandContext(ctx,\"echo\",\"git\") }\n")
+	fs, err := enumerate(d, []string{"cmd"})
+	if err != nil || len(fs) != 1 {
+		t.Fatalf("findings = %v, %v", fs, err)
+	}
+}
+
+func TestEnumerator_ExcludesTests(t *testing.T) {
+	d := t.TempDir()
+	src := "package p\nimport \"os/exec\"\nfunc f(){exec.Command(\"git\")}\n"
+	write(t, d, "cmd/x_test.go", src)
+	fs, err := enumerate(d, []string{"cmd"})
+	if err != nil || len(fs) != 0 {
+		t.Fatalf("test file = %v, %v", fs, err)
+	}
+	write(t, d, "cmd/x.go", src)
+	fs, err = enumerate(d, []string{"cmd"})
+	if err != nil || len(fs) != 1 {
+		t.Fatalf("go file = %v, %v", fs, err)
+	}
+}
+
+func TestEnumerator_ParseErrorNamesFile(t *testing.T) {
+	d := t.TempDir()
+	write(t, d, "cmd/bad.go", "package p\nfunc (")
+	_, err := enumerate(d, []string{"cmd"})
+	if err == nil || !strings.Contains(err.Error(), "bad.go") {
+		t.Fatalf("error = %v", err)
+	}
+}


### PR DESCRIPTION
## M1 — one absolute-path git resolver, and a gate that can see the shape `gofmt` produces

V1 mission iteration 298. M1 of `m-git-binary-resolution-sweep`. **M2-M4 (the other 88 sites) are deliberately out of scope.**

### The problem

93 bare-name `exec.Command("git", ...)` sites resolve git through whatever `PATH` holds at run time — 44 in `cmd/ailang`, 43 in the long-lived `internal/coordinator` daemon, 5 in `internal/pkg`, 1 in `internal/eval_harness`. A hardened absolute-path resolver already existed and was trapped in `package main` with **zero** consumers outside its own file. SonarCloud flags only 4 of the 93, because only those 4 were touched inside the new-code period; fixing those 4 alone would be gate-satisfying, not a fix.

### What landed

`internal/gitexec` (stdlib-only leaf, importable by `package main` and `internal/*`), the 4 flagged sites converted, `help.go` migrated, and `make check-git-exec` wired into CI.

Two contracts are the point of the milestone, and both came out of quorum review:

- **Cache SUCCESS only.** The reviewed draft cached success *and* failure in a `sync.Once`. That is a new failure mode, not a preserved one — 43 of the 93 sites are in the coordinator daemon, so one early miss would break every future git task in that process until restart. `sync.Once` is the wrong primitive for a retryable operation; resolution now sits behind a mutex and a failure is re-attempted next call.
- **The enumerator is `go/ast`-based, not a line regex.** `grep` is line-anchored and `gofmt` wraps an argument list as soon as it grows, so a future multi-line `git` call would be invisible to a regex gate. The regex survives only as a cross-check scoped to `cmd/` + `internal/` — never over the fixtures, which exist precisely to make the two arms disagree.

**Anti-vacuity is by ADDITION, not only removal.** A removal proves a check fires; only an addition proves it *looks*. The addition mutant moves the AST count 89 → 90 while the regex arm stays at 89, and the gate reds on both the missing baseline entry and the arm disagreement.

### Measured, not assumed

| | |
|---|---|
| Pristine AST total | **93** (the doc's original 92 was stale at its base) |
| Post-conversion | **89** AST / **89** regex, agreeing, per-file diff empty |
| Baseline seeded | **89** across 16 files, by fresh measurement — not hardcoded |
| `LookPath("git")` outside `internal/gitexec` | **0** |

`make ci` is **not** invoked by `ci.yml` in this repo (0 occurrences against a control of 33 `run: make` lines), so wiring the target into the `ci:` aggregate alone would not have run it. Two explicit workflow steps were added.

### Review trail

Pick-time quorum blocked **twice**, 3/3 reviewers present both rounds, 0 absent. Every objection was measured before routing rather than forwarded:

- **CONFIRMED** — the security claim was wider than the mechanism. `resolveGit` checks `filepath.IsAbs` and nothing else, so "or writable" was false and the residual S4036 "reviewed-safe" disposition was unearned. Narrowed to the delivered property; both non-properties (writability, TOCTOU) now stated.
- **CONFIRMED** — the failure-caching regression above.
- **REFUTED** — zero in-repo string-matches of `os/exec`'s not-found text (rc=1, control 2918).
- **REFUTED (round 2, shared by both survivors)** — they read `watchdog.go:57` as an existing git site the regex misses. It is `exec.Command("bash", "-c", …)`, not git. A multi-line-aware enumeration over 1,254 non-test Go files returns 93, identical to the single-line count, differing-file list empty. The blind spot was **prospective, not present** — which changed the urgency, not the fix.

The sprint planner then found a contradiction in the design's own gate contract: HID-6 clauses 2 and 3 were jointly unsatisfiable (any AST/regex disagreement = gate failure, *and* ship a fixture designed to make them disagree — measured: regex 0, AST 1). An executor implementing both literally would have built a gate that fails on its own fixture. Fixed before routing.

### Gates

Re-run by the controller **outside** the codex sandbox on darwin/arm64, all rc=0: build · vet · gitexec+enumerator tests · `check-git-exec` · `test-check-git-exec` · `check-boundaries` · `check-file-sizes` · `check-changelog` · `gofmt`. The two suites the executor correctly labelled `UNINFORMATIVE UNDER SANDBOX` (httptest loopback bind denied) were re-run outside it against a freshly built ldflags-stamped binary matching `git describe` — both rc=0.

`go build ./...` is rc=1 on untouched `dev` (`cmd/wasm` has no native `main`) and was **rejected from the acceptance list rather than shipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
