### PR TITLE
fix(docs-sync): docs-10 — verify-examples vacuous on two axes

### DIFF
--- a/design_docs/docs-10-brief.md
+++ b/design_docs/docs-10-brief.md
@@ -1,0 +1,91 @@
+# docs-10 sprint brief — verify-examples is vacuous on two independent axes
+
+**Not a design doc.** Per `docs-mission.md`'s Guardrails ("most items here need no design doc at
+all — prefer a Gate-2 reality-check straight into a sprint"), this is a routing declaration only —
+it exists so `tools/launchd/derive-planner-lane.sh` can route the planner instead of failing closed
+to opus for a missing `Planner-Lane` field. It carries no design claims and needs no quorum.
+
+**Planner-Lane**: opus-required
+
+(Both target files live at the repo-root `scripts/`, which matches none of this mission's
+`MISSION_PLANNER_ALLOWLIST` patterns — `tools/*`, `.claude/skills/mission-control/SKILL.md`,
+`.claude/skills/design-doc-creator/*`, `docs/*`, `examples/*`, `README.md`, `CHANGELOG.md`,
+`.claude/skills/docs-sync/scripts/*` — that last one is a different directory tree from repo-root
+`scripts/`. A `codex-ok` declaration would fail closed to opus anyway via
+`path-not-in-codex-allowlist`, so this declares the honest outcome directly.)
+
+## Task
+
+Fix two independent vacuous-pass defects in the docs mission's example-verification tooling.
+Confirmed still present at current HEAD by reading both files and both GitHub issues in full
+(`gh issue view 670 --repo sunholo-data/ailang`, `gh issue view 654 --repo sunholo-data/ailang`).
+
+### 1. `scripts/verify_examples.go` never compares `expected.stdout` (issue #670)
+
+`runExample` (currently ~line 120–292) decides pass/fail purely from `err == nil` plus a stderr
+scan for `Error:`/`error:`. It never reads `examples/manifest.json`'s per-entry `expected.stdout`
+field at all, so an example can print anything and still pass. Confirmed empirically in the issue
+by corrupting one entry's `expected.stdout` to a deliberately wrong literal and observing
+`make verify-examples` still exit 0.
+
+Fix: load `examples/manifest.json` (the same `internal/manifest` package `scripts/validate_manifest.go`
+already uses) and, for each example whose manifest entry has a **non-empty** `expected.stdout`,
+compare it against the captured `stdout.String()` in `runExample`. On a mismatch, set
+`result.Status = "failed"` with an error message showing both values (or a diff), the same way a
+non-zero exit is reported today. Entries with empty/absent `expected.stdout` are unaffected — do
+not require a stdout match where none is recorded (a check of the live manifest shows only 20 of
+199 entries currently carry a non-empty `expected.stdout`; forcing all 199 to match an empty
+string is out of scope and would falsely fail the other 179).
+
+Add the anti-vacuity floor the issue itself proposes: if the count of entries with a non-empty
+`expected.stdout` that actually got checked is zero, fail loudly (non-zero exit, clear stderr
+message) rather than silently reporting a clean run — this is the same shape as the #654 floor
+below and prevents this new check from becoming its own vacuous no-op (e.g. if the manifest
+schema ever changes shape).
+
+Acceptance behavior: corrupting one manifest entry's `expected.stdout` to a value that does not
+match that example's actual stdout must make `make verify-examples` report that example as
+**failed** (currently it reports rc=0 / all passed). Restoring the manifest byte-identically must
+return the suite to green. An example with no recorded `expected.stdout` must be unaffected by
+this change.
+
+### 2. `scripts/validate_manifest.go` prints `checked` but never asserts it (issue #654)
+
+The `checked` counter (incremented per successfully-parsed example, currently ~line 83) is printed
+in the summary line (~line 93) but compared to nothing. The only non-zero exit path is
+`driftCount > 0` (~lines 103–108). If the enumeration in `m.Examples` ever returns effectively
+nothing resolvable (a glob change, a path move, an empty/broken manifest), the tool still prints
+`0 modules checked, 0 drift, 0 missing-on-disk` followed by the green
+`✓ manifest \`modules\` field is in sync with actual imports` line, and exits 0.
+
+Fix: before printing the success line, assert `checked > 0`. If `checked == 0`, print a loud
+failure to stderr (e.g. `INSTRUMENT FAILURE: validate_manifest enumerated 0 modules`) and exit 1
+instead of printing the green line — this must apply in both `--ci` and non-`--ci` mode, since a
+zero-enumeration is a broken instrument regardless of CI mode, not a matter of drift tolerance.
+Use the honest minimum floor (`checked > 0`), not a fixed larger threshold — the issue explicitly
+flags a fixed floor like `>= 150` as needing an ongoing maintenance story that is out of scope here.
+
+Acceptance behavior: with the enumeration forced to return zero resolvable examples (e.g. by
+pointing `--dir`/`--manifest` at an empty/nonexistent set, or temporarily faking zero matches),
+`validate_manifest` must exit non-zero and print the loud failure message instead of the green
+"✓ ... in sync" line. Normal runs against the real manifest must be unaffected (still exit 0 when
+`driftCount == 0` and `checked > 0`).
+
+### Non-goals
+
+- Do not unify or restage the two files' unrelated responsibilities (stdout truth belongs to
+  `verify_examples.go`; `modules`-drift truth belongs to `validate_manifest.go` — the header comment
+  in `validate_manifest.go` already documents this split; preserve it).
+- Do not attempt to backfill/re-capture the 179 manifest entries with empty `expected.stdout` — that
+  is a separate, larger corpus-quality task, not this fix.
+- Do not change `missingCount` handling in `validate_manifest.go` (already deliberately a warning,
+  not a hard failure, per the file's own header comment) — only the unasserted `checked` floor is in
+  scope.
+- Do not add the staged flag/rollout machinery issue #670 sketches as one *possible* sequencing
+  (flag-gated report → repair stale entries → full gate) — with only 20 entries actually carrying a
+  pinned value, a direct fix is small enough not to need that staging.
+
+## Files
+
+- `scripts/verify_examples.go`
+- `scripts/validate_manifest.go`

--- a/design_docs/docs-10-sprint-plan.md
+++ b/design_docs/docs-10-sprint-plan.md
@@ -1,0 +1,383 @@
+# docs-10 Sprint Plan
+
+## Sprint summary
+
+Close two independent vacuous-pass defects in the docs mission's example-verification
+tooling: `scripts/verify_examples.go` never compares `examples/manifest.json`'s
+per-entry `expected.stdout` (issue #670), and `scripts/validate_manifest.go` prints a
+`checked` count it never asserts (issue #654). Two small, independent milestones —
+M1 (stdout truth) and M2 (enumeration floor) — each landing with a negative control
+that is *measured red on the pristine tree before the fix and green only because of
+the fix*, not merely "the gate passes".
+
+Both defects are confirmed present at `227d1e370`; both negative controls were run on
+the unmodified tree and both currently exit 0 (see "Baseline measurements" below).
+
+## Baseline measurements (run on the pristine worktree at `227d1e370`)
+
+| Command | Result on the UNMODIFIED tree |
+|---|---|
+| `go build ./scripts/...` | rc=0, no output |
+| `go run ./scripts/verify_examples.go --parallel 8 --json` | rc=0 — 217 total, 211 passed, **0 failed**, 6 skipped |
+| `go run ./scripts/validate_manifest.go --ci` | rc=0 — `193 modules checked, 0 drift, 1 missing-on-disk` |
+| `go run ./scripts/validate_manifest.go --dir /nonexistent/xyz --ci` | **rc=0** — `0 modules checked, 0 drift, 199 missing-on-disk` followed by the green `✓ manifest \`modules\` field is in sync` line. **This is the #654 vacuity, reproduced.** |
+
+Manifest population (measured, `examples/manifest.json`, 199 entries):
+
+- 20 entries carry a non-empty `expected.stdout`; 179 do not.
+- 198 of 199 resolve on disk under `importextract.ResolvePath` semantics
+  (`examples/<path>`, else `examples/runnable/<path>`); no two entries resolve to the
+  same file, so a resolved-path keyed index is unambiguous.
+- Of the 20 pinned entries, **16** resolve under `examples/runnable/` (the default
+  sweep scope) and one of those 16 — `exit_code.ail` — is on `skippedExamples`.
+  **The default gate will therefore perform exactly 15 stdout comparisons.** Under
+  `--all` it performs 19.
+
+Three facts that a naive implementation of #670 would trip over — all measured, not
+assumed:
+
+1. **`ailang run` prints a status preamble to STDOUT**, not stderr:
+   `→ Type checking...\n→ Effect checking...\n✓ Running <path>\n`. Every one of the
+   15 pinned entries therefore mismatches on a raw `stdout == expected` compare.
+   A naive fix turns the gate red 15/15 for the wrong reason.
+2. **`hello.ail` emits no trailing newline** (`Hello, AILANG!`) while its pin is
+   `Hello, AILANG!\n`. The comparison must be trailing-newline-insensitive.
+3. After preamble-stripping + trailing-newline-insensitive comparison, **17 of 19
+   pinned entries match and 2 genuinely do not**:
+   - `runnable/arithmetic.ail` — pin is `42\n3.14159\ntrue\nHello, AILANG!\n`; the
+     example actually prints `x = 11\ny = 2\nz = 13\n`, which is what the example's
+     own inline comments say it should print. The pin is a stale copy-paste from a
+     different example. This is exactly the class of rot #670 exists to catch.
+   - `runnable/process_stdin_write.ail` — pin includes three lines echoed by the
+     `cat` subprocess (`hello from AILANG` / `streaming to subprocess` / `done!`)
+     that the harness never captures, because `ailang` exits before `cat` flushes.
+     Measured deterministic: 10/10 serial runs produced byte-identical stdout
+     containing only `wrote line 1..3`, and both the default and `--all` harness
+     runs agreed.
+
+Consequently M1 **cannot land green without repairing those two pinned values** — see
+the Scope note.
+
+`make verify-examples-all` (`--all --threshold 60`) is **already red on the pristine
+tree** (405 total / 305 passed / 94 failed; it exits non-zero on `failed > 0`
+regardless of the threshold). Do not use it as an acceptance gate for either
+milestone; it measures a pre-existing condition.
+
+## Scope note — one file beyond the brief's Files list, tightly bounded
+
+The brief lists only `scripts/verify_examples.go` and `scripts/validate_manifest.go`.
+The baseline measurement above shows that is insufficient for M1 to land green: two
+committed `expected.stdout` values are genuinely stale, so the new check correctly
+turns `make verify-examples` red until they are corrected. M1 therefore also edits
+**`examples/manifest.json`**, under a hard cap:
+
+- ONLY the `expected.stdout` string of `runnable/arithmetic.ail` and
+  `runnable/process_stdin_write.ail` may change.
+- No other field, no other entry, no reformat of the file, and **no backfilling of
+  the 179 entries with an empty `expected.stdout`** — that remains a non-goal.
+- `git diff examples/manifest.json` at the end of M1 must show exactly two changed
+  string values and nothing else.
+
+`examples/*` is inside the mission's planner allowlist, so this is a bounded widening
+of the brief's Files list on measured evidence — not a scope drift.
+
+---
+
+## M1 — Enforce `expected.stdout` in verify_examples.go (#670)
+
+Estimated effort: 0.5–1 day; medium risk (the comparison must not go vacuously red).
+
+Files: `scripts/verify_examples.go`, `examples/manifest.json` (two pinned values only).
+
+### Implementation
+
+**Task 1a — build a resolved-path → pinned-stdout index, once, before any goroutine.**
+
+In `scripts/verify_examples.go` (which already carries `//go:build ignore` and is run
+via `go run`), add imports of `github.com/sunholo-data/ailang/internal/manifest` and
+`github.com/sunholo-data/ailang/scripts/internal/importextract` — the same two
+packages `scripts/validate_manifest.go` already uses, so no new dependency enters the
+tree.
+
+Add package-level state next to the existing `useAllExamples` / `useTrace` block:
+
+- `var pinnedStdout map[string]string` — key: `filepath.ToSlash(filepath.Clean(resolvedPath))`, value: the non-empty `Expected.Stdout`.
+- `var pinnedTotal int` — count of manifest entries with a non-empty `Expected.Stdout`, resolvable or not (used only in the floor's diagnostic message).
+- `var stdoutChecked atomic.Int64` (`sync/atomic`) — comparisons actually performed.
+
+Populate it from `main()`, immediately after flag parsing and before any of the
+`verifyExamples*` / `runUpdateBaselines` dispatch, via a `loadPinnedStdout()` helper:
+
+- `m, err := manifest.Load("examples/manifest.json")`. On error, print
+  `INSTRUMENT FAILURE: verify_examples could not load examples/manifest.json: <err>`
+  to stderr and `os.Exit(1)`. **No silent fallback** — a verifier that cannot read
+  its own oracle must not report a clean run (CLAUDE.md Principle 2).
+- For each entry: skip if `ex.Expected == nil || ex.Expected.Stdout == ""`; else
+  `pinnedTotal++`, then `full, ok := importextract.ResolvePath("examples", ex.Path)`
+  and, if `ok`, record `pinnedStdout[filepath.ToSlash(filepath.Clean(full))] = ex.Expected.Stdout`.
+  Do **not** hand-roll the path resolution — reuse `ResolvePath`, so this tool and
+  `validate_manifest.go` cannot disagree about which file an entry names. (Measured:
+  106 of 199 entries use a flat `hello.ail`-style path that only resolves under
+  `examples/runnable/`, so string-munging the walked path would silently miss them.)
+
+Populating from `main()` (single-goroutine) and only *reading* the map inside
+`runExample` keeps the parallel path (`runExamplesParallel`, default `parallelism=8`)
+race-free without a mutex; only the counter is atomic.
+
+**Task 1b — compare in `runExample`, after the existing pass/fail determination.**
+
+Insert the comparison after the `err != nil` / stderr-scan block that currently sets
+`result.Status` (the block ending at the `result.Status = "passed"` assignment), and
+*before* the `useTrace` trace-verification block. Guard it with:
+
+- `if useTrace { skip }` — under `--trace` the run is invoked with `--emit-trace jsonl`
+  and trace JSONL is interleaved with program output on stdout, so a stdout comparison
+  there would be measuring the trace, not the program. Skipping is correct; the floor
+  in Task 1c is skipped for the same reason.
+- `if result.Status != "passed" { skip }` — a failed or skipped example already has a
+  verdict; do not double-report, and do not count it toward the floor.
+- Look up `pinnedStdout[filepath.ToSlash(filepath.Clean(filename))]`; if absent, skip
+  (this is the 179-entry / unpinned majority, which must remain unaffected).
+
+When a pin is present:
+
+1. `stdoutChecked.Add(1)` (count the comparison, whatever its outcome).
+2. Strip the runner preamble from the captured `stdout.String()` with a small helper
+   `stripRunPreamble(out, filename string) string`: build the anchor
+   `"✓ Running " + filepath.ToSlash(filename) + "\n"`; if `strings.Index(out, anchor)`
+   is `>= 0`, return everything AFTER that anchor; otherwise return `out` unchanged.
+   Anchoring on the example's own path makes this deterministic and unable to eat
+   program output unless the program prints that exact line. **Do not** add `--quiet`
+   to the run arguments instead: that would change `result.Output` (and hence
+   `examples_report.json`) for every example and make the pinned examples run under
+   different flags from the gated set.
+3. Compare `strings.TrimRight(got, "\n") == strings.TrimRight(want, "\n")` — byte-exact
+   apart from trailing newlines (required: `hello.ail` emits no trailing newline; see
+   Baseline fact 2). Do **not** trim leading whitespace, do not normalise interior
+   whitespace, and do not fall back to a substring/`HasSuffix` test — those would
+   re-introduce vacuity.
+4. On mismatch: `result.Status = "failed"` and set `result.Error` to a message that
+   shows both sides, e.g.
+   `fmt.Sprintf("stdout mismatch vs manifest expected.stdout\n  expected: %q\n  actual:   %q", want, got)`.
+   Use `%q` so trailing-newline and invisible-character differences are legible.
+
+**Task 1c — the anti-vacuity floor.**
+
+After the sweep completes and before the existing exit decisions, in **all three** of
+`verifyExamplesPlain`, `verifyExamplesJSON` and `verifyExamplesMarkdown` (a shared
+`enforceStdoutFloor()` helper called from each is preferred), assert:
+
+```
+if !useTrace && stdoutChecked.Load() == 0 {
+    fmt.Fprintf(os.Stderr, "INSTRUMENT FAILURE: verify_examples compared 0 pinned expected.stdout values (manifest has %d non-empty pins)\n", pinnedTotal)
+    os.Exit(1)
+}
+```
+
+Do not apply the floor in `runUpdateBaselines` (it is a generator, not a gate) and do
+not apply it under `--trace` (comparison is deliberately disabled there).
+
+Ordering in JSON mode: emit the floor message **after** the report has been encoded to
+stdout, so the report is still written. Note that `make verify-examples` redirects
+`2>&1` into `examples_report.json`, so a tripped floor will append a non-JSON line to
+that artifact — this matches the existing behaviour of the threshold failure path and
+is acceptable because the gate is failing anyway. Do not restructure the makefile to
+avoid it (out of scope).
+
+In `verifyExamplesPlain` only, also print the count in the summary block, e.g.
+`fmt.Printf("  Stdout pins checked: %d\n", stdoutChecked.Load())`. Plain mode is not
+consumed by the gate, so this is free, and it is what makes the positive control in
+AC-3 observable. Do not add a field to `reporttypes.ExampleResult` /
+`VerificationReport` — that file is out of scope.
+
+**Task 1d — repair the two genuinely stale pins (`examples/manifest.json`).**
+
+- `runnable/arithmetic.ail`: set `expected.stdout` to `"x = 11\ny = 2\nz = 13\n"`.
+- `runnable/process_stdin_write.ail`: set `expected.stdout` to
+  `"wrote line 1\nwrote line 2\nwrote line 3\n"`.
+
+Edit these two string values in place with a text edit; do not round-trip the file
+through a JSON dumper (that reformats all 199 entries). Do not run
+`go run ./scripts/backfill_manifest_modules.go` as part of this task — **measured: it
+rewrites `examples/manifest.json` byte-for-byte even when drift is 0.**
+
+If, on the executor's machine, the new check flags any pinned entry *other* than these
+two, that is a new finding: report it with the `%q` diff and stop. Do not loosen the
+comparator to make it green, and do not clear a pin to silence it. (If
+`process_stdin_write.ail` proves flaky rather than deterministic — run it 10× and
+compare hashes; it was 10/10 identical here — the correct response is to clear that
+one pin to `""` and record why in the entry's `description`, not to weaken the
+comparator.)
+
+### Non-goals (binding)
+
+Do not backfill the 179 empty `expected.stdout` entries; do not add flag-gated staging
+or a report-only mode; do not touch `scripts/internal/reporttypes`, `make/examples.mk`,
+`internal/manifest`, `cmd/**` or `internal/**`; do not move `modules`-drift
+responsibility into this file.
+
+### Acceptance criteria
+
+1. **Negative control — a corrupted pin must FLIP the result.** With the fixed tree:
+
+   ```bash
+   cp examples/manifest.json /tmp/docs10_manifest.bak
+   shasum /tmp/docs10_manifest.bak                       # record
+   python3 - <<'PY'
+   p = 'examples/manifest.json'
+   s = open(p).read()
+   # hello.ail's pin, replaced TEXTUALLY so the other 198 entries are untouched.
+   old = '"stdout": "Hello, AILANG!\\n"'
+   assert s.count(old) == 1, 'expected exactly one occurrence, got %d' % s.count(old)
+   open(p, 'w').write(s.replace(old, '"stdout": "DELIBERATELY WRONG\\n"'))
+   PY
+   go run ./scripts/verify_examples.go --parallel 8 --json > /tmp/docs10_neg.json 2>&1; echo "rc=$?"
+   cp /tmp/docs10_manifest.bak examples/manifest.json
+   shasum examples/manifest.json                          # must equal the recorded hash
+   ```
+
+   Required: rc **1** (it is rc 0 today — measured), `/tmp/docs10_neg.json` shows
+   `runnable/hello.ail` with `"status": "failed"` and an error naming both the
+   expected and actual strings, and the restore is byte-identical (hashes match).
+2. **Negative control — the floor must FLIP too.** Temporarily point the index at a
+   manifest with no pins and confirm the floor fires rather than a clean run:
+
+   ```bash
+   python3 - <<'PY'
+   import json
+   d = json.load(open('examples/manifest.json'))
+   n = 0
+   for e in d['examples']:
+       if e.get('expected', {}).get('stdout'):
+           e['expected']['stdout'] = ''
+           n += 1
+   assert n == 20, n
+   json.dump(d, open('/tmp/docs10_nopins.json', 'w'), indent=2)
+   PY
+   ```
+
+   (A JSON round-trip is safe here because the output is a throwaway temp file — do
+   NOT round-trip the real `examples/manifest.json`, which would reformat all 199
+   entries. A regex over the raw text is not safe: several pinned values contain
+   escaped quotes, e.g. `json_jint.ail`.)
+
+   Run the verifier with `loadPinnedStdout()` reading `/tmp/docs10_nopins.json` (a
+   one-line temporary edit, reverted immediately — do NOT ship a `--manifest` flag).
+   Required: rc **1** and stderr containing
+   `INSTRUMENT FAILURE: verify_examples compared 0 pinned expected.stdout values`.
+   Revert the temporary edit and confirm `git diff scripts/verify_examples.go` no
+   longer mentions `/tmp/`.
+3. **Positive control — the check is actually running and is not vacuous.**
+   `go run ./scripts/verify_examples.go --parallel 8` prints
+   `Stdout pins checked: 15` (exactly 15 — 16 pinned entries resolve under
+   `examples/runnable/`, minus `exit_code.ail`, which is on `skippedExamples`) and
+   exits 0.
+4. **No collateral reds.** `go run ./scripts/verify_examples.go --parallel 8 --json`
+   exits **0** with 217 total / 211 passed / **0 failed** / 6 skipped — the same
+   triple as the pristine baseline. An example with no pinned `expected.stdout` must
+   be unaffected.
+5. **Manifest diff is exactly two strings.** `git diff examples/manifest.json` shows
+   only the `expected.stdout` values of `runnable/arithmetic.ail` and
+   `runnable/process_stdin_write.ail`; `git diff --stat` shows 2 files changed in
+   total for M1 (`scripts/verify_examples.go`, `examples/manifest.json`).
+6. `go build ./scripts/...` exits 0, and `gofmt -l scripts/verify_examples.go` prints
+   nothing.
+
+### Verification (what the planner actually ran, pristine tree, `227d1e370`)
+
+- `go build ./scripts/...` → rc 0.
+- `go run ./scripts/verify_examples.go --parallel 8 --json` → rc 0; 217/211/0/6.
+- Compared every pinned `expected.stdout` against the report's captured `output`:
+  0/15 match raw (all differ by the stdout preamble) → the preamble finding.
+- Re-compared with anchor-stripping + trailing-newline trimming across `--all`:
+  **17 match, 2 mismatch** (`arithmetic.ail`, `process_stdin_write.ail`), 1 skipped.
+- `./bin/ailang run --caps Process,IO examples/runnable/process_stdin_write.ail` ×10 →
+  10/10 identical stdout hashes (`a3a0f98d0c7b`).
+- `scripts/verify_examples.go` has **no `--help`**: `main()` hand-parses `os.Args` and
+  silently ignores unknown flags, so `--help` would run the full sweep. Use
+  `--json` / `--markdown` / plain as above.
+
+---
+
+## M2 — Assert the `checked` floor in validate_manifest.go (#654)
+
+Estimated effort: <0.5 day; low risk. Independent of M1 — no shared code path.
+
+Files: `scripts/validate_manifest.go`.
+
+### Implementation
+
+In `main()`, the drift loop increments `checked` (currently line ~83) and the summary
+line prints it (~line 93), but the only non-zero exit is `driftCount > 0` (~103–108).
+Insert the floor **after** the summary `fmt.Printf` and **before** the
+`if driftCount > 0 { … } else { … }` block:
+
+```go
+if checked == 0 {
+    fmt.Fprintf(os.Stderr, "\n%s validate_manifest enumerated 0 modules (%d entries in manifest, %d missing on disk)\n",
+        red("INSTRUMENT FAILURE:"), len(m.Examples), missingCount)
+    fmt.Fprintf(os.Stderr, "A zero-enumeration means the instrument is broken, not that the manifest is clean.\n")
+    os.Exit(1)
+}
+```
+
+Requirements:
+
+- The exit must be unconditional on `*ciMode` — a zero enumeration is a broken
+  instrument in both modes, not a drift-tolerance question (brief, §2).
+- It must run **before** the green `✓ manifest \`modules\` field is in sync with actual
+  imports` line, so that line is never printed on a zero enumeration.
+- Use the honest floor `checked == 0`. Do **not** introduce a fixed threshold such as
+  `>= 150`; that needs a maintenance story that is out of scope.
+- Do not change `missingCount` handling (still a warning, per the file's header
+  comment), do not change the schema-load failure path, and do not alter the
+  `driftCount` exit semantics.
+- Keep the header comment accurate: add one sentence to the existing block comment
+  noting that a zero enumeration is a hard failure.
+
+### Acceptance criteria
+
+1. **Negative control — the exit code must FLIP.**
+   `go run ./scripts/validate_manifest.go --dir /nonexistent/xyz --ci; echo $?` →
+   **1** after the fix (**measured 0 on the pristine tree**, printing
+   `0 modules checked, 0 drift, 199 missing-on-disk` and then the green line).
+   Its stderr must contain `INSTRUMENT FAILURE:` and `enumerated 0 modules`, and its
+   stdout must **not** contain `field is in sync with actual imports`.
+2. **The same control flips in non-CI mode.**
+   `go run ./scripts/validate_manifest.go --dir /nonexistent/xyz; echo $?` → **1**
+   (also 0 on the pristine tree).
+3. **Positive control — a real run is unaffected.**
+   `go run ./scripts/validate_manifest.go --ci; echo $?` → **0**, printing
+   `193 modules checked, 0 drift, 1 missing-on-disk` and the green in-sync line —
+   identical to the pristine baseline.
+4. **The pre-existing drift arm still works.** `make validate-manifest-selftest`
+   passes. ⚠ Measured: that target runs `backfill_manifest_modules.go`, which
+   **rewrites `examples/manifest.json` byte-for-byte even at 0 drift.** Back the file
+   up first (`cp examples/manifest.json /tmp/docs10_m2.bak`) and restore it after,
+   then confirm `shasum` matches and `git status --porcelain examples/manifest.json`
+   is clean (or, after M1, shows only M1's two-string diff).
+5. `go build ./scripts/...` exits 0 and `gofmt -l scripts/validate_manifest.go` prints
+   nothing. `git diff --stat` for M2 shows exactly one file changed.
+
+### Verification (what the planner actually ran, pristine tree, `227d1e370`)
+
+- `go run ./scripts/validate_manifest.go --ci` → rc 0,
+  `193 modules checked, 0 drift, 1 missing-on-disk`, green line printed.
+- `go run ./scripts/validate_manifest.go --dir /nonexistent/xyz --ci` → **rc 0**,
+  `0 modules checked, 0 drift, 199 missing-on-disk`, green line printed. The #654
+  vacuity is reproduced, and this exact command is a working negative control that
+  reaches the `checked == 0` branch **without** tripping the schema-load path (an
+  empty-`examples` temp manifest would fail `manifest.Load`'s statistics check first
+  and would therefore be a vacuous control).
+- `go run ./scripts/backfill_manifest_modules.go` → rc 0 but changed
+  `examples/manifest.json`'s hash (`600e9016…` → `3574d75e…`); restored from backup.
+- `go build ./scripts/...` → rc 0.
+
+---
+
+## Sequencing and reporting
+
+M1 and M2 touch disjoint files and can be done in either order or in parallel. The
+executor should report, for each milestone, the negative control's **before** and
+**after** exit codes side by side — a milestone whose negative control was never
+observed red on the pristine tree has not been verified, only asserted.

--- a/examples/manifest.json
+++ b/examples/manifest.json
@@ -79,7 +79,7 @@
       ],
       "description": "Show type class usage with multiple types",
       "expected": {
-        "stdout": "42\n3.14159\ntrue\nHello, AILANG!\n",
+        "stdout": "x = 11\ny = 2\nz = 13\n",
         "exit_code": 0
       }
     },
@@ -2099,7 +2099,7 @@
         "std/result"
       ],
       "expected": {
-        "stdout": "hello from AILANG\nstreaming to subprocess\ndone!\nwrote line 1\nwrote line 2\nwrote line 3\n",
+        "stdout": "wrote line 1\nwrote line 2\nwrote line 3\n",
         "exit_code": 0
       }
     },

--- a/scripts/validate_manifest.go
+++ b/scripts/validate_manifest.go
@@ -14,6 +14,9 @@
 // as warnings (pre-existing stale entries), not hard failures, so a legacy drift
 // doesn't wedge CI — modules drift on a RESOLVABLE file is the hard gate.
 //
+// Enumerating ZERO modules is itself a hard failure, in both modes: a run that
+// checked nothing is a broken instrument, not a clean manifest.
+//
 //	go run ./scripts/validate_manifest.go            # report
 //	go run ./scripts/validate_manifest.go --ci       # non-zero on drift
 package main
@@ -99,6 +102,16 @@ func main() {
 			return green("0")
 		}(),
 		yellow(fmt.Sprintf("%d", missingCount)))
+
+	// Anti-vacuity floor: a sweep that enumerated nothing cannot testify that the
+	// manifest is in sync. Unconditional on --ci — this is not a drift-tolerance
+	// question, it is a broken instrument.
+	if checked == 0 {
+		fmt.Fprintf(os.Stderr, "\n%s validate_manifest enumerated 0 modules (%d entries in manifest, %d missing on disk)\n",
+			red("INSTRUMENT FAILURE:"), len(m.Examples), missingCount)
+		fmt.Fprintf(os.Stderr, "A zero-enumeration means the instrument is broken, not that the manifest is clean.\n")
+		os.Exit(1)
+	}
 
 	if driftCount > 0 {
 		fmt.Fprintf(os.Stderr, "\n%s %d manifest `modules` entr(ies) are out of date.\n", red("DRIFT:"), driftCount)

--- a/scripts/verify_examples.go
+++ b/scripts/verify_examples.go
@@ -14,8 +14,11 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/sunholo-data/ailang/internal/manifest"
+	"github.com/sunholo-data/ailang/scripts/internal/importextract"
 	"github.com/sunholo-data/ailang/scripts/internal/reporttypes"
 )
 
@@ -58,6 +61,10 @@ func main() {
 	// Set global flag for findAllExamples
 	useAllExamples = allExamples
 
+	// Build the manifest expected.stdout index BEFORE any goroutine starts, so
+	// the parallel sweep only ever reads it (no mutex needed).
+	loadPinnedStdout()
+
 	if updateBaselines {
 		runUpdateBaselines()
 		return
@@ -79,6 +86,85 @@ var (
 	updateBaselines = false
 	parallelism     = 8 // max concurrent example runs
 )
+
+// manifestPath is the oracle this verifier compares captured stdout against.
+// Deliberately NOT a flag: the gate must not be able to point itself at a
+// weaker oracle.
+const manifestPath = "examples/manifest.json"
+
+var (
+	// pinnedStdout maps a resolved on-disk example path (slash-normalized) to
+	// the non-empty expected.stdout committed in the manifest. Populated once
+	// from main() before any goroutine starts, then read-only.
+	pinnedStdout map[string]string
+	// pinnedTotal counts manifest entries carrying a non-empty expected.stdout,
+	// resolvable on disk or not. Diagnostic only (see enforceStdoutFloor).
+	pinnedTotal int
+	// stdoutChecked counts comparisons actually performed, whatever the outcome.
+	stdoutChecked atomic.Int64
+)
+
+// loadPinnedStdout builds the resolved-path -> expected.stdout index from the
+// manifest. Path resolution reuses importextract.ResolvePath — the same helper
+// validate_manifest.go uses — so the two tools cannot disagree about which file
+// a manifest entry names (106 of 199 entries use a bare "hello.ail"-style path
+// that only resolves under examples/runnable/).
+//
+// A manifest that cannot be loaded is a HARD failure: a verifier that cannot
+// read its own oracle must not go on to report a clean run (CLAUDE.md #2).
+func loadPinnedStdout() {
+	pinnedStdout = make(map[string]string)
+
+	m, err := manifest.Load(manifestPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "INSTRUMENT FAILURE: verify_examples could not load %s: %v\n", manifestPath, err)
+		os.Exit(1)
+	}
+
+	for _, ex := range m.Examples {
+		if ex.Expected == nil || ex.Expected.Stdout == "" {
+			continue
+		}
+		pinnedTotal++
+		full, ok := importextract.ResolvePath("examples", ex.Path)
+		if !ok {
+			continue
+		}
+		pinnedStdout[filepath.ToSlash(filepath.Clean(full))] = ex.Expected.Stdout
+	}
+}
+
+// stripRunPreamble removes `ailang run`'s status preamble — "→ Type checking...",
+// "→ Effect checking...", "✓ Running <path>" — from captured output. The runner
+// prints that preamble to STDOUT, not stderr, so a raw comparison against a
+// manifest pin would mismatch on every single pinned entry.
+//
+// The strip anchors on the example's OWN path, so it is deterministic and
+// cannot eat program output unless the program prints that exact line. (Adding
+// --quiet to the run instead would change result.Output for every example and
+// run the pinned examples under different flags from the rest of the set.)
+func stripRunPreamble(out, filename string) string {
+	anchor := "✓ Running " + filepath.ToSlash(filename) + "\n"
+	if idx := strings.Index(out, anchor); idx >= 0 {
+		return out[idx+len(anchor):]
+	}
+	return out
+}
+
+// enforceStdoutFloor turns a sweep that compared ZERO pinned expected.stdout
+// values into a hard failure. A gate performing no comparisons is
+// indistinguishable from one whose oracle is broken, and must never be reported
+// as a clean run. Not applied under --trace (comparison is deliberately
+// disabled there) nor in --update-baselines (a generator, not a gate).
+func enforceStdoutFloor() {
+	if useTrace {
+		return
+	}
+	if stdoutChecked.Load() == 0 {
+		fmt.Fprintf(os.Stderr, "INSTRUMENT FAILURE: verify_examples compared 0 pinned expected.stdout values (manifest has %d non-empty pins)\n", pinnedTotal)
+		os.Exit(1)
+	}
+}
 
 // skippedExamples lists files that are intentionally excluded from
 // verify-examples because they exercise behavior that cannot succeed
@@ -280,6 +366,26 @@ done:
 			result.Error = stderrStr
 		} else {
 			result.Status = "passed"
+		}
+	}
+
+	// Compare captured stdout against the manifest's pinned expected.stdout (#670).
+	// Skipped under --trace, where the run emits trace JSONL interleaved on
+	// stdout — a comparison there would be measuring the trace, not the program.
+	// Skipped for non-passing examples: they already have a verdict, and must
+	// not be double-reported or counted toward the floor.
+	if !useTrace && result.Status == "passed" {
+		if want, ok := pinnedStdout[filepath.ToSlash(filepath.Clean(filename))]; ok {
+			stdoutChecked.Add(1)
+			got := stripRunPreamble(stdout.String(), filename)
+			// Byte-exact apart from TRAILING newlines only (hello.ail emits no
+			// trailing newline while its pin carries one). No leading-whitespace
+			// trim, no interior normalization, no substring fallback — each of
+			// those would re-introduce the vacuity this check exists to remove.
+			if strings.TrimRight(got, "\n") != strings.TrimRight(want, "\n") {
+				result.Status = "failed"
+				result.Error = fmt.Sprintf("stdout mismatch vs manifest expected.stdout\n  expected: %q\n  actual:   %q", want, got)
+			}
 		}
 	}
 
@@ -687,6 +793,7 @@ func verifyExamplesPlain(threshold float64) {
 	fmt.Printf("  Passed: %d\n", passed)
 	fmt.Printf("  Failed: %d\n", failed)
 	fmt.Printf("  Skipped: %d\n", skipped)
+	fmt.Printf("  Stdout pins checked: %d\n", stdoutChecked.Load())
 
 	if useTrace {
 		summary := computeTraceSummary(allResults)
@@ -701,6 +808,8 @@ func verifyExamplesPlain(threshold float64) {
 
 	// One-line summary (useful for CI)
 	fmt.Printf("\nExamples: %d/%d passed (%.1f%%)\n", passed, total, passRate)
+
+	enforceStdoutFloor()
 
 	// Threshold check
 	if threshold > 0 && passRate < threshold {
@@ -756,6 +865,9 @@ func verifyExamplesJSON(threshold float64) {
 		fmt.Fprintf(os.Stderr, "Error encoding JSON: %v\n", err)
 		os.Exit(1)
 	}
+
+	// After the report is on stdout, so a tripped floor still leaves the artifact.
+	enforceStdoutFloor()
 
 	// Threshold check
 	passRate := 0.0
@@ -843,6 +955,8 @@ func verifyExamplesMarkdown() {
 	fmt.Println()
 	fmt.Printf("**Summary:** %d passed, %d failed, %d skipped (Total: %d)\n",
 		len(passed), len(failed), len(skipped), len(passed)+len(failed)+len(skipped))
+
+	enforceStdoutFloor()
 
 	if len(failed) > 0 {
 		os.Exit(1)


### PR DESCRIPTION
## Summary
- Queue item `docs-10` (docs-mission, clause 1). Two independent vacuous-pass defects in the docs mission's example-verification tooling, found by Gate 0's weekly external-issue sweep: reported at #670 and #654.
- `scripts/verify_examples.go`'s `runExample` never compared `examples/manifest.json`'s per-entry `expected.stdout` — an example could print anything and still pass (the defect in #670). Fixed: index pinned stdout once in `main()` (reusing `importextract.ResolvePath`, the same resolver `validate_manifest.go` already uses), compare trailing-newline-insensitively after stripping the `ailang run` status preamble, and fail loudly (`INSTRUMENT FAILURE`) if the count of comparisons performed is ever zero. The counter is `sync/atomic` under the default `--parallel 8`, confirmed race-clean with `go run -race`.
- Fixing this surfaced two genuinely stale pins — `arithmetic.ail`'s pin was a copy-paste from a different example, `process_stdin_write.ail` pinned subprocess output the harness never captures (measured 10/10 deterministic without it). Corrected both; these are the only two `expected.stdout` values changed in the 199-entry manifest.
- `scripts/validate_manifest.go` printed a `checked` count but never asserted a floor on it, so an enumeration silently returning zero (bad `--dir`, a path move) still printed the green "in sync" line and exited 0 (the defect in #654). Fixed with a `checked == 0` hard floor, unconditional on `--ci`, before the success line prints.

## Routing
- Designer: `claude-sonnet-5` (Agent-tool pin) — read-only research, wrote `design_docs/docs-10-brief.md` (a lightweight routing brief, not a full design doc, per this mission's established convention for well-specified tooling fixes).
- Planner: `opus` (Agent-tool pin) — `MISSION_PLANNER_MODEL=codex:gpt-5.6-luna` is not expressible via the Agent tool in this session (same limitation recorded in this mission's iteration-2 log); `tools/launchd/derive-planner-lane.sh` independently resolves this brief to `opus declared:opus-required` anyway, since neither target file is in `MISSION_PLANNER_ALLOWLIST` — so the routing outcome is correct regardless. Wrote `design_docs/docs-10-sprint-plan.md` with baseline measurements for every acceptance criterion taken on the pristine tree before planning.
- Executor: `opus` (Agent-tool pin; same MISSION_EXECUTOR_MODEL=`codex:gpt-5.6-luna` limitation, FLAGGED) — isolated worktree, no git-write ops, controller reviewed and committed the diff.
- Evaluator: `sonnet` (Agent-tool pin, isolated worktree, generator≠judge held) — **PASS 97/100, zero blocking**. Independently re-ran all 11 plan acceptance criteria from scratch (not trusting the executor's report) plus 5 of its own adversarial mutations (whitespace-only pins, a well-formed zero-example manifest exercising both floors independently, `--all` vs default pin counts, `--trace` suppression, and the `-race` check).

## Test plan
- [x] Negative control (#670): corrupting `hello.ail`'s pin flips it to `failed` with a message showing both expected and actual; restore is byte-identical by hash. (rc 0 → rc 1)
- [x] Negative control (floor, #670): pointing the pin index at a manifest with zero non-empty pins fires `INSTRUMENT FAILURE: verify_examples compared 0 pinned expected.stdout values`.
- [x] Positive control: `Stdout pins checked: 15` (default sweep), `19` under `--all` — matches the manifest's actual pinned/resolvable count.
- [x] No collateral reds: full JSON sweep stays 217 total / 211 passed / 0 failed / 6 skipped, identical to the pristine baseline.
- [x] Negative control (#654), both modes: `validate_manifest.go --dir /nonexistent/xyz` (with and without `--ci`) flips from rc 0 + green "in sync" line to rc 1 + `INSTRUMENT FAILURE: ... enumerated 0 modules`.
- [x] `make validate-manifest-selftest` still passes (manifest backed up/restored around it — `backfill_manifest_modules.go` rewrites the file byte-for-byte even at zero drift, a pre-existing behavior out of scope here).
- [x] `go build ./scripts/...`, `go vet ./scripts/...`, `gofmt -l` clean on both changed files; `go build ./...` has one pre-existing unrelated `cmd/wasm` linker issue this diff does not touch.
- [x] Diff scope: exactly 3 files (`scripts/verify_examples.go`, `scripts/validate_manifest.go`, `examples/manifest.json`); manifest diff is exactly the two named string values; nothing under `internal/**`, `cmd/**`, or `scripts/internal/reporttypes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
