### PR TITLE
fix(docs-sync): docs-6 — check_examples.sh absolute-path bug + audit scope comments

### DIFF
--- a/.claude/skills/docs-sync/scripts/audit_design_docs.sh
+++ b/.claude/skills/docs-sync/scripts/audit_design_docs.sh
@@ -17,6 +17,7 @@ echo "Project root: $PROJECT_ROOT"
 echo ""
 
 # Count design docs
+# Scope: these totals count every Markdown file in each lifecycle directory, including sprint plans and other supporting docs; they intentionally need not match feature-only roadmap totals from derive_roadmap_versions.sh.
 PLANNED_COUNT=$(find "$PROJECT_ROOT/design_docs/planned" -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
 IMPLEMENTED_COUNT=$(find "$PROJECT_ROOT/design_docs/implemented" -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
 

--- a/.claude/skills/docs-sync/scripts/check_examples.sh
+++ b/.claude/skills/docs-sync/scripts/check_examples.sh
@@ -61,12 +61,13 @@ FAILED_FILES=""
 
 for file in $files; do
     basename=$(basename "$file")
+    relative_file="${file#$PROJECT_ROOT/}"
 
     # Try to compile/check the file
-    if "$PROJECT_ROOT/bin/ailang" run --entry main --caps IO "$file" >/dev/null 2>&1; then
+    if (cd "$PROJECT_ROOT" && "$PROJECT_ROOT/bin/ailang" run --entry main --caps IO "$relative_file") >/dev/null 2>&1; then
         echo "  [OK] $basename"
         ((PASSED++))
-    elif "$PROJECT_ROOT/bin/ailang" run --entry main "$file" >/dev/null 2>&1; then
+    elif (cd "$PROJECT_ROOT" && "$PROJECT_ROOT/bin/ailang" run --entry main "$relative_file") >/dev/null 2>&1; then
         echo "  [OK] $basename (no caps)"
         ((PASSED++))
     else

--- a/.claude/skills/docs-sync/scripts/derive_roadmap_versions.sh
+++ b/.claude/skills/docs-sync/scripts/derive_roadmap_versions.sh
@@ -157,6 +157,7 @@ fi
 # ============================================
 # SUMMARY STATISTICS
 # ============================================
+# Scope: these totals count feature design docs while excluding sprint plans, and they intentionally need not match audit_design_docs.sh totals, which include every Markdown file in the lifecycle directories.
 if $JSON_OUTPUT; then
     # Count planned vs implemented
     planned_count=$(find "$PROJECT_ROOT/design_docs/planned" -name "*.md" 2>/dev/null | grep -v sprint | wc -l | tr -d ' ')


### PR DESCRIPTION
## Summary
- `check_examples.sh` passed ABSOLUTE paths to `ailang run`, tripping false `MOD010` module-path-mismatch failures for nearly every runnable example. Fixed by `cd`ing to `PROJECT_ROOT` and invoking each example with a path relative to it.
- Folds in DOCS-2-04: `audit_design_docs.sh` and `derive_roadmap_versions.sh` report different design-doc population totals by design (different scopes). Added a one-paragraph scope comment to each near its count-printing logic; this PR does not try to unify the two totals.

Result: check_examples.sh now reports 173 passed / 2 failed (`batch_processing.ail`, `cli_args_demo.ail` — a separate, already-documented `Env`-capability gap, out of scope here) / 42 skipped, up from the 166/9/42 baseline recorded at docs-2 now that docs-5's main-entrypoint fixes have landed.

Docs mission queue item `docs-6` (design_docs/docs-mission.md). Sprint plan: design_docs/docs-6-sprint-plan.md.

## Routing
- Planner: `codex:gpt-5.6-luna` (subscription lane), ephemeral worktree.
- Executor: `codex:gpt-5.6-luna` (subscription lane), sprint worktree, no git-write ops — controller reviewed and committed the uncommitted diff.
- Evaluator: `sonnet` (Agent-tool pin, isolated worktree, generator≠judge held) — **PASS 98/100, zero blocking**. Independently rebuilt a fresh binary, reproduced the pre-fix MOD010 failure, ran a sole-killer mutation check (reverting the fix reproduces 12/29/176), confirmed the fix is not cwd-dependent, and verified both scope comments against the actual script logic.

## Test plan
- [x] Fresh binary build + `bash .claude/skills/docs-sync/scripts/check_examples.sh` from repo root: 173 passed / 2 failed / 42 skipped (independently reproduced by both controller and evaluator)
- [x] `bash -n` clean on all three changed scripts
- [x] `git diff --name-only` limited to `.claude/skills/docs-sync/scripts/{check_examples,audit_design_docs,derive_roadmap_versions}.sh` — nothing under `internal/**`/`cmd/**`
- [x] Mutation check: reverting the fix reproduces the pre-fix false-failure counts

Co-Authored-By: codex gpt-5.6-luna
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>