### PR TITLE
fix(ci): update Pi lifecycle inventory for quality-monitor

### DIFF
--- a/cmd/ailang/pi_setup_test.go
+++ b/cmd/ailang/pi_setup_test.go
@@ -71,8 +71,8 @@ func TestPiFilesystemLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("embedded files: %v", err)
 	}
-	if got, want := len(names), 10; got != want {
-		t.Fatalf("embedded asset count = %d, want %d (9 extensions + README)", got, want)
+	if got, want := len(names), 11; got != want {
+		t.Fatalf("embedded asset count = %d, want %d (10 extensions + README)", got, want)
 	}
 	var extensionCount int
 	for _, name := range names {
@@ -87,8 +87,8 @@ func TestPiFilesystemLifecycle(t *testing.T) {
 			t.Errorf("installed %s differs from embedded asset", name)
 		}
 	}
-	if extensionCount != 9 {
-		t.Fatalf("installed extension count = %d, want 9", extensionCount)
+	if extensionCount != 10 {
+		t.Fatalf("installed extension count = %d, want 10", extensionCount)
 	}
 
 	manifestBefore := readPiManifestForTest(t, home)
@@ -100,7 +100,7 @@ func TestPiFilesystemLifecycle(t *testing.T) {
 	if err := installPiExtensions(home, &stdout, &stderr); err != nil {
 		t.Fatalf("idempotent install: %v", err)
 	}
-	if !strings.Contains(stdout.String(), "current: 10") {
+	if !strings.Contains(stdout.String(), "current: 11") {
 		t.Fatalf("second install did not report all assets current:\n%s", stdout.String())
 	}
 	manifestAfter := readPiManifestForTest(t, home)


### PR DESCRIPTION
Gate-1 required-CI recovery for M-DX-QUALITY-MONITOR.\n\nUpdates the lifecycle test's frozen inventory from 10 total / 9 extensions to 11 total / 10 extensions after quality-monitor joined the embedded suite. No production code changes.\n\nVerified: focused lifecycle test, mutation red/restored green, go test ./cmd/ailang, make test, make lint, make verify-pi-assets. Independent evaluator PASS 100/100.