### PR TITLE
refactor(coordinator): route git commands through gitexec

### DIFF
--- a/.ailang/state/sprints/sprint_M-GIT-BINARY-RESOLUTION-SWEEP.json
+++ b/.ailang/state/sprints/sprint_M-GIT-BINARY-RESOLUTION-SWEEP.json
@@ -123,7 +123,7 @@
     },
     {
       "id": "M2_COORDINATOR_SWEEP",
-      "description": "Mechanical conversion of the remaining 42 internal/coordinator sites to gitexec.Command / gitexec.CommandContext, preserving each site's cmd.Dir vs -C convention verbatim. No new decision; the contract is frozen by M1. Lands as its own PR after M1. Five sites in this repo already discard the error (_ = cmd.Run(): daemon_tasks_exec_run.go:461,463; worktree.go:239; and coordinator_browse.go:87,240 in M3) — conversion PRESERVES that silent swallow, which the design explicitly does not fix.",
+      "description": "Mechanical conversion of the remaining 42 internal/coordinator sites to gitexec.Command / gitexec.CommandContext, preserving each site's cmd.Dir vs -C convention verbatim. No new decision; the contract is frozen by M1. Lands as its own PR after M1. Eight sites across M2+M3 already discard the error: six in M2 (approval_processor.go 2, daemon_tasks_exec_run.go 2, worktree.go 2) and two in M3 (coordinator_browse.go 2). Conversion PRESERVES those silent swallows, which the design explicitly does not fix.",
       "estimated_loc": 90,
       "dependencies": ["M1_GITEXEC_CONTRACT_AND_GATE"],
       "files": [
@@ -139,14 +139,14 @@
       ],
       "acceptance_criteria": [
         "[base at M2 start: 89] AST enumerator total over cmd+internal == 47, re-derived by measurement",
-        "[base at M2 start: rc=1 'tighten the baseline'] `make check-git-exec` => rc=0 with the ratcheted baseline (the below-baseline branch G4 makes an unratcheted baseline fail loudly, so this AC IS falsifiable at M2's own base)",
+        "[pristine M2 base with matching 89-site baseline: rc=0; negative control after conversion with the 89-site baseline preserved: rc=1 with seven 'tighten the baseline' diagnostics] `make check-git-exec` => rc=0 with the ratcheted 47-site baseline (the below-baseline branch G4 makes the preserved baseline fail loudly, so this AC is falsifiable on the converted tree)",
         "[base 0 -> >=1] `grep -c 'gitexec' internal/coordinator/merge.go` >= 1",
         "REGRESSION GATE (rc=0 before and after): `go test ./internal/coordinator/... -count=1`"
       ],
       "passes": true,
       "started": "2026-08-28T14:47:00+02:00",
       "completed": "2026-08-28T14:55:15+02:00",
-      "notes": "Completed in mission iteration 300 on sprint/iter300-git-exec-m2: converted exactly 42 internal/coordinator bare-name Git subprocess sites across the seven planned files to internal/gitexec, preserving arguments, Dir conventions, error behavior, and all four M2 silent swallows. daemon_tasks_exec_run.go retains os/exec solely for the non-Git ailang publish command. Fresh AST and regex measurements agree at 47; the 89-site baseline failed with the expected tighten-the-baseline diagnostics before being ratcheted to 47. Coordinator and gitexec tests, narrowed build, full make test, lint, formatting, file-size, boundary, changelog, gate self-test, and missing-fixture anti-vacuity checks all passed."
+      "notes": "Completed in mission iteration 300 on sprint/iter300-git-exec-m2: converted exactly 42 internal/coordinator bare-name Git subprocess sites across the seven planned files to internal/gitexec, preserving arguments, Dir conventions, error behavior, and all six M2 silent swallows. daemon_tasks_exec_run.go retains os/exec solely for the non-Git ailang publish command. Fresh AST and regex measurements agree at 47; on the converted tree the preserved 89-site baseline failed with seven expected tighten-the-baseline diagnostics before being ratcheted to 47. PR #958 follow-up: its first Sonar analysis was red at 31.0% new-code coverage and 3.9% duplicated-line density, so focused real-repository tests were added for merge, worktree inspection/cleanup, and both auto-commit paths; artifact-path accumulation was factored to remove the duplicate block; and four reported repeated Git tokens moved to package constants. A local coverprofile mapped 50/57 diff-added executable lines covered (87.7%); Sonar must remeasure after push. Coordinator and gitexec tests, narrowed build, full make test, lint, formatting, file-size, boundary, changelog, gate self-test, and missing-fixture anti-vacuity checks all passed."
     },
     {
       "id": "M3_CMD_AILANG_SWEEP",

--- a/.ailang/state/sprints/sprint_M-GIT-BINARY-RESOLUTION-SWEEP.json
+++ b/.ailang/state/sprints/sprint_M-GIT-BINARY-RESOLUTION-SWEEP.json
@@ -143,10 +143,10 @@
         "[base 0 -> >=1] `grep -c 'gitexec' internal/coordinator/merge.go` >= 1",
         "REGRESSION GATE (rc=0 before and after): `go test ./internal/coordinator/... -count=1`"
       ],
-      "passes": null,
-      "started": null,
-      "completed": null,
-      "notes": "NOT executed in iteration 298. Deferred by design; the M1 gate already prevents the class from growing while this waits."
+      "passes": true,
+      "started": "2026-08-28T14:47:00+02:00",
+      "completed": "2026-08-28T14:55:15+02:00",
+      "notes": "Completed in mission iteration 300 on sprint/iter300-git-exec-m2: converted exactly 42 internal/coordinator bare-name Git subprocess sites across the seven planned files to internal/gitexec, preserving arguments, Dir conventions, error behavior, and all four M2 silent swallows. daemon_tasks_exec_run.go retains os/exec solely for the non-Git ailang publish command. Fresh AST and regex measurements agree at 47; the 89-site baseline failed with the expected tighten-the-baseline diagnostics before being ratcheted to 47. Coordinator and gitexec tests, narrowed build, full make test, lint, formatting, file-size, boundary, changelog, gate self-test, and missing-fixture anti-vacuity checks all passed."
     },
     {
       "id": "M3_CMD_AILANG_SWEEP",

--- a/changelogs/v0.32-current.md
+++ b/changelogs/v0.32-current.md
@@ -56,6 +56,9 @@ Added the concurrency-safe `internal/gitexec` resolver, which caches successful 
 retries after failure, and migrated the four Sonar-flagged calls plus the stale-binary probe.
 A new AST-based CI ratchet inventories the remaining bare-name calls, checks its own fixtures,
 and reports the intentionally uncovered variable, shell, syscall, and non-Go classes.
+The coordinator sweep now routes all 42 remaining Git subprocesses through that resolver while
+preserving every command argument, working-directory convention, and existing error path. The
+ratchet consequently drops from 89 bare-name sites to 47.
 
 ### Changed — prompt freeze integrity now covers every registry entry
 

--- a/design_docs/planned/v0_35_0/m-git-binary-resolution-sweep-sprint-plan.md
+++ b/design_docs/planned/v0_35_0/m-git-binary-resolution-sweep-sprint-plan.md
@@ -300,7 +300,7 @@ answers: *what would this still pass under, if the claim were false?*
 
 ---
 
-## 4. M2-M4 — mechanical conversions (NOT this iteration)
+## 4. M2-M4 — mechanical conversions (separate iterations)
 
 Each is its own PR, each ratchets `scripts/git_exec_baseline.txt` downward, each adds **no**
 new decision. The contract is frozen by M1; the only per-site work is replacing
@@ -308,7 +308,7 @@ new decision. The contract is frozen by M1; the only per-site work is replacing
 `exec.CommandContext(ctx, "git", args…)` with `gitexec.CommandContext(ctx, args…)`,
 preserving each site's `cmd.Dir` vs `-C` convention verbatim.
 
-### M2 — `internal/coordinator` (1d, 42 sites, 7 files)
+### M2 — `internal/coordinator` (1d, 42 sites, 7 files) — ✅ completed iteration 300
 `worktree.go` 15, `merge.go` 8, `approval_processor.go` 6, `artifact_discovery.go` 5,
 `daemon_tasks_exec_run.go` 4, `daemon_tasks_worktrees.go` 3, `observatory_sync.go` 1.
 Acceptance: baseline sum = **47** (89 − 42, re-derived); `make check-git-exec` rc=0;

--- a/design_docs/planned/v0_35_0/m-git-binary-resolution-sweep-sprint-plan.md
+++ b/design_docs/planned/v0_35_0/m-git-binary-resolution-sweep-sprint-plan.md
@@ -313,9 +313,21 @@ preserving each site's `cmd.Dir` vs `-C` convention verbatim.
 `daemon_tasks_exec_run.go` 4, `daemon_tasks_worktrees.go` 3, `observatory_sync.go` 1.
 Acceptance: baseline sum = **47** (89 − 42, re-derived); `make check-git-exec` rc=0;
 `go test ./internal/coordinator/... -count=1` rc=0 (base rc=0, regression gate).
-Note: 5 sites here and in M3 already discard the error (`_ = cmd.Run()`,
-`daemon_tasks_exec_run.go:461,463`, `coordinator_browse.go:87,240`, `worktree.go:239`).
+The pristine M2 base with its matching 89-site baseline is rc=0. The falsifiable negative
+control is the converted tree with that 89-site baseline preserved: rc=1 with seven
+`tighten the baseline` diagnostics. Ratcheting the baseline to 47 restores rc=0.
+Note: 8 sites here and in M3 already discard the error: 6 in M2
+(`approval_processor.go` 2, `daemon_tasks_exec_run.go` 2, `worktree.go` 2) and 2 in M3
+(`coordinator_browse.go` 2).
 Conversion **preserves** that silent swallow; the design explicitly does not fix them.
+
+Execution deviation for PR #958: the mechanical conversion's first Sonar analysis was red
+on new-code coverage (31.0%) and duplicated-line density (3.9%). The executor added focused
+real-repository tests for merge, worktree inspection/cleanup, and both auto-commit paths;
+factored artifact-path accumulation to remove the reported duplicate block; and replaced the
+four reported repeated Git tokens with package constants. A local coverprofile mapped 50 of
+57 diff-added executable lines as covered (87.7%) before push; Sonar itself must remeasure
+after the follow-up commit is pushed.
 
 ### M3 — `cmd/ailang` (1d, 41 sites, 7 files)
 `coordinator_cloud.go` 14, `coordinator_browse.go` 11, `chains_diff.go` 4,

--- a/internal/coordinator/approval_processor.go
+++ b/internal/coordinator/approval_processor.go
@@ -6,10 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 
+	"github.com/sunholo-data/ailang/internal/gitexec"
 	"github.com/sunholo-data/ailang/internal/messaging"
 	"github.com/sunholo-data/ailang/internal/observatory"
 	"github.com/sunholo-data/ailang/internal/telemetry"
@@ -525,7 +525,7 @@ func processRejection(ctx context.Context, span trace.Span, params *ApprovalPara
 // autoCommitWorktreeChanges commits any uncommitted changes in the worktree.
 func autoCommitWorktreeChanges(worktreePath, taskTitle string) error {
 	// Check for changes
-	statusCmd := exec.Command("git", "-C", worktreePath, "status", "--porcelain")
+	statusCmd := gitexec.Command("-C", worktreePath, "status", "--porcelain")
 	statusOutput, err := statusCmd.Output()
 	if err != nil {
 		return fmt.Errorf("failed to check git status: %w", err)
@@ -536,14 +536,14 @@ func autoCommitWorktreeChanges(worktreePath, taskTitle string) error {
 	}
 
 	// Add all changes
-	addCmd := exec.Command("git", "-C", worktreePath, "add", "-A")
+	addCmd := gitexec.Command("-C", worktreePath, "add", "-A")
 	if output, err := addCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to stage changes: %s", output)
 	}
 
 	// Commit
 	commitMsg := fmt.Sprintf("Agent work: %s\n\nAuto-committed on approval", taskTitle)
-	commitCmd := exec.Command("git", "-C", worktreePath, "commit", "-m", commitMsg)
+	commitCmd := gitexec.Command("-C", worktreePath, "commit", "-m", commitMsg)
 	if output, err := commitCmd.CombinedOutput(); err != nil {
 		// Check if it's just "nothing to commit"
 		if strings.Contains(string(output), "nothing to commit") {
@@ -562,17 +562,17 @@ func cleanupWorktree(worktreePath string) {
 	}
 
 	// Get the branch name before removing worktree
-	branchCmd := exec.Command("git", "-C", worktreePath, "rev-parse", "--abbrev-ref", "HEAD")
+	branchCmd := gitexec.Command("-C", worktreePath, "rev-parse", "--abbrev-ref", "HEAD")
 	branchOutput, _ := branchCmd.Output()
 	branchName := strings.TrimSpace(string(branchOutput))
 
 	// Remove the worktree
-	removeCmd := exec.Command("git", "worktree", "remove", worktreePath, "--force")
+	removeCmd := gitexec.Command("worktree", "remove", worktreePath, "--force")
 	removeCmd.Run() // Ignore errors
 
 	// Also delete the branch
 	if branchName != "" && branchName != "HEAD" {
-		deleteCmd := exec.Command("git", "branch", "-D", branchName)
+		deleteCmd := gitexec.Command("branch", "-D", branchName)
 		deleteCmd.Run() // Ignore errors
 	}
 }

--- a/internal/coordinator/approval_processor.go
+++ b/internal/coordinator/approval_processor.go
@@ -525,7 +525,7 @@ func processRejection(ctx context.Context, span trace.Span, params *ApprovalPara
 // autoCommitWorktreeChanges commits any uncommitted changes in the worktree.
 func autoCommitWorktreeChanges(worktreePath, taskTitle string) error {
 	// Check for changes
-	statusCmd := gitexec.Command("-C", worktreePath, "status", "--porcelain")
+	statusCmd := gitexec.Command("-C", worktreePath, "status", gitFlagPorcelain)
 	statusOutput, err := statusCmd.Output()
 	if err != nil {
 		return fmt.Errorf("failed to check git status: %w", err)
@@ -562,7 +562,7 @@ func cleanupWorktree(worktreePath string) {
 	}
 
 	// Get the branch name before removing worktree
-	branchCmd := gitexec.Command("-C", worktreePath, "rev-parse", "--abbrev-ref", "HEAD")
+	branchCmd := gitexec.Command("-C", worktreePath, gitCommandRevParse, "--abbrev-ref", "HEAD")
 	branchOutput, _ := branchCmd.Output()
 	branchName := strings.TrimSpace(string(branchOutput))
 

--- a/internal/coordinator/artifact_discovery.go
+++ b/internal/coordinator/artifact_discovery.go
@@ -84,59 +84,48 @@ func (ad *ArtifactDiscovery) getChangedFiles() ([]string, error) {
 	// NOTE: Uses two-dot (..) not three-dot (...) to show only what HEAD added,
 	// not symmetric difference which would show changes from parallel branches
 	if base != "" {
-		cmd := gitexec.Command("diff", "--name-only", base+"..HEAD")
+		cmd := gitexec.Command("diff", gitFlagNameOnly, base+"..HEAD")
 		cmd.Dir = ad.WorktreePath
 		output, err := cmd.Output()
-		if err == nil && len(output) > 0 {
-			files := strings.Split(strings.TrimSpace(string(output)), "\n")
-			for _, f := range files {
-				if f != "" {
-					allFiles = append(allFiles, f)
-				}
-			}
+		if err == nil {
+			allFiles = appendUniqueFiles(allFiles, output)
 		}
 	}
 
 	// Also check uncommitted changes (staged + unstaged)
-	cmd := gitexec.Command("diff", "--name-only", "HEAD")
+	cmd := gitexec.Command("diff", gitFlagNameOnly, "HEAD")
 	cmd.Dir = ad.WorktreePath
 	output, err := cmd.Output()
-	if err == nil && len(output) > 0 {
-		files := strings.Split(strings.TrimSpace(string(output)), "\n")
-		for _, f := range files {
-			if f != "" && !sliceContains(allFiles, f) {
-				allFiles = append(allFiles, f)
-			}
-		}
+	if err == nil {
+		allFiles = appendUniqueFiles(allFiles, output)
 	}
 
 	// Get staged changes (in case HEAD doesn't exist yet)
-	cmd = gitexec.Command("diff", "--name-only", "--cached")
+	cmd = gitexec.Command("diff", gitFlagNameOnly, "--cached")
 	cmd.Dir = ad.WorktreePath
 	output, err = cmd.Output()
-	if err == nil && len(output) > 0 {
-		files := strings.Split(strings.TrimSpace(string(output)), "\n")
-		for _, f := range files {
-			if f != "" && !sliceContains(allFiles, f) {
-				allFiles = append(allFiles, f)
-			}
-		}
+	if err == nil {
+		allFiles = appendUniqueFiles(allFiles, output)
 	}
 
 	// Get untracked files
 	cmd = gitexec.Command("ls-files", "--others", "--exclude-standard")
 	cmd.Dir = ad.WorktreePath
 	output, err = cmd.Output()
-	if err == nil && len(output) > 0 {
-		files := strings.Split(strings.TrimSpace(string(output)), "\n")
-		for _, f := range files {
-			if f != "" && !sliceContains(allFiles, f) {
-				allFiles = append(allFiles, f)
-			}
-		}
+	if err == nil {
+		allFiles = appendUniqueFiles(allFiles, output)
 	}
 
 	return allFiles, nil
+}
+
+func appendUniqueFiles(files []string, output []byte) []string {
+	for _, file := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if file != "" && !sliceContains(files, file) {
+			files = append(files, file)
+		}
+	}
+	return files
 }
 
 // detectBaseBranch determines which branch to use as the base for comparison.
@@ -173,7 +162,7 @@ func (ad *ArtifactDiscovery) detectBaseBranch() string {
 
 // branchExists checks if a branch exists in the worktree.
 func (ad *ArtifactDiscovery) branchExists(branch string) bool {
-	cmd := gitexec.Command("rev-parse", "--verify", branch)
+	cmd := gitexec.Command(gitCommandRevParse, "--verify", branch)
 	cmd.Dir = ad.WorktreePath
 	err := cmd.Run()
 	return err == nil

--- a/internal/coordinator/artifact_discovery.go
+++ b/internal/coordinator/artifact_discovery.go
@@ -2,9 +2,10 @@ package coordinator
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/sunholo-data/ailang/internal/gitexec"
 )
 
 // ArtifactDiscovery provides deterministic artifact discovery using git diff.
@@ -83,7 +84,7 @@ func (ad *ArtifactDiscovery) getChangedFiles() ([]string, error) {
 	// NOTE: Uses two-dot (..) not three-dot (...) to show only what HEAD added,
 	// not symmetric difference which would show changes from parallel branches
 	if base != "" {
-		cmd := exec.Command("git", "diff", "--name-only", base+"..HEAD")
+		cmd := gitexec.Command("diff", "--name-only", base+"..HEAD")
 		cmd.Dir = ad.WorktreePath
 		output, err := cmd.Output()
 		if err == nil && len(output) > 0 {
@@ -97,7 +98,7 @@ func (ad *ArtifactDiscovery) getChangedFiles() ([]string, error) {
 	}
 
 	// Also check uncommitted changes (staged + unstaged)
-	cmd := exec.Command("git", "diff", "--name-only", "HEAD")
+	cmd := gitexec.Command("diff", "--name-only", "HEAD")
 	cmd.Dir = ad.WorktreePath
 	output, err := cmd.Output()
 	if err == nil && len(output) > 0 {
@@ -110,7 +111,7 @@ func (ad *ArtifactDiscovery) getChangedFiles() ([]string, error) {
 	}
 
 	// Get staged changes (in case HEAD doesn't exist yet)
-	cmd = exec.Command("git", "diff", "--name-only", "--cached")
+	cmd = gitexec.Command("diff", "--name-only", "--cached")
 	cmd.Dir = ad.WorktreePath
 	output, err = cmd.Output()
 	if err == nil && len(output) > 0 {
@@ -123,7 +124,7 @@ func (ad *ArtifactDiscovery) getChangedFiles() ([]string, error) {
 	}
 
 	// Get untracked files
-	cmd = exec.Command("git", "ls-files", "--others", "--exclude-standard")
+	cmd = gitexec.Command("ls-files", "--others", "--exclude-standard")
 	cmd.Dir = ad.WorktreePath
 	output, err = cmd.Output()
 	if err == nil && len(output) > 0 {
@@ -172,7 +173,7 @@ func (ad *ArtifactDiscovery) detectBaseBranch() string {
 
 // branchExists checks if a branch exists in the worktree.
 func (ad *ArtifactDiscovery) branchExists(branch string) bool {
-	cmd := exec.Command("git", "rev-parse", "--verify", branch)
+	cmd := gitexec.Command("rev-parse", "--verify", branch)
 	cmd.Dir = ad.WorktreePath
 	err := cmd.Run()
 	return err == nil

--- a/internal/coordinator/daemon_tasks_exec_run.go
+++ b/internal/coordinator/daemon_tasks_exec_run.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sunholo-data/ailang/internal/gitexec"
 	"github.com/sunholo-data/ailang/internal/messaging"
 	"github.com/sunholo-data/ailang/internal/observatory"
 	"github.com/sunholo-data/ailang/internal/pkg"
@@ -453,10 +454,10 @@ func (d *Daemon) executeTask(task *TaskRecord) error {
 							d.logger.Printf("Deterministic version bump: %s → %s (%s) for %s",
 								manifest.Package.Version, newVersion, bumpType, agentConfig.ID)
 							// Commit the version bump
-							commitCmd := exec.Command("git", "-C", worktreePath, "add", "-A")
+							commitCmd := gitexec.Command("-C", worktreePath, "add", "-A")
 							commitCmd.Run()
 							commitMsg := fmt.Sprintf("chore: bump %s %s → %s (%s update)", manifest.Package.Name, manifest.Package.Version, newVersion, bumpType)
-							exec.Command("git", "-C", worktreePath, "commit", "-m", commitMsg).Run()
+							gitexec.Command("-C", worktreePath, "commit", "-m", commitMsg).Run()
 						}
 					} else {
 						d.logger.Printf("Warning: Version bump failed for %s: %v", agentConfig.ID, bumpErr)
@@ -677,7 +678,7 @@ func (d *Daemon) executeTask(task *TaskRecord) error {
 // but don't affect task completion.
 func (d *Daemon) enrichResolutionEnvelope(ctx context.Context, task *TaskRecord, worktreePath string) {
 	// Get git diff (HEAD~1..HEAD)
-	diffCmd := exec.Command("git", "diff", "HEAD~1..HEAD", "--stat")
+	diffCmd := gitexec.Command("diff", "HEAD~1..HEAD", "--stat")
 	diffCmd.Dir = worktreePath
 	diffOutput, err := diffCmd.Output()
 	if err != nil {
@@ -686,7 +687,7 @@ func (d *Daemon) enrichResolutionEnvelope(ctx context.Context, task *TaskRecord,
 	}
 
 	// Get commit message
-	logCmd := exec.Command("git", "log", "-1", "--pretty=%B")
+	logCmd := gitexec.Command("log", "-1", "--pretty=%B")
 	logCmd.Dir = worktreePath
 	commitMsg, err := logCmd.Output()
 	if err != nil {

--- a/internal/coordinator/daemon_tasks_worktrees.go
+++ b/internal/coordinator/daemon_tasks_worktrees.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/sunholo-data/ailang/internal/gitexec"
 )
 
 // syncWorktreeState syncs worktree manager in-memory state with actual git worktrees.
@@ -123,7 +124,7 @@ func (d *Daemon) cleanupWorktreesForTerminalTasks() {
 // This ensures agent work is captured even if the agent forgot to commit.
 func autoCommitWorktree(worktreePath, taskTitle string, logger *log.Logger) error {
 	// Check for uncommitted changes (including untracked files)
-	statusCmd := exec.Command("git", "status", "--porcelain")
+	statusCmd := gitexec.Command("status", "--porcelain")
 	statusCmd.Dir = worktreePath
 	output, err := statusCmd.Output()
 	if err != nil {
@@ -140,7 +141,7 @@ func autoCommitWorktree(worktreePath, taskTitle string, logger *log.Logger) erro
 	logger.Printf("Changes:\n%s", string(output))
 
 	// Add all changes (including untracked files)
-	addCmd := exec.Command("git", "add", "-A")
+	addCmd := gitexec.Command("add", "-A")
 	addCmd.Dir = worktreePath
 	if err := addCmd.Run(); err != nil {
 		return fmt.Errorf("git add failed: %w", err)
@@ -150,7 +151,7 @@ func autoCommitWorktree(worktreePath, taskTitle string, logger *log.Logger) erro
 	commitMsg := fmt.Sprintf("Auto-commit: %s\n\nCommitted by AILANG coordinator after agent completion.\n\n🤖 Generated with Claude Code", taskTitle)
 
 	// Commit the changes
-	commitCmd := exec.Command("git", "commit", "-m", commitMsg)
+	commitCmd := gitexec.Command("commit", "-m", commitMsg)
 	commitCmd.Dir = worktreePath
 	commitOutput, err := commitCmd.CombinedOutput()
 	if err != nil {

--- a/internal/coordinator/daemon_tasks_worktrees.go
+++ b/internal/coordinator/daemon_tasks_worktrees.go
@@ -124,7 +124,7 @@ func (d *Daemon) cleanupWorktreesForTerminalTasks() {
 // This ensures agent work is captured even if the agent forgot to commit.
 func autoCommitWorktree(worktreePath, taskTitle string, logger *log.Logger) error {
 	// Check for uncommitted changes (including untracked files)
-	statusCmd := gitexec.Command("status", "--porcelain")
+	statusCmd := gitexec.Command("status", gitFlagPorcelain)
 	statusCmd.Dir = worktreePath
 	output, err := statusCmd.Output()
 	if err != nil {

--- a/internal/coordinator/git_args.go
+++ b/internal/coordinator/git_args.go
@@ -1,0 +1,7 @@
+package coordinator
+
+const (
+	gitCommandRevParse = "rev-parse"
+	gitFlagNameOnly    = "--name-only"
+	gitFlagPorcelain   = "--porcelain"
+)

--- a/internal/coordinator/gitexec_sweep_test.go
+++ b/internal/coordinator/gitexec_sweep_test.go
@@ -1,0 +1,175 @@
+package coordinator
+
+import (
+	"context"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGitexecSweep_MergeOperations(t *testing.T) {
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	if err := initTestGitRepo(repoDir); err != nil {
+		t.Fatalf("initialize repository: %v", err)
+	}
+	if err := runGit(repoDir, "checkout", "-b", "feature"); err != nil {
+		t.Fatalf("create feature branch: %v", err)
+	}
+	writeAndCommitTestFile(t, repoDir, "feature.txt", "feature\n", "add feature")
+
+	ctx := context.Background()
+	diff, err := GetWorktreeDiff(ctx, repoDir, "main", "")
+	if err != nil {
+		t.Fatalf("get worktree diff: %v", err)
+	}
+	if !strings.Contains(diff, "feature.txt") {
+		t.Fatalf("diff does not name feature.txt: %q", diff)
+	}
+
+	branch, err := getWorktreeBranch(ctx, repoDir)
+	if err != nil {
+		t.Fatalf("get worktree branch: %v", err)
+	}
+	if branch != "feature" {
+		t.Fatalf("branch = %q, want feature", branch)
+	}
+
+	files, err := getChangedFiles(ctx, repoDir, "main", "")
+	if err != nil {
+		t.Fatalf("get changed files: %v", err)
+	}
+	if len(files) != 1 || files[0] != "feature.txt" {
+		t.Fatalf("changed files = %v, want [feature.txt]", files)
+	}
+
+	linkedWorktree := filepath.Join(filepath.Dir(repoDir), "linked-worktree")
+	if err := runGit(repoDir, "worktree", "add", "-b", "probe", linkedWorktree, "main"); err != nil {
+		t.Fatalf("create linked worktree: %v", err)
+	}
+	t.Cleanup(func() { _ = runGit(repoDir, "worktree", "remove", "--force", linkedWorktree) })
+	gotMainRepo := getMainRepoPath(linkedWorktree)
+	gotInfo, gotErr := os.Stat(gotMainRepo)
+	wantInfo, wantErr := os.Stat(repoDir)
+	if gotErr != nil || wantErr != nil || !os.SameFile(gotInfo, wantInfo) {
+		t.Fatalf("main repo path = %q, want filesystem identity with %q (got err %v, want err %v)", gotMainRepo, repoDir, gotErr, wantErr)
+	}
+
+	if err := gitCheckout(ctx, repoDir, "main"); err != nil {
+		t.Fatalf("checkout main: %v", err)
+	}
+	if output, err := gitMerge(ctx, repoDir, "feature"); err != nil {
+		t.Fatalf("merge feature: %v\n%s", err, output)
+	}
+	head, err := getHeadCommit(ctx, repoDir)
+	if err != nil {
+		t.Fatalf("get head commit: %v", err)
+	}
+	if head == "" {
+		t.Fatal("head commit is empty")
+	}
+	if err := gitMergeAbort(ctx, repoDir); err == nil {
+		t.Fatal("merge abort unexpectedly succeeded without an active merge")
+	}
+}
+
+func TestGitexecSweep_WorktreeInspectionAndCleanup(t *testing.T) {
+	tmpDir := t.TempDir()
+	repoDir := filepath.Join(tmpDir, "repo")
+	if err := initTestGitRepo(repoDir); err != nil {
+		t.Fatalf("initialize repository: %v", err)
+	}
+
+	wm, err := NewWorktreeManager(repoDir, filepath.Join(tmpDir, "worktrees"), 2)
+	if err != nil {
+		t.Fatalf("create worktree manager: %v", err)
+	}
+	wt, err := wm.CreateWorktree("coverage-task", "main")
+	if err != nil {
+		t.Fatalf("create worktree: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(wt.Path, "changed.txt"), []byte("changed\n"), 0644); err != nil {
+		t.Fatalf("write worktree change: %v", err)
+	}
+
+	hasChanges, err := wm.HasChanges("coverage-task")
+	if err != nil {
+		t.Fatalf("check worktree changes: %v", err)
+	}
+	if !hasChanges {
+		t.Fatal("worktree change was not detected")
+	}
+	summary, err := wm.GetChangeSummary("coverage-task")
+	if err != nil {
+		t.Fatalf("get worktree summary: %v", err)
+	}
+	if len(summary.FilesChanged) != 1 || summary.FilesChanged[0] != "changed.txt" {
+		t.Fatalf("changed files = %v, want [changed.txt]", summary.FilesChanged)
+	}
+	if got := GetDefaultBranch(repoDir); got != "main" {
+		t.Fatalf("default branch = %q, want main", got)
+	}
+
+	if err := wm.CleanupAll(); err != nil {
+		t.Fatalf("cleanup worktrees: %v", err)
+	}
+	if wm.Count() != 0 {
+		t.Fatalf("worktree count = %d after cleanup, want 0", wm.Count())
+	}
+	if _, err := os.Stat(wt.Path); !os.IsNotExist(err) {
+		t.Fatalf("worktree path still exists after cleanup: %v", err)
+	}
+}
+
+func TestGitexecSweep_AutoCommitPaths(t *testing.T) {
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	if err := initTestGitRepo(repoDir); err != nil {
+		t.Fatalf("initialize repository: %v", err)
+	}
+	logger := log.New(io.Discard, "", 0)
+
+	if err := os.WriteFile(filepath.Join(repoDir, "daemon.txt"), []byte("daemon\n"), 0644); err != nil {
+		t.Fatalf("write daemon change: %v", err)
+	}
+	if err := autoCommitWorktree(repoDir, "daemon path", logger); err != nil {
+		t.Fatalf("daemon auto-commit: %v", err)
+	}
+	assertGitWorktreeClean(t, repoDir)
+
+	if err := os.WriteFile(filepath.Join(repoDir, "approval.txt"), []byte("approval\n"), 0644); err != nil {
+		t.Fatalf("write approval change: %v", err)
+	}
+	if err := autoCommitWorktreeChanges(repoDir, "approval path"); err != nil {
+		t.Fatalf("approval auto-commit: %v", err)
+	}
+	assertGitWorktreeClean(t, repoDir)
+}
+
+func writeAndCommitTestFile(t *testing.T, repoDir, name, contents, message string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(repoDir, name), []byte(contents), 0644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	if err := runGit(repoDir, "add", name); err != nil {
+		t.Fatalf("stage %s: %v", name, err)
+	}
+	if err := runGit(repoDir, "commit", "-m", message); err != nil {
+		t.Fatalf("commit %s: %v", name, err)
+	}
+}
+
+func assertGitWorktreeClean(t *testing.T, repoDir string) {
+	t.Helper()
+	cmd := exec.Command("git", "status", "--porcelain")
+	cmd.Dir = repoDir
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git status: %v", err)
+	}
+	if len(output) != 0 {
+		t.Fatalf("worktree is dirty: %s", output)
+	}
+}

--- a/internal/coordinator/merge.go
+++ b/internal/coordinator/merge.go
@@ -120,7 +120,7 @@ func GetWorktreeDiff(ctx context.Context, worktreePath, baseBranch, baseCommit s
 
 // getWorktreeBranch returns the current branch name in the worktree.
 func getWorktreeBranch(ctx context.Context, worktreePath string) (string, error) {
-	cmd := gitexec.CommandContext(ctx, "rev-parse", "--abbrev-ref", "HEAD")
+	cmd := gitexec.CommandContext(ctx, gitCommandRevParse, "--abbrev-ref", "HEAD")
 	cmd.Dir = worktreePath
 	output, err := cmd.Output()
 	if err != nil {
@@ -143,7 +143,7 @@ func getChangedFiles(ctx context.Context, worktreePath, baseBranch, baseCommit s
 		}
 	}
 
-	cmd := gitexec.CommandContext(ctx, "diff", "--name-only", base+"..HEAD")
+	cmd := gitexec.CommandContext(ctx, "diff", gitFlagNameOnly, base+"..HEAD")
 	cmd.Dir = worktreePath
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -171,7 +171,7 @@ func getMainRepoPath(worktreePath string) string {
 	}
 
 	// Get the git directory of the worktree
-	cmd := gitexec.Command("rev-parse", "--git-dir")
+	cmd := gitexec.Command(gitCommandRevParse, "--git-dir")
 	cmd.Dir = worktreePath
 	output, err := cmd.Output()
 	if err != nil {
@@ -220,7 +220,7 @@ func gitMergeAbort(ctx context.Context, repoPath string) error {
 
 // getHeadCommit returns the HEAD commit hash.
 func getHeadCommit(ctx context.Context, repoPath string) (string, error) {
-	cmd := gitexec.CommandContext(ctx, "rev-parse", "HEAD")
+	cmd := gitexec.CommandContext(ctx, gitCommandRevParse, "HEAD")
 	cmd.Dir = repoPath
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/coordinator/merge.go
+++ b/internal/coordinator/merge.go
@@ -4,9 +4,10 @@ package coordinator
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/sunholo-data/ailang/internal/gitexec"
 )
 
 // MergeResult contains the result of a merge operation.
@@ -108,7 +109,7 @@ func GetWorktreeDiff(ctx context.Context, worktreePath, baseBranch, baseCommit s
 	}
 
 	// Compare against the base to show all changes made by this task
-	cmd := exec.CommandContext(ctx, "git", "diff", base+"..HEAD")
+	cmd := gitexec.CommandContext(ctx, "diff", base+"..HEAD")
 	cmd.Dir = worktreePath
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -119,7 +120,7 @@ func GetWorktreeDiff(ctx context.Context, worktreePath, baseBranch, baseCommit s
 
 // getWorktreeBranch returns the current branch name in the worktree.
 func getWorktreeBranch(ctx context.Context, worktreePath string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd := gitexec.CommandContext(ctx, "rev-parse", "--abbrev-ref", "HEAD")
 	cmd.Dir = worktreePath
 	output, err := cmd.Output()
 	if err != nil {
@@ -142,7 +143,7 @@ func getChangedFiles(ctx context.Context, worktreePath, baseBranch, baseCommit s
 		}
 	}
 
-	cmd := exec.CommandContext(ctx, "git", "diff", "--name-only", base+"..HEAD")
+	cmd := gitexec.CommandContext(ctx, "diff", "--name-only", base+"..HEAD")
 	cmd.Dir = worktreePath
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -170,7 +171,7 @@ func getMainRepoPath(worktreePath string) string {
 	}
 
 	// Get the git directory of the worktree
-	cmd := exec.Command("git", "rev-parse", "--git-dir")
+	cmd := gitexec.Command("rev-parse", "--git-dir")
 	cmd.Dir = worktreePath
 	output, err := cmd.Output()
 	if err != nil {
@@ -192,7 +193,7 @@ func getMainRepoPath(worktreePath string) string {
 
 // gitCheckout checks out a branch in the given repo.
 func gitCheckout(ctx context.Context, repoPath, branch string) error {
-	cmd := exec.CommandContext(ctx, "git", "checkout", branch)
+	cmd := gitexec.CommandContext(ctx, "checkout", branch)
 	cmd.Dir = repoPath
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -203,7 +204,7 @@ func gitCheckout(ctx context.Context, repoPath, branch string) error {
 
 // gitMerge merges a branch into the current branch.
 func gitMerge(ctx context.Context, repoPath, branch string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "merge", "--no-edit", branch)
+	cmd := gitexec.CommandContext(ctx, "merge", "--no-edit", branch)
 	cmd.Dir = repoPath
 	output, err := cmd.CombinedOutput()
 	return string(output), err
@@ -211,7 +212,7 @@ func gitMerge(ctx context.Context, repoPath, branch string) (string, error) {
 
 // gitMergeAbort aborts an in-progress merge.
 func gitMergeAbort(ctx context.Context, repoPath string) error {
-	cmd := exec.CommandContext(ctx, "git", "merge", "--abort")
+	cmd := gitexec.CommandContext(ctx, "merge", "--abort")
 	cmd.Dir = repoPath
 	_, err := cmd.CombinedOutput()
 	return err
@@ -219,7 +220,7 @@ func gitMergeAbort(ctx context.Context, repoPath string) error {
 
 // getHeadCommit returns the HEAD commit hash.
 func getHeadCommit(ctx context.Context, repoPath string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "HEAD")
+	cmd := gitexec.CommandContext(ctx, "rev-parse", "HEAD")
 	cmd.Dir = repoPath
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/coordinator/observatory_sync.go
+++ b/internal/coordinator/observatory_sync.go
@@ -7,12 +7,12 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/sunholo-data/ailang/internal/gitexec"
 	"github.com/sunholo-data/ailang/internal/observatory"
 )
 
@@ -214,7 +214,7 @@ func (s *ObservatorySync) generateAssignmentID(taskID, agentID string) string {
 
 // getGitRemote returns the git remote URL for a path, or empty string if not a git repo.
 func (s *ObservatorySync) getGitRemote(path string) string {
-	cmd := exec.Command("git", "-C", path, "remote", "get-url", "origin")
+	cmd := gitexec.Command("-C", path, "remote", "get-url", "origin")
 	output, err := cmd.Output()
 	if err != nil {
 		return ""

--- a/internal/coordinator/worktree.go
+++ b/internal/coordinator/worktree.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -113,7 +112,7 @@ func (wm *WorktreeManager) CreateWorktree(taskID, baseBranch string) (*Worktree,
 	// Capture the commit hash of baseBranch BEFORE creating worktree
 	// This is stable - the branch ref may move later, but this commit is fixed
 	baseCommit := ""
-	commitCmd := exec.Command("git", "rev-parse", baseBranch)
+	commitCmd := gitexec.Command("rev-parse", baseBranch)
 	commitCmd.Dir = wm.repoDir
 	if commitOutput, err := commitCmd.Output(); err == nil {
 		baseCommit = strings.TrimSpace(string(commitOutput))
@@ -124,7 +123,7 @@ func (wm *WorktreeManager) CreateWorktree(taskID, baseBranch string) (*Worktree,
 	worktreePath := filepath.Join(wm.baseDir, sanitizeTaskID(taskID))
 
 	// Create the worktree with a new branch from the specified base branch
-	cmd := exec.Command("git", "worktree", "add", "-b", branchName, worktreePath, baseBranch)
+	cmd := gitexec.Command("worktree", "add", "-b", branchName, worktreePath, baseBranch)
 	cmd.Dir = wm.repoDir
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -155,7 +154,7 @@ func (wm *WorktreeManager) RemoveWorktree(taskID string) error {
 	}
 
 	// Remove the worktree
-	cmd := exec.Command("git", "worktree", "remove", "--force", wt.Path)
+	cmd := gitexec.Command("worktree", "remove", "--force", wt.Path)
 	cmd.Dir = wm.repoDir
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -163,7 +162,7 @@ func (wm *WorktreeManager) RemoveWorktree(taskID string) error {
 	}
 
 	// Delete the branch
-	cmd = exec.Command("git", "branch", "-D", wt.Branch)
+	cmd = gitexec.Command("branch", "-D", wt.Branch)
 	cmd.Dir = wm.repoDir
 	_ = cmd.Run() // Ignore errors - branch might already be deleted
 
@@ -205,7 +204,7 @@ func (wm *WorktreeManager) CleanupOrphaned() (int, error) {
 	defer wm.mu.Unlock()
 
 	// Run git worktree prune
-	cmd := exec.Command("git", "worktree", "prune")
+	cmd := gitexec.Command("worktree", "prune")
 	cmd.Dir = wm.repoDir
 	if err := cmd.Run(); err != nil {
 		return 0, fmt.Errorf("failed to prune worktrees: %w", err)
@@ -230,13 +229,13 @@ func (wm *WorktreeManager) CleanupAll() error {
 
 	var lastErr error
 	for taskID, wt := range wm.worktrees {
-		cmd := exec.Command("git", "worktree", "remove", "--force", wt.Path)
+		cmd := gitexec.Command("worktree", "remove", "--force", wt.Path)
 		cmd.Dir = wm.repoDir
 		if err := cmd.Run(); err != nil {
 			lastErr = err
 		}
 
-		cmd = exec.Command("git", "branch", "-D", wt.Branch)
+		cmd = gitexec.Command("branch", "-D", wt.Branch)
 		cmd.Dir = wm.repoDir
 		_ = cmd.Run()
 
@@ -248,7 +247,7 @@ func (wm *WorktreeManager) CleanupAll() error {
 
 // loadExisting loads existing worktrees from git
 func (wm *WorktreeManager) loadExisting() error {
-	cmd := exec.Command("git", "worktree", "list", "--porcelain")
+	cmd := gitexec.Command("worktree", "list", "--porcelain")
 	cmd.Dir = wm.repoDir
 	output, err := cmd.Output()
 	if err != nil {
@@ -314,7 +313,7 @@ func validateRepoDir(repoDir string) error {
 }
 
 func findGitRoot() (string, error) {
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	cmd := gitexec.Command("rev-parse", "--show-toplevel")
 	output, err := cmd.Output()
 	if err != nil {
 		return "", err
@@ -333,7 +332,7 @@ func (wm *WorktreeManager) HasChanges(taskID string) (bool, error) {
 	}
 
 	// Check for uncommitted changes using git status
-	cmd := exec.Command("git", "status", "--porcelain")
+	cmd := gitexec.Command("status", "--porcelain")
 	cmd.Dir = wt.Path
 	output, err := cmd.Output()
 	if err != nil {
@@ -361,7 +360,7 @@ func (wm *WorktreeManager) GetChangeSummary(taskID string) (*WorktreeChanges, er
 	}
 
 	// Get list of changed files
-	cmd := exec.Command("git", "status", "--porcelain")
+	cmd := gitexec.Command("status", "--porcelain")
 	cmd.Dir = wt.Path
 	output, err := cmd.Output()
 	if err != nil {
@@ -376,13 +375,13 @@ func (wm *WorktreeManager) GetChangeSummary(taskID string) (*WorktreeChanges, er
 	}
 
 	// Get diff summary
-	cmd = exec.Command("git", "diff", "--stat", "HEAD")
+	cmd = gitexec.Command("diff", "--stat", "HEAD")
 	cmd.Dir = wt.Path
 	diffOutput, _ := cmd.Output() // Ignore errors
 	changes.DiffSummary = strings.TrimSpace(string(diffOutput))
 
 	// Get commit count ahead of origin
-	cmd = exec.Command("git", "rev-list", "--count", "origin/dev..HEAD")
+	cmd = gitexec.Command("rev-list", "--count", "origin/dev..HEAD")
 	cmd.Dir = wt.Path
 	countOutput, _ := cmd.Output()
 	if count := strings.TrimSpace(string(countOutput)); count != "" {
@@ -425,7 +424,7 @@ func sanitizeTaskID(taskID string) string {
 // This avoids hardcoding branch names like "main" or "dev".
 func GetDefaultBranch(repoPath string) string {
 	// Method 1: Check symbolic ref (works if origin/HEAD is set)
-	cmd := exec.Command("git", "symbolic-ref", "refs/remotes/origin/HEAD")
+	cmd := gitexec.Command("symbolic-ref", "refs/remotes/origin/HEAD")
 	cmd.Dir = repoPath
 	if output, err := cmd.Output(); err == nil {
 		// Output: refs/remotes/origin/dev -> extract "dev"
@@ -436,7 +435,7 @@ func GetDefaultBranch(repoPath string) string {
 	}
 
 	// Method 2: Query remote directly (slower but more reliable)
-	cmd = exec.Command("git", "remote", "show", "origin")
+	cmd = gitexec.Command("remote", "show", "origin")
 	cmd.Dir = repoPath
 	if output, err := cmd.Output(); err == nil {
 		// Parse "HEAD branch: dev" from output

--- a/internal/coordinator/worktree.go
+++ b/internal/coordinator/worktree.go
@@ -112,7 +112,7 @@ func (wm *WorktreeManager) CreateWorktree(taskID, baseBranch string) (*Worktree,
 	// Capture the commit hash of baseBranch BEFORE creating worktree
 	// This is stable - the branch ref may move later, but this commit is fixed
 	baseCommit := ""
-	commitCmd := gitexec.Command("rev-parse", baseBranch)
+	commitCmd := gitexec.Command(gitCommandRevParse, baseBranch)
 	commitCmd.Dir = wm.repoDir
 	if commitOutput, err := commitCmd.Output(); err == nil {
 		baseCommit = strings.TrimSpace(string(commitOutput))
@@ -247,7 +247,7 @@ func (wm *WorktreeManager) CleanupAll() error {
 
 // loadExisting loads existing worktrees from git
 func (wm *WorktreeManager) loadExisting() error {
-	cmd := gitexec.Command("worktree", "list", "--porcelain")
+	cmd := gitexec.Command("worktree", "list", gitFlagPorcelain)
 	cmd.Dir = wm.repoDir
 	output, err := cmd.Output()
 	if err != nil {
@@ -306,14 +306,14 @@ func validateRepoDir(repoDir string) error {
 	if !info.IsDir() {
 		return fmt.Errorf("worktree repo dir %q is not a directory", repoDir)
 	}
-	if err := gitexec.Command("-C", repoDir, "rev-parse", "--git-dir").Run(); err != nil {
+	if err := gitexec.Command("-C", repoDir, gitCommandRevParse, "--git-dir").Run(); err != nil {
 		return fmt.Errorf("worktree repo dir %q is not a git repository: %w", repoDir, err)
 	}
 	return nil
 }
 
 func findGitRoot() (string, error) {
-	cmd := gitexec.Command("rev-parse", "--show-toplevel")
+	cmd := gitexec.Command(gitCommandRevParse, "--show-toplevel")
 	output, err := cmd.Output()
 	if err != nil {
 		return "", err
@@ -332,7 +332,7 @@ func (wm *WorktreeManager) HasChanges(taskID string) (bool, error) {
 	}
 
 	// Check for uncommitted changes using git status
-	cmd := gitexec.Command("status", "--porcelain")
+	cmd := gitexec.Command("status", gitFlagPorcelain)
 	cmd.Dir = wt.Path
 	output, err := cmd.Output()
 	if err != nil {
@@ -360,7 +360,7 @@ func (wm *WorktreeManager) GetChangeSummary(taskID string) (*WorktreeChanges, er
 	}
 
 	// Get list of changed files
-	cmd := gitexec.Command("status", "--porcelain")
+	cmd := gitexec.Command("status", gitFlagPorcelain)
 	cmd.Dir = wt.Path
 	output, err := cmd.Output()
 	if err != nil {

--- a/scripts/git_exec_baseline.txt
+++ b/scripts/git_exec_baseline.txt
@@ -5,12 +5,5 @@ cmd/ailang/coordinator_cloud_github.go 2
 cmd/ailang/coordinator_inspect.go 4
 cmd/ailang/coordinator_utils.go 3
 cmd/ailang/messages_send.go 3
-internal/coordinator/approval_processor.go 6
-internal/coordinator/artifact_discovery.go 5
-internal/coordinator/daemon_tasks_exec_run.go 4
-internal/coordinator/daemon_tasks_worktrees.go 3
-internal/coordinator/merge.go 8
-internal/coordinator/observatory_sync.go 1
-internal/coordinator/worktree.go 15
 internal/eval_harness/gemini_evaluator_bridge.go 1
 internal/pkg/gitcache.go 5


### PR DESCRIPTION
Mission-control iteration 300, M-GIT-BINARY-RESOLUTION-SWEEP M2.

Converts exactly 42 coordinator Git subprocess sites across seven files to the M1 gitexec contract, preserves arguments, working-directory conventions, and error handling, and ratchets the bare-site baseline from 89 to 47.

Independent evaluator: PASS 100/100, zero blocking findings. Generator gpt-5.6-sol; independent judge gpt-5.5 fallback because the Agent interface did not expose the configured sonnet pin.

Verified: coordinator and gitexec tests, narrowed build, full make test, lint, fmt, boundaries, file sizes, changelog, gate self-tests, missing-fixture anti-vacuity, and pre-ratchet failure.