### PR TITLE
fix(ci): give process-tree discovery its own deadline (reconciled onto dev; supersedes #971)

### DIFF
--- a/tools/eval/motoko_connection_probe.sh
+++ b/tools/eval/motoko_connection_probe.sh
@@ -124,8 +124,10 @@ benchmark=${4:-hello_world}
 ailang_bin=${AILANG_BIN:-ailang}
 timeout_secs=${PROBE_TIMEOUT_SECS:-900}
 MAX_TREE_NODES=${PROBE_MAX_TREE_NODES:-4096}
+TREE_DISCOVERY_SECS=${PROBE_TREE_DISCOVERY_SECS:-30}
 [[ "$timeout_secs" =~ ^[1-9][0-9]*$ ]] || instrument_failure "PROBE_TIMEOUT_SECS must be a positive integer"
 [[ "$MAX_TREE_NODES" =~ ^[1-9][0-9]*$ ]] || instrument_failure "PROBE_MAX_TREE_NODES must be a positive integer"
+[[ "$TREE_DISCOVERY_SECS" =~ ^[1-9][0-9]*$ ]] || instrument_failure "PROBE_TREE_DISCOVERY_SECS must be a positive integer"
 [[ $(uname -sm) == "Darwin arm64" ]] || instrument_failure "live probe requires darwin/arm64"
 command -v dig >/dev/null || instrument_failure "dig is required"
 command -v lsof >/dev/null || instrument_failure "lsof is required"
@@ -209,11 +211,12 @@ assert_pid_scope() {
 }
 
 sample_tree() {
-  local root=$1 raw_file=$2 deadline=$3 pids
+  local root=$1 raw_file=$2 pids discovery_deadline
+  discovery_deadline=$(( $(date +%s) + TREE_DISCOVERY_SECS ))
   if [[ -n "${PROBE_TEST_PID_SCOPE+x}" ]]; then
     pids=$PROBE_TEST_PID_SCOPE
   else
-    if ! pids=$(descendant_pids "$root" "$deadline"); then
+    if ! pids=$(descendant_pids "$root" "$discovery_deadline"); then
       instrument_failure "process-tree discovery failed"
     fi
   fi
@@ -268,7 +271,7 @@ run_lane() {
       { wait "$pid"; } >/dev/null 2>&1 || true
       instrument_failure "lane $lane exceeded ${timeout_secs}s sampling deadline"
     fi
-    sample_tree "$pid" "$raw_file" "$deadline"
+    sample_tree "$pid" "$raw_file"
     sleep 1
   done
   { wait "$pid"; } 2>/dev/null || lane_rc=$?

--- a/tools/eval/test_motoko_connection_probe.sh
+++ b/tools/eval/test_motoko_connection_probe.sh
@@ -359,7 +359,7 @@ expect_failure "descendant discovery deadline refuses at the caller" "process-tr
 expect_failure "lane sampling deadline refuses" "exceeded 1s sampling deadline" \
   run_live PROBE_TEST_DRIVER_SLEEP=10 PROBE_TIMEOUT_SECS=1
 expect_failure "bounded termination deadline refuses" "bounded termination deadline" \
-  run_live PROBE_TEST_DRIVER_SLEEP=20 PROBE_TEST_IGNORE_TERM=1 PROBE_TIMEOUT_SECS=1
+  run_live PROBE_TEST_DRIVER_SLEEP=20 PROBE_TEST_IGNORE_TERM=1 PROBE_TIMEOUT_SECS=1 PROBE_TREE_DISCOVERY_SECS=30
 
 success_artifact="$tmp_dir/success/probe.json"
 mkdir -p "$tmp_dir/success"
@@ -435,21 +435,18 @@ fi
 # makes the process tree self-referential and never empties the queue — the only way to reach the
 # in-loop `date` check. The stub was written for this and no invocation used it, so the branch
 # that actually bounds the walk was unexercised while an arm claimed the deadline was pinned.
-# WIDER CAP FOR THIS ARM ONLY (deflake, 2026-08-27). The self-referential pgrep
-# walk normally trips the probe's 1s internal deadline in a second or two — but
-# each loop iteration SPAWNS a stub process, and on a contended shared CI runner
-# those spawns degrade until total wall time blows through the global 120s arm
-# cap long before the per-iteration date check accumulates to its limit. CI run
-# 33001432738 (2026-08-26) failed exactly here on a commit touching no related
-# files, and the identical suite passed on the next commit. The refusal itself
-# is what this arm proves and it still MUST happen — the generosity only widens
-# how long we wait for a degraded runner to get there, and stays bounded.
-_arm_cap_saved=$ARM_CAP_SECS
-ARM_CAP_SECS=$(( ARM_CAP_SECS * 5 ))
+# DETERMINISTIC BY CONSTRUCTION (de-race, 2026-08-31): discovery and the lane deadline are now
+# independently bounded. This arm pins the discovery deadline to a 1s bound
+# (PROBE_TREE_DISCOVERY_SECS=1) so the process-tree walk trips its in-loop date check in about a
+# second no matter how fast or slow the machine is, while the LANE deadline is raised to 60s
+# (PROBE_TIMEOUT_SECS=60) so the lane's bounded-termination branch can NEVER win the race. The
+# scoped high node ceiling keeps that independent refusal structurally unreachable during the
+# arm's window. The discriminating wall-clock message must fire promptly, so no widened arm cap
+# is needed.
 expect_failure "descendant discovery refuses on the real wall-clock deadline" "process-tree discovery deadline expired (wall clock)" \
-  env PATH="$live_bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=1 PROBE_MAX_TREE_NODES=50000 PROBE_TEST_PGREP_LOOP=1 \
-    PROBE_STUB_STATE="$tmp_dir/lane-pgreploop" /bin/bash "$probe" treatment control "$tmp_dir/pgreploop.json"
-ARM_CAP_SECS=$_arm_cap_saved
+  env PATH="$live_bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=60 PROBE_TREE_DISCOVERY_SECS=1 \
+    PROBE_MAX_TREE_NODES=50000 PROBE_TEST_PGREP_LOOP=1 PROBE_STUB_STATE="$tmp_dir/lane-pgreploop" \
+    /bin/bash "$probe" treatment control "$tmp_dir/pgreploop.json"
 
 cap_secs_fixture=2
 cap_start=$(date +%s)
@@ -695,12 +692,16 @@ expect_failure "tree node ceiling rejects invalid values" \
   "PROBE_MAX_TREE_NODES must be a positive integer" \
   env PROBE_MAX_TREE_NODES=invalid /bin/bash "$probe" treatment control "$tmp_dir/invalid-node-limit.json"
 
+expect_failure "tree discovery deadline rejects invalid values" \
+  "PROBE_TREE_DISCOVERY_SECS must be a positive integer" \
+  env PROBE_TREE_DISCOVERY_SECS=invalid /bin/bash "$probe" treatment control "$tmp_dir/invalid-tree-discovery.json"
+
 expect_failure "descendant discovery refuses on the node-count ceiling" "process-tree discovery exceeded 3 nodes" \
   env PATH="$live_bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=60 PROBE_MAX_TREE_NODES=3 \
     PROBE_TEST_PGREP_LOOP=1 PROBE_STUB_STATE="$tmp_dir/lane-node-limit" \
     /bin/bash "$probe" treatment control "$tmp_dir/node-limit.json"
 
-# The D4 ceiling override belongs on arm :449's own env line and nowhere else. A per-command
+# The D4 ceiling override belongs on the wall-clock discovery arm's own env line and nowhere else. A per-command
 # env assignment never persists into this shell, so this is invariantly quiet on a correct
 # tree. It fires on exactly two leak shapes: an edit that promotes the override to a
 # file-global assignment or export, and an ambient PROBE_MAX_TREE_NODES in the caller's
@@ -715,7 +716,7 @@ fi
 # a removal proves the check FIRES; only an addition proves it LOOKS. Adding a new refusal to the
 # probe passes the whole suite byte-identically, so the coverage claim is a one-time manual count
 # that silently rots on the next edit. Count the branches and refuse when the number moves.
-expected_refusal_branches=27
+expected_refusal_branches=28
 # Every counter below reads $probe. Assert it resolves to a file BEFORE any of them run, so
 # that no grep in this gate can fall through to reading stdin.
 [[ -f "$probe" ]] || { echo "not ok - refusal-branch gate: \$probe does not resolve to a file; instrument failure, not a verdict" >&2; exit 1; }


### PR DESCRIPTION
Mission-control iteration 317. **dev CI is red; V1 owns this repo, so the red outranks the queue.** This lands iteration 308's fix (PR #971), reconciled onto current dev.

## The red

`launchd drivers (bash 3.2)`, step 4, on `origin/dev` HEAD `75a2b8b40`:

```
not ok - bounded termination deadline refuses lacked expected message: bounded termination deadline
process-tree discovery deadline expired (wall clock)
INSTRUMENT FAILURE: process-tree discovery failed
```

## It is a race, not a regression — measured two independent ways

**(1) Outcome divergence on byte-identical code.** The same job is `success` on the parent `ef55ed075` and `failure` on `75a2b8b40`. The `tools/eval/*` blobs are **identical** between those two commits:

| file | `ef55ed075` (green) | `75a2b8b40` (red) |
|---|---|---|
| `motoko_connection_probe.sh` | `dcc91a1eb` | `dcc91a1eb` |
| `test_motoko_connection_probe.sh` | `5b00f4edb` | `5b00f4edb` |

Control: the docs blob that commit *did* change correctly differs. `75a2b8b40` touched only `design_docs/` and `.claude/`.

**(2) Reproduced locally by varying the axis the mechanism depends on.** On the unmodified `origin/dev` tree, 8 runs quiet: **8/8 rc=0**. Same tree under 8 CPU spinners: run 4 failed with the **exact CI signature** above. The bound is wall-clock and the stimulus forks one `pgrep` per node, so machine speed is the variable.

## Mechanism

`run_lane()` computed **one** deadline from `PROBE_TIMEOUT_SECS` and used it for **two** bounds — the lane's own sampling/termination check, and the process-tree **discovery** bound threaded into `descendant_pids`. Two arms need **opposite** branches to win:

| arm | needs |
|---|---|
| `bounded termination deadline refuses` | the TERMINATION branch to win |
| `descendant discovery refuses on the real wall-clock deadline` | the DISCOVERY branch to win |

They were separated only by machine speed.

## The fix

`PROBE_TREE_DISCOVERY_SECS` (default 30, validated like `PROBE_MAX_TREE_NODES`) gives discovery its own bound, computed in `sample_tree` at call time. Each arm pins its own knobs, so neither outcome depends on machine speed:

- bounded-termination arm: `PROBE_TIMEOUT_SECS=1 PROBE_TREE_DISCOVERY_SECS=30`
- wall-clock arm: `PROBE_TIMEOUT_SECS=60 PROBE_TREE_DISCOVERY_SECS=1`

This retires the `ARM_CAP_SECS * 5` widening added 2026-08-27, which was a calibration band-aid on this same race.

## Reconciliation with #1008 — both intents survive

Supersedes #971 (V1 iteration 308), which went `CONFLICTING` when motoko's #1008 (`64ca81852`) landed on the same two files. The two changes are orthogonal by design and neither supersedes the other; all of #1008 is preserved:

- the wall-clock arm still asserts the **discriminating** message `process-tree discovery deadline expired (wall clock)`, not the generic wrapper;
- it still carries the scoped `PROBE_MAX_TREE_NODES=50000` on **its own `env` line** (attended ruling `D-MOTOKO-6N-1`, decision D4) — not promoted to a file-global or an export;
- the suite-scope `PROBE_MAX_TREE_NODES` guard, the `[[ -f "$probe" ]]` assertion and the echo-shaped refusal counter are untouched.

`expected_refusal_branches` moves **27 → 28**, re-derived by running the gate's own three counting expressions against the reconciled probe (`20 + 5 + 3`), not by arithmetic.

## Gates (all re-run by the controller **outside** the executor sandbox, darwin/arm64)

| gate | rc |
|---|---|
| `bash -n tools/eval/motoko_connection_probe.sh` | 0 |
| `bash -n tools/eval/test_motoko_connection_probe.sh` | 0 |
| full suite, run 1 | 0 — 42 ok, 0 not ok |
| full suite, run 2 | 0 — 42 ok, 0 not ok |
| full suite, run 3 | 0 — 42 ok, 0 not ok |
| `make test-launchd-drivers` | 0 — *launchd drivers: tests + bash 3.2 syntax OK* |

Base was 41 arms; 42 is the new `PROBE_TREE_DISCOVERY_SECS` validation arm. The `PATH=$PATH:/usr/sbin` prefix is load-bearing — without it the suite refuses at its second line on a missing `lsof`, measured in both arms at base.

Windows and ubuntu legs unrun locally; this is a darwin-only self-hosted job.

Executor `codex:gpt-5.6-sol` (sandboxed worktree, no git writes). Reviewed by an independent Sonnet evaluator in its own worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
