### PR TITLE
fix(ci): re-sync embedded pi assets after the README-only edit in ebc089c33

### DIFF
--- a/cmd/ailang/pi_assets/README.md
+++ b/cmd/ailang/pi_assets/README.md
@@ -34,6 +34,19 @@ First session per machine prompts once to trust the project; after that every
 session arms the gate and gets the tools (`ailang_check`, `builtins_search`,
 `freshness_report`, `quota_report`). Verify with `pi -p --no-session "call quota_report"`.
 
+**⚠ Headless sessions never see that prompt and are silently extension-less until
+trust is saved** (measured 2026-08-31 on pi 0.84.4; pi ≤0.73 had no gate at all).
+`-p` / `--mode json` / `--mode rpc` show no trust prompt — with no saved decision they
+fall back to `defaultProjectTrust: "ask"`, which *ignores* project resources and reports
+no error anywhere. The fix is one saved decision in `~/.pi/agent/trust.json` (flat map,
+canonical path → `true`, parent directories inherit): trust the PARENT that contains all
+checkouts and worktrees, e.g. on the rig `/Users/voightkampff/dev/sunholo-data` and
+`/Users/voightkampff/.ailang-driver-pin`. Fresh mission worktrees are new paths every
+fire, so per-project trust does not scale — parent trust is the mechanism. And when
+verifying, require `tool_execution_start`/`end` events in the JSON stream: a substring
+match on the tool name is satisfied by the model merely *echoing* it, and `pi list`
+lists settings-installed packages only, not repo-auto extensions.
+
 ### Tier 2 — cloud/fleet images: installed at build time
 
 `docker/Dockerfile.agent-pi` runs `ailang pi install` as the `ailang` runtime


### PR DESCRIPTION
`dev` is red on `test` step 20, "Verify embedded pi assets are in sync":

```
DRIFT: cmd/ailang/pi_assets is stale vs .pi/extensions — run 'make pi-assets'
```

## Cause

`ebc089c33` added 13 lines to `.pi/extensions/README.md` (the pi ≥ 0.84 headless trust-gate note) without mirroring them into the embedded copy. `make verify-pi-assets` is `diff -rq -x '.*'` over the two trees, so a source-only edit reds it.

Attribution — `test` verdict walked back over dev:

| commit | `test` |
|---|---|
| `d65a0900c` | failure |
| `ebc089c33` | **failure** ← first |
| `15cec372b` | success |
| `9f267cf1f` | success |

## Fix

The gate's own remedy, `make pi-assets`. Nothing hand-edited — the target copies `.pi/extensions/*` into `cmd/ailang/pi_assets/`.

## Verification

| step | result |
|---|---|
| baseline `make verify-pi-assets` | rc=2, DRIFT on `README.md` |
| `make pi-assets` | rc=0 — `pi_assets synced from .pi/extensions` |
| `make verify-pi-assets` | **rc=0** |
| `diff -rq -x '.*' .pi/extensions cmd/ailang/pi_assets` | IDENTICAL |
| `cmp .pi/extensions/README.md cmd/ailang/pi_assets/README.md` | byte-identical |
| `git status --porcelain` | only `cmd/ailang/pi_assets/README.md` |
| `go test ./cmd/ailang -run 'TestPiFilesystemLifecycle\|TestDecidePiInstall'` | **rc=0** |

Those two tests read the embedded assets, so they are the behavioural check on the regenerated copy rather than just a re-run of the diff.

**Non-vacuity:** appending a single byte to the embedded README makes `diff -rq` report a difference, so the rc=0 above is a measurement and not a gate that cannot fail. Restored and re-verified identical afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
