### PR TITLE
docs(docs-2): first docs-sync sweep — scored drift register + tooling-defect finding

### DIFF
--- a/docs/docs-sync-findings.md
+++ b/docs/docs-sync-findings.md
@@ -1,0 +1,63 @@
+# Docs-sync findings register
+
+Internal tracking page for sprint `docs-2` (2026-08-28). This page is intentionally not
+published or added to the Docusaurus sidebar. Each finding is sized as a possible future queue
+item and has one primary mission clause.
+
+## Evidence summary
+
+| Instrument | Result |
+|---|---|
+| `audit_design_docs.sh` | `rc=0`; five architecture pages referenced planned material; all 159/1030 design-doc counts were reported as audit scope |
+| `check_versions.sh` | `rc=0`; git and stable release `v0.34.0`, active/latest prompt `v0.16.6`; `intro.mdx` contains stale `v0.16.0` |
+| `check_examples.sh` | `rc=0`; raw output 12 passed / 29 failed / 176 skipped is unreliable because it passes absolute paths |
+| `derive_roadmap_versions.sh --full --check` | `rc=0`; 126 planned docs, 682 implemented docs in this instrument's scope; roadmap consistency clean |
+| `generate_report.sh` | `rc=0`; report generated; repeats the version status, five future-page hits, and embedded-snippet warning |
+
+The prescribed fresh binary was built at `bin/ailang` with version and commit ldflags. The corrected
+sweep ran from the repository root and passed relative paths to that binary. It executed all 217
+`examples/runnable/*.ail` files: **166 pass, 9 genuine failures, and 42 no-module/non-running**.
+Observatory memory warnings were not counted as failures. The 9 failures are listed separately
+below. The two design-doc population totals above are instrument-scope differences, not silently
+merged into one number; the roadmap checker is the source for the overdue aggregate.
+
+## Scored findings
+
+| ID | Description | Clause | Severity | Evidence / reproduction | Disposition |
+|---|---|---:|---|---|---|
+| DOCS-2-01 | `check_examples.sh` over-reports module-path failures when given absolute paths. | 1 | HIGH | `bash .claude/skills/docs-sync/scripts/check_examples.sh` produced 12/29; relative-path execution produced 166/9/42. Absolute paths conflict with declarations such as `module examples/runnable/X`, causing false `MOD010` results. | Standalone tooling queue item. Do not edit the script in this sprint; fixing it requires widening the allowlist to `.claude/skills/docs-sync/scripts/*` or routing to V1. |
+| DOCS-2-02 | Intro page names IFC Labels as `v0.16.0` while the latest prompt is `v0.16.6`. | 1 | MEDIUM | `check_versions.sh` reports `[STALE] intro.mdx references v0.16.0, latest is v0.16.6`. | Defer to a future item; `docs/docs/intro.mdx` is nested and outside this sprint's single-level `docs/*` allowlist. |
+| DOCS-2-03 | 126 planned design documents are overdue relative to `v0.34.0`. | 1 | HIGH | `bash .claude/skills/docs-sync/scripts/derive_roadmap_versions.sh --full --check` reports overdue material from `v0.29.0` through `v0.34.0`, with summary `Planned design docs: 126`. | Aggregate follow-up queue item. Triage and move/relabel incrementally; do not rewrite all 126 here. |
+| DOCS-2-04 | The design-doc audit and roadmap report expose different population totals and should state their scopes. | 1 | MEDIUM | `audit_design_docs.sh` reports Planned 159 / Implemented 1030, while `derive_roadmap_versions.sh --full --check` reports Planned 126 / Implemented 682. Both returned `rc=0`. | Route to a bounded diagnostic reconciliation item; retain both raw results until scope rules are documented. |
+| DOCS-2-05 | `block_demo.ail` is runnable by module path but has no `main` entrypoint. | 2 | LOW | Relative sweep: `entrypoint 'main' not found`; exports are `singleLine`, `compute`, `multiStep`. | Classify explicitly as helper/library or add a documented entrypoint in a future examples cleanup; not a compiler regression. |
+| DOCS-2-06 | `test_module_minimal.ail` has no `main` entrypoint. | 2 | LOW | Relative sweep: `entrypoint 'main' not found`; export is `hello`. | Future examples-harness classification cleanup; invoke an explicit export or mark non-runnable. |
+| DOCS-2-07 | `simple_func_match.ail` has no `main` entrypoint. | 2 | LOW | Relative sweep: `entrypoint 'main' not found`; export is `test`. | Future examples-harness classification cleanup; invoke an explicit export or mark non-runnable. |
+| DOCS-2-08 | `match_arm_block.ail` has no `main` entrypoint. | 2 | LOW | Relative sweep: `entrypoint 'main' not found`; export is `test`. | Future examples-harness classification cleanup; invoke an explicit export or mark non-runnable. |
+| DOCS-2-09 | `match_in_block.ail` has no `main` entrypoint. | 2 | LOW | Relative sweep: `entrypoint 'main' not found`; export is `test`. | Future examples-harness classification cleanup; invoke an explicit export or mark non-runnable. |
+| DOCS-2-10 | `nested_match_minimal.ail` has no `main` entrypoint. | 2 | LOW | Relative sweep: `entrypoint 'main' not found`; export is `test`. | Future examples-harness classification cleanup; invoke an explicit export or mark non-runnable. |
+| DOCS-2-11 | `match_arm_block_io.ail` has no `main` entrypoint. | 2 | LOW | Relative sweep: `entrypoint 'main' not found`; export is `test`. | Future examples-harness classification cleanup; invoke an explicit export or mark non-runnable. |
+| DOCS-2-12 | `batch_processing.ail` requires `Env`, but the generic checker retries only with `IO` and no caps. | 2 | MEDIUM | Relative sweep reports `effect 'Env' requires capability`; the file's own usage comment specifies `--caps IO,Env`. | Fix the verifier invocation or classify this example as capability-specific; no source edit made. |
+| DOCS-2-13 | `cli_args_demo.ail` requires `Env`, but the generic checker retries only with `IO` and no caps. | 2 | MEDIUM | Relative sweep reports `effect 'Env' requires capability`; the source imports `std/env (getArgs)`. | Fix the verifier invocation or classify this example as capability-specific; no source edit made. |
+
+## Clean controls and non-findings
+
+- The five `audit_design_docs.sh` hits were inspected: `debug-tools.mdx`, `adding-operators.md`,
+  `anf.md`, and `architecture/index.md` describe implemented/current architecture; `types.md`
+  clearly labels structural reflection for user-defined type classes as planned. No false
+  planned/current claim was scored. These nested pages remain unedited.
+- Version constants are clean: stable release matches git tag and active prompt matches the latest
+  prompt file. Only the nested intro reference is stale.
+- Roadmap-page versus design-doc-folder consistency is clean (`derive_roadmap_versions.sh`), and
+  the four reference pages checked for implemented-design-doc links are clean.
+- The example sweep's 166 passes include successful files without a module declaration. The 42
+  bucket contains files that could not be run under the default `main`/capability invocation and
+  are not asserted to be all defects without a bounded classification pass.
+- No clause-3 site-build, clause-4 missing-page, clause-5 taxonomy, clause-6 benchmark, or
+  clause-7 request-handling defect was established by these diagnostics. Those remain separate
+  mission work rather than unsupported findings here.
+
+## Routing notes
+
+The highest-priority work is the diagnostic instrument defect (`DOCS-2-01`), the overdue-doc
+aggregate (`DOCS-2-03`), and the stale nested intro reference (`DOCS-2-02`). The nested-file and
+skill-script restrictions are deliberate sprint boundaries; none of those fixes landed here.

--- a/sprint-plan-docs-2.md
+++ b/sprint-plan-docs-2.md
@@ -1,0 +1,69 @@
+# Sprint Plan: docs-2 — docs-sync diagnostic sweep and drift register
+
+## Overview
+
+- Routing brief: `design_docs/docs-2-brief.md` (routing declaration; no design doc required).
+- Mission: documentation website upkeep, first real docs-sync sweep.
+- Size: S, approximately one focused day.
+- Primary output: [`docs/docs-sync-findings.md`](docs/docs-sync-findings.md), an internal page with scored, clause-tagged queue rows.
+- No commits. The controller will review and finalize the diff.
+
+The executor must use the prescribed fresh binary and relative-path example methodology. The existing `check_examples.sh` absolute-path failure is a verified tooling defect and must be recorded, not fixed here.
+
+## Day plan
+
+### M1 — Reproduce and establish the evidence ledger
+
+Run all five diagnostics and record return codes and material output:
+
+```text
+bash .claude/skills/docs-sync/scripts/audit_design_docs.sh
+bash .claude/skills/docs-sync/scripts/check_versions.sh
+bash .claude/skills/docs-sync/scripts/check_examples.sh
+bash .claude/skills/docs-sync/scripts/derive_roadmap_versions.sh --full --check
+bash .claude/skills/docs-sync/scripts/generate_report.sh
+```
+
+Build the prescribed scratch `bin/ailang`, then execute the runnable examples from the repository root using relative paths. Partition results into passing, genuine failures, helper/library examples without `main`, no-module cases, and environmental/runtime warnings. The controller baseline to carry forward is 166 pass / 9 genuine fail / 42 no-module or non-running among 217 runnable files; the script’s 12/29 raw verdict count is unreliable because of its absolute-path bug.
+
+Confirm `git check-ignore -v docs/docs-sync-findings.md` is empty before banking the deliverable.
+
+### M2 — Classify and score
+
+Produce future-queue-sized rows. Each row must contain:
+
+- stable finding ID;
+- one-line concrete description;
+- primary clause tag (`1`–`7`);
+- rough severity (`HIGH`, `MEDIUM`, `LOW`, or `INFO`);
+- evidence and reproduction command/output;
+- disposition (in-scope fix, follow-up queue item, or control/non-finding).
+
+Required established rows:
+
+1. HIGH, clause-1-adjacent tooling: `check_examples.sh` over-reports module-path failures when passed absolute paths. State the exact allowlist decision needed to fix it (`.claude/skills/docs-sync/scripts/*` widening or V1 routing); do not edit the script.
+2. MEDIUM, clause 1: `docs/docs/intro.mdx` references prompt v0.16.0 while the latest is v0.16.6. The fix is nested/out of scope here.
+3. Aggregate clause 1: 126 planned design docs are overdue relative to shipped versions. Do not perform a 126-document rewrite; list it as a separate follow-up queue item and mention only trivially verified mislabels if found.
+4. Clause 2 example rows: record the nine corrected genuine failures individually or in small actionable groups, classify `block_demo.ail` as a possible helper/library false positive, and keep the 42 no-module/non-running cases lower-priority/unclassified unless a bounded check proves more.
+
+Inspect the five audit hits (`debug-tools.mdx`, `adding-operators.md`, `anf.md`, `architecture/index.md`, and `types.md`) before scoring. A page that accurately describes a still-future feature is a control; a shipped feature described as future is a real clause-1 row. These nested pages may be reported but must not be edited under this sprint’s single-level `docs/*` allowlist.
+
+Record the clean roadmap consistency check as a control, not a finding. Do not invent clause-3/4/5/6/7 defects without bounded evidence; clause-5 and clause-6 work belongs to docs-4/docs-3.
+
+### M3 — Write and gate the register
+
+Write the top-level internal page with methodology, summary counts, scored findings, clean controls, and routing notes. Apply only a truly trivial in-scope fix if one is found; do not touch nested docs source/constants, mission controller files, or docs-sync tooling.
+
+## Acceptance and verification
+
+- `test -s docs/docs-sync-findings.md` passes.
+- `git check-ignore -v docs/docs-sync-findings.md` produces no output.
+- All five diagnostics were attempted and their rc values are recorded.
+- The page is not added to the published sidebar.
+- Any changed `.ail` file passes `make verify-examples`; any syntax-bearing docs change is checked with `ailang check`.
+- No evals, benchmark banking, rig lock, or git commit.
+- Final diff contains no forbidden-path changes.
+
+## Risks and routing
+
+The main risk is confusing diagnostic defects with product defects. The absolute-path `MOD010` issue is already verified as an instrument bug; the executor should preserve that fact and prominently route its repair decision to Mark/controller. The overdue-doc aggregate is intentionally a queue seed, not a mass audit. The nested `intro.mdx` and architecture-page fixes require a future item with a widened/appropriate allowlist.

--- a/sprint_docs-2.json
+++ b/sprint_docs-2.json
@@ -1,0 +1,114 @@
+{
+  "sprint_id": "docs-2",
+  "title": "Docs-sync diagnostic sweep and scored drift register",
+  "design_doc": null,
+  "brief": "design_docs/docs-2-brief.md",
+  "mission": "docs",
+  "status": "planned",
+  "planner_lane": "codex-ok",
+  "target_version": "v0.34.0",
+  "estimated_days": 1,
+  "scope": {
+    "primary_deliverable": "docs/docs-sync-findings.md",
+    "allowed_paths": [
+      "tools/*",
+      "docs/*",
+      "examples/*",
+      "README.md",
+      "CHANGELOG.md",
+      ".claude/skills/mission-control/SKILL.md",
+      ".claude/skills/design-doc-creator/*"
+    ],
+    "out_of_scope": [
+      "design_docs/docs-mission.md",
+      "design_docs/docs-mission-log.md",
+      ".claude/skills/docs-sync/**",
+      "docs/docs/**",
+      "docs/src/**",
+      "internal/**",
+      "cmd/**",
+      "benchmark reruns or eval banking"
+    ]
+  },
+  "verified_by_controller": [
+    "check_examples.sh uses absolute runnable-example paths and therefore produces false MOD010 module-path failures for declarations such as module examples/runnable/X; this is a tooling defect, not a language regression",
+    "The defective script reported 12 passed and 29 failed among 41 verdicts, with 176 no-module skips; those raw counts must not be used as the truth source",
+    "Using the same freshly built binary with relative paths from repo root produced 166 pass, 9 genuine failures, and 42 no-module/non-running cases across 217 runnable examples; block_demo.ail lacks main and may be a helper/library classification issue",
+    "check_versions.sh: git and website stable release are v0.34.0, latest prompt is v0.16.6, and docs/docs/intro.mdx references v0.16.0",
+    "derive_roadmap_versions.sh --full --check found 126 planned design docs, including overdue v0.29.0-v0.31.0 material; the roadmap-pages-vs-folders consistency control was clean",
+    "audit_design_docs.sh flagged debug-tools.mdx, adding-operators.md, anf.md, architecture/index.md, and types.md; each must be inspected to distinguish a valid future claim from stale status",
+    "The five flagged architecture pages are nested paths and cannot be edited under this sprint's single-level docs/* allowlist"
+  ],
+  "milestones": [
+    {
+      "id": "M1_REPRODUCE",
+      "name": "Re-run diagnostics and establish evidence ledger",
+      "estimated_hours": 2,
+      "tasks": [
+        "Run audit_design_docs.sh, check_versions.sh, check_examples.sh, derive_roadmap_versions.sh --full --check, and generate_report.sh against current HEAD; record command, rc, date, and material output",
+        "Build the prescribed fresh bin/ailang with version and commit ldflags",
+        "Run the corrected examples sweep from repo root with relative paths; separate pass, genuine failure, no module declaration, helper/library classification, and runtime/environment noise",
+        "Confirm docs/docs-sync-findings.md is not ignored with git check-ignore -v and preserve a clean starting git status"
+      ],
+      "files": ["bin/ailang (gitignored scratch binary only)", "docs/docs-sync-findings.md"],
+      "acceptance_criteria": [
+        "All five diagnostics were attempted and their return codes are recorded",
+        "The raw absolute-path check_examples.sh counts are explicitly labelled unreliable",
+        "Corrected example evidence uses relative paths and does not count observatory warnings as syntax failures"
+      ]
+    },
+    {
+      "id": "M2_CLASSIFY",
+      "name": "Classify and score drift by clauses 1-7",
+      "estimated_hours": 3,
+      "tasks": [
+        "Create one small future-queue-ready row per actionable drift item, with ID, one-line description, clause tag, severity, evidence/source, disposition, and recommended follow-up",
+        "Include the HIGH clause-1-adjacent check_examples.sh instrument defect as a prominent standalone row; state that fixing it requires widening the allowlist to .claude/skills/docs-sync/scripts/* or routing to V1, and do not edit the script",
+        "Include the moderate stale v0.16.0 intro reference as a clause-1 row, but mark the nested-file fix as deferred/out of scope",
+        "Include one aggregate HIGH/MEDIUM clause-1 row for the 126 overdue planned docs; do not adjudicate or rewrite all 126, and optionally list only trivially verified implemented mislabels",
+        "Inspect all five audit hits and score only those that still make a false planned/future claim; record valid planned claims as controls or non-findings",
+        "Classify the corrected example results under clause 2, distinguishing genuine defects from helper examples and unclassified no-module cases",
+        "Capture any clause-3, clause-4, clause-5, clause-6, or clause-7 observations only when supported by the diagnostics or a bounded spot-check; explicitly record clean controls"
+      ],
+      "files": ["docs/docs-sync-findings.md"],
+      "acceptance_criteria": [
+        "Every finding has a unique ID, one-line description, exactly one primary clause tag from 1-7, rough severity, and actionable next disposition",
+        "Findings are scored/prioritized so the controller can lift rows directly into the mission queue",
+        "Known controller-verified facts are carried forward without re-litigating their established mechanism",
+        "No nested docs page, docs-sync script, mission controller file, or internal/cmd file is proposed for modification"
+      ]
+    },
+    {
+      "id": "M3_BANK",
+      "name": "Write, lint, and gate the findings register",
+      "estimated_hours": 1,
+      "tasks": [
+        "Write docs/docs-sync-findings.md as an internal, non-published-nav tracking page with summary counts, methodology caveats, scored table, clean controls, and follow-up routing",
+        "Apply only trivial fixes that are genuinely within the allowlist; do not fix the nested intro/version constant or docs-sync script in this sprint",
+        "Run markdown/content sanity checks, re-run any affected example or ailang check required by an in-scope syntax-bearing change, and verify the file is non-empty and not ignored"
+      ],
+      "files": ["docs/docs-sync-findings.md", "examples/* only if a trivial verified fix is justified"],
+      "acceptance_criteria": [
+        "test -s docs/docs-sync-findings.md succeeds",
+        "git check-ignore -v docs/docs-sync-findings.md emits no output",
+        "The findings page contains no sidebar/nav entry and no unsupported claim that a blocked nested-file fix landed",
+        "Any changed .ail file passes make verify-examples; any syntax-bearing docs change passes ailang check on its source example",
+        "No git commit is created"
+      ]
+    }
+  ],
+  "hard_constraints": [
+    "Do not edit design_docs/docs-mission.md or design_docs/docs-mission-log.md",
+    "Do not modify any file under .claude/skills/docs-sync/",
+    "Do not plan edits outside the stated blast radius; docs/* is single-level",
+    "Do not run or bank evals and do not acquire a rig lock",
+    "Do not use the check_examples.sh absolute-path pass/fail totals as corrected truth",
+    "Do not commit; the controller finalizes the commit after executor review"
+  ],
+  "final_gates": [
+    "All five diagnostic commands attempted and evidence recorded",
+    "test -s docs/docs-sync-findings.md",
+    "git check-ignore -v docs/docs-sync-findings.md is empty",
+    "git status confirms no forbidden-path changes and no commit was made"
+  ]
+}


### PR DESCRIPTION
## Summary
- First real docs-sync sweep for the docs mission (`docs-2`, queue item promoted above `docs-1` on 2026-08-28).
- Adds `docs/docs-sync-findings.md`: 13 scored, clause-tagged findings from running the `docs-sync` skill's five diagnostics end to end.
- Headline finding (DOCS-2-01, HIGH): `.claude/skills/docs-sync/scripts/check_examples.sh` passes ABSOLUTE paths to `ailang run`, which trips false `MOD010` module-path-mismatch failures for nearly every example carrying a `module examples/runnable/X` declaration. The script's own raw output (12 passed / 29 failed / 176 skipped) is unreliable; a corrected relative-path sweep with a freshly built binary gives 166 pass / 9 genuine fail / 42 no-module across all 217 `examples/runnable/*.ail` files.
- Also found: a stale `v0.16.0` prompt reference in `intro.mdx` (nested, out of this sprint's single-level `docs/*` allowlist), 126 overdue planned design docs, a design-doc population-count mismatch between `audit_design_docs.sh` and `derive_roadmap_versions.sh`, and two examples (`batch_processing.ail`, `cli_args_demo.ail`) needing an `Env` capability the generic checker never tries.
- No source/`.ail`/Go files changed — deliberately, per the brief's "scored list, not a large content rewrite" scope and the mission's blast-radius allowlist (nested `docs/docs/**` pages and `.claude/skills/docs-sync/**` itself are both out of scope this sprint).

## Verification
- Independent sprint-evaluator (sonnet, vendor-distinct from the codex executor) re-derived every load-bearing claim from scratch in its own isolated worktree — the absolute-path bug, the exact 166/9/42 sweep (down to the same 9 failing filenames), the Env-capability gap, and the population-count mismatch all reproduced exactly. **PASS 92/100**, zero blocking findings.
- `git check-ignore -v docs/docs-sync-findings.md` confirmed the deliverable is not gitignored.

## Test plan
- [x] All five docs-sync diagnostics run clean (rc=0)
- [x] `docs/docs-sync-findings.md` non-empty, not gitignored, landed in the commit
- [x] No edits outside blast radius (verified via `git show --stat`)
- [ ] CI green on `dev` after merge (Gate 3b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)