### PR TITLE
fix(dx): preserve identical unmanaged pi extensions

### DIFF
--- a/cmd/ailang/pi_setup.go
+++ b/cmd/ailang/pi_setup.go
@@ -55,11 +55,10 @@ type piManagedManifest struct {
 
 // decidePiInstall returns the action for one embedded file:
 //   - "install"   absent on disk → write + record
-//   - "adopt"     present, content identical to embedded, previously unmanaged → record only
 //   - "current"   present, managed, content identical, same binary version → nothing
 //   - "update"    managed content is unchanged since install and this binary ships a newer asset → replace safely
 //   - "conflict-user-modified"  managed file whose content changed on disk → preserve, suggest
-//   - "conflict-unmanaged"      present, unmanaged, different content → preserve, suggest
+//   - "conflict-unmanaged"      present and unmanaged → preserve, suggest
 func decidePiInstall(
 	name string,
 	embedded []byte,
@@ -71,22 +70,19 @@ func decidePiInstall(
 	if diskHash == "" {
 		return "install", false
 	}
+	if managed == nil {
+		return "conflict-unmanaged", true
+	}
 	if diskHash == embeddedHash {
-		if managed != nil {
-			if managed.Version == binaryVersion {
-				return "current", false
-			}
-			return "update", false
+		if managed.Version == binaryVersion {
+			return "current", false
 		}
-		return "adopt", false
+		return "update", false
 	}
-	if managed != nil {
-		if diskHash == managed.SHA256 {
-			return "update", false
-		}
-		return "conflict-user-modified", true
+	if diskHash == managed.SHA256 {
+		return "update", false
 	}
-	return "conflict-unmanaged", true
+	return "conflict-user-modified", true
 }
 
 // ── embedded assets + manifest IO ────────────────────────────────────────────
@@ -169,7 +165,7 @@ func installPiExtensions(home string, stdout, stderr io.Writer) error {
 	}
 	managed := readPiManaged(home)
 
-	var installed, updated, adopted, unchanged, conflicts int
+	var installed, updated, unchanged, conflicts int
 	for _, name := range names {
 		data := embedded[name]
 		target := filepath.Join(extDir, name)
@@ -191,9 +187,6 @@ func installPiExtensions(home string, stdout, stderr io.Writer) error {
 			}
 			managed[name] = piManagedFile{SHA256: sha256Hex(data), Version: Version, Size: int64(len(data))}
 			installed++
-		case "adopt":
-			managed[name] = piManagedFile{SHA256: sha256Hex(data), Version: Version, Size: int64(len(data))}
-			adopted++
 		case "current":
 			unchanged++
 		case "update":
@@ -226,8 +219,8 @@ func installPiExtensions(home string, stdout, stderr io.Writer) error {
 	}
 
 	fmt.Fprintf(stdout, "%s pi extensions in %s\n", green("✓"), extDir)
-	fmt.Fprintf(stdout, "  installed: %d, updated: %d, adopted: %d, current: %d, conflicts preserved: %d\n",
-		installed, updated, adopted, unchanged, conflicts)
+	fmt.Fprintf(stdout, "  installed: %d, updated: %d, current: %d, conflicts preserved: %d\n",
+		installed, updated, unchanged, conflicts)
 	if installed+updated > 0 {
 		fmt.Fprintf(stdout, "  %s restart pi sessions to load the refreshed extension set\n", cyan("ℹ"))
 	}

--- a/cmd/ailang/pi_setup_test.go
+++ b/cmd/ailang/pi_setup_test.go
@@ -23,7 +23,7 @@ func TestDecidePiInstall(t *testing.T) {
 		suggested bool
 	}{
 		{name: "absent → install", diskHash: "", managed: nil, want: "install"},
-		{name: "identical unmanaged → adopt", diskHash: sha256Hex([]byte(embeddedContent)), managed: nil, want: "adopt"},
+		{name: "identical unmanaged → conflict, preserve", diskHash: sha256Hex([]byte(embeddedContent)), managed: nil, want: "conflict-unmanaged", suggested: true},
 		{name: "managed identical, same binary → current",
 			diskHash: sha256Hex([]byte(embeddedContent)),
 			managed:  &piManagedFile{SHA256: sha256Hex([]byte(embeddedContent)), Version: v2},
@@ -238,6 +238,60 @@ func TestPiInstallPreservesUnmanagedConflict(t *testing.T) {
 	}
 	if !bytes.Equal(suggested, embedded[name]) {
 		t.Fatal("unmanaged conflict suggestion differs from embedded asset")
+	}
+}
+
+func TestPiIdenticalUnmanagedAssetRemainsUnmanaged(t *testing.T) {
+	home := t.TempDir()
+	extDir := piExtensionsDir(home)
+	if err := os.MkdirAll(extDir, 0o755); err != nil {
+		t.Fatalf("mkdir extension dir: %v", err)
+	}
+	embedded, _, err := piEmbeddedFiles()
+	if err != nil {
+		t.Fatalf("embedded files: %v", err)
+	}
+	name := "provider-quota.ts"
+	target := filepath.Join(extDir, name)
+	if err := os.WriteFile(target, embedded[name], 0o644); err != nil {
+		t.Fatalf("write identical unmanaged asset: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := installPiExtensions(home, &stdout, &stderr); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if got, err := os.ReadFile(target); err != nil || !bytes.Equal(got, embedded[name]) {
+		t.Fatalf("identical unmanaged asset was not preserved: got %q, err %v", got, err)
+	}
+	if _, managed := readPiManifestForTest(t, home).Files[name]; managed {
+		t.Fatal("identical unmanaged asset was adopted into the managed manifest")
+	}
+	if !strings.Contains(stderr.String(), name+" — preserved") {
+		t.Fatalf("identical unmanaged warning missing:\n%s", stderr.String())
+	}
+	suggested, err := os.ReadFile(piSuggestedPath(home, name))
+	if err != nil {
+		t.Fatalf("read identical unmanaged suggestion: %v", err)
+	}
+	if !bytes.Equal(suggested, embedded[name]) {
+		t.Fatal("identical unmanaged suggestion differs from embedded asset")
+	}
+
+	stdout.Reset()
+	if err := statusPiExtensions(home, &stdout); err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "UNMANAGED  "+name) {
+		t.Fatalf("status did not report identical unmanaged asset as UNMANAGED:\n%s", stdout.String())
+	}
+
+	stdout.Reset()
+	if err := uninstallPiExtensions(home, &stdout); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	if got, err := os.ReadFile(target); err != nil || !bytes.Equal(got, embedded[name]) {
+		t.Fatalf("uninstall removed or changed identical unmanaged asset: got %q, err %v", got, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve pre-existing unmanaged Pi extensions even when their bytes match the embedded asset
- keep them out of the managed manifest and report them as `UNMANAGED`
- add lifecycle coverage proving warnings, suggested copies, and uninstall survival

## Verification

- `go test ./... -count=1`
- `go test ./cmd/ailang -count=1`
- `go vet ./cmd/ailang`
- `make lint`
- `make fmt-check`
- `make verify-pi-assets`
- `git diff --check`

Independent evaluator: PASS 97/100, zero blocking findings (`gpt-5.6-luna`; executor `gpt-5.6-sol`).

Part of M-DX-PI-HARNESS M5 closeout. D-49 remains separate and open.
