### PR TITLE
fix(ci): give process-tree discovery its own deadline

### DIFF
--- a/tools/eval/motoko_connection_probe.sh
+++ b/tools/eval/motoko_connection_probe.sh
@@ -124,8 +124,10 @@ benchmark=${4:-hello_world}
 ailang_bin=${AILANG_BIN:-ailang}
 timeout_secs=${PROBE_TIMEOUT_SECS:-900}
 MAX_TREE_NODES=${PROBE_MAX_TREE_NODES:-4096}
+TREE_DISCOVERY_SECS=${PROBE_TREE_DISCOVERY_SECS:-30}
 [[ "$timeout_secs" =~ ^[1-9][0-9]*$ ]] || instrument_failure "PROBE_TIMEOUT_SECS must be a positive integer"
 [[ "$MAX_TREE_NODES" =~ ^[1-9][0-9]*$ ]] || instrument_failure "PROBE_MAX_TREE_NODES must be a positive integer"
+[[ "$TREE_DISCOVERY_SECS" =~ ^[1-9][0-9]*$ ]] || instrument_failure "PROBE_TREE_DISCOVERY_SECS must be a positive integer"
 [[ $(uname -sm) == "Darwin arm64" ]] || instrument_failure "live probe requires darwin/arm64"
 command -v dig >/dev/null || instrument_failure "dig is required"
 command -v lsof >/dev/null || instrument_failure "lsof is required"
@@ -209,11 +211,12 @@ assert_pid_scope() {
 }
 
 sample_tree() {
-  local root=$1 raw_file=$2 deadline=$3 pids
+  local root=$1 raw_file=$2 pids discovery_deadline
+  discovery_deadline=$(( $(date +%s) + TREE_DISCOVERY_SECS ))
   if [[ -n "${PROBE_TEST_PID_SCOPE+x}" ]]; then
     pids=$PROBE_TEST_PID_SCOPE
   else
-    if ! pids=$(descendant_pids "$root" "$deadline"); then
+    if ! pids=$(descendant_pids "$root" "$discovery_deadline"); then
       instrument_failure "process-tree discovery failed"
     fi
   fi
@@ -268,7 +271,7 @@ run_lane() {
       { wait "$pid"; } >/dev/null 2>&1 || true
       instrument_failure "lane $lane exceeded ${timeout_secs}s sampling deadline"
     fi
-    sample_tree "$pid" "$raw_file" "$deadline"
+    sample_tree "$pid" "$raw_file"
     sleep 1
   done
   { wait "$pid"; } 2>/dev/null || lane_rc=$?

--- a/tools/eval/test_motoko_connection_probe.sh
+++ b/tools/eval/test_motoko_connection_probe.sh
@@ -273,7 +273,7 @@ expect_failure "descendant discovery deadline refuses at the caller" "process-tr
 expect_failure "lane sampling deadline refuses" "exceeded 1s sampling deadline" \
   run_live PROBE_TEST_DRIVER_SLEEP=10 PROBE_TIMEOUT_SECS=1
 expect_failure "bounded termination deadline refuses" "bounded termination deadline" \
-  run_live PROBE_TEST_DRIVER_SLEEP=20 PROBE_TEST_IGNORE_TERM=1 PROBE_TIMEOUT_SECS=1
+  run_live PROBE_TEST_DRIVER_SLEEP=20 PROBE_TEST_IGNORE_TERM=1 PROBE_TIMEOUT_SECS=1 PROBE_TREE_DISCOVERY_SECS=30
 
 success_artifact="$tmp_dir/success/probe.json"
 mkdir -p "$tmp_dir/success"
@@ -349,21 +349,17 @@ fi
 # makes the process tree self-referential and never empties the queue — the only way to reach the
 # in-loop `date` check. The stub was written for this and no invocation used it, so the branch
 # that actually bounds the walk was unexercised while an arm claimed the deadline was pinned.
-# WIDER CAP FOR THIS ARM ONLY (deflake, 2026-08-27). The self-referential pgrep
-# walk normally trips the probe's 1s internal deadline in a second or two — but
-# each loop iteration SPAWNS a stub process, and on a contended shared CI runner
-# those spawns degrade until total wall time blows through the global 120s arm
-# cap long before the per-iteration date check accumulates to its limit. CI run
-# 33001432738 (2026-08-26) failed exactly here on a commit touching no related
-# files, and the identical suite passed on the next commit. The refusal itself
-# is what this arm proves and it still MUST happen — the generosity only widens
-# how long we wait for a degraded runner to get there, and stays bounded.
-_arm_cap_saved=$ARM_CAP_SECS
-ARM_CAP_SECS=$(( ARM_CAP_SECS * 5 ))
+# DETERMINISTIC BY CONSTRUCTION (de-race, 2026-08-31): discovery and the lane deadline are now
+# independently bounded. This arm pins the discovery deadline to a 1s bound
+# (PROBE_TREE_DISCOVERY_SECS=1) so the process-tree walk trips its in-loop date check in about a
+# second no matter how fast or slow the machine is, while the LANE deadline is raised to 60s
+# (PROBE_TIMEOUT_SECS=60) so the lane's bounded-termination branch can NEVER win the race. The
+# refusal fires as soon as the discovery deadline passes — no wide arm cap needed, and no race to
+# the 600s arm cap.
 expect_failure "descendant discovery refuses on the real wall-clock deadline" "process-tree discovery failed" \
-  env PATH="$live_bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=1 PROBE_TEST_PGREP_LOOP=1 \
-    PROBE_STUB_STATE="$tmp_dir/lane-pgreploop" /bin/bash "$probe" treatment control "$tmp_dir/pgreploop.json"
-ARM_CAP_SECS=$_arm_cap_saved
+  env PATH="$live_bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=60 PROBE_TREE_DISCOVERY_SECS=1 \
+    PROBE_TEST_PGREP_LOOP=1 PROBE_STUB_STATE="$tmp_dir/lane-pgreploop" \
+    /bin/bash "$probe" treatment control "$tmp_dir/pgreploop.json"
 
 cap_secs_fixture=2
 cap_start=$(date +%s)
@@ -465,6 +461,10 @@ expect_failure "tree node ceiling rejects invalid values" \
   "PROBE_MAX_TREE_NODES must be a positive integer" \
   env PROBE_MAX_TREE_NODES=invalid /bin/bash "$probe" treatment control "$tmp_dir/invalid-node-limit.json"
 
+expect_failure "tree discovery deadline rejects invalid values" \
+  "PROBE_TREE_DISCOVERY_SECS must be a positive integer" \
+  env PROBE_TREE_DISCOVERY_SECS=invalid /bin/bash "$probe" treatment control "$tmp_dir/invalid-tree-discovery.json"
+
 expect_failure "descendant discovery refuses on the node-count ceiling" "process-tree discovery exceeded 3 nodes" \
   env PATH="$live_bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=60 PROBE_MAX_TREE_NODES=3 \
     PROBE_TEST_PGREP_LOOP=1 PROBE_STUB_STATE="$tmp_dir/lane-node-limit" \
@@ -474,7 +474,7 @@ expect_failure "descendant discovery refuses on the node-count ceiling" "process
 # a removal proves the check FIRES; only an addition proves it LOOKS. Adding a new refusal to the
 # probe passes the whole suite byte-identically, so the coverage claim is a one-time manual count
 # that silently rots on the next edit. Count the branches and refuse when the number moves.
-expected_refusal_branches=24
+expected_refusal_branches=25
 actual_instrument_failures=$(grep -c 'instrument_failure "' "$probe")
 actual_usage_refusals=$(grep -cE '\|\| usage$' "$probe")
 # Anti-vacuity: a counter that returns zero is a broken instrument, not a clean result.


### PR DESCRIPTION
Mission-control iteration 308 — second half of the dev CI-red preemption.

## The defect

`tools/eval/motoko_connection_probe.sh` `run_lane()` computed **one** deadline from `PROBE_TIMEOUT_SECS` and used it for **two different bounds**:

- the lane's own sampling/termination check (`if (( now > deadline ))`), and
- the process-tree **discovery** bound, threaded down through `sample_tree` into `descendant_pids`.

Because both bounds were the same instant, which branch fired was decided by how fast the machine was, not by what the test was exercising. Two arms of `tools/eval/test_motoko_connection_probe.sh` need **opposite** branches to win that race:

| arm | needs |
|---|---|
| `bounded termination deadline refuses` | the TERMINATION branch to win |
| `descendant discovery refuses on the real wall-clock deadline` | the DISCOVERY branch to win |

They were separated only by machine speed.

## Evidence (controller-measured, first-party)

- dev CI red at `0b35abd5d`: arm 27 got `process-tree discovery deadline expired` / `INSTRUMENT FAILURE: process-tree discovery failed` instead of the message it asserts.
- Same suite red at `8146e62bc` (2026-08-29) on the **sibling** arm, that time by running past its 600s arm cap.
- Locally (darwin/arm64) the suite is rc=0, 40/40 — a local green proves nothing about this class.
- `launchd drivers (bash 3.2)` **passed** on PR #969 and on merge `c29ec1d00`, whose `tools/eval/**` bytes are **identical** to the tree where it failed. Outcome divergence on byte-identical code — the variable is the environment.

## The fix

`PROBE_TREE_DISCOVERY_SECS` (default 30, validated exactly like `PROBE_MAX_TREE_NODES`). `sample_tree` computes its discovery deadline at call time; the lane deadline is no longer threaded into discovery. Each arm now drives **its own** knob, so neither outcome depends on machine speed.

This also retires the `ARM_CAP_SECS * 5` widening added 2026-08-27 for the sibling arm — that was a calibration band-aid on this same race. The refusal now fires in about a second regardless of contention, so the wide cap is no longer needed.

## Verification

| gate | base (pristine dev) | post-change |
|---|---|---|
| `/bin/bash tools/eval/test_motoko_connection_probe.sh` | rc=0, 40 arms | rc=0, **41** arms |
| `/bin/bash -n tools/eval/motoko_connection_probe.sh` | rc=0 | rc=0 |
| `/bin/bash -n tools/eval/test_motoko_connection_probe.sh` | rc=0 | rc=0 |
| `make test-launchd-drivers` | rc=0 | rc=0 |

**Determinism drill (the load-bearing one):** suite run 5× under 8 CPU spinners (load average ~24–28) → exit codes `0 0 0 0 0`, 41/41 arms each run. Varying *contention* is the axis this defect actually lives on.

`expected_refusal_branches` 24 → 25, with a new arm pinning the new knob's validation refusal.

Green on darwin/arm64 locally; the ubuntu/windows matrix legs are unrun here and are exactly what this PR's CI is for.

Executor: DeepSeek V4 Flash 0731 via the pi lane (the codex lane is quota-exhausted this fire). The lane hit its 30-minute wall cap during the under-load drill and is FLAGGED as `wall_timeout` in the iteration record; the controller re-ran every gate and the drill first-party.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
