### PR TITLE
test(probe): make the wall-clock discovery arm assert its own refusal (motoko iter-32, D4)

### DIFF
--- a/design_docs/planned/m-motoko-discovery-arm-discriminating-refusal-sprint-plan.md
+++ b/design_docs/planned/m-motoko-discovery-arm-discriminating-refusal-sprint-plan.md
@@ -1,0 +1,488 @@
+# Sprint Plan: M-MOTOKO-DISCOVERY-ARM-DISCRIMINATING-REFUSAL
+
+**Design doc**: [`design_docs/planned/m-motoko-discovery-arm-discriminating-refusal.md`](m-motoko-discovery-arm-discriminating-refusal.md)
+**Sprint JSON**: `.ailang/state/sprints/sprint_m-motoko-discovery-arm-discriminating-refusal.json`
+**Planned**: 2026-09-01 (mission iteration 32)
+**Base commit**: `48817dcdd` (= `origin/dev`), worktree `/Users/voightkampff/dev/sunholo-data/.wt-motoko-iter32-sprint`
+**Target**: v0.34.1 · **Risk**: low (code) / medium (schedule — see §Risks)
+**Design status**: cleared to plan. Four quorum rounds; the ceiling surface was resolved by attended
+ruling **D-MOTOKO-6N-1** (Mark Edmondson, 2026-09-01, option (B) = adopt §D4). Round-4's two
+consistency defects were fixed verbatim under the narrow-refinement carve-out. **This plan does not
+re-open the design.**
+
+---
+
+## 0. How to read this plan
+
+Four milestones. **M1, M2, M3 each change code and each leaves the suite green**, so each is an
+independently committable, bisectable point. **M4 changes no product code** — it produces the mutation
+evidence and records it in the design doc.
+
+Three standing rules for the executor, and they are not optional:
+
+1. **The executor makes NO git writes.** No `git add`, no `git commit`, no `git checkout`, no
+   `git stash`, no branch operations. The worktree is deliberately uncommitted; the **controller**
+   commits, one commit per milestone, after the milestone's acceptance block is green. If a milestone's
+   acceptance goes red, stop and report — do not proceed to the next milestone.
+2. **Restore mutants from a `cp` backup, never `git checkout --`.** The sprint's own edits are
+   uncommitted, so `git checkout -- <file>` would delete them. Every mutation is bracketed by
+   `cp <file> <file>.bak.<tag>` before and `cp <file>.bak.<tag> <file>` after, and the restore is
+   **verified by sha256 equality against the pre-mutation hash**, not assumed.
+3. **Capture exit codes without a pipe**: `cmd > /tmp/out 2>&1; rc=$?`. The controller's shell is zsh
+   and the suite is `/bin/bash`; `${PIPESTATUS[0]}` is not to be used anywhere.
+
+All paths below are relative to the worktree root
+`/Users/voightkampff/dev/sunholo-data/.wt-motoko-iter32-sprint`. Abbreviations used throughout:
+
+- `P` = `tools/eval/motoko_connection_probe.sh`
+- `T` = `tools/eval/test_motoko_connection_probe.sh`
+
+**These are the only two files this sprint may modify**, plus the design doc (M4) and this plan's JSON.
+
+---
+
+## 1. Baseline — measured on the pristine tree, this iteration
+
+Every acceptance command in this plan was run on the **unmodified** tree at `48817dcdd` before the plan
+was written. The measured base result is recorded beside each criterion in the milestone sections, and
+the whole set is summarised here. **No criterion in this plan was found red at base.**
+
+Environment at measurement time:
+
+| Fact | Measured |
+|---|---|
+| Worktree base | `48817dcdd`, clean except the (uncommitted) design doc |
+| `sw_vers -productVersion` | `26.5.2` |
+| `/bin/bash --version` | GNU bash 3.2.57(1)-release, arm64-apple-darwin25 |
+| `command -v timeout gtimeout` | **neither exists** — see §Bounded waits |
+| `uptime` load avg / `hw.ncpu` | 13.87–18.52 on **16** CPUs — heavily contended |
+| sha256 `P` | `7a75c6984f743e1742316c6684dae1898ffc72b4db9266b7925e370c7faeef88` |
+| sha256 `T` | `bd5302f596201a63bace988c9aae68bdb57bc9d3232f382e360cc4f1ca461ee6` |
+
+**Base suite (the load-bearing baseline):**
+
+```bash
+/bin/bash tools/eval/test_motoko_connection_probe.sh > /tmp/base_suite.log 2>&1; rc=$?
+```
+→ **rc=0, 41 `ok`, 0 `not ok`, 50s**, last line `PASS: 41 probe self-test arms ran`.
+Arm numbering confirmed in that log: **arm 33** = "descendant discovery refuses on the real wall-clock
+deadline" (`T:449`), **arm 40** = "descendant discovery refuses on the node-count ceiling" (`T:698`),
+**arm 41** = the refusal-branch gate, which at base prints `(24)`.
+
+**Base static values** (each command run at base; `grep -c` counts *lines in the named file*):
+
+| Command | Base |
+|---|---|
+| `bash -n $P` | rc=0 |
+| `bash -n $T` | rc=0 |
+| `grep -c 'echo "process-tree discovery' $P` | 3 |
+| `grep -c 'instrument_failure "' $P` | 19 |
+| `grep -cE '\|\| usage$' $P` | 5 |
+| `grep -Fc 'echo "process-tree discovery deadline expired" >&2' $P` | **2** (the two branches that share a string — the defect) |
+| `grep -Fc 'process-tree discovery deadline expired (test stub)' $P` | 0 |
+| `grep -Fc 'process-tree discovery deadline expired (wall clock)' $P` | 0 |
+| `grep -Fc 'MAX_TREE_NODES=${PROBE_MAX_TREE_NODES:-4096}' $P` | 1 (**`-F` mandatory**; the non-`-F` form returns a false **0** on this rig — re-confirmed this iteration) |
+| `grep -c 'PROBE_MAX_TREE_NODES=50000' $T` | 0 |
+| `grep -cE '^(export )?PROBE_MAX_TREE_NODES=' $T` | 0 (control `grep -c '^ARM_CAP_SECS=' $T` = 3) |
+| `grep -Fc '"descendant discovery refuses on the real wall-clock deadline" "process-tree discovery failed"' $T` | 1 |
+| `grep -Fc '"descendant discovery deadline refuses at the caller" "process-tree discovery failed"' $T` | 1 |
+| `grep -Fc 'ARM_CAP_SECS=$(( ARM_CAP_SECS * 5 ))' $T` | 1 |
+| `grep -Fc 'expected_refusal_branches=24' $T` / `...=27` | 1 / 0 |
+| `grep -Fc 'actual_echo_refusals' $T` | 0 |
+| `grep -Fc '[[ -f "$probe" ]]' $T` | 0 |
+| `grep -Fc 'PROBE_MAX_TREE_NODES is set at suite scope' $T` | 0 |
+| `PROBE_MAX_TREE_NODES=50000 /bin/bash $T` | **rc=0, 41 ok, 0 not ok, 57s** — i.e. an ambient global ceiling is **invisible today**. This is A3.7's base and it is exactly the hole the locality guard closes. |
+
+**Edit positions re-verified at base** (the design doc's V17, all confirmed unchanged):
+`P:182` and `P:187` = the two identical `echo` messages; `P:195` = the node-ceiling message;
+`P:126` = `MAX_TREE_NODES=${PROBE_MAX_TREE_NODES:-4096}`; `P:217` = the caller collapse.
+`T:447-452` = the arm-cap widening + arm :449 + restore; `T:450` = arm :449's `env` line;
+`T:358` = the stub arm's drive; `T:698-701` = the node-ceiling arm; `T:707` =
+`expected_refusal_branches=24`. `T:5` assigns `probe=${PROBE_UNDER_TEST:-$script_dir/motoko_connection_probe.sh}`
+and `T:2` is `set -uo pipefail`.
+
+**Stub rate re-measured at this base, this iteration** (the suite's own `pgrep` stub, extracted verbatim
+from `T:255-261`, N=2000 per trial, timed with `date +%s`): **181 / 166 / 181 iter/s** at load average
+13.87–18.52. The design doc's V23 recorded 181/200/200; iteration 31's quiet-machine figures were
+474.9/652.7/648.6. **The rig is currently at or slightly below the slow end of the doc's own range** —
+which is a schedule fact, not a design fact. See §Risks R1.
+
+### Bounded waits
+
+There is **no `timeout(1)` and no `gtimeout` on this machine**, so every bound comes from the harness,
+not from a shell wrapper:
+
+- Short commands (`grep`, `bash -n`, `sed`, `cp`, `shasum`): default tool timeout is ample.
+- **Full suite runs (clean, ~50–60s)**: run with an explicit tool timeout of **300000 ms**.
+- **T1 mutant run**: run with **`run_in_background: true`** and poll the log. Do **not** run it in the
+  foreground: its arm :449 walks to the 50,000-node ceiling and, at the rates measured above, that arm
+  alone is **~250–301s**, giving a whole-suite time of roughly **280–340s** — and under a load spike it
+  can approach the 600s widened arm cap, which would exceed the harness's own 600s foreground ceiling.
+  **A multi-minute T1 is EXPECTED, not a hang.** Iteration 31's 44s figure was measured at the *default*
+  ceiling under the old design and **does not transfer**.
+- **T2 mutant run**: arm 40's walk falls back to its own `PROBE_TIMEOUT_SECS=60` wall clock, so budget
+  **~60s for that arm alone**; run with a tool timeout of **300000 ms**.
+
+---
+
+## 2. Milestones
+
+### M1 — probe: three refusal branches, three distinct messages
+
+**Design doc**: Implementation Plan Phase 1; decision (a).
+**Files**: `P` only. **~2 lines changed.**
+
+**Change** — in `descendant_pids`:
+
+| line | from | to |
+|---|---|---|
+| `P:182` | `    echo "process-tree discovery deadline expired" >&2` | `    echo "process-tree discovery deadline expired (test stub)" >&2` |
+| `P:187` | `      echo "process-tree discovery deadline expired" >&2` | `      echo "process-tree discovery deadline expired (wall clock)" >&2` |
+
+Preserve the existing indentation exactly (4 spaces at 182, 6 at 187). `P:195` (the node-ceiling
+message) and `P:217` (the caller collapse) are **not** touched.
+
+**Why this is green on its own**: arm :449 and arm :357 both still assert the caller wrapper
+`process-tree discovery failed`, which is unchanged, and the gate's `echo "process-tree discovery`
+count is still 3. So M1 commits clean.
+
+**Acceptance block** — run all of these; every one must hold:
+
+| # | Command | **Base** | Required after M1 |
+|---|---|---|---|
+| A1.1 | `bash -n tools/eval/motoko_connection_probe.sh; rc=$?` | rc=0 | rc=0 |
+| A1.2 | `grep -c 'echo "process-tree discovery' tools/eval/motoko_connection_probe.sh` | 3 | 3 (re-wording must not change the count) |
+| A1.3 | `grep -Fc 'process-tree discovery deadline expired (test stub)' tools/eval/motoko_connection_probe.sh` | 0 | **1** |
+| A1.4 | `grep -Fc 'process-tree discovery deadline expired (wall clock)' tools/eval/motoko_connection_probe.sh` | 0 | **1** |
+| A1.5 | `grep -Fc 'echo "process-tree discovery deadline expired" >&2' tools/eval/motoko_connection_probe.sh` | 2 | **0** — no two branches share a string (Design Freeze) |
+| A1.6 | `grep -Fc 'process-tree discovery exceeded $MAX_TREE_NODES nodes' tools/eval/motoko_connection_probe.sh` | 1 | 1 (node-ceiling message untouched) |
+| A1.7 | `grep -Fc 'instrument_failure "process-tree discovery failed"' tools/eval/motoko_connection_probe.sh` | 1 | 1 (caller collapse untouched — Non-Goal: no production-semantics change) |
+| A1.8 | `/bin/bash tools/eval/test_motoko_connection_probe.sh > /tmp/m1_suite.log 2>&1; rc=$?` | rc=0, 41 ok, 0 not ok, 50s | rc=0, 41 ok, 0 not ok |
+
+**Commit (controller, not executor)**: `fix(probe): distinct refusal message per descendant_pids branch`.
+
+---
+
+### M2 — test: arm :449 asserts the wall-clock message and carries the scoped ceiling
+
+**Design doc**: Implementation Plan Phase 2; decisions (b), (c); attended ruling D-MOTOKO-6N-1.
+**Files**: `T` only. **~2 lines changed.** **Depends on M1** (the asserted string must exist first).
+
+**Change** — the arm at `T:449-450` becomes:
+
+```bash
+expect_failure "descendant discovery refuses on the real wall-clock deadline" "process-tree discovery deadline expired (wall clock)" \
+  env PATH="$live_bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=1 PROBE_MAX_TREE_NODES=50000 PROBE_TEST_PGREP_LOOP=1 \
+    PROBE_STUB_STATE="$tmp_dir/lane-pgreploop" /bin/bash "$probe" treatment control "$tmp_dir/pgreploop.json"
+```
+
+Exactly two edits: the expectation string, and **one added token** `PROBE_MAX_TREE_NODES=50000`
+inserted after `PROBE_TIMEOUT_SECS=1` on the `env` line. **Everything else on those lines is
+byte-identical**, including `PROBE_STUB_STATE` and the continuation backslashes.
+
+**Do not touch** `T:447` (`_arm_cap_saved=$ARM_CAP_SECS`), `T:448`
+(`ARM_CAP_SECS=$(( ARM_CAP_SECS * 5 ))`) or `T:452` (the restore). The 5x widening is **KEPT** per the
+Design Freeze — it is now also T1's outer bound.
+
+**Do not** add an `export`, and **do not** add a `PROBE_MAX_TREE_NODES=` assignment anywhere at file
+scope. A2.3 is the criterion that reds if that happens.
+
+**Acceptance block**:
+
+| # | Command | **Base** | Required after M2 |
+|---|---|---|---|
+| A2.1 | `bash -n tools/eval/test_motoko_connection_probe.sh; rc=$?` | rc=0 | rc=0 |
+| A2.2 | `grep -c 'PROBE_MAX_TREE_NODES=50000' tools/eval/test_motoko_connection_probe.sh` | 0 | **exactly 1** — >1 means the override spread to another arm; 0 means D4 was not applied |
+| A2.3 | `grep -cE '^(export )?PROBE_MAX_TREE_NODES=' tools/eval/test_motoko_connection_probe.sh` | 0 (control `grep -c '^ARM_CAP_SECS=' $T` = 3) | **0** — the static half of the locality claim |
+| A2.4 | `grep -n -B1 'PROBE_MAX_TREE_NODES=50000' tools/eval/test_motoko_connection_probe.sh` | (no match) | the matched line is arm :449's `env` line, and the `-B1` line is that arm's own `expect_failure` header — **proving the token is on THIS arm, not merely present in the file** |
+| A2.5 | `grep -Fc 'expect_failure "descendant discovery refuses on the real wall-clock deadline" "process-tree discovery deadline expired (wall clock)"' tools/eval/test_motoko_connection_probe.sh` | 0 | **1** |
+| A2.6 | `grep -Fc '"descendant discovery refuses on the real wall-clock deadline" "process-tree discovery failed"' tools/eval/test_motoko_connection_probe.sh` | 1 | **0** — the vacuous assertion is gone |
+| A2.7 | `grep -Fc '"descendant discovery deadline refuses at the caller" "process-tree discovery failed"' tools/eval/test_motoko_connection_probe.sh` | 1 | **1** — arm :357 still tests the caller collapse (decision (b)) |
+| A2.8 | `grep -Fc 'ARM_CAP_SECS=$(( ARM_CAP_SECS * 5 ))' tools/eval/test_motoko_connection_probe.sh` | 1 | 1 — widening kept |
+| A2.9 | `grep -Fc '"descendant discovery refuses on the node-count ceiling" "process-tree discovery exceeded 3 nodes"' tools/eval/test_motoko_connection_probe.sh` | 1 | 1 — arm 40 untouched |
+| A2.10 | `grep -Fc 'MAX_TREE_NODES=${PROBE_MAX_TREE_NODES:-4096}' tools/eval/motoko_connection_probe.sh` (**`-F` mandatory**) | 1 | 1 — every other arm keeps the 4096 default |
+| A2.11 | `/bin/bash tools/eval/test_motoko_connection_probe.sh > /tmp/m2_suite.log 2>&1; rc=$?` | rc=0, 41 ok, 0 not ok, 50s | rc=0, 41 ok, 0 not ok. **Also record the wall time** — the doc's iteration-31 evaluator measured the scoped override as free on the happy path (47.1s); a materially longer run would mean the ceiling is being reached on arm 33, which would be a finding worth reporting. |
+| A2.12 | `grep -c '^ok 33 - descendant discovery refuses on the real wall-clock deadline' /tmp/m2_suite.log` | 1 (in the base log) | 1 — the arm is still arm 33 and still passes |
+
+**Commit (controller)**: `test(probe): arm :449 asserts the wall-clock branch, ceiling scoped to its env line (D-MOTOKO-6N-1)`.
+
+---
+
+### M3 — test: refusal-branch gate counts the echo refusals, and enforces ceiling locality
+
+**Design doc**: Implementation Plan Phase 3; decision (f); round-4 fix V26.
+**Files**: `T` only. **~15 lines added, 1 changed.** Independent of M1/M2 in content; sequenced third so
+each commit is green.
+
+**Change** — replace the gate block that currently begins at `T:707` (`expected_refusal_branches=24`)
+so the region reads:
+
+```bash
+# The D4 ceiling override belongs on arm :449's own env line and nowhere else. A per-command
+# env assignment never persists into this shell, so this is invariantly quiet on a correct
+# tree. It fires on exactly two leak shapes: an edit that promotes the override to a
+# file-global assignment or export, and an ambient PROBE_MAX_TREE_NODES in the caller's
+# environment — which would silently re-parameterise every arm that does not pin its own
+# ceiling. Both un-hermeticize the suite.
+if [[ -n "${PROBE_MAX_TREE_NODES:-}" ]]; then
+  echo "not ok - PROBE_MAX_TREE_NODES is set at suite scope; the ceiling override must stay on arm env lines" >&2
+  exit 1
+fi
+
+# Refusal-branch drift gate.  <-- KEEP the existing 4-line comment here verbatim
+expected_refusal_branches=27
+# Every counter below reads $probe. Assert it resolves to a file BEFORE any of them run, so
+# that no grep in this gate can fall through to reading stdin.
+[[ -f "$probe" ]] || { echo "not ok - refusal-branch gate: \$probe does not resolve to a file; instrument failure, not a verdict" >&2; exit 1; }
+actual_instrument_failures=$(grep -c 'instrument_failure "' "$probe")
+actual_usage_refusals=$(grep -cE '\|\| usage$' "$probe")
+actual_echo_refusals=$(grep -c 'echo "process-tree discovery' "$probe")
+# Anti-vacuity: a counter that returns zero is a broken instrument, not a clean result.
+if (( actual_instrument_failures == 0 || actual_usage_refusals == 0 || actual_echo_refusals == 0 )); then
+  echo "not ok - refusal-branch counter matched nothing; instrument failure, not a verdict" >&2
+  exit 1
+fi
+actual_refusal_branches=$(( actual_instrument_failures + actual_usage_refusals + actual_echo_refusals ))
+```
+
+The drift-comparison `if` block and the final `pass_arm` line below it are **unchanged**.
+Notes: the count moves 24 → 27 because the gate now **covers** three previously-unguarded branches, not
+because this work adds any (`19 + 5 + 3 = 27`). `\$probe` inside the double-quoted `echo` is intentional —
+the message must print the literal text `$probe`. No bash-4 constructs: `[[ -n ... ]]`, `[[ -f ... ]]`
+and `(( a || b || c ))` are all bash-3.2-safe.
+
+**Acceptance block**:
+
+| # | Command | **Base** | Required after M3 |
+|---|---|---|---|
+| A3.1 | `bash -n tools/eval/test_motoko_connection_probe.sh; rc=$?` | rc=0 | rc=0 |
+| A3.2 | `grep -Fc 'expected_refusal_branches=27' $T` / `grep -Fc 'expected_refusal_branches=24' $T` | 0 / 1 | **1 / 0** |
+| A3.3 | `grep -Fc 'actual_echo_refusals' tools/eval/test_motoko_connection_probe.sh` | 0 | **≥ 3** (assignment, anti-vacuity test, sum) |
+| A3.4 | `grep -Fc '[[ -f "$probe" ]]' tools/eval/test_motoko_connection_probe.sh` | 0 | **≥ 1** |
+| A3.5 | `grep -Fc 'PROBE_MAX_TREE_NODES is set at suite scope' tools/eval/test_motoko_connection_probe.sh` | 0 | **1** |
+| A3.6 | `/bin/bash tools/eval/test_motoko_connection_probe.sh > /tmp/m3_suite.log 2>&1; rc=$?` | rc=0, 41 ok, 0 not ok, 50s | rc=0, **41** ok, 0 not ok — the guard lives inside the gate flow, so the **arm count must NOT move** |
+| A3.7 | `grep -c 'refusal-branch count still matches the set this suite covers (27)' /tmp/m3_suite.log` | 0 (base log says `(24)`) | **1** |
+| A3.8 | `PROBE_MAX_TREE_NODES=50000 /bin/bash tools/eval/test_motoko_connection_probe.sh > /tmp/m3_ambient.log 2>&1; rc=$?` | **rc=0, 41 ok, 0 not ok, 57s** — an ambient global ceiling is invisible at base | **rc=1**, and `/tmp/m3_ambient.log` contains `not ok - PROBE_MAX_TREE_NODES is set at suite scope`, with **40** preceding `ok` lines. This is the runtime twin of A2.3 and the cheap, non-mutation half of T4's evidence. |
+| A3.9 | `grep -cE '^(export )?PROBE_MAX_TREE_NODES=' tools/eval/test_motoko_connection_probe.sh` | 0 | 0 — M3 must not itself introduce a suite-scope assignment |
+
+**Commit (controller)**: `test(probe): refusal-branch gate counts echo refusals (24→27) and refuses a leaked ceiling`.
+
+---
+
+### M4 — mutation validation (T1–T4), produced by running
+
+**Design doc**: Implementation Plan Phase 4; Testing Strategy T1–T4.
+**Files**: no change to `P` or `T` (each mutant is applied and then restored byte-identically). The
+milestone's **product** is the recorded evidence, written into the design doc's Testing Strategy table
+as an **"Observed (iteration 32)"** column. That doc edit is the committable artefact.
+
+> **The red sets below are PREDICTIONS the executor must PRODUCE BY RUNNING.** Iteration-31's red sets
+> were measured under the OLD design (arm :449 at the default 4096 ceiling) and **do not transfer**.
+> Do not copy a predicted number into the record. If a produced result differs from the prediction,
+> **record the produced result and report the divergence** — that is a finding, not a failure to fix.
+
+**Mutation protocol — identical for all four, and non-negotiable:**
+
+```bash
+# 0. pre-hash and back up (cp, NOT git)
+shasum -a 256 <file>                                  # record as SHA_PRE
+cp <file> /tmp/it32.<tag>.bak
+
+# 1. apply the mutant (sed / editor), then prove it LANDED
+shasum -a 256 <file>                                  # must DIFFER from SHA_PRE
+
+# 2. prove it PARSES
+bash -n <file>; rc=$?                                 # must be rc=0
+
+# 3. prove it had its INTENDED EFFECT — a query against the SYSTEM's own view,
+#    not against the file's bytes (see each row for the specific query)
+
+# 4. run the suite, capturing rc WITHOUT a pipe
+/bin/bash tools/eval/test_motoko_connection_probe.sh > /tmp/it32.<tag>.log 2>&1; rc=$?
+
+# 5. restore from the cp backup and PROVE the restore
+cp /tmp/it32.<tag>.bak <file>
+shasum -a 256 <file>                                  # must EQUAL SHA_PRE
+```
+
+Step 5 is mandatory **before** the next mutant is applied. Never run two mutants at once. Never use
+`git checkout --` at step 5.
+
+Note on all four red sets: `expect_failure` and the gate both `exit 1` on the first failure, so the
+suite **aborts at the failing arm**. The expected shape is therefore *"N `ok` lines, then one
+`not ok`, then nothing"* — **not** "41 minus one".
+
+#### T1 — neuter the in-loop wall clock (the load-bearing acceptance)
+
+- **File**: `P`. **Mutant**: at `P:186`, `if (( $(date +%s) > deadline )); then` →
+  `if false && (( $(date +%s) > deadline )); then`.
+- **Effect assertion (the system's own view, NOT the file's bytes)**: a grep for the injected
+  `if false` text would only prove the edit exists, which step 1's sha256 already proves. The sound
+  assertion is **the mutant run's own stderr**, read out of `/tmp/it32.t1.log`:
+  it **must contain** `process-tree discovery exceeded 50000 nodes` — the ceiling's message, which can
+  only appear if the wall clock did *not* fire — and it **must not contain**
+  `process-tree discovery deadline expired (wall clock)`. Two greps over the log, both read from the
+  run. (Run these *after* step 4; T1 is the one row whose effect assertion is necessarily
+  post-execution.)
+- **Run it with `run_in_background: true`** and poll `/tmp/it32.t1.log`. Budget **280–340s**;
+  under a load spike, up to the 600s widened arm cap.
+- **Predicted, to be produced**: rc=1; **32 `ok` lines then**
+  `not ok - descendant discovery refuses on the real wall-clock deadline lacked expected message: process-tree discovery deadline expired (wall clock)`,
+  followed by the captured stderr showing `process-tree discovery exceeded 50000 nodes`.
+- **Cap-shaped fallback, explicitly allowed and explicitly recorded**: if the arm instead reports
+  `exceeded its 600s arm cap`, that is **still a red and still satisfies T1's verdict** — only its
+  diagnosticity degrades (design doc, decision (c): "It does not stop being a red"). Record it as
+  **cap-shaped** and say so; do not present it as message-shaped. The optional confirmation run is
+  `PROBE_SELFTEST_ARM_CAP_SECS=600 /bin/bash <suite>` (a `:-` default at `T:9`, so this is an
+  environment override that touches no file and does **not** trip the ceiling-locality guard, which
+  looks only at `PROBE_MAX_TREE_NODES`). If used, record **both** runs.
+- **Records**: red set as run, wall time of the whole suite, wall time of arm 33 if separable, and the
+  `uptime` load average at run time (the rate, and therefore the duration, is load-dependent).
+
+#### T2 — neuter the node ceiling only (proves the two arms are separable)
+
+- **File**: `P`. **Mutant**: at `P:194`, `if (( visited > MAX_TREE_NODES )); then` →
+  `if false && (( visited > MAX_TREE_NODES )); then`.
+- **Effect assertion**: the run's own output — arm 40 must fail for **lacking** the ceiling message,
+  which is only possible if the ceiling branch is dead.
+- **Predicted, to be produced**: rc=1; **arm 33 still `ok`** (this is the point of the row — the
+  wall-clock arm no longer depends on the node ceiling), then **39 `ok` lines then**
+  `not ok - descendant discovery refuses on the node-count ceiling lacked expected message: process-tree discovery exceeded 3 nodes`.
+  Arm 40's walk now ends on its own `PROBE_TIMEOUT_SECS=60` wall clock, so **budget ~60s for that arm
+  alone**; whole-suite ~110s. Iteration 31's E7 *shape* (39 ok, 1 not ok, only arm 40) is the
+  prediction; its timings are not.
+- **Run** in the foreground with a 300000 ms tool timeout.
+
+#### T3 — addition-shaped mutant (proves the gate LOOKS, not merely FIRES)
+
+- **File**: `P`. **Mutant**: insert immediately after `P:128` (the `PROBE_MAX_TREE_NODES` validation,
+  which is after `instrument_failure` is defined at `P:4`) one dead-but-real refusal branch:
+  ```bash
+  [[ -z "${PROBE_TEST_T3_MUTANT_BRANCH:-}" ]] || instrument_failure "T3 mutation-validation branch"
+  ```
+  The guard is never satisfied in any arm, so **no arm's behaviour changes** — only the gate's count.
+  A removal-shaped mutant would prove only that a check fires; this addition is what proves it looks.
+- **Effect assertion (system's view)**: `grep -c 'instrument_failure "' "$P"` reports **20** where base
+  reported 19 — read through the same expression the gate itself uses.
+- **Predicted, to be produced**: rc=1; **40 `ok` lines then**
+  `not ok - refusal-branch drift: probe has 28 refusal branches,` followed by the gate's two
+  continuation lines naming 27. **Fast run** (~55s) — the added branch never executes.
+- **Run** in the foreground with a 300000 ms tool timeout.
+
+#### T4 — scoping-locality mutant (proves "scoped" is enforced, not decorative)
+
+- **File**: `T`. **Mutant — the token survives; only its SCOPE moves.** Two coupled edits:
+  1. **delete** ` PROBE_MAX_TREE_NODES=50000` from arm :449's `env` line;
+  2. **add** `export PROBE_MAX_TREE_NODES=50000` near the top of the file (immediately after `T:9`,
+     the `ARM_CAP_SECS` assignment).
+- **Why this shape and not a removal**: on the happy path a global export is behaviourally
+  **indistinguishable** from the scoped form — arm 40's own `env`-line `=3` still wins, and the wall
+  clock still fires first on every arm — so a plain removal proves nothing on a green run. Only the
+  moved-scope shape can distinguish "scoped to one arm" from "global", and A3.8's base measurement
+  (`rc=0, 41 ok` with an ambient 50000 at base) is the direct evidence that the distinction is otherwise
+  invisible.
+- **Effect assertion (system's view + statics)**: `grep -cE '^(export )?PROBE_MAX_TREE_NODES=' "$T"`
+  flips **0 → 1** (S7/A2.3 reds), and `grep -n -B1 'PROBE_MAX_TREE_NODES=50000' "$T"` no longer shows
+  the arm :449 `env` line — i.e. A2.4's locality claim reds too.
+- **Predicted, to be produced**: rc=1; **40 `ok` lines then a NAMED red** —
+  `not ok - PROBE_MAX_TREE_NODES is set at suite scope; the ceiling override must stay on arm env lines`.
+  ~55s. **This must be the guard's message, not a drift or arm failure**; any other red shape means the
+  guard is in the wrong place in the gate flow.
+- **Run** in the foreground with a 300000 ms tool timeout.
+
+#### M4 acceptance block
+
+| # | Criterion | **Base** | Required |
+|---|---|---|---|
+| A4.1 | For each of T1–T4: SHA_PRE recorded, post-mutation sha256 **differs**, `bash -n` **rc=0**, effect assertion holds, post-restore sha256 **equals** SHA_PRE | The protocol's own steps are all base-runnable (`shasum`, `cp`, `bash -n` all rc=0 at base) | all four complete, all four restored byte-identically |
+| A4.2 | `shasum -a 256 tools/eval/motoko_connection_probe.sh tools/eval/test_motoko_connection_probe.sh` after **all** mutants are restored | `7a75c698…` / `bd5302f5…` at base | equals the **post-M3** hashes (recorded at M3 acceptance), **not** the base hashes — M1–M3 legitimately changed both files |
+| A4.3 | Red set for each of T1–T4 recorded **as run** (rc, `ok` count, the exact `not ok` line, wall time, `uptime` at run time) | n/a — must be produced | four recorded red sets, each rc=1 |
+| A4.4 | Final clean re-run after all restores: `/bin/bash tools/eval/test_motoko_connection_probe.sh > /tmp/m4_final.log 2>&1; rc=$?` | rc=0, 41 ok, 50s | rc=0, 41 ok, 0 not ok, gate line shows `(27)` |
+| A4.5 | Design doc Testing Strategy table gains an **"Observed (iteration 32)"** column populated from A4.3, and any prediction/observation divergence is stated in prose | n/a | present |
+| A4.6 | `git status --porcelain` lists **only** the two shell files, the design doc and this plan — **no `.bak` files, no stray logs in the tree** (keep all `.bak` and `.log` files under `/tmp`). The sprint JSON does **not** appear: `.ailang/` is gitignored (`.gitignore:82`), which is why it is not in the base line count either. | 1 line: ` M design_docs/planned/m-motoko-discovery-arm-discriminating-refusal.md` | as stated |
+
+**Commit (controller)**: `docs(mission): record iteration-32 mutation validation (T1–T4) for row 6n`.
+
+---
+
+### Out of plan, but named by the design doc
+
+Decision (e) says the #971 hand-over is **a message to the V1 mission**, not a rebase, and Non-Goals
+says **motoko does not touch #971**. That message is **not** one of the doc's four implementation
+phases, so it is not a milestone here. It is left to the controller as a post-sprint action, and the
+executor must not attempt it. `PROBE_TREE_DISCOVERY_SECS` was re-confirmed **absent** at this HEAD
+(0 occurrences in both files; control `PROBE_TIMEOUT_SECS` = 3 in `P`, 12 in `T`), so #971 has not
+landed and no rebase question arises during this sprint.
+
+---
+
+## 3. Sequencing and dependencies
+
+```
+M1 (probe messages)  ──► M2 (arm :449)  ──► M3 (gate)  ──► M4 (mutation validation)
+   green: 41 ok           green: 41 ok       green: 41 ok      green: 41 ok after restore
+```
+
+- **M2 depends on M1**: reversing the order reds arm 33 (it would assert a string the probe does not
+  yet emit). M3 is content-independent of M1/M2 but is sequenced last among the code milestones so that
+  every intermediate commit is green.
+- **M4 depends on all three**: T1's predicted ceiling message (`exceeded 50000 nodes`) requires M2's
+  scoped override, and T3/T4 exercise M3's gate.
+- **Bisect property**: `git bisect` across M1→M2→M3 never lands on a commit where
+  `/bin/bash tools/eval/test_motoko_connection_probe.sh` is red. This is asserted by A1.8, A2.11 and
+  A3.6 respectively, each of which must be **run**, not assumed.
+
+## 4. Effort
+
+| Milestone | Edits | Run time | Wall estimate |
+|---|---|---|---|
+| M1 | 2 lines in `P` | 1 suite run (~50–60s) | ~15 min |
+| M2 | 2 lines in `T` | 1 suite run (~50–60s) | ~20 min |
+| M3 | ~15 lines in `T` | 2 suite runs (~120s) | ~35 min |
+| M4 | 0 product lines; 4 mutants + restores; 1 doc table | 5 suite runs, one of them 280–340s | ~2.0–2.5 h |
+| **Total** | **~20 lines across 2 files** | ~11–12 min of suite time | **~3.5 h** |
+
+This matches the design doc's own estimate (~3–4 h). The dominant cost is T1's walk to the 50,000-node
+ceiling, which is load-dependent.
+
+## 5. Risks
+
+**R1 — T1 runs long enough to be mistaken for a hang, or long enough to go cap-shaped.**
+*Measured, not hypothetical.* At the stub rates measured on this rig **at plan time** (166–181 iter/s),
+a 50,000-node walk is **276–301s**, i.e. only **2.0–2.2x** under the 600s widened cap. The design doc
+states the range as **2.2x–5.7x**; the low end of my measurement sits **marginally below the doc's
+stated floor**, purely because ambient load is higher now than when V23/V24 were taken. *Mitigation*:
+run T1 in the background with polling; treat >105s as normal; accept and **label** a cap-shaped red
+per decision (c); optionally confirm with `PROBE_SELFTEST_ARM_CAP_SECS=600` and record both runs.
+*This is a schedule and diagnosticity risk, not a verdict risk — T1 reds either way.*
+
+**R2 — a mutant is left applied.** *Mitigation*: A4.1's sha256-equality restore proof after **every**
+mutant, plus A4.2's whole-file hash check and A4.4's clean re-run at the end. The `cp`-backup rule
+(never `git checkout --`) is what keeps the restore from also deleting M1–M3.
+
+**R3 — the ceiling override silently leaks to suite scope in a later edit.** *Mitigation*: this is
+exactly what M3's guard plus A2.3/A3.9 (static) and A3.8/T4 (runtime) exist for, and A3.8 has a base
+measurement proving the hole is real today.
+
+**R4 — line numbers drift between milestones.** M3 adds lines at `T:707+`, i.e. **after** arm :449 at
+`T:449-452`, so M2's positions are stable in the M1→M2→M3 order. If the executor deviates from that
+order, re-derive positions with `grep -n` rather than trusting the numbers in this plan.
+
+**R5 — a `grep` pattern silently misfires.** *Measured trap*: `grep -c 'MAX_TREE_NODES=${PROBE_MAX_TREE_NODES:-4096}'`
+returns a false **0** on this rig (the `${...:-...}` text misparses as a regex); only the `-F` form
+returns 1. **Every literal-string criterion in this plan uses `-F`.** Do not drop it.
+
+**R6 — CI runner behaviour is unmeasurable locally.** Per decision (d), the settling measurement is the
+"launchd drivers (bash 3.2)" leg of the first PR carrying this work: arm 33 must pass with the new
+unique message. **Out of scope for the executor**; noted for the controller when the PR opens.
+
+## 6. Definition of done
+
+- M1, M2, M3 each applied, each acceptance block green **as run**, three controller commits.
+- M4's four mutants each applied, asserted (landed / parses / effect), run, red set **recorded as
+  produced**, and restored with sha256 proof.
+- Final clean suite: rc=0, 41 `ok`, 0 `not ok`, gate arm prints `(27)`.
+- `git status --porcelain` shows only `tools/eval/motoko_connection_probe.sh`,
+  `tools/eval/test_motoko_connection_probe.sh`, the design doc and this plan. The sprint JSON lives
+  under `.ailang/`, which is gitignored (`.gitignore:82`), so it is never listed.
+- **Zero git writes by the executor.**

--- a/design_docs/planned/m-motoko-discovery-arm-discriminating-refusal.md
+++ b/design_docs/planned/m-motoko-discovery-arm-discriminating-refusal.md
@@ -1,6 +1,6 @@
 # M-MOTOKO-DISCOVERY-ARM-DISCRIMINATING-REFUSAL: make the real wall-clock discovery refusal observable and reachable
 
-**Status**: PARKED — needs-human-review (design quorum BLOCKED 3/3 in both rounds; see Quorum Verification Log)
+**Status**: REVISED per attended human ruling D-MOTOKO-6N-1 (Mark Edmondson, 2026-09-01, commit `878e0a5a0`) — awaiting design quorum round 3. Rounds 1-2 were BLOCKED 3/3; the ruling selected §D4 (scoped ceiling), now applied throughout. See Quorum Verification Log.
 **Target**: v0.34.1
 **Priority**: P1 (High — a REQUIRED-adjacent CI gate is vacuous: arm 33 of the 41-arm self-test cannot fail for the reason its name claims)
 **Estimated**: 1 iteration (~3-4 hours implementation + mutation validation)
@@ -47,7 +47,8 @@ excluded from it.
 
 **Success Metrics:** the baseline suite stays green (41 ok); the E2 mutant (neuter the wall clock) reds
 the suite with arm :449 as the failing arm; a node-ceiling-only mutant does NOT red arm :449; an
-addition-shaped mutant moves the branch-count gate.
+addition-shaped mutant moves the branch-count gate; a scoping mutant (the ceiling override moved from
+arm :449's `env` line to suite scope) reds a named arm, proving the override is LOCAL, not global.
 
 ## High-Impact Decisions
 
@@ -81,33 +82,112 @@ The three refusal branches in `descendant_pids` get three distinct, self-documen
 | arm | drives | asserts after this work | still meaningful because |
 |---|---|---|---|
 | :357 "descendant discovery deadline refuses at the caller" | test stub | `process-tree discovery failed` (unchanged) | tests the caller collapse of a `descendant_pids` failure |
-| :449 "descendant discovery refuses on the real wall-clock deadline" | real walk | `process-tree discovery deadline expired (wall clock)` | tests the real wall-clock branch specifically |
+| :449 "descendant discovery refuses on the real wall-clock deadline" | real walk, `PROBE_MAX_TREE_NODES=50000` scoped to its own `env` line (D4) | `process-tree discovery deadline expired (wall clock)` | tests the real wall-clock branch specifically; the scoped ceiling makes the node bound structurally unreachable inside the wall-clock window (see (c)) |
 | 40 "descendant discovery refuses on the node-count ceiling" | real walk, `MAX_TREE_NODES=3` | `process-tree discovery exceeded 3 nodes` (unchanged) | tests the node-ceiling branch specifically |
 
 Each arm now asserts a distinct observable, so no two arms can pass for the same reason.
 
-### (c) Making arm :449 reach the wall-clock branch deterministically
+### (c) Making arm :449 reach the wall-clock branch deterministically — D4, per the attended ruling
 
-The wall clock fires on **wall time** (`date +%s > deadline`, ~1s with `PROBE_TIMEOUT_SECS=1`); the node
-ceiling fires on **iteration count** (`visited > MAX_TREE_NODES`). Which fires first is a race that
-depends on machine speed. **Corrected wording (evaluator finding 2, iteration 31): an earlier draft of
-this paragraph claimed the arm's verdict is "independent of which bound fires", and that is false and
-self-contradictory.** The arm's verdict depends on the wall clock firing — that is the entire point of
-the fix, and T1 is the demonstration. What actually changes is the FAILURE MODE of losing the race: the
-arm asserts a message only the wall-clock branch can emit (`process-tree discovery deadline expired
-(wall clock)`), so if the node ceiling ever won, the arm would RED — loudly, and on a clean tree —
-rather than pass vacuously. Today it passes either way, which is the defect. The node ceiling stays at
-its **default** `MAX_TREE_NODES` (4096) as a fail-fast backstop.
-**This trade is exactly what both quorum rounds rejected**, from opposite directions, and it is the
-open question the park hands to the human: trading a silent false PASS for a possible loud false RED is
-an improvement only if the false RED is rare on the CI host, and that rate is not measured (decision
-(d)). See D4 for the synthesis that would avoid the trade altogether.
+The wall clock fires on **wall time** (`date +%s > deadline`, nominally ~1s with `PROBE_TIMEOUT_SECS=1`);
+the node ceiling fires on **iteration count** (`visited > MAX_TREE_NODES`). Which fires first is a race
+that depends on machine speed. Note that `date +%s` has 1-second granularity, so the true wall-clock
+window is **0-2s**, not 1s: the deadline is one whole second past the start second, and the in-loop
+check can trip anywhere from almost immediately (walk starts just before the clock rolls) to just under
+2s in.
+
+**Position (supersedes the round-1 and round-2 positions, per attended ruling D-MOTOKO-6N-1):** arm
+:449's own `env` line carries a scoped override, **`PROBE_MAX_TREE_NODES=50000`** — the §D4 design.
+Every other arm keeps the default 4096: the override is a per-command `env`-line assignment, which does
+not persist past the one probe invocation, and nothing is exported at suite scope (the gate refuses if
+it is — see (f) and T4). This is the synthesis the iteration-31 evaluator recorded in §D4 and Mark
+Edmondson selected, attended, on 2026-09-01.
+
+**Why the scoped form answers both rejections at once.** Round 1 rejected the original
+`PROBE_MAX_TREE_NODES=1000000` override: effectively unbounded, it turns a wall-clock regression into a
+hang that only the arm cap can end (at the measured stub rates below, 1,000,000 iterations ≈ 1,532-2,106s,
+so the 600s widened cap ALWAYS fires first — a cap-shaped timeout, not a message-shaped red). Round 2
+rejected removing the override: at the default 4096 the race stays live, and a fast CI runner could hit
+the ceiling inside the window and spuriously RED a clean tree. A scoped middle value is neither: it is
+bounded, so a regression still fail-fasts on the ceiling's own message inside the cap (answering round
+1), and it is far enough out that the ceiling is structurally unreachable inside the wall-clock window —
+the race is removed by arithmetic, not bet on (answering round 2) — and because it rides the arm's own
+`env` line, it is not a global raise (the residue of round 1's objection that a global change perturbs
+every arm's fail-fast).
+
+**Deriving 50,000.** Inputs: the corrected E9 stub rates, measured against this suite's own `pgrep`
+stub (474.9 / 652.7 / 648.6 iter/s), and the 0-2s worst-case window.
+
+- **Default 4096 is too close.** 4096 / 652.7 ≈ 6.3s and 4096 / 474.9 ≈ 8.6s — a 6.3-8.6x margin
+  against the nominal 1s window, but only **3.1-4.3x against the true 2s worst case** (losing the race
+  needs just 4096 / 2s = 2,048 iter/s). That is the "6-9x margin holding on a CI host nobody has
+  measured" that the ruling declines to bet on — and the honest worst-case number is smaller still.
+- **50,000 removes the race, and iteration 32 measured a HARD physical bound under it (V25).** A
+  ceiling C wins the race only if the runner sustains ≥ C/2 iter/s inside the window. C = 50,000
+  requires **25,000 iter/s** — **38x** the fastest rate ever observed for this stub (652.7 iter/s) and
+  **125x** the contended rate re-measured at this base (200 iter/s, V23). The bound is stronger than a
+  rate extrapolation: the walk spawns **one process per iteration by construction**
+  (`pgrep -P "$current"`), and on this machine `/usr/bin/true` — no bash, no script, the absolute
+  physical floor — spawns at **205-250/s** (V25). 25,000 iter/s is therefore **~100x the bare-spawn
+  ceiling of the hardware**, not merely 38x a stub benchmark. **This refutes `gpt5-6-sol`'s round-3
+  objection** ("a sufficiently fast runner can exceed 25,000 iterations/s") by measurement rather than
+  by argument: no machine that must fork a process per iteration reaches it.
+- **50,000 keeps the backstop bounded — CORRECTED at iteration 32 (V23/V24), and this leg is weaker
+  than first written.** With the wall clock dead (the T1 regression this arm exists to catch), the
+  ceiling ends the walk in 50,000 / rate seconds. At the QUIET rates (474.9-652.7 iter/s) that is
+  **77-105s**, inside the 600s widened cap with ≈ 5.7x headroom — the figure this doc originally
+  carried. At the CONTENDED rates re-measured at this base (**181-200 iter/s**, V23, under load
+  average 20.59 on 16 CPUs, V24) it is **250-276s**, i.e. only **≈ 2.2x** under the cap. The honest
+  statement is therefore a range, not a point: **backstop headroom is 2.2x-5.7x depending on ambient
+  load**, and the 5.7x figure is the quiet-machine end of it, not the operating point.
+  **What degrades, and what does not.** On a runner more than ~2.2x slower than this already-contended
+  measurement, T1 stops being a message-shaped red (`process-tree discovery exceeded 50000 nodes`) and
+  becomes a **cap-shaped** red at 600s. It does **not** stop being a red: T1's verdict is unchanged,
+  only its diagnosticity. That is the correct reading of round 1's objection, which was aimed at
+  `PROBE_MAX_TREE_NODES=1000000` — a value at which the cap fires ALWAYS (1,532-2,106s at quiet rates,
+  4,000-5,500s at contended ones), so the ceiling's own message was unreachable in every configuration
+  rather than in a contended tail.
+- **Feasible interval — RE-DERIVED at iteration 32 with the full observed rate range, and the result
+  is that the doc's original interval was an artefact of using ONE rate for BOTH legs.** The two legs
+  pull in opposite directions and each must take its own worst case: the race leg is worst at the
+  FASTEST observed rate, the backstop leg at the SLOWEST. Race: a ≥ 30x margin at 652.7 iter/s needs
+  C ≥ 30 x 2 x 652.7 ≈ **39,200**. Backstop: inside the 600s cap at 5x contention of the slowest
+  observed rate (181 iter/s, V23) needs C ≤ 600 x 181 / 5 ≈ **21,700**. **At those two margins the
+  interval is EMPTY** — the original `[≈39,000, ≈57,000]` was non-empty only because both legs were
+  evaluated at quiet-machine rates. The original derivation is retained above as history; this is the
+  correction.
+- **Why 50,000 nonetheless stands, and what it costs.** The two margins are not symmetric in
+  consequence. Violating the RACE margin produces a **spurious red on a clean tree** — a false
+  accusation, the failure round 2 rejected and the one this arm exists to avoid. Violating the
+  BACKSTOP margin produces a **correct red, less precisely diagnosed** (cap-shaped instead of
+  message-shaped) in a configuration that is *already* a regression. Given an empty interval, the doc
+  chooses to satisfy the leg whose violation is a wrong verdict and to accept, explicitly, a
+  degradation in the leg whose violation is only a wrong explanation. At C = 50,000 the race margin is
+  **38x** at the fastest observed rate and **125x** at the contended rate (V23), while the backstop is
+  **2.2x-5.7x** under the cap (V24). **This is a stated trade, not a satisfied constraint**, and it is
+  flagged as such for the round-4 reviewers rather than presented as an interval membership.
+
+**What the arm still fail-fasts on:** a dead or mis-scoped wall clock (T1 — red on a ceiling-message
+mismatch in ~77-105s at measured rates), a walk with BOTH bounds dead (the 600s cap, as before), and
+the compound case of a wall-clock regression on a runner more than ~5.7x slower than this machine's
+slowest measured rate (cap-shaped red — acceptable, because that configuration is already a
+regression; a clean wall clock reds nothing).
+
+**Failure-mode framing (unchanged from the iteration-31 correction, evaluator finding 2):** the arm's
+verdict depends on the wall clock firing — T1 is the demonstration — and the arm asserts a message only
+the wall-clock branch can emit, so if the ceiling somehow won anyway, the arm would RED loudly on a
+clean tree rather than pass vacuously. D4 does not change that shape; it moves the ceiling far enough
+out that the spurious red cannot happen at any measured or plausibly extrapolated rate, while keeping
+it close enough in to remain a real backstop.
 
 Measured (iteration 31), on the machine E7/E8/T1 all ran on — the controller's own pin worktree; no row
 here establishes that it is the same machine as any other referenced in this doc (evaluator finding 4).
-At the DEFAULT ceiling,
-the wall clock is what fires (E8: minimal fix only, no ceiling change → rc=0, 41 ok, 0 not ok, 50s). The
-`PROBE_MAX_TREE_NODES=1000000` mechanism is **not needed for the arm to pass** and is deleted.
+At the DEFAULT ceiling, the wall clock is what fires (E8: minimal fix only, no ceiling change → rc=0,
+41 ok, 0 not ok, 50s), and the iteration-31 evaluator measured the D4 scoped override as free on the
+happy path (41/41 ok, 47.1s, indistinguishable from baseline). The original
+`PROBE_MAX_TREE_NODES=1000000` mechanism is **not needed for the arm to pass** and stays deleted; D4
+re-introduces a ceiling override at 50,000, scoped, for the reasons derived above — not because the arm
+needs it to pass, but so that its passing does not depend on an unmeasured runner losing a live race.
 
 The 5x widened arm cap (test_motoko_connection_probe.sh:447-452) is **kept**. **The justification is the
 CI incident the code comment already cites (run 33001432738, 2026-08-26), NOT the timings below**
@@ -156,18 +236,46 @@ a gap, and precisely the branches this defect is about. The design extends the g
 
 - add `actual_echo_refusals=$(grep -c 'echo "process-tree discovery' "$probe")` (counts exactly the 3
   descendant_pids refusals; verified V6),
+- **assert the target file exists BEFORE any counter runs** — `[[ -f "$probe" ]] || { echo "not ok -
+  refusal-branch gate: \$probe does not resolve to a file; instrument failure, not a verdict" >&2; exit 1; }`
+  — so that no `grep` in this gate can ever fall through to reading stdin,
 - extend the anti-vacuity floor to require `actual_echo_refusals != 0`,
 - `expected_refusal_branches` moves **24 → 27** (19 + 5 + 3).
 
 The count moves because the gate now covers the previously-unguarded echo refusals, not because this
 work adds a new refusal branch (it does not — it only re-words two existing messages).
 
+The gate section also gains a **ceiling-locality guard** (new in this revision, in service of D4's
+"scoped" claim): before the drift count, the suite refuses if `PROBE_MAX_TREE_NODES` is set in the
+suite's own scope at gate time —
+
+```bash
+if [[ -n "${PROBE_MAX_TREE_NODES:-}" ]]; then
+  echo "not ok - PROBE_MAX_TREE_NODES is set at suite scope; the ceiling override must stay on arm env lines" >&2
+  exit 1
+fi
+```
+
+A per-command `env`-line assignment (arm :449's D4 override, arm 40's `=3`, the invalid-value arm)
+never persists into the suite's shell, so this is invariantly quiet on a correct tree. It fires on
+exactly two leak shapes: a future edit that promotes the override to a file-global assignment or
+`export`, and an ambient `PROBE_MAX_TREE_NODES` in the caller's environment. The second is deliberate
+fail-loud hermeticity, not collateral: an ambient override silently re-parameterises every arm that
+does not pin its own ceiling, which un-hermeticizes the suite. The guard lives inside the existing gate
+flow (like the anti-vacuity floor), so the arm count stays 41. Without it, nothing in the suite would
+distinguish "scoped to one arm" from "global" — the happy path is byte-identical either way, which is
+why T4 (Testing Strategy) is required to prove this guard LOOKS.
+
 ## Design Freeze
 
 - The three `descendant_pids` branches keep distinct messages; no two branches share a string.
-- Arm :449 asserts `process-tree discovery deadline expired (wall clock)`; the node ceiling stays at its
-  default `MAX_TREE_NODES` (4096) as a fail-fast backstop; the 5x widened cap is kept.
-- The refusal-branch gate counts echo-based process-tree refusals and `expected_refusal_branches=27`.
+- Arm :449 asserts `process-tree discovery deadline expired (wall clock)` and carries
+  `PROBE_MAX_TREE_NODES=50000` on its own `env` line (§D4, applied per attended ruling D-MOTOKO-6N-1);
+  every other arm keeps the default 4096 as its fail-fast backstop; the override is never exported or
+  assigned at suite scope, and the gate's ceiling-locality guard refuses if it is; the 5x widened cap
+  is kept.
+- The refusal-branch gate counts echo-based process-tree refusals and `expected_refusal_branches=27`,
+  and gains the ceiling-locality guard (see (f)).
 - No change to the probe's production refusal *outcome* (exit 1, caller wrapper); only the diagnostic
   stderr strings at lines 182/187 change.
 - No fix to #971; no runner-only speculative change; no widening into row 6o.
@@ -175,6 +283,10 @@ work adds a new refusal branch (it does not — it only re-words two existing me
 ## Verification Log
 
 Base commit: **a223e7274** (`git log --oneline -1` → `a223e7274 M2: pipeline.BuildCanonicalJSON + hidden internal-dump-iface (iteration 312) (#998)`). All rows measured in this worktree at that commit unless noted. Rows V1-V11 are re-derived here; E1-E8 and T1 are controller-measured, iteration 31, and cited as such.
+
+**Rows V12-V21 are the iteration-32 revision's rows**, measured at **`48817dcdd`** (= `origin/dev` at
+revision time) in the iteration-32 revision worktree. The Success Criteria are re-baselined on them.
+Where a V12+ row repeats an earlier row's command, the V12+ observation is the one the criteria cite.
 
 | # | Claim | Command | Observed output |
 |---|---|---|---|
@@ -193,6 +305,22 @@ Base commit: **a223e7274** (`git log --oneline -1` → `a223e7274 M2: pipeline.B
 | E7 | Neuter the node ceiling ALONE, wall clock alive (controller-measured, iteration 31) | apply `if false && (( visited > MAX_TREE_NODES ))` at the node-ceiling site; `bash -n`; run suite; restore byte-identical | parses rc=0; effect asserted (neutered 0->1, live 1->0); suite rc=1, 39 ok, 1 not ok — the ONLY failing arm is arm 40 ("descendant discovery refuses on the node-count ceiling"); arm 33 ("real wall-clock deadline") still `ok`. Restored byte-identical. |
 | E8 | Minimal fix only, NO ceiling change, default MAX_TREE_NODES=4096 (controller-measured, iteration 31) | apply only the message distinction (probe line 182 -> "(test stub)", line 187 -> "(wall clock)") and arm :449's new assertion; `bash -n` both; run suite; restore byte-identical | both files `bash -n` rc=0; effect asserted (2 distinct messages present); `/bin/bash tools/eval/test_motoko_connection_probe.sh` -> rc=0, 41 ok, 0 not ok, 50s. On the machine previously claimed to exhibit the race, at the DEFAULT ceiling, the WALL CLOCK is what fires. `PROBE_MAX_TREE_NODES=1000000` is not needed for the arm to pass. Restored byte-identical, `git status --porcelain` 0 lines. |
 | T1 | Load-bearing acceptance, measured (controller-measured, iteration 31) | apply the SAME minimal fix as E8 AND the E2 mutant (wall clock neutered), ceiling untouched at default (asserted: neutered wall-clock site = 1, live node-ceiling site = 1); run suite; restore byte-identical | rc=1, 44 seconds; failing arm exactly: `not ok - descendant discovery refuses on the real wall-clock deadline / lacked expected message: process-tree discovery deadline expired (wall clock)`. Clean rc=0/50s vs mutant rc=1/44s — outcomes DIFFER, and the mutant run is FASTER than the clean one, not a 120-second hang. Restored byte-identical; both files sha256-verified; `git status --porcelain` 0 lines. |
+| V12 | Iteration-32 worktree is at `48817dcdd` and clean | `git log --oneline -1`; `git status --porcelain \| wc -l` | `48817dcdd docs(mission): file D-53 — the 4 UNCLASSIFIED docs from the D-51 inventory (#1006)`; `0` |
+| V13 | Baseline suite is green at `48817dcdd` (re-baselines S1) | `/bin/bash tools/eval/test_motoko_connection_probe.sh` | rc=0; `ok` lines 41; `not ok` lines 0; 54.1s wall; last line `PASS: 41 probe self-test arms ran` |
+| V14 | Both files parse at `48817dcdd` | `bash -n tools/eval/motoko_connection_probe.sh`; `bash -n tools/eval/test_motoko_connection_probe.sh` | rc=0; rc=0 |
+| V15 | #971's mechanism still absent at `48817dcdd`, so decision (e) holds | `grep -c 'PROBE_TREE_DISCOVERY_SECS'` in each file; same-file control `grep -c 'PROBE_TIMEOUT_SECS'` | 0 occurrences in `tools/eval/motoko_connection_probe.sh` (grep rc=1) and 0 in `tools/eval/test_motoko_connection_probe.sh` (grep rc=1); control: 3 in the probe, 12 in the test |
+| V16 | PR #971 still OPEN/MERGEABLE at revision time | `gh pr view 971 --json state,mergeable,headRefOid,updatedAt` | `OPEN`, `MERGEABLE`, head `8a384e81b7e9f0f6b4b4588b462fb35ef74b7bf4`, updated `2026-08-31T06:57:30Z` |
+| V17 | Touched positions unchanged at `48817dcdd`: arm :449 block spans :447-:452 (save/widen/arm/restore), stub arm drive at :358, node-ceiling arm at :698-:701 with `PROBE_TIMEOUT_SECS=60 PROBE_MAX_TREE_NODES=3`, gate `expected_refusal_branches=24` at :707 | `grep -n '_arm_cap_saved\|ARM_CAP_SECS=\|real wall-clock deadline\|expected_refusal_branches\|node-count ceiling\|PROBE_TEST_DESCENDANT_FAILURE=1' tools/eval/test_motoko_connection_probe.sh`; `sed -n '440,475p;694,702p'` of the same file | :447 `_arm_cap_saved=$ARM_CAP_SECS`; :448 `ARM_CAP_SECS=$(( ARM_CAP_SECS * 5 ))`; :449 the wall-clock arm asserting `process-tree discovery failed`; :450 its env line `env PATH="$live_bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=1 PROBE_TEST_PGREP_LOOP=1`; :452 restore; :358 `run_live PROBE_TEST_DESCENDANT_FAILURE=1`; :698-:701 the node-ceiling arm; :707 `expected_refusal_branches=24` |
+| V18 | No suite-scope assignment/export of the ceiling exists at base (the locality guard's precondition) | `grep -cE '^(export )?PROBE_MAX_TREE_NODES=' tools/eval/test_motoko_connection_probe.sh`; same-file anchored control `grep -c '^ARM_CAP_SECS='` | 0 occurrences in `tools/eval/test_motoko_connection_probe.sh` (grep rc=1); control 3 (rc=0; lines 9, 448, 452). Note: the first control attempted, `grep -c 'export '`, is itself 0 in this file (it contains no exports at all), so the anchored-assignment control is the sound same-scope positive |
+| V19 | The D4 token is absent at base (S6's base value) | `grep -c 'PROBE_MAX_TREE_NODES=50000' tools/eval/test_motoko_connection_probe.sh`; same-file control `grep -c 'PROBE_MAX_TREE_NODES=3 '` | 0 occurrences in `tools/eval/test_motoko_connection_probe.sh` (grep rc=1); control 1 (rc=0, the node-ceiling arm's env line) |
+| V20 | Gate components at `48817dcdd` re-derive V5/V6 | `grep -c 'echo "process-tree discovery'`, `grep -c 'instrument_failure "'`, `grep -cE '\|\| usage$'`, all on `tools/eval/motoko_connection_probe.sh` | 3; 19; 5 (all rc=0; 19 + 5 = 24, matching :707; + 3 echo refusals = the new 27) |
+| V21 | The default-ceiling line exists verbatim at :126; the `-F` form is the sound instrument for it | `grep -Fc 'MAX_TREE_NODES=${PROBE_MAX_TREE_NODES:-4096}' tools/eval/motoko_connection_probe.sh`; control `grep -c 'PROBE_MAX_TREE_NODES'` same file | `-F` count 1 (rc=0); control 2 (rc=0; lines 126, 128). Measured trap: the same pattern WITHOUT `-F` returns 0 (rc=1) on this rig's grep — the `${...:-...}` text misparses as regex — so S7 below mandates `grep -F` |
+
+| V22 | The pgrep stub is BYTE-IDENTICAL between the rate-measurement commit `a223e7274` and this doc's base `48817dcdd`, so oc-glm-5-2's named mechanism ("the stub implementation may have changed") cannot be the cause of any rate difference | `git show a223e7274:tools/eval/test_motoko_connection_probe.sh > /tmp/old`; `sed -n '250,266p'` each side; `cmp -s`; `shasum -a 256`; whole-file control `cmp -s /tmp/old <file>` | stub region **IDENTICAL**, sha256 `abffefd3622943b01fb598688c2ffc32b6f6409b04097548873119cffba9cd7d` on BOTH sides; whole-file control: **SAME** (the file did not change at all between the two commits) |
+| V23 | Stub rate RE-MEASURED at `48817dcdd` as oc-glm-5-2 asked — and it is **3.3-3.6x SLOWER** than the iteration-31 figures the 50,000 derivation rests on | extract the stub verbatim from `sed -n '255,261p' tools/eval/test_motoko_connection_probe.sh` (sha `3d487e95f2494ea3`), sanity-check it echoes its last arg under `PROBE_TEST_PGREP_LOOP=1` (`out=12345`), then 3 trials of N=2000 invocations timed with `date +%s` | **181 / 200 / 200 iter/s** (11s / 10s / 10s), against iteration 31's **474.9 / 652.7 / 648.6 iter/s**. Same machine, byte-identical stub (V22) — so the variable is neither the code nor the machine |
+| V24 | The cause of V23's spread is **ambient load**, not the instrument: a finer clock agrees, and the rig is heavily contended | `uptime`; `sysctl -n hw.ncpu`; `ps -A -o %cpu,comm \| sort -rn \| head`; then the same spawn loop timed with python `time.perf_counter()` instead of `date +%s` | load averages **20.59 / 18.07 / 16.96** on **16** CPUs, with a 100%-CPU editor helper and five ~48% `bash` processes (sibling missions); `date`-timed `/usr/bin/true` **200-250 spawns/s** vs `perf_counter`-timed **205.2 / 205.8 / 219.2 spawns/s** — the two clocks AGREE, so `date +%s` granularity is refuted as the explanation |
+| V25 | **gpt5-6-sol's round-3 objection is REFUTED by measurement**: no runner can sustain the 25,000 iter/s that a 50,000 ceiling would need to win the race | same spawn loop against `/usr/bin/true` — no bash, no script, the ABSOLUTE physical floor per iteration on this machine — plus the spawn-free control loop to prove the harness is not the bound | `/usr/bin/true` = **200-250 spawns/s** (`date`) / **205.2-219.2** (`perf_counter`); spawn-free control = **200,000 iter/s**, so the loop harness is ~1000x away from being the limiter. 25,000 iter/s is **~100x** the bare-spawn ceiling of this machine. The walk spawns one process per iteration BY CONSTRUCTION (`pgrep -P "$current"`), so this bound is structural, not incidental |
+| V26 | `gemini-3-1-pro`'s round-4 premise is REFUTED: `$probe` cannot be unset, so the gate's `grep` cannot fall through to stdin | `grep -n 'probe='`; `grep -cE '^[[:space:]]*probe='`; `grep -c '"$probe"'`; `head -5 ... | grep -n 'set '`; same-file control `grep -cE '^[[:space:]]*live_bin='` | assigned once at `:5` as `probe=${PROBE_UNDER_TEST:-$script_dir/motoko_connection_probe.sh}` (a `:-` default, so never unset); `set -uo pipefail` at `:2`; **27** uses of `"$probe"` in the file, including the two sibling counters in this same gate; control = **1**. Hazard class still closed defensively by the `[[ -f "$probe" ]]` assertion added to Phase 3 |
 
 ## Solution Design
 
@@ -200,9 +328,11 @@ Base commit: **a223e7274** (`git log --oneline -1` → `a223e7274 M2: pipeline.B
 
 The fix is small and confined to two shell files. In the probe, the two `descendant_pids` refusal
 messages that currently share a string are made distinct, so the real wall-clock branch has a unique
-observable. In the test, arm :449 asserts that unique observable; the node ceiling stays at its default
-`MAX_TREE_NODES` (4096) as a fail-fast backstop; the 5x widened cap is kept; and the refusal-branch gate
-is extended to count the echo-based refusals it previously ignored.
+observable. In the test, arm :449 asserts that unique observable and carries `PROBE_MAX_TREE_NODES=50000`
+on its own `env` line (§D4, per the attended ruling), making the node ceiling structurally unreachable
+inside the wall-clock window on that arm while every other arm keeps the default 4096; the 5x widened
+cap is kept; and the refusal-branch gate is extended to count the echo-based refusals it previously
+ignored and to refuse if the ceiling override leaks to suite scope.
 
 ### Architecture
 
@@ -210,9 +340,11 @@ is extended to count the echo-based refusals it previously ignored.
   touched. Its three refusal branches emit three distinct messages. The caller (`sample_tree`, line
   217) is unchanged: it still collapses any `descendant_pids` failure to
   `instrument_failure "process-tree discovery failed"`. Production refusal *outcome* is unchanged.
-- **Test (`test_motoko_connection_probe.sh`)** — arm :449 (lines 449-452) and the refusal-branch gate
-  (lines 707-722) are the only regions touched. Arm :449's assertion changes (no env change — the node
-  ceiling stays at its default); the gate's counters and expected total change.
+- **Test (`test_motoko_connection_probe.sh`)** — arm :449 (lines 447-452) and the refusal-branch gate
+  (lines 707-722) are the only regions touched. Arm :449's assertion changes AND its `env` line gains
+  `PROBE_MAX_TREE_NODES=50000` (a per-command assignment scoped to that one probe invocation — not an
+  export, not a suite-scope variable); the gate gains the echo counter, the extended anti-vacuity
+  floor, the new expected total, and the ceiling-locality guard.
 
 ### Conflict Surface
 
@@ -231,7 +363,8 @@ is extended to count the echo-based refusals it previously ignored.
 **Positions touched:**
 
 - Probe lines 182 and 187 (the two echo messages).
-- Test lines 449-452 (arm :449 assertion) and lines 707-722 (refusal-branch gate).
+- Test lines 447-452 (arm :449 assertion + its `env` line) and lines 707-722 (refusal-branch gate +
+  ceiling-locality guard). Positions re-verified at `48817dcdd` (V17).
 
 **What must still work:** all 41 arms pass (V2); both files parse under `bash -n` (V3, V4); the node
 ceiling arm (40) still asserts `process-tree discovery exceeded 3 nodes`; the stub arm (:357) still
@@ -239,8 +372,9 @@ asserts the caller wrapper; the run_lane fixture arm still passes; the gate arm 
 new count.
 
 **What deliberately changes:** the two probe stderr strings at lines 182/187 (cosmetic diagnostic
-change; the refusal outcome is unchanged); arm :449's assertion; the gate's count (24 → 27) and
-anti-vacuity floor.
+change; the refusal outcome is unchanged); arm :449's assertion and its `env` line (gains
+`PROBE_MAX_TREE_NODES=50000`); the gate's count (24 → 27), anti-vacuity floor, and new
+ceiling-locality guard.
 
 **Shell constraints:** both files are shell; `bash -n` is the only syntax gate, and the CI shell is GNU
 bash 3.2.57 on arm64-apple-darwin25. No bash-4+ constructs are introduced (no associative arrays, no
@@ -252,57 +386,80 @@ bash 3.2.57 on arm64-apple-darwin25. No bash-4+ constructs are introduced (no as
 `echo "process-tree discovery deadline expired (test stub)" >&2` and line 187 to
 `echo "process-tree discovery deadline expired (wall clock)" >&2`. `bash -n` must stay rc=0.
 
-**Phase 2 — arm :449 (~20 min).** In `test_motoko_connection_probe.sh`, replace the arm :449 block
-(lines 447-452) with a single `expect_failure` asserting `process-tree discovery deadline expired
-(wall clock)`. No env change: the node ceiling stays at its default `MAX_TREE_NODES` (4096) as a
-fail-fast backstop. The `_arm_cap_saved` / `ARM_CAP_SECS=$(( ARM_CAP_SECS * 5 ))` widening is KEPT (see
-decision (c)).
+**Phase 2 — arm :449 (~20 min).** In `test_motoko_connection_probe.sh`, in the arm :449 block
+(lines 447-452, verified V17): change the `expect_failure` expectation string to `process-tree
+discovery deadline expired (wall clock)`, and add exactly one token, **`PROBE_MAX_TREE_NODES=50000`**,
+to the arm's `env` line at :450, after `PROBE_TIMEOUT_SECS=1`. The line becomes:
 
-**Phase 3 — refusal-branch gate (~30 min).** In `test_motoko_connection_probe.sh`, add
+```bash
+  env PATH="$live_bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=1 PROBE_MAX_TREE_NODES=50000 PROBE_TEST_PGREP_LOOP=1 \
+```
+
+This is the D4 env change (attended ruling D-MOTOKO-6N-1): a per-command assignment scoped to this one
+probe invocation — no `export`, no suite-scope assignment anywhere in the file. The
+`_arm_cap_saved` / `ARM_CAP_SECS=$(( ARM_CAP_SECS * 5 ))` widening is KEPT (see decision (c); the 600s
+cap is now also the T1 backstop's outer bound).
+
+**Phase 3 — refusal-branch gate (~35 min).** In `test_motoko_connection_probe.sh`, add
 `actual_echo_refusals=$(grep -c 'echo "process-tree discovery' "$probe")`, extend the anti-vacuity floor
-to require it non-zero, set `expected_refusal_branches=27`, and add it to the total.
+to require it non-zero, set `expected_refusal_branches=27`, and add it to the total. Immediately before
+the drift count, add the ceiling-locality guard from decision (f) (refuse if
+`${PROBE_MAX_TREE_NODES:-}` is non-empty at suite scope).
 
 **Phase 4 — baseline + mutation validation (~2-3 hours).** Run the baseline suite (must stay 41 ok), then
-run the E2 mutant, the node-ceiling-only mutant, and the addition-shaped mutant (see Testing Strategy),
-recording each mutant's red set.
+run the T1 (wall-clock) mutant, the T2 (node-ceiling-only) mutant, the T3 addition-shaped mutant, and the
+T4 scoping mutant (see Testing Strategy), recording each mutant's red set AS RUN — the iteration-31 red
+sets were measured under the old default-ceiling design and are predictions here, not results.
 
 ## Files to Modify/Create
 
 **Modified:**
 - `tools/eval/motoko_connection_probe.sh` — lines 182, 187 (distinct refusal messages).
-- `tools/eval/test_motoko_connection_probe.sh` — arm :449 (assertion); refusal-branch
-  gate (echo counter, anti-vacuity, `expected_refusal_branches=27`).
+- `tools/eval/test_motoko_connection_probe.sh` — arm :449 (assertion + `PROBE_MAX_TREE_NODES=50000` on
+  its `env` line at :450); refusal-branch gate (echo counter, anti-vacuity,
+  `expected_refusal_branches=27`, ceiling-locality guard).
 
 **Created:** none.
 
 ## Success Criteria
 
-Each criterion names a command and its result on the **unmodified** tree (a criterion already red at
-base is broken). All are green at base and must stay green after this work.
+Each criterion names a command and its measured result on the **unmodified** tree at **`48817dcdd`**
+(re-baselined for this revision, per the rule that a criterion must be baselined on the tree that will
+run it; a command that cannot run cleanly at base is broken). S6 is the one criterion whose value is
+DESIGNED to move (0 → 1); every other criterion must hold its base value.
 
-| # | Command | Result at base (a223e7274) | Must hold after |
+| # | Command | Result at base (`48817dcdd`) | Must hold after |
 |---|---|---|---|
-| S1 | `/bin/bash tools/eval/test_motoko_connection_probe.sh` | rc=0, 41 ok, 0 not ok, `PASS: 41 probe self-test arms ran` (V2) | rc=0, 41 ok, 0 not ok |
-| S2 | `bash -n tools/eval/motoko_connection_probe.sh` | rc=0 (V3) | rc=0 |
-| S3 | `bash -n tools/eval/test_motoko_connection_probe.sh` | rc=0 (V4) | rc=0 |
-| S4 | `grep -c 'echo "process-tree discovery' tools/eval/motoko_connection_probe.sh` | 3 (V6) | 3 (the two re-worded messages keep the count) |
-| S5 | `grep -c 'instrument_failure "' tools/eval/motoko_connection_probe.sh` + `grep -cE '\|\| usage$'` + echo count | 24 (V5) | 27 (gate now counts the echo refusals) |
+| S1 | `/bin/bash tools/eval/test_motoko_connection_probe.sh` | rc=0, 41 ok, 0 not ok, 54.1s, `PASS: 41 probe self-test arms ran` (V13) | rc=0, 41 ok, 0 not ok |
+| S2 | `bash -n tools/eval/motoko_connection_probe.sh` | rc=0 (V14) | rc=0 |
+| S3 | `bash -n tools/eval/test_motoko_connection_probe.sh` | rc=0 (V14) | rc=0 |
+| S4 | `grep -c 'echo "process-tree discovery' tools/eval/motoko_connection_probe.sh` | 3 occurrences in that file (V20) | 3 (the two re-worded messages keep the count) |
+| S5 | `grep -c 'instrument_failure "'` + `grep -cE '\|\| usage$'` + S4's echo count, all on `tools/eval/motoko_connection_probe.sh` | 19 + 5 + 3 = 27 (V20) | 19 + 5 + 3 = 27, and the gate's `expected_refusal_branches` equals this sum |
+| S6 | `grep -c 'PROBE_MAX_TREE_NODES=50000' tools/eval/test_motoko_connection_probe.sh` | 0 occurrences in that file (V19; grep rc=1; same-file control `PROBE_MAX_TREE_NODES=3 ` = 1) | **exactly 1**, and it is on arm :449's `env` line — more than 1 means the override spread to another arm; 0 means D4 was not applied |
+| S7 | `grep -cE '^(export )?PROBE_MAX_TREE_NODES=' tools/eval/test_motoko_connection_probe.sh` | 0 occurrences in that file (V18; grep rc=1; same-file anchored control `^ARM_CAP_SECS=` = 3) | 0 — **this is the criterion that REDS if the scoping leaks to suite scope**; its runtime twin is the gate's ceiling-locality guard, exercised by T4 |
+| S8 | `grep -Fc 'MAX_TREE_NODES=${PROBE_MAX_TREE_NODES:-4096}' tools/eval/motoko_connection_probe.sh` (the `-F` is mandatory — V21 measured the non-`-F` form returning a false 0 on this rig's grep) | 1 occurrence in that file (V21) | 1 — the probe's default stays 4096, so every arm without its own override keeps it |
 
 ## Testing Strategy
 
-Each row names the OBSERVABLE and confirms it is produced **by** the mechanism, not alongside it. Each
-mutant's expected red set is produced by RUNNING it, not asserted.
+Each row names the OBSERVABLE and confirms it is produced **by** the mechanism, not alongside it.
 
-| # | Mutant | Kills which mutation | Observable | Produced by |
+**Re-derivation notice (this revision):** iteration 31's T1/E7 measurements were taken under the OLD
+design — arm :449 at the **default** ceiling. Under D4's scoped ceiling the mutants traverse different
+code-path lengths (a dead wall clock now runs to 50,000 nodes, not 4,096), so those numbers **do not
+transfer**. Every "expected" column below is a PREDICTION the executor must PRODUCE BY RUNNING on the
+modified tree; the iteration-31 figures are cited only as the prior design's measurements.
+
+| # | Mutant | Kills which mutation | Predicted observable (executor must produce by running) | Produced by |
 |---|---|---|---|---|
-| T1 | E2 mutant: neuter the in-loop wall clock (`if false && (( $(date +%s) > deadline ))`) | the vacuity this doc fixes | suite reds; arm :449 is the failing arm with `lacked expected message: process-tree discovery deadline expired (wall clock)` | the wall-clock mechanism — the wall clock is dead, so its unique message cannot appear; the node ceiling (default 4096) or the 120s cap ends the walk with a different message. **MEASURED by the controller at iteration 31: rc=1, 44s, failing arm exactly as stated; re-run required by the executor.** |
-| T2 | node-ceiling-only mutant: neuter `if (( visited > MAX_TREE_NODES ))` | the two arms being separable | arm :449 still passes (wall clock fires at ~1s); arm 40 reds with `lacked expected message: process-tree discovery exceeded 3 nodes` | the wall-clock mechanism for :449 (alive, fires at ~1s); the node-ceiling mechanism for arm 40 (dead, so its unique message cannot appear). **MEASURED by the controller at iteration 31 (E7): suite rc=1, 39 ok, 1 not ok — the ONLY failing arm is arm 40; arm 33 still `ok`; re-run required by the executor.** |
+| T1 | E2 mutant: neuter the in-loop wall clock (`if false && (( $(date +%s) > deadline ))`) | the vacuity this doc fixes | suite reds; arm :449 is the failing arm with `lacked expected message: process-tree discovery deadline expired (wall clock)`; the arm's stderr shows `process-tree discovery exceeded 50000 nodes`; the arm runs **~250-276s at the CONTENDED stub rates re-measured at this base (V23: 181-200 iter/s)**, and ~77-105s only at iteration-31's quiet rates (474.9-652.7 iter/s) — cap headroom is correspondingly **2.2x-5.7x**, not 5.7x. *(Corrected at round 4 on `oc-glm-5-2`'s objection: (c) had been corrected and this row had not, so the executor's primary reference for the load-bearing acceptance carried a premise the doc's own V23 had already refuted — understating runtime ~3x and overstating headroom ~2.5x. The executor must therefore allow for a multi-minute T1 and must NOT read a >105s run as a hang.)* (well under the 600s widened cap), so whole-suite time will be MATERIALLY LONGER than iteration 31's 44s — that figure was measured at the default ceiling and does not transfer | the wall-clock mechanism — the wall clock is dead, so its unique message cannot appear; the SCOPED ceiling (50,000) ends the walk with its own message |
+| T2 | node-ceiling-only mutant: neuter `if (( visited > MAX_TREE_NODES ))` | the two arms being separable | arm :449 still passes (wall clock fires inside its 0-2s window; the scoped override is irrelevant when the ceiling is dead); arm 40 reds with `lacked expected message: process-tree discovery exceeded 3 nodes` — its walk now ends on its own wall clock (`PROBE_TIMEOUT_SECS=60`), so expect that arm to take ~60s; iteration 31's E7 shape (39 ok, 1 not ok, only arm 40) is the prediction, its timings are not | the wall-clock mechanism for :449 (alive); the node-ceiling mechanism for arm 40 (dead, so its unique message cannot appear) |
 | T3 | addition-shaped mutant: add a new `instrument_failure "..."` refusal branch to the probe | the gate LOOKS (a removal proves a check FIRES; only an addition proves it LOOKS) | gate reds with `refusal-branch drift: probe has 28 refusal branches` | the gate mechanism — the count moved 27 → 28 and the gate refuses |
+| T4 | scoping-locality mutant: DELETE `PROBE_MAX_TREE_NODES=50000` from arm :449's `env` line and ADD `export PROBE_MAX_TREE_NODES=50000` near the top of the test file — the token survives, only its SCOPE moves | the "scoped" claim itself — D4 without locality is just a global raise, which round 1 rejected | a NAMED red: the gate's ceiling-locality guard fires with `PROBE_MAX_TREE_NODES is set at suite scope; the ceiling override must stay on arm env lines`; statically, S7 flips 0 → 1 and S6's arm-line count drops to 0 | the locality-guard mechanism — and ONLY it: on the happy path a global export is behaviorally indistinguishable from the scoped form (arm 40's own `env`-line `=3` overrides any export; the wall clock still fires first on every arm), so without the guard this mutant passes the whole suite. A removal-shaped mutant (just deleting the override) proves nothing here on a green run for the same reason; the moved-scope shape is what proves the guard LOOKS |
 
 T1 is the load-bearing acceptance: it is red at base (V8) and must be green after this work. T2 proves
 the wall-clock arm no longer depends on the node ceiling. T3 proves the extended gate still catches new
-refusal branches. T1 and T2 (E7) were measured by the controller at iteration 31; the executor must
-re-run them on the modified tree.
+refusal branches. T4 proves the D4 override is LOCAL — that the design's word "scoped" is enforced, not
+decorative. All four red sets are to be produced by the executor on the modified tree.
 
 ## Quorum Verification Log
 
@@ -310,6 +467,10 @@ re-run them on the modified tree.
 |---|---|---|---|---|
 | 1 | `.ailang/state/mission-quorum/m-motoko-discovery-arm-discriminating-refusal-2026-09-01T00-35-20Z.json` | **BLOCKED** ($0.0806) | 3/3 external (`gpt5-6-sol`, `gemini-3-1-pro`, `oc-glm-5-2`) — **no absentees** | `PROBE_MAX_TREE_NODES=1000000`: makes one outcome likely rather than guaranteed; forces a 120s hang on regression; efficacy shown only where the race is absent |
 | 2 | `.ailang/state/mission-quorum/m-motoko-discovery-arm-discriminating-refusal-2026-09-01T00-43-50Z.json` | **BLOCKED** ($0.0781) | 3/3 external — **no absentees** | the same surface from the other side: removing the override leaves the wall-clock-versus-ceiling race in place, so a fast CI runner could hit the ceiling and the arm would spuriously RED on a clean tree |
+| 3 | `.ailang/state/mission-quorum/m-motoko-discovery-arm-discriminating-refusal-2026-09-01T15-31-29Z.json` | **BLOCKED** ($0.1403) | 3/3 external — **no absentees** (`.synthesis.absent_reviewers` = `[]`, cross-checked `[.reviewers[]|select(.present==false)]` = `[]`) | **`gemini-3-1-pro` FLIPPED TO PASS — the first pass in three rounds.** The two rejects again localise on the ceiling surface, and BOTH are *premise* objections rather than design objections: `gpt5-6-sol` — "a sufficiently fast runner can exceed 25,000 iter/s, so the arm is still race-dependent"; `oc-glm-5-2` — "the rates feeding the 50,000 derivation were measured at `a223e7274`, the doc is baselined at `48817dcdd`, and no row re-measures them; the stub at :254-262 may have changed" |
+| 3b | controller measurement pass (no reviewer spend) | **OBJECTIONS MEASURED, NOT FORWARDED** | — | Per the rule that a reviewer's objection is a claim too, both round-3 objections were RUN rather than routed to a designer. `gpt5-6-sol`'s is **REFUTED** (V25: 25,000 iter/s is ~100x this machine's bare `/usr/bin/true` spawn ceiling, and the walk forks one process per iteration by construction). `oc-glm-5-2`'s named mechanism is **REFUTED** (V22: the test file is byte-identical between the two commits — the stub cannot have changed) but its underlying ask is **SATISFIED AND PARTLY UPHELD** (V23/V24: re-measured at this base the rate is 181-200 iter/s, 3.3-3.6x slower, from ambient load alone — which leaves the race leg stronger and the backstop leg weaker than the doc claimed, and makes the doc's feasible interval EMPTY at its own stated margins). The derivation in (c) is corrected accordingly and the residual is stated as a trade, not hidden. |
+| 4 | `.ailang/state/mission-quorum/m-motoko-discovery-arm-discriminating-refusal-2026-09-01T15-41-57Z.json` | **BLOCKED** ($0.0776) | **2/3 external — `gpt5-6-sol` ABSENT (budget), so this round is N-1** (recorded, not silently passed; the degradation cannot manufacture a false pass here because the verdict is BLOCKED either way) | **THE SURFACE MOVED.** For the first time in four rounds NEITHER objection touches the ceiling, the race, the value or the design. Both are internal-consistency defects introduced by the round-3/4 controller revision: `gemini-3-1-pro` — Phase 3's `grep -c ... "$probe"` rests on an unverified premise and could read stdin unbounded; `oc-glm-5-2` — (c) was corrected with V23's rates but the **T1 row was not**, so the load-bearing acceptance still quoted the superseded 77-105s / 5.7x figures |
+| 4b | narrow-refinement carve-out APPLIED (no reviewer spend, no designer run) | **FIXES APPLIED VERBATIM → route to planner** | — | Both round-4 objections (a) carry a concrete reviewer-authored fix and (b) dispute completeness, not design DIRECTION — the carve-out's two conditions. **`oc-glm-5-2`'s fix applied verbatim**: the T1 row now carries the contended figures (~250-276s, 2.2x-5.7x) and an explicit instruction not to read a >105s run as a hang. **`gemini-3-1-pro`'s premise is REFUTED by measurement** (V26) — `probe` is assigned at `test_motoko_connection_probe.sh:5` with a `:-` default, the file runs under `set -u` (line 2), and `"$probe"` is already used **27** times including by the two sibling counters in this very gate — so it cannot be unset and `set -u` would abort rather than hang. The named HAZARD is nonetheless real and cheap to close, so the fix is applied in substance rather than argued away: Phase 3 now asserts `[[ -f "$probe" ]]` before any counter runs. Using a literal path instead, as the objection proposed, was rejected as it would make the new counter inconsistent with the two beside it. |
 
 Per the mission-control rule on repeated blocks, the surface each round's objections landed on was
 tracked rather than the round count. Both rounds localise on ONE surface (the race), and **no
@@ -318,6 +479,23 @@ the one re-quorum the protocol allows are spent, and no remaining objection carr
 reviewer-authored fix that does not simply re-propose the mechanism the previous round rejected, so
 the narrow-refinement carve-out does not apply. **Disposition: PARK `needs-human-review`.** This is a
 JUDGMENT park, not a capacity park: nothing unblocks it on a clock.
+
+**Round-3 disposition (iteration 32).** Round 3 BLOCKED, so the doc is NOT force-passed. What changed
+is that both surviving objections are *premise* objections, and the controller measured them instead of
+buying another revision round (V22-V25). One is refuted outright; the other's mechanism is refuted while
+its ask is satisfied by re-measurement — and the re-measurement partly upholds it, which is recorded in
+(c) rather than argued away. **The design DIRECTION is now unobjected**: `gemini-3-1-pro` passes, and
+neither reject proposes a different design — both dispute the evidence behind one constant. Under the
+narrow-refinement rule this is the controller's to fix verbatim; the doc nonetheless goes to a **fourth
+round** rather than straight to planning, because the corrected derivation contains a controller-authored
+judgement (which leg to satisfy when the interval is empty) that ought to be checked by someone other
+than its author.
+
+**Superseded 2026-09-01 (retained as history):** the park was resolved by the attended human ruling
+D-MOTOKO-6N-1 (commit `878e0a5a0`), which chose option (B) — hold for D4, scope the override to arm
+:449's `env` line, remove the race structurally, and spend one more iteration and a third quorum round
+"as the right price for ending the argument instead of deferring it to a red CI leg". The third round
+is authorized by that ruling, not by the controller re-opening a spent revision budget.
 
 ### E9 — the controller's refutation of the reviewers' shared premise, AND ITS CORRECTION
 
@@ -344,26 +522,45 @@ measured the arm's behaviour DIRECTLY rather than inferring it from a rate. What
 the SIZE of the margin offered as grounds for reconsidering three unanimous rejections — it is ~6x
 smaller than stated. A ~6-9x local margin on this hardware is materially weaker evidence about a
 different, historically contention-prone CI host than a ~52x one, and the human decision should be
-taken on the corrected number.
+taken on the corrected number. It was: the 2026-09-01 attended ruling cites exactly this corrected
+margin ("a 6-9x margin holding on a CI host nobody has measured") as the thing not to bet on.
 
-### D4 — a design the doc, its author and all three reviewers missed (evaluator, iteration 31)
+### D4 — a design the doc, its author and all three reviewers missed (evaluator, iteration 31) — **APPLIED**
 
 Scoping `PROBE_MAX_TREE_NODES` to arm :449's own `env` line — rather than raising it globally or
 deleting the override entirely — makes the ceiling structurally unreachable inside the wall-clock
 window while leaving every other arm at the default. The evaluator measured it as free on the happy
-path (41/41 ok, 47.1s, indistinguishable from baseline). A middle value (e.g. 50,000) would keep a
-bounded fail-fast backstop rather than either the ~6-9s the default gives or the ~600s the old
-widened cap gave. This is the synthesis both quorum rounds were circling and neither reached; it is
-recorded here rather than applied, because the revision budget is spent and applying it would be a
-controller-invented resolution to a blocked quorum.
+path (41/41 ok, 47.1s, indistinguishable from baseline). A middle value keeps a bounded fail-fast
+backstop rather than either the ~6-9s the default gives or the ~600s the old widened cap gave. This
+is the synthesis both quorum rounds were circling and neither reached. **The synthesis is the
+iteration-31 evaluator's.** It was recorded here rather than applied, because the revision budget was
+spent and applying it unilaterally would have been a controller-invented resolution to a blocked
+quorum.
+
+**Status: APPLIED in this revision (iteration 32), by attended human ruling D-MOTOKO-6N-1 — Mark
+Edmondson, 2026-09-01, commit `878e0a5a0` (author `mark@aitanalabs.com`, provenance verified by the
+controller as an attended identity, not the fleet bot). The ruling, verbatim:**
+
+> **(B) HOLD for D4. Scope `PROBE_MAX_TREE_NODES` to that one arm's env line and remove the race
+> structurally rather than betting on a 6-9x margin holding on a CI host nobody has measured. The
+> reviewers blocked twice for the same reason and D4 is what all three were circling; one more
+> iteration and a third quorum round is the right price for ending the argument instead of deferring
+> it to a red CI leg. Take it as a normal queue pick under row 6p, as the loop proposed.**
+
+The concrete value (50,000) and its derivation are in decision (c); the locality enforcement (gate
+guard, S6/S7, T4) is in decisions (c) and (f).
 
 ## Deferred Decisions
 
-- **Whether the node ceiling ever wins the race on a contended CI runner.** The arm no longer depends on
-  which bound fires, so this is not load-bearing for the arm's verdict. If a future CI leg shows the
-  node ceiling firing before the wall clock on arm :449, the arm REDS (loudly, correctly) rather than
-  passing vacuously; the measurement that settles it is the wall-clock arm's stderr on the "launchd
-  drivers (bash 3.2)" leg.
+- **Whether the CI runner's iteration rate is anywhere near the D4 bound.** Under D4 this entry changes
+  character: it is no longer "whether the node ceiling ever wins the race" — on arm :449 the ceiling is
+  structurally unreachable inside the wall-clock window at any measured or plausibly extrapolated rate
+  (it would take ≥ 25,000 stub iterations/second, ~38x the fastest rate measured; decision (c)) — but
+  the runner's ACTUAL rate has still never been measured, and only CI can measure it (decision (d)).
+  What remains deferred is the empirical confirmation, not the design bet. If the invariant somehow
+  failed anyway, the arm REDS loudly with `process-tree discovery exceeded 50000 nodes` in its stderr —
+  the designed failure shape, diagnosable on sight; the measurement that settles it is the wall-clock
+  arm's stderr on the "launchd drivers (bash 3.2)" leg of the first PR carrying this work.
 - **Whether the gate extension is kept.** It is in scope here (it closes the exact gap this defect is
   about). If a reviewer judges it out of scope, the count stays 24 (echo messages are not counted) and
   the gate gap is tracked as a follow-up row; the measurement that settles it is the gate arm's pass/fail
@@ -381,8 +578,10 @@ controller-invented resolution to a blocked quorum.
 
 ## Timeline
 
-One iteration (~3-4 hours): Phase 1 (~15 min) → Phase 2 (~20 min) → Phase 3 (~30 min) → Phase 4 baseline
-+ mutation validation (~2 hours) → doc/verification polish (~1 hour). The design is now SMALLER than the
-original estimate: three edit sites (probe lines 182/187, arm :449 assertion, gate) and no ceiling
-manipulation, so the previous ~4-6 hour estimate is reduced. If the mutation validation exceeds the
-budget, the gate extension (Phase 3) is the first cut, per Deferred Decisions.
+One iteration (~3-4 hours): Phase 1 (~15 min) → Phase 2 (~20 min) → Phase 3 (~35 min) → Phase 4 baseline
++ mutation validation (~2-2.5 hours) → doc/verification polish (~1 hour). Four edit sites: probe lines
+182/187, arm :449 (assertion + one env token), gate (counter + locality guard). Phase 4 is longer than
+iteration 31's runs because T1's dead-wall-clock walk now runs to the scoped ceiling (~250-276s contended, ~77-105s quiet — V23; at
+measured rates, per arm) and T4 is new. If mutation validation exceeds the budget, the echo-count gate
+extension is the first cut (per Deferred Decisions) — the ceiling-locality guard is NOT cuttable, since
+it is what makes the ruling's word "scoped" enforced rather than asserted.

--- a/tools/eval/motoko_connection_probe.sh
+++ b/tools/eval/motoko_connection_probe.sh
@@ -179,12 +179,12 @@ descendant_pids() {
   local root=$1 deadline=$2 current child visited=0
   local -a queue=("$root") result=()
   if [[ "${PROBE_TEST_DESCENDANT_FAILURE:-0}" == 1 ]]; then
-    echo "process-tree discovery deadline expired" >&2
+    echo "process-tree discovery deadline expired (test stub)" >&2
     return 1
   fi
   while ((${#queue[@]} > 0)); do
     if (( $(date +%s) > deadline )); then
-      echo "process-tree discovery deadline expired" >&2
+      echo "process-tree discovery deadline expired (wall clock)" >&2
       return 1
     fi
     current=${queue[0]}

--- a/tools/eval/test_motoko_connection_probe.sh
+++ b/tools/eval/test_motoko_connection_probe.sh
@@ -446,8 +446,8 @@ fi
 # how long we wait for a degraded runner to get there, and stays bounded.
 _arm_cap_saved=$ARM_CAP_SECS
 ARM_CAP_SECS=$(( ARM_CAP_SECS * 5 ))
-expect_failure "descendant discovery refuses on the real wall-clock deadline" "process-tree discovery failed" \
-  env PATH="$live_bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=1 PROBE_TEST_PGREP_LOOP=1 \
+expect_failure "descendant discovery refuses on the real wall-clock deadline" "process-tree discovery deadline expired (wall clock)" \
+  env PATH="$live_bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=1 PROBE_MAX_TREE_NODES=50000 PROBE_TEST_PGREP_LOOP=1 \
     PROBE_STUB_STATE="$tmp_dir/lane-pgreploop" /bin/bash "$probe" treatment control "$tmp_dir/pgreploop.json"
 ARM_CAP_SECS=$_arm_cap_saved
 

--- a/tools/eval/test_motoko_connection_probe.sh
+++ b/tools/eval/test_motoko_connection_probe.sh
@@ -700,19 +700,34 @@ expect_failure "descendant discovery refuses on the node-count ceiling" "process
     PROBE_TEST_PGREP_LOOP=1 PROBE_STUB_STATE="$tmp_dir/lane-node-limit" \
     /bin/bash "$probe" treatment control "$tmp_dir/node-limit.json"
 
+# The D4 ceiling override belongs on arm :449's own env line and nowhere else. A per-command
+# env assignment never persists into this shell, so this is invariantly quiet on a correct
+# tree. It fires on exactly two leak shapes: an edit that promotes the override to a
+# file-global assignment or export, and an ambient PROBE_MAX_TREE_NODES in the caller's
+# environment — which would silently re-parameterise every arm that does not pin its own
+# ceiling. Both un-hermeticize the suite.
+if [[ -n "${PROBE_MAX_TREE_NODES:-}" ]]; then
+  echo "not ok - PROBE_MAX_TREE_NODES is set at suite scope; the ceiling override must stay on arm env lines" >&2
+  exit 1
+fi
+
 # Refusal-branch drift gate. Every arm above proves a branch that EXISTS goes red when neutered —
 # a removal proves the check FIRES; only an addition proves it LOOKS. Adding a new refusal to the
 # probe passes the whole suite byte-identically, so the coverage claim is a one-time manual count
 # that silently rots on the next edit. Count the branches and refuse when the number moves.
-expected_refusal_branches=24
+expected_refusal_branches=27
+# Every counter below reads $probe. Assert it resolves to a file BEFORE any of them run, so
+# that no grep in this gate can fall through to reading stdin.
+[[ -f "$probe" ]] || { echo "not ok - refusal-branch gate: \$probe does not resolve to a file; instrument failure, not a verdict" >&2; exit 1; }
 actual_instrument_failures=$(grep -c 'instrument_failure "' "$probe")
 actual_usage_refusals=$(grep -cE '\|\| usage$' "$probe")
+actual_echo_refusals=$(grep -c 'echo "process-tree discovery' "$probe")
 # Anti-vacuity: a counter that returns zero is a broken instrument, not a clean result.
-if (( actual_instrument_failures == 0 || actual_usage_refusals == 0 )); then
+if (( actual_instrument_failures == 0 || actual_usage_refusals == 0 || actual_echo_refusals == 0 )); then
   echo "not ok - refusal-branch counter matched nothing; instrument failure, not a verdict" >&2
   exit 1
 fi
-actual_refusal_branches=$(( actual_instrument_failures + actual_usage_refusals ))
+actual_refusal_branches=$(( actual_instrument_failures + actual_usage_refusals + actual_echo_refusals ))
 if (( actual_refusal_branches != expected_refusal_branches )); then
   echo "not ok - refusal-branch drift: probe has $actual_refusal_branches refusal branches," >&2
   echo "         this suite is written for $expected_refusal_branches. Add an arm for the new" >&2


### PR DESCRIPTION
## What

The wall-clock arm of the motoko connection probe's self-test could not fail for the reason it names.
All three `descendant_pids` refusal branches emitted the same string, and the caller collapses every one
of them into the generic `process-tree discovery failed`, so an arm greping that wrapper passed whichever
branch fired. Reported at #975, filed by V1 iteration 308's evaluator against motoko's instrument.

Ghost-disciplined at motoko HEAD before being believed: neutering the in-loop wall clock outright left
the whole suite green, this arm included.

## Changes (3 code commits, each independently green)

- **M1** — the three refusal branches get distinct messages (`(test stub)` / `(wall clock)` / the
  node-ceiling message already differed). The refusal *outcome* is untouched; only stderr diagnostics move.
- **M2** — the arm asserts `process-tree discovery deadline expired (wall clock)`, which only the
  wall-clock branch can emit, and carries a scoped `PROBE_MAX_TREE_NODES=50000` on its own `env` line.
- **M3** — the refusal-branch drift gate now counts the three echo-shaped refusals (24 → 27), gains an
  anti-vacuity floor for the new counter, a `[[ -f "$probe" ]]` assertion so no counter can fall through
  to reading stdin, and a guard refusing a suite-scope `PROBE_MAX_TREE_NODES`.

## Gates — all re-run by the controller OUTSIDE the executor sandbox, on darwin/arm64

| Gate | At base | After |
|---|---|---|
| `/bin/bash tools/eval/test_motoko_connection_probe.sh` | rc=0, 41 ok, 0 not ok, gate prints `(24)` | **rc=0, 41 ok, 0 not ok, 84s, gate prints `(27)`**, arm 33 ok |
| `bash -n` both files | rc=0 | rc=0 |
| `PROBE_MAX_TREE_NODES=50000 /bin/bash <suite>` | **rc=0, 41 ok** | **rc=1** on `not ok - PROBE_MAX_TREE_NODES is set at suite scope` |

The third row is the point: the new locality guard goes 0 → 1 on exactly its own mechanism, so it is a
gate rather than a decoration. M1 and M2 boundary runs were each 41/41 green, so the series bisects.

Windows and ubuntu legs are unrun locally; this is shell-only and darwin-measured.

## Provenance

Four quorum rounds. Rounds 1–3 blocked 3/3 external on ONE surface — the race between the wall clock
(wall time) and the node ceiling (iteration count). `gemini-3-1-pro` flipped to pass at round 3. The
surface was settled by an attended human ruling (decision `D-MOTOKO-6N-1`, 2026-09-01) selecting D4,
the synthesis iteration 31's evaluator found. Round 4 was N−1 (`gpt5-6-sol` absent on budget, recorded
rather than silently passed) and its two objections were *premise* objections, so they were measured
rather than forwarded:

- `gpt5-6-sol` — **refuted**. A 50,000 ceiling wins the race only at ≥25,000 iterations/second; the walk
  forks one process per iteration by construction, and bare `/usr/bin/true` spawns at ~205–250/s here.
  That is ~100x, not a rate extrapolation.
- `oc-glm-5-2` — **mechanism refuted, ask satisfied and partly upheld**. The test file is byte-identical
  between the rate-measurement commit and this base, so the stub cannot have changed; but re-measuring
  found 181–200 iter/s against iteration 31's 474–653, a 3.3–3.6x spread from ambient load alone
  (load average 20.59 on 16 CPUs, confirmed against a second clock). That leaves the race leg stronger
  and the backstop leg weaker than the doc claimed, and the doc now states the residual as an explicit
  trade rather than as a satisfied constraint.

## Not in scope

`PROBE_TREE_DISCOVERY_SECS` is 0 occurrences at this base, so #971 has not landed. It is another
mission's PR and motoko has not touched it; whichever merges second rebases. The two changes are
orthogonal — #971 changes *which deadline* bounds discovery, this changes *which message* the
wall-clock branch emits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
