### PR TITLE
M3: pkg.BuildModuleIface subprocess wrapper + PublishLimits (iteration 313)

### DIFF
--- a/internal/pkg/iface_subprocess.go
+++ b/internal/pkg/iface_subprocess.go
@@ -43,9 +43,28 @@ func (e *ModuleIfaceTimeoutError) Error() string {
 
 func (e *ModuleIfaceTimeoutError) Unwrap() error { return context.DeadlineExceeded }
 
-var resolveIfaceBinary = func() (string, error) {
+// isAilangBinaryPath reports whether path names the ailang compiler itself.
+//
+// Extracted from resolveIfaceBinary so it can be pinned directly: every test
+// that drives BuildModuleIface overrides resolveIfaceBinary wholesale, so
+// replacing that function's entire body with an always-failing stub left the
+// whole suite green (measured, iteration 313 — the sprint evaluator's finding,
+// reproduced first-party). This predicate decides WHICH binary gets exec'd, so
+// it is the half worth pinning.
+func isAilangBinaryPath(path string) bool {
+	if path == "" {
+		return false
+	}
+	base := filepath.Base(path)
+	return strings.TrimSuffix(base, filepath.Ext(base)) == "ailang"
+}
+
+// realResolveIfaceBinary is the production implementation. It is a named
+// function so tests can reach it even while the resolveIfaceBinary var is
+// overridden (TestMain replaces the var for every BuildModuleIface arm).
+func realResolveIfaceBinary() (string, error) {
 	executablePath, executableErr := os.Executable()
-	if executableErr == nil && strings.TrimSuffix(filepath.Base(executablePath), filepath.Ext(executablePath)) == "ailang" {
+	if executableErr == nil && isAilangBinaryPath(executablePath) {
 		return executablePath, nil
 	}
 	path, lookupErr := exec.LookPath("ailang")
@@ -54,6 +73,8 @@ var resolveIfaceBinary = func() (string, error) {
 	}
 	return path, nil
 }
+
+var resolveIfaceBinary = realResolveIfaceBinary
 
 // BuildModuleIface compiles modulePath in an isolated ailang subprocess and
 // returns its canonical interface representation.

--- a/internal/pkg/iface_subprocess.go
+++ b/internal/pkg/iface_subprocess.go
@@ -1,0 +1,117 @@
+package pkg
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sunholo-data/ailang/internal/iface"
+)
+
+// PublishLimits bounds the work performed while constructing package interfaces.
+type PublishLimits struct {
+	Overall            time.Duration
+	PerModule          time.Duration
+	MaxExportedModules int
+}
+
+// DefaultPublishLimits returns the default limits for a publish operation.
+func DefaultPublishLimits() PublishLimits {
+	return PublishLimits{
+		Overall:            60 * time.Second,
+		PerModule:          10 * time.Second,
+		MaxExportedModules: 64,
+	}
+}
+
+// ModuleIfaceTimeoutError reports that one module exceeded its compile deadline.
+type ModuleIfaceTimeoutError struct {
+	ModulePath string
+	Limit      time.Duration
+}
+
+func (e *ModuleIfaceTimeoutError) Error() string {
+	return fmt.Sprintf("building interface for module %q timed out after %s", e.ModulePath, e.Limit)
+}
+
+func (e *ModuleIfaceTimeoutError) Unwrap() error { return context.DeadlineExceeded }
+
+var resolveIfaceBinary = func() (string, error) {
+	executablePath, executableErr := os.Executable()
+	if executableErr == nil && strings.TrimSuffix(filepath.Base(executablePath), filepath.Ext(executablePath)) == "ailang" {
+		return executablePath, nil
+	}
+	path, lookupErr := exec.LookPath("ailang")
+	if lookupErr != nil {
+		return "", fmt.Errorf("resolve ailang binary (current executable %q is not the publisher): %w", executablePath, lookupErr)
+	}
+	return path, nil
+}
+
+// BuildModuleIface compiles modulePath in an isolated ailang subprocess and
+// returns its canonical interface representation.
+func BuildModuleIface(ctx context.Context, packageDir, modulePath string, lim PublishLimits) (*iface.InterfaceJSON, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	packageRoot, err := filepath.Abs(packageDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve package directory: %w", err)
+	}
+	manifest, err := LoadManifest(packageRoot)
+	if err != nil {
+		return nil, fmt.Errorf("load package manifest: %w", err)
+	}
+	if lim.MaxExportedModules > 0 && len(manifest.Exports.Modules) > lim.MaxExportedModules {
+		return nil, fmt.Errorf("package exports %d modules, exceeding limit of %d", len(manifest.Exports.Modules), lim.MaxExportedModules)
+	}
+
+	moduleCtx := ctx
+	cancel := func() {}
+	if lim.PerModule > 0 {
+		moduleCtx, cancel = context.WithTimeout(ctx, lim.PerModule)
+	}
+	defer cancel()
+
+	binary, err := resolveIfaceBinary()
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.CommandContext(moduleCtx, binary, "internal-dump-iface", packageRoot, modulePath)
+	cmd.Dir = packageRoot
+	setProcessGroup(cmd)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+	if moduleCtx.Err() != nil {
+		if cmd.Process != nil {
+			_ = killProcessGroup(cmd.Process.Pid)
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if errors.Is(moduleCtx.Err(), context.DeadlineExceeded) {
+			return nil, &ModuleIfaceTimeoutError{ModulePath: modulePath, Limit: lim.PerModule}
+		}
+		return nil, moduleCtx.Err()
+	}
+	if runErr != nil {
+		return nil, fmt.Errorf("build interface for module %q: %w: %s", modulePath, runErr, stderr.String())
+	}
+
+	var result iface.InterfaceJSON
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		return nil, fmt.Errorf("decode interface for module %q: %w", modulePath, err)
+	}
+	return &result, nil
+}

--- a/internal/pkg/iface_subprocess_canonical_test.go
+++ b/internal/pkg/iface_subprocess_canonical_test.go
@@ -1,0 +1,117 @@
+// Package pkg_test holds the ONE assertion that cannot live in `package pkg`.
+//
+// Sprint acceptance criterion M3-A5 is "subprocess bytes == the in-process
+// canonical builder's bytes". Satisfying it literally means importing
+// internal/pipeline, and `package pkg` cannot: internal/pipeline imports
+// internal/pkg (package_resolver.go:12), so an internal test file importing it
+// fails with `import cycle not allowed in test`. Measured, iteration 313.
+//
+// An EXTERNAL test package has no such problem — measured in the same breath,
+// the identical import from `package pkg_test` compiles and runs (rc=0). Go
+// links the internal and external test files into ONE test binary, so the
+// TestMain in iface_subprocess_test.go — which builds the child `ailang` and
+// overrides resolveIfaceBinary — still applies here.
+//
+// The first cut of this milestone compared BuildModuleIface's output against a
+// second direct invocation of the SAME `internal-dump-iface` subcommand that
+// BuildModuleIface itself shells out to. That is a real assertion (it is the
+// sole killer for the cmd.Dir hunk) but it compares the mechanism to itself and
+// leaves the plan's actual criterion resting on a transitive argument through a
+// different package's test. This file closes that gap directly.
+package pkg_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/pipeline"
+	"github.com/sunholo-data/ailang/internal/pkg"
+)
+
+// TestBuildModuleIface_MatchesCanonicalBuilder is M3-A5 in its literal form:
+// the subprocess wrapper's result must equal what pipeline.BuildCanonicalJSON
+// produces in-process for the same package directory and module path.
+//
+// Kills: any divergence between the wrapper's decode/re-encode round trip and
+// the canonical serialization — including a wrapper that silently returns a
+// zero-valued InterfaceJSON, which `{}` would unmarshal into without error.
+func TestBuildModuleIface_MatchesCanonicalBuilder(t *testing.T) {
+	const modulePath = "test/pkg/canonical"
+	const source = "module test/pkg/canonical\n\nexport func answer() -> int { 42 }\n"
+
+	dir := t.TempDir()
+	writeCanonicalFixture(t, dir, modulePath, source)
+
+	ctx := context.Background()
+
+	wantBytes, err := pipeline.BuildCanonicalJSON(ctx, dir, modulePath)
+	if err != nil {
+		t.Fatalf("pipeline.BuildCanonicalJSON: %v", err)
+	}
+	// Anti-vacuity floor: an empty or `{}` "want" would make every comparison
+	// below trivially satisfiable. Fail loudly rather than pass quietly.
+	if len(wantBytes) == 0 {
+		t.Fatal("instrument failure: canonical builder returned zero bytes")
+	}
+
+	got, err := pkg.BuildModuleIface(ctx, dir, modulePath, pkg.DefaultPublishLimits())
+	if err != nil {
+		t.Fatalf("BuildModuleIface: %v", err)
+	}
+	if got == nil {
+		t.Fatal("BuildModuleIface returned a nil interface")
+	}
+
+	// Second anti-vacuity floor, aimed at the value rather than the bytes:
+	// the fixture exports exactly one function, so a wrapper returning a
+	// zero-valued struct must not reach the comparison undetected.
+	// NOTE: inside t.TempDir() the compiler auto-relaxes MOD010 and reports the
+	// module as its full temp-qualified path, so pin the SUFFIX. Asserting
+	// equality here would pin the fixture's location rather than the mechanism.
+	if !strings.HasSuffix(got.Module, modulePath) {
+		t.Fatalf("module = %q, want a name ending in %q", got.Module, modulePath)
+	}
+	if len(got.Funcs) != 1 || got.Funcs[0].Name != "answer" {
+		t.Fatalf("funcs = %+v, want exactly one func named \"answer\"", got.Funcs)
+	}
+
+	gotBytes, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal wrapper result: %v", err)
+	}
+
+	// Compare as normalized JSON values rather than raw bytes: the canonical
+	// builder's output is the ground truth, and re-marshaling a decoded struct
+	// is not required to reproduce its whitespace.
+	var wantAny, gotAny any
+	if err := json.Unmarshal(wantBytes, &wantAny); err != nil {
+		t.Fatalf("unmarshal canonical bytes: %v", err)
+	}
+	if err := json.Unmarshal(gotBytes, &gotAny); err != nil {
+		t.Fatalf("unmarshal wrapper bytes: %v", err)
+	}
+	wantNorm, _ := json.Marshal(wantAny)
+	gotNorm, _ := json.Marshal(gotAny)
+	if string(wantNorm) != string(gotNorm) {
+		t.Fatalf("wrapper output differs from the in-process canonical builder\n got: %s\nwant: %s", gotNorm, wantNorm)
+	}
+}
+
+func writeCanonicalFixture(t *testing.T, dir, modulePath, source string) {
+	t.Helper()
+	manifest := "[package]\nname = \"test/pkg\"\nversion = \"0.1.0\"\nedition = \"1\"\n\n[exports]\nmodules = [\"" + modulePath + "\"]\n"
+	if err := os.WriteFile(filepath.Join(dir, "ailang.toml"), []byte(manifest), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	modFile := filepath.Join(dir, filepath.FromSlash(modulePath)+".ail")
+	if err := os.MkdirAll(filepath.Dir(modFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(modFile, []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/pkg/iface_subprocess_resolver_test.go
+++ b/internal/pkg/iface_subprocess_resolver_test.go
@@ -1,0 +1,108 @@
+package pkg
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestIsAilangBinaryPath pins the predicate that decides WHICH binary
+// BuildModuleIface exec's.
+//
+// Why this file exists: every test that drives BuildModuleIface overrides
+// resolveIfaceBinary in TestMain, so replacing that function's whole body with
+// an always-failing stub left all six named arms PASSing (measured, iteration
+// 313 — reproduced first-party from the sprint evaluator's blocking finding).
+// Neither branch was pinned, including the primary one. The naming decision is
+// now a pure function and is pinned here directly.
+func TestIsAilangBinaryPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/usr/local/bin/ailang", true},
+		{"ailang", true},
+		{filepath.Join("some", "dir", "ailang"), true},
+		{"ailang.exe", true},     // the Windows publisher
+		{"/tmp/pkg.test", false}, // the go test binary — the case that matters
+		{"/usr/local/bin/ailangx", false},
+		{"/usr/local/bin/notailang", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isAilangBinaryPath(tc.path); got != tc.want {
+			t.Errorf("isAilangBinaryPath(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+// TestResolveIfaceBinary_FallsBackToPath exercises the REAL resolver's fallback
+// branch: when the running executable is not itself `ailang` (which is always
+// true under `go test`, where os.Executable() is `<pkg>.test`), resolution must
+// go through exec.LookPath and find the binary on PATH.
+//
+// Kills: an inverted or short-circuited fallback that returns the test binary,
+// and a resolver that ignores PATH entirely.
+func TestResolveIfaceBinary_FallsBackToPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stub binary permissions differ on windows; the predicate test covers the naming half")
+	}
+
+	// Precondition, asserted rather than assumed: under `go test` the running
+	// executable must NOT look like ailang, or this test would take the primary
+	// branch and prove nothing about the fallback.
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	if isAilangBinaryPath(self) {
+		t.Fatalf("instrument failure: test binary %q looks like ailang, so the fallback branch is not reachable here", self)
+	}
+
+	stubDir := t.TempDir()
+	stub := filepath.Join(stubDir, "ailang")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir)
+
+	// Call the real implementation, not the TestMain override.
+	got, err := realResolveIfaceBinary()
+	if err != nil {
+		t.Fatalf("resolveIfaceBinary: %v", err)
+	}
+	if got != stub {
+		t.Fatalf("resolved %q, want the stub on PATH %q", got, stub)
+	}
+}
+
+// TestResolveIfaceBinary_ErrorsWhenAbsent pins the refusal branch: no ailang on
+// PATH and a non-ailang executable must produce an error, never a bare path
+// that would later exec something arbitrary.
+func TestResolveIfaceBinary_ErrorsWhenAbsent(t *testing.T) {
+	t.Setenv("PATH", t.TempDir()) // empty dir: nothing named ailang
+	got, err := realResolveIfaceBinary()
+	if err == nil {
+		t.Fatalf("expected an error when no ailang is on PATH, got %q", got)
+	}
+}
+
+// TestBuildModuleIface_ExportLimitBoundary pins the exactly-at-limit case.
+//
+// Kills: flipping `>` to `>=` in the export-limit check. Measured at iteration
+// 313 (the evaluator's non-blocking finding, reproduced first-party): that
+// mutation reddened NOTHING in the whole package, because only the
+// over-the-limit case was exercised.
+func TestBuildModuleIface_ExportLimitBoundary(t *testing.T) {
+	const modulePath = "test/pkg/boundary"
+	dir := writeIfaceFixture(t, modulePath, "module test/pkg/boundary\n\nexport func ok() -> int { 1 }\n")
+
+	lim := DefaultPublishLimits()
+	lim.MaxExportedModules = 1 // the fixture declares exactly one exported module
+
+	if _, err := BuildModuleIface(context.Background(), dir, modulePath, lim); err != nil {
+		t.Fatalf("exactly-at-limit package must be allowed, got: %v", err)
+	}
+}

--- a/internal/pkg/iface_subprocess_test.go
+++ b/internal/pkg/iface_subprocess_test.go
@@ -1,0 +1,258 @@
+package pkg
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+var ifaceTestBinary string
+
+func TestMain(m *testing.M) {
+	if mode := os.Getenv("AILANG_IFACE_TEST_HELPER"); mode != "" {
+		runIfaceTestHelper(mode)
+		os.Exit(0)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "ailang-iface-test-")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.RemoveAll(tmpDir)
+	ifaceTestBinary = filepath.Join(tmpDir, "ailang")
+	if runtime.GOOS == "windows" {
+		ifaceTestBinary += ".exe"
+	}
+	build := exec.Command("go", "build", "-o", ifaceTestBinary, "./cmd/ailang")
+	build.Dir = filepath.Join("..", "..")
+	if output, buildErr := build.CombinedOutput(); buildErr != nil {
+		fmt.Fprintf(os.Stderr, "build test ailang: %v\n%s", buildErr, output)
+		os.Exit(1)
+	}
+	resolveIfaceBinary = func() (string, error) { return ifaceTestBinary, nil }
+	os.Exit(m.Run())
+}
+
+func runIfaceTestHelper(mode string) {
+	switch mode {
+	case "fail":
+		fmt.Fprintln(os.Stderr, "injected child failure")
+		os.Exit(23)
+	case "block":
+		if marker := os.Getenv("AILANG_IFACE_SURVIVAL_MARKER"); marker != "" {
+			child := exec.Command(os.Args[0])
+			child.Env = append(os.Environ(), "AILANG_IFACE_TEST_HELPER=grandchild")
+			if err := child.Start(); err != nil {
+				os.Exit(24)
+			}
+		}
+		if ready := os.Getenv("AILANG_IFACE_READY_MARKER"); ready != "" {
+			_ = os.WriteFile(ready, []byte("ready"), 0o600)
+		}
+		time.Sleep(5 * time.Second)
+	case "grandchild":
+		time.Sleep(400 * time.Millisecond)
+		_ = os.WriteFile(os.Getenv("AILANG_IFACE_SURVIVAL_MARKER"), []byte("survived"), 0o600)
+	case "proxy":
+		wantDir := os.Getenv("AILANG_IFACE_EXPECT_DIR")
+		gotDir, err := os.Getwd()
+		if err != nil || gotDir != wantDir {
+			fmt.Fprintf(os.Stderr, "child working directory = %q, want %q: %v\n", gotDir, wantDir, err)
+			os.Exit(25)
+		}
+		cmd := exec.Command(os.Getenv("AILANG_IFACE_REAL_BINARY"), os.Args[1:]...)
+		cmd.Env = removeEnv(os.Environ(), "AILANG_IFACE_TEST_HELPER")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			os.Exit(26)
+		}
+	}
+}
+
+func TestBuildModuleIface_ReturnsError(t *testing.T) {
+	t.Run("missing file", func(t *testing.T) {
+		dir := writeIfaceFixture(t, "test/pkg/missing", "")
+		if _, err := BuildModuleIface(context.Background(), dir, "test/pkg/missing", DefaultPublishLimits()); err == nil {
+			t.Fatal("BuildModuleIface succeeded for a missing module file")
+		}
+	})
+	t.Run("type error", func(t *testing.T) {
+		dir := writeIfaceFixture(t, "test/pkg/broken", "module test/pkg/broken\nexport func broken() -> int = \"wrong\"\n")
+		if _, err := BuildModuleIface(context.Background(), dir, "test/pkg/broken", DefaultPublishLimits()); err == nil {
+			t.Fatal("BuildModuleIface succeeded for a module with a type error")
+		}
+	})
+	t.Run("non-zero child", func(t *testing.T) {
+		dir := writeIfaceFixture(t, "test/pkg/main", validIfaceModule)
+		withIfaceHelper(t, "fail", nil)
+		if _, err := BuildModuleIface(context.Background(), dir, "test/pkg/main", DefaultPublishLimits()); err == nil || !strings.Contains(err.Error(), "injected child failure") {
+			t.Fatalf("BuildModuleIface error = %v, want injected child failure", err)
+		}
+	})
+}
+
+func TestBuildModuleIface_Cancellation(t *testing.T) {
+	dir := writeIfaceFixture(t, "test/pkg/main", validIfaceModule)
+	ready := filepath.Join(t.TempDir(), "ready")
+	survived := filepath.Join(t.TempDir(), "survived")
+	withIfaceHelper(t, "block", map[string]string{
+		"AILANG_IFACE_READY_MARKER":    ready,
+		"AILANG_IFACE_SURVIVAL_MARKER": survived,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := BuildModuleIface(ctx, dir, "test/pkg/main", DefaultPublishLimits())
+		done <- err
+	}()
+	waitForFile(t, ready)
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("BuildModuleIface error = %v, want context.Canceled", err)
+	}
+	if runtime.GOOS != "windows" {
+		time.Sleep(500 * time.Millisecond)
+		if _, err := os.Stat(survived); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("cancelled subprocess left its process-group child alive: stat error = %v", err)
+		}
+	}
+}
+
+func TestBuildModuleIface_PerModuleDeadline(t *testing.T) {
+	defaults := DefaultPublishLimits()
+	if defaults.Overall != 60*time.Second || defaults.PerModule != 10*time.Second || defaults.MaxExportedModules != 64 {
+		t.Fatalf("DefaultPublishLimits = %+v, want overall=60s per-module=10s max-exports=64", defaults)
+	}
+	dir := writeIfaceFixture(t, "test/pkg/main", validIfaceModule)
+	withIfaceHelper(t, "block", nil)
+	lim := DefaultPublishLimits()
+	lim.PerModule = 50 * time.Millisecond
+	_, err := BuildModuleIface(context.Background(), dir, "test/pkg/main", lim)
+	var timeoutErr *ModuleIfaceTimeoutError
+	if !errors.As(err, &timeoutErr) {
+		t.Fatalf("BuildModuleIface error = %T %v, want *ModuleIfaceTimeoutError", err, err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("BuildModuleIface error = %v, want context.DeadlineExceeded compatibility", err)
+	}
+}
+
+func TestBuildModuleIface_ExportLimit(t *testing.T) {
+	dir := t.TempDir()
+	mods := make([]string, 65)
+	for i := range mods {
+		mods[i] = fmt.Sprintf("\"test/pkg/mod%d\"", i)
+	}
+	writeFile(t, filepath.Join(dir, "ailang.toml"), manifestFor(strings.Join(mods, ", ")))
+	lim := DefaultPublishLimits()
+	lim.MaxExportedModules = 64
+	_, err := BuildModuleIface(context.Background(), dir, "test/pkg/mod0", lim)
+	if err == nil || !strings.Contains(err.Error(), "exceeding limit of 64") {
+		t.Fatalf("BuildModuleIface error = %v, want export-limit refusal", err)
+	}
+}
+
+func TestBuildModuleIface_MatchesInProcess(t *testing.T) {
+	dir := writeIfaceFixture(t, "test/pkg/main", validIfaceModule)
+	withIfaceHelper(t, "proxy", map[string]string{
+		"AILANG_IFACE_EXPECT_DIR":  dir,
+		"AILANG_IFACE_REAL_BINARY": ifaceTestBinary,
+	})
+	got, err := BuildModuleIface(context.Background(), dir, "test/pkg/main", DefaultPublishLimits())
+	if err != nil {
+		t.Fatalf("BuildModuleIface: %v", err)
+	}
+	gotBytes, err := json.MarshalIndent(got, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal BuildModuleIface result: %v", err)
+	}
+	cmd := exec.Command(ifaceTestBinary, "internal-dump-iface", dir, "test/pkg/main")
+	cmd.Dir = dir
+	wantBytes, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("internal-dump-iface: %v", err)
+	}
+	if !bytes.Equal(gotBytes, bytes.TrimSpace(wantBytes)) {
+		t.Fatalf("wrapper JSON differs from canonical subprocess bytes\ngot:\n%s\nwant:\n%s", gotBytes, wantBytes)
+	}
+}
+
+func TestBuildModuleIface_ModulePathResolution(t *testing.T) {
+	dir := writeIfaceFixture(t, "test/pkg/declared", "")
+	_, err := BuildModuleIface(context.Background(), dir, "test/pkg/declared", DefaultPublishLimits())
+	if err == nil || !strings.Contains(err.Error(), "declared.ail") {
+		t.Fatalf("BuildModuleIface error = %v, want missing resolved module file", err)
+	}
+}
+
+const validIfaceModule = "module test/pkg/main\nexport func answer() -> int = 42\n"
+
+func writeIfaceFixture(t *testing.T, modulePath, source string) string {
+	t.Helper()
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "ailang.toml"), manifestFor(fmt.Sprintf("%q", modulePath)))
+	if source != "" {
+		writeFile(t, filepath.Join(dir, filepath.FromSlash(modulePath)+".ail"), source)
+	}
+	return dir
+}
+
+func manifestFor(modules string) string {
+	return "[package]\nname = \"test/pkg\"\nversion = \"0.1.0\"\nedition = \"1\"\n\n[exports]\nmodules = [" + modules + "]\n"
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func withIfaceHelper(t *testing.T, mode string, extra map[string]string) {
+	t.Helper()
+	oldResolver := resolveIfaceBinary
+	resolveIfaceBinary = func() (string, error) { return os.Args[0], nil }
+	t.Cleanup(func() { resolveIfaceBinary = oldResolver })
+	t.Setenv("AILANG_IFACE_TEST_HELPER", mode)
+	for key, value := range extra {
+		t.Setenv(key, value)
+	}
+}
+
+func waitForFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for helper marker %s", path)
+}
+
+func removeEnv(env []string, key string) []string {
+	prefix := key + "="
+	result := make([]string, 0, len(env))
+	for _, entry := range env {
+		if !strings.HasPrefix(entry, prefix) {
+			result = append(result, entry)
+		}
+	}
+	return result
+}


### PR DESCRIPTION
## M3 — `pkg.BuildModuleIface` subprocess wrapper + `PublishLimits`

Sprint 1 M3 of `m-registry-interface-hash-blind-to-signatures` (iteration 313). M1 landed at iteration 311, M2 at iteration 312.

`internal/pkg/iface_subprocess.go` adds `BuildModuleIface(ctx, packageDir, modulePath, lim)`, which invokes the hidden `ailang internal-dump-iface` subcommand (shipped in M2) via `exec.CommandContext` with `cmd.Dir` = the absolute package root, its own process group, and a per-module `context.WithTimeout`. Plus `PublishLimits` (overall 60s / per-module 10s / max 64 exported modules), injectable so the deadline arms run in 50ms rather than 10s.

### Two corrections to the plan, both measured before routing

1. **Return type.** The design doc specifies `(*iface.Iface, error)`; the plan's D2 corrected it to `(*iface.InterfaceJSON, error)` and the plan is right — `iface.IfaceItem.Type` is `*types.Scheme` while canonical JSON's `FuncJSON.Type` is a rendered string. But D2's stated *premise* is false as worded: it claims no deserializer exists, and `internal/types/json.go:723` defines `UnmarshalScheme`. The conclusion survives (that function consumes the types package's own Scheme JSON, which the canonical interface JSON does not carry). Recorded so a later milestone does not inherit the premise.
2. **Scope.** Doc AC14 (`TestBuildModuleIface_ModulePathResolution`, decision D7b) is absent from the plan's M3 list. The doc wins on scope; implemented here.

Import direction was verified *before* routing rather than after: `internal/iface` does not reach `internal/pkg` (0 of 104 transitive deps, control 13 internal imports), so `internal/pkg → internal/iface` introduces no cycle. This is M2's lesson applied ahead of the defect.

### The judge earned this PR its second commit

Evaluator (sonnet, its own worktree, distinct provider from the codex executor) returned **PASS 79/100 with two BLOCKING findings**. Both reproduced first-party before being acted on:

- **The import-cycle justification for deviating from M3-A5 was false.** An *internal* test importing `internal/pipeline` really does cycle (rc=1); an *external* `package pkg_test` one does not (rc=0). The first cut therefore compared the wrapper against the same subcommand it invokes. Fixed with a `package pkg_test` file satisfying M3-A5 literally. This was a **controller** error — the directive authorised the fallback and never named the external-test-package route.
- **`resolveIfaceBinary` had no coverage on either branch**, not just the fallback the executor disclosed: replacing its whole body with an always-failing stub left all six named arms passing. Fixed by extracting a pure `isAilangBinaryPath` predicate and a named `realResolveIfaceBinary`, with table, fallback and refusal arms.

Plus one new non-blocking finding closed: the export-limit `>` → `>=` mutant reddened **nothing**, because only the over-limit case was exercised.

### Mutation proof

Each mutant asserted LANDED (sha256 delta) and BUILDS (rc=0) first; red sets read by test **name**, not exit code; source restored from a copy and confirmed byte-identical.

| Mutant | Before | After |
|---|---|---|
| whole resolver body neutered | nothing red | SOLE killer `TestResolveIfaceBinary_FallsBackToPath` |
| `isAilangBinaryPath` inverted | n/a | reds 3 resolver arms |
| export limit `>` → `>=` | nothing red | SOLE killer `TestBuildModuleIface_ExportLimitBoundary` |
| `cmd.Dir` neutered | SOLE killer `MatchesInProcess` | unchanged |
| `setProcessGroup` dropped | SOLE killer `Cancellation` | unchanged |
| `PublishLimits` defaults zeroed | SOLE killer `PerModuleDeadline` | unchanged |

### Gates

All re-run by the controller **outside** the codex sandbox, under `-v` (`--- PASS:` lines print only under `-v`; without it a passing test yields rc=0 and zero PASS lines, indistinguishable from "no tests to run" — measured). `internal/pkg` **256 PASS / 0 FAIL**; scoped build, `vet`, `check-boundaries`, `check-file-sizes`, `check-changelog` all rc=0; `gofmt` 0 files; `internal/pipeline`, `internal/iface`, `cmd/ailang` all rc=0. All six original named arms were **RED at base**. `go build ./...` is rc=1 on the pristine tree (`cmd/wasm`) and was deliberately excluded from the gate list.

### Declared residuals

The `ctx.Err()` early return and the `filepath.Abs` normalization have **no killer** (independently confirmed by the judge); `PublishLimits.Overall` has no consumer until publish orchestration lands in a later milestone. Named rather than given tests that could only assert an implementation detail.

Executor: codex `gpt-5.6-sol` (probe rc=0), sandboxed worktree, no git writes. It correctly labelled the whole-package gate `UNINFORMATIVE UNDER SANDBOX` (httptest could not bind `[::1]:0`); green when re-run outside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
