### PR TITLE
docs(examples): docs-5 — add main entrypoints to 7 parser-regression fixtures

### DIFF
--- a/examples/manifest.json
+++ b/examples/manifest.json
@@ -145,7 +145,10 @@
         "demo",
         "blocks"
       ],
-      "description": "Block Demo example"
+      "description": "Block Demo example",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "block_recursion.ail",
@@ -902,7 +905,10 @@
       "tags": [
         "pattern-matching"
       ],
-      "description": "Match arm with explicit block containing match"
+      "description": "Match arm with explicit block containing match",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "match_arm_block_io.ail",
@@ -921,7 +927,10 @@
       "tags": [
         "pattern-matching"
       ],
-      "description": "Even simpler: block with let THEN match"
+      "description": "Even simpler: block with let THEN match",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "math_trig.ail",
@@ -998,7 +1007,10 @@
         "pattern-matching",
         "records"
       ],
-      "description": "Absolute minimal case: single nested match with block arms"
+      "description": "Absolute minimal case: single nested match with block arms",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "nested_match_simple.ail",
@@ -2660,7 +2672,10 @@
       "tags": [
         "testing"
       ],
-      "description": "Test Module Minimal example"
+      "description": "Test Module Minimal example",
+      "modules": [
+        "std/io"
+      ]
     },
     {
       "path": "type_classes.ail",

--- a/examples/runnable/block_demo.ail
+++ b/examples/runnable/block_demo.ail
@@ -1,4 +1,5 @@
 module examples/runnable/block_demo
+import std/io (println)
 
 export func compute() -> int {
   let x = 1 + 2
@@ -15,4 +16,10 @@ export func multiStep() -> int {
   let a = 10
   let b = 20
   a + b
+}
+
+export func main() -> () ! {IO} {
+  println(show(compute()))
+  println(show(singleLine()))
+  println(show(multiStep()))
 }

--- a/examples/runnable/match_arm_block.ail
+++ b/examples/runnable/match_arm_block.ail
@@ -1,4 +1,5 @@
 module examples/runnable/match_arm_block
+import std/io (println)
 
 // Match arm with explicit block containing match
 
@@ -12,4 +13,8 @@ export func test() -> int {
       }
     }
   }
+}
+
+export func main() -> () ! {IO} {
+  println(show(test()))
 }

--- a/examples/runnable/match_arm_block_io.ail
+++ b/examples/runnable/match_arm_block_io.ail
@@ -15,3 +15,7 @@ export func test() -> () ! {IO} {
     }
   }
 }
+
+export func main() -> () ! {IO} {
+  test()
+}

--- a/examples/runnable/match_in_block.ail
+++ b/examples/runnable/match_in_block.ail
@@ -1,4 +1,5 @@
 module examples/runnable/match_in_block
+import std/io (println)
 
 // Even simpler: block with let THEN match
 
@@ -8,4 +9,8 @@ export func test() -> int {
   match y {
     (a, b) => a + b
   }
+}
+
+export func main() -> () ! {IO} {
+  println(show(test()))
 }

--- a/examples/runnable/nested_match_minimal.ail
+++ b/examples/runnable/nested_match_minimal.ail
@@ -1,4 +1,5 @@
 module examples/runnable/nested_match_minimal
+import std/io (println)
 
 // Absolute minimal case: single nested match with block arms
 
@@ -12,4 +13,8 @@ export func test() -> int {
       }
     }
   }
+}
+
+export func main() -> () ! {IO} {
+  println(show(test()))
 }

--- a/examples/runnable/simple_func_match.ail
+++ b/examples/runnable/simple_func_match.ail
@@ -14,3 +14,7 @@ export func test() -> () ! {IO} {
     _ => ()
   }
 }
+
+export func main() -> () ! {IO} {
+  test()
+}

--- a/examples/runnable/test_module_minimal.ail
+++ b/examples/runnable/test_module_minimal.ail
@@ -1,5 +1,10 @@
 module examples/runnable/test_module_minimal
+import std/io (println)
 
 export func hello() -> string {
   "hello"
+}
+
+export func main() -> () ! {IO} {
+  println(hello())
 }


### PR DESCRIPTION
## Summary
- Queue item `docs-5` (docs-mission, clause 2: examples compile and run). Adds a `main` entrypoint to 7 small AILANG example fixtures under `examples/runnable/` that `docs/docs-sync-findings.md` (DOCS-2-05 through DOCS-2-11) flagged as failing `entrypoint 'main' not found` — parser-regression fixtures that the generic runnable-examples checker sweeps as if they were user demos. No existing exported function bodies/signatures changed, purely additive.
- Fixes a `examples/manifest.json` module-drift on 5 of those files (found by independent evaluator re-check): the new `import std/io (println)` needed a matching `"modules": ["std/io"]` manifest entry so `make verify-examples`'s drift check stays in sync.
- `batch_processing.ail` / `cli_args_demo.ail` (the other 2 of the original 9 findings, DOCS-2-12/13) already have `main` entrypoints in current `dev` — resolved independently, out of scope here.

This work was recovered from a died-mid-flight docs-mission iteration (2026-08-28, abandoned worktree, 94 commits stale) whose sprint brief/plan matched this scope exactly; base files were confirmed byte-identical to current `dev` before reapplying. Independently verified twice by a separate sprint-evaluator agent (fresh binary build, own negative control, own manifest re-run) — round 1 found the manifest drift (blocking), round 2 confirmed the fix and PASSed.

## Test plan
- [x] `ailang check` + `ailang run --caps IO` rc=0 on all 7 changed files (verified by controller and independently by evaluator)
- [x] Negative control: pre-edit file fails with `entrypoint 'main' not found` (verified twice, independently)
- [x] `make verify-examples`: 211 passed / 0 failed, 193 modules checked / 0 drift
- [x] Diff scope confirmed limited to the 7 example files + manifest.json — no changes to `batch_processing.ail`, `cli_args_demo.ail`, `check_examples.sh`, or mission docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)