### PR TITLE
docs(mission): iteration 4 — credit iteration 3's orphaned landings, land docs-1

### DIFF
--- a/design_docs/docs-mission-dashboard.md
+++ b/design_docs/docs-mission-dashboard.md
@@ -1,28 +1,37 @@
 # Docs Mission Dashboard (snapshot — history lives in the charter + log)
 
-**Last updated**: 2026-08-31T08:07Z, iteration 2.
+**Last updated**: 2026-09-02T05:15Z, iteration 4.
 
 ## Status
-Recovered a died-mid-flight prior fire: `docs-9` ("intro.mdx is stale at v0.16.0") was verified
-FALSE — the version tags are intentional historical ship-versions, not current-version claims —
-and `[RULED OUT]`. Landed [PR #973](https://github.com/sunholo-data/ailang/pull/973) →
-`ad7542ba5` (squash). `check_versions.sh`'s Check 3 (the false-positiving instrument) is deleted.
-CI/Deploy-docs poll on the merge commit was still in flight when this dashboard was written; see
-the log entry for the final read.
+Two died-mid-flight fires credited/landed this session. Iteration 3 (retroactive): `docs-5`
+(examples hygiene, PR #997), `docs-6` (fix `check_examples.sh`'s absolute-path bug, PR #1004), and
+`docs-10` (verify-examples anti-vacuity floor, #670/#654, PR #1010) were all already merged on
+`origin/dev` while the charter still tagged them `[NEXT]` — re-verified fresh (`make
+verify-examples`: 211/0/6; `check_examples.sh`: 173/2/42) and queue tags corrected. Iteration 4
+(fresh work): recovered `docs-1`'s planner output (PR #1016) and executed it on
+`codex:gpt-5.6-luna`. Round-1 evaluator (sonnet) FAILED 58/100 — a genuinely empty poll result
+crashed the router instead of reporting `checked=0 forwarded=0`. Fixed and independently
+re-verified by the controller (not taken on trust); round-2 evaluator PASSED 90/100. Landed
+[PR #1018](https://github.com/sunholo-data/ailang/pull/1018) → `e65e96b15`, CI green (16 checks,
+one pre-existing inherited `SonarCloud Code Analysis` red — V1's domain, not actioned).
 
 ## Blocking on Mark
-None. D-1 and D-2 (previous decisions) are both `RESOLVED`. No new ask this iteration.
+None. Decision ledger: 2 rows, both `RESOLVED`. No new ask this iteration.
 
 ## Queue (top = next)
-1. `[LANDED]` docs-2 · clauses 1+3 · first `docs-sync` sweep.
-2. `[RULED OUT]` docs-9 · intro.mdx version claim was a false positive of `check_versions.sh`.
-3. `[NEXT]` docs-5 · clause 2 · fix the 9 genuinely-failing runnable examples.
-4. `[NEXT]` docs-6 · clause 1 · fix `check_examples.sh`'s absolute-path bug.
-5. `[NEXT]` docs-10 (new, this iteration) · `make verify-examples` never compares `expected.stdout`
-   and has no anti-vacuity floor (#670, #654 — found by the weekly external-issue sweep).
-6. `[PARKED]` docs-8 · 126 overdue planned design docs (aggregate triage).
-7. `[NEXT]` docs-1 · clause 7 · build the inbox-routing trigger.
-8. `[PARKED]` docs-3 / docs-4 · benchmark audit / taxonomy pass.
+1. `[LANDED]` docs-0 · charter ratified (attended).
+2. `[LANDED]` docs-2 · clauses 1+3 · first `docs-sync` sweep.
+3. `[RULED OUT]` docs-9 · intro.mdx version claim was a false positive of `check_versions.sh`.
+4. `[LANDED]` docs-5 · clause 2 · 9 genuinely-failing runnable examples fixed.
+5. `[LANDED]` docs-6 · clause 1 · `check_examples.sh`'s absolute-path bug fixed.
+6. `[LANDED]` docs-10 · verify-examples anti-vacuity floor (#670, #654).
+7. `[RULED OUT]` docs-7 · "mission cannot edit its own content" — premise was false.
+8. `[PARKED]` docs-8 · 126 overdue planned design docs (aggregate triage) — next natural pick,
+   unblocked now that docs-6/docs-7 are resolved, not yet started (one item/iteration).
+9. `[LANDED]` docs-1 · clause 7 · inbox-routing trigger built and verified.
+10. `[PARKED]` docs-3 / docs-4 · benchmark audit / taxonomy pass.
+
+**Queue is empty of `[NEXT]` items.** Next fire should pick up `docs-8` per its own sequencing note.
 
 ## Loop cadence + routing
 launchd `dev.ailang.mission-docs`, every 6h, staggered against v1/world/motoko. Routing ladder:
@@ -30,9 +39,11 @@ subscription (`claude-sonnet-5`/`codex:gpt-5.6-luna`) → flat-rate (Ollama Clou
 OpenRouter twin. Evaluator vendor-disjoint from executor at every rung. Metered ceiling $1/iter.
 
 ## Cost this iteration
-$0.00 of $1 — no new model-role spawns; this iteration verified and landed a prior fire's output
-plus controller-session bookkeeping (Gate 0 weekly sweep, Gate 4/5).
+$0.00 of $1 — codex (executor, 2 rounds across docs-1) and sonnet (evaluator, 2 rounds; also
+controller session) are both subscription-lane; no metered $ calls.
 
 ## Quota posture
-No fallback triggered. `launchd drivers (bash 3.2)` still red on `origin/dev`'s recent ancestry —
-pre-existing, already flagged to V1 (repo owner); not re-flagged.
+No fallback triggered this session; codex probes rc=0 throughout. `SonarCloud Code Analysis`
+still red on `origin/dev`'s recent ancestry — pre-existing, V1's domain (repo owner); not
+re-flagged. `launchd drivers (bash 3.2)` confirmed a transient flake (green on re-run), not a
+standing red.

--- a/design_docs/docs-mission-log.md
+++ b/design_docs/docs-mission-log.md
@@ -303,3 +303,157 @@ iteration's own sweep script hit the shared skill's own documented zsh 1-indexed
 (rule 3a's "AND THE ARRAY THIS RULE JUST PRESCRIBED IS 1-INDEXED IN ZSH" clause) on its first
 draft and self-corrected via the length-assertion discipline the same rule prescribes. Filed here
 as a confirmation the existing rule works as written, not as a gap.
+
+## ITERATION 3 — died mid-flight, credited retroactively by iteration 4 (2026-09-02)
+
+**Pick**: this iteration's own record was never written — Gate 2's died-mid-flight check (iteration
+4) found three merged PRs bearing this mission's routing conventions and a fourth, unmerged, sitting
+in an orphaned worktree, with zero trace of "ITERATION 3" anywhere in the charter/log
+(`grep -c "ITERATION 3\b"` = 0/0, known-present control `grep -c "ITERATION 2\b"` = 1/1 in log/none
+elsewhere — instrument confirmed working). The fire worked the queue in order (`docs-5` → `docs-6` →
+`docs-10`, all `[NEXT]` per iteration 2's own **Next** field) then began `docs-1`, producing a
+complete brief + sprint plan before dying — recovered separately as iteration 4's own pick (see
+below). This entry is retroactive bookkeeping only; none of the verification below was re-derived
+from zero by iteration 4 beyond what's noted, since the PRs' own routing/test-plan sections and a
+fresh `make verify-examples`/`check_examples.sh` run (iteration 4, see its own entry) already
+constitute independent confirmation.
+
+**Outcome**: **LANDED** (3 items).
+- `docs-5` (examples hygiene): [PR #997](https://github.com/sunholo-data/ailang/pull/997) →
+  merged 2026-09-01T03:21Z. Added `main` entrypoints to 7 fixtures; fixed a manifest module-drift
+  on 5 of them (evaluator-caught). `batch_processing.ail`/`cli_args_demo.ail` (the other 2 of the
+  original 9 findings) already had entrypoints on `dev` — resolved independently, out of scope.
+  Evaluator round 1 blocking (manifest drift), round 2 PASS.
+- `docs-6` (fix `check_examples.sh`'s absolute-path bug + DOCS-2-04 scope comments):
+  [PR #1004](https://github.com/sunholo-data/ailang/pull/1004) → merged 2026-09-01T10:19Z.
+  Routing: planner+executor `codex:gpt-5.6-luna`, evaluator `sonnet` — **PASS 98/100**, zero
+  blocking, mutation-checked (reverting the fix reproduces the pre-fix 12/29/176 counts).
+- `docs-10` (verify-examples vacuous on two axes, #670/#654):
+  [PR #1010](https://github.com/sunholo-data/ailang/pull/1010) → merged 2026-09-01T21:44Z.
+  Routing: designer `claude-sonnet-5`, planner+executor fell back to `opus` (Agent tool in that
+  session could not express the `codex:gpt-5.6-luna` pin — same limitation iteration 2 recorded,
+  FLAGGED again there, not re-litigated here), evaluator `sonnet` — **PASS 97/100**, zero blocking,
+  11 acceptance criteria plus 5 adversarial mutations independently re-run from scratch.
+
+**Iteration 4's own re-verification before crediting these landed** (not inherited): fresh
+`make verify-examples` run — 211 passed, 0 failed, 6 skipped, manifest "193 modules checked, 0
+drift, 1 missing-on-disk", "✅ verify-examples: all examples pass and manifest is in sync"; fresh
+`check_examples.sh` run — 173 passed, 2 failed (`batch_processing.ail`, `cli_args_demo.ail` — the
+known, explicitly out-of-scope Env-capability gap), 42 skipped, matching PR #1004's own claimed
+counts exactly. Both are real, non-vacuous greens under `docs-10`'s anti-vacuity floor, not
+inherited from the pre-fix instrument.
+
+**Cost**: metered $0.00 (codex/sonnet/opus are all subscription-lane per this mission's routing
+table; no `pi:`/managed_agents/quorum-reviewer calls in any of the three PRs' routing sections).
+Quota buckets: codex (planner+executor, docs-6), opus (planner+executor fallback, docs-10),
+claude-sonnet-5 (designer, docs-10), sonnet (evaluator, all three).
+
+**Next**: `docs-1` (iteration 4's own pick — see below).
+
+**Ruled out**: nothing new; no ruled-out claims in any of the three PR bodies.
+
+**DECISIONS FOR MARK**: none — nothing in these three PRs raised a new ask.
+
+**FLAGGED**: `docs-10`'s planner+executor could not express `codex:gpt-5.6-luna` via the Agent tool
+in that session and fell back to `opus`, per PR #1010's own Routing section — same capability
+limitation iteration 2 already flagged; carried forward rather than re-litigated (re-probing a
+capability limit is a rule-3a(i) vacuous check).
+
+**Retro**: no skill edit — this entry's only job is closing the "orphaned iteration" gap Gate 2's
+died-mid-flight rule warns about (skipping a number silently). Two consecutive died-mid-flight
+fires (this one, and the docs-1 planner run recovered as PR #1016) in the same short window is a
+pattern worth naming for whoever reviews mission health, not a single-instance skill gap.
+
+## ITERATION 4 — 2026-09-02T04:08Z
+
+**Pick**: Gate 2's died-mid-flight check found an open, `MERGEABLE` PR
+([#1016](https://github.com/sunholo-data/ailang/pull/1016)) recovering iteration 3's complete
+`docs-1` brief + sprint plan from an orphaned worktree (`.wt-docs-iter3-docs1` under the pin root,
+detached at the same commit as the PR head, clean, no uncommitted state), plus a second, unrelated
+stale worktree (`.planner-wt-iter3-docs-5`, a superseded routing-declaration commit predating
+`docs-5`'s already-landed fix — pruned, nothing to recover). Also found `docs-5`/`docs-6`/`docs-10`
+all landed on `origin/dev` while the charter still tagged them `[NEXT]` — see iteration 3's own
+retroactive entry above. Picked `docs-1` (this iteration's real item) after re-verifying the other
+three genuinely landed rather than redoing them.
+
+**Gate 1 CI health**: `CI` and `Deploy Documentation to GitHub Pages` both `success` on
+`origin/dev`'s HEAD; SHA-addressed `commits/<sha>/check-runs` showed **16** checks, one NOT-GREEN
+(`SonarCloud Code Analysis: failure`) — confirmed inherited from the parent commit too (not from
+any recent merge), and out of this mission's domain per Gate 1's repo-ownership scoping
+(`sunholo-data/ailang` is V1's territory for CI reds); not actioned, noted for the report.
+
+**PR #1016's own CI**: one job red (`launchd drivers (bash 3.2)`) on a PR touching only two
+markdown planning files — a known-flaky wall-clock-deadline test in the launchd driver suite (the
+failing assertion was `descendant discovery refuses on the real wall-clock deadline`), confirmed
+unrelated to the diff (same check reads `success` on both the PR's base and `origin/dev`'s current
+tip). Re-ran the failed job (rule 3d — negative control before crediting a red to anything): green
+on re-run, confirming the flake diagnosis rather than assuming it. Merged
+[PR #1016](https://github.com/sunholo-data/ailang/pull/1016) → `4f94edf70`.
+
+**Execution**: routed `docs-1` to `codex:gpt-5.6-luna` (executor, per the mission's routing table)
+in an isolated worktree, using the recovered brief + sprint plan verbatim (no re-planning). Codex
+probe rc=0 before the real run.
+
+- **Round 1**: codex built `tools/messaging/docs_inbox_router.sh` (238 lines). Controller
+  independently re-verified every acceptance command before committing (not trusting the
+  executor's self-report): `bash -n` rc=0, `shellcheck` rc=0, `--selftest` rc=0 (reproduced
+  checked=5/forwarded=3 then checked=3/forwarded=0 duplicate suppression), forced total-store
+  failure rc=1 with empty stdout and a clear stderr message, no process-wide
+  `export AILANG_MESSAGES*`, forward shape (`--to docs-mission --reason "..." <id>`) matches
+  clause 7's verification log verbatim, diff scope exactly one new file under `tools/`. Committed,
+  opened [PR #1018](https://github.com/sunholo-data/ailang/pull/1018).
+- **Evaluator round 1** (sonnet, own isolated worktree, generator≠judge held — codex executor vs
+  sonnet evaluator, distinct providers): **FAIL 58/100**. Live-reproduced a BLOCKING bug:
+  `poll_messages`/`poll_github` fed a `jq` command substitution into a `while read` heredoc
+  (`<<EOF\n$(jq ...)\nEOF`); when the store legitimately returns zero items — the ordinary,
+  most-common state for a low-traffic poller — the heredoc still contains one blank line, so the
+  loop executes once with `message_id=""` and hits the "item without an ID" guard, aborting the
+  ENTIRE run on a VALID empty read. Non-blocking: no `pipefail` on `is_doc_related`'s
+  `jq | grep` pipe (lower risk, input pre-validated upstream); `record_key` is O(n²) per append
+  (not a concern at this router's traffic).
+- **Round 2**: routed the evaluator's exact finding back to `codex:gpt-5.6-luna` (same worktree,
+  continuing work, not a re-plan). Fix: capture `jq` output into a variable, gate loop entry on
+  non-emptiness (`done <<<"$rows"` behind `[ -n "$rows" ]`), applied to both poll functions; added
+  a `--selftest` empty-poll case. Controller independently reproduced BOTH the original failure (on
+  the round-1 commit, with hand-built `[]`-returning fixtures distinct from the script's own
+  `--selftest` fixtures) and the fix (on the round-2 commit, same fixtures) — not taken on the
+  executor's or the evaluator's word alone. Re-ran the forced-failure regression check (still rc=1,
+  clean) and the export/scope checks (still clean). Committed, pushed.
+- **Evaluator round 2** (sonnet, same isolated worktree, updated to the new commit): **PASS
+  90/100**, zero blocking. Independently rebuilt its own `[]`-returning fixtures (not the script's),
+  confirmed the round-1 bug is genuinely fixed, re-confirmed the failure-regression check, and
+  scanned the round-2 diff itself for new defects (jq-failure propagation via `|| die`, and whether
+  `[ -n "$rows" ]` could misfire on an all-empty-field-but-real item — tested and confirmed no).
+  Non-blocking: no CHANGELOG entry (correctly scoped low-severity — internal ops tool, not
+  public-facing).
+
+**Gate 3b**: merged [PR #1018](https://github.com/sunholo-data/ailang/pull/1018) (squash) →
+`e65e96b15`. Polled the merge commit itself (squash produces a new SHA) with bounded chained waits
+until all 16 checks settled: 15 green, the same pre-existing `SonarCloud Code Analysis` red as Gate
+1 found (confirmed inherited, V1's domain, not actioned). **LANDED.**
+
+**Cost**: metered $0.00 (codex is subscription-lane; both evaluator rounds were sonnet Agent-tool
+sub-agents, Anthropic quota, not metered $). Quota buckets: codex (executor, 2 rounds), sonnet
+(evaluator, 2 rounds + controller session).
+
+**Next**: queue is now empty of `[NEXT]` items — remaining rows are `[PARKED]`
+(`docs-3`, `docs-4`, `docs-8`) or `[LANDED]`/`[RULED OUT]`. `docs-8` (126 overdue planned design
+docs) is the only PARKED item explicitly sequenced to become available now that `docs-6`/`docs-7`
+are resolved ("Sequence after docs-6/docs-7 land or are ruled out") — flagging as the natural next
+pick for a future iteration, not picked here since Standing rule 1 caps this iteration at one
+backlog item (bookkeeping-only picks aside) and `docs-1` was already substantial.
+
+**Ruled out**: nothing new.
+
+**DECISIONS FOR MARK**: none — no new ask this iteration.
+
+**FLAGGED**: none new. `SonarCloud Code Analysis` remains red on `origin/dev` (inherited, V1's
+domain) — noted, not re-flagged as newly-discovered (already visible in this mission's iteration 1
+FLAGGED row).
+
+**Retro**: no skill edit this iteration (no ≥2-friction gap found in the shared skill itself — the
+died-mid-flight, negative-control, and generator≠judge disciplines all worked exactly as
+documented). Process observation for this mission's own charter, not the shared skill: two
+consecutive died-mid-flight fires in one short window (iteration 3, and the `docs-1` planner run
+recovered as PR #1016) is a pattern worth Mark's attention if it recurs a third time — not yet at
+the evidence bar for a charter change.

--- a/design_docs/docs-mission-status-archive.md
+++ b/design_docs/docs-mission-status-archive.md
@@ -3,6 +3,206 @@
 Append-only. Newest entry at the TOP (Gate 4 moves the 4th-newest charter stamp here, per
 `docs-mission.md`'s rotation rule). The charter itself always carries the newest 3.
 
+## STATUS 2026-08-28 — **BAR RATIFIED ATTENDED**; queue reordered so the next fire touches the website
+
+Mark closed `docs-0` by human decision after reading iteration 0's result. Two changes, both his:
+
+1. **The bar is ratified** — not by a passing quorum, but because the seven clauses are Mark's own
+   attended selection, so a quorum blocking them second-guesses the human it exists to represent.
+   The objections that survived measurement were about **queue items' implementation**, not the bar;
+   they are preserved and re-enter at each item's own design gate, where they are actionable.
+2. **`docs-2` promoted above `docs-1`.** The original ordering was an authoring error that put
+   clause-7 infrastructure ahead of every clause that changes a published page. The measurement that
+   forced this: after a full iteration, **files changed under `docs/` was zero**.
+
+**The mechanism-level lesson, routed to the shared skill rather than to this mission:** charter
+ratification and design review are different jobs. Running a backlog-bearing governance document
+through a design quorum blocks at the wrong gate — the reviewers keep finding new things to say
+about work that has not been designed yet, so each round raises *new* objections instead of
+converging. Three rounds, no convergence, **6 of 9 objections refuted by direct measurement**.
+
+Iteration 0's real yield is kept and was never the ratification: two corrections to the
+human-authored charter (the CI path-filter citation, the fail-closed framing), a refuted
+"silent fallback" claim, and one **fleet-wide** skill fix (`0e341cc57`) — the shared Gate-0
+Current-State block had been reading V1's kill switch, queue and log for *every* non-V1 mission.
+
+## CURRENT GOAL
+
+1. **Iteration 0 (definition)**: ratify the bar below with Mark through the design quorum, then
+   score the backlog against it into `required` / `nice` / `post`. Output: an ordered queue in this
+   doc. Standing up the `docs-mission` inbox-routing **trigger** that clause 7 depends on is queue
+   item **docs-1** (see Queue and clause 7) — a later, separate iteration, not part of iteration 0
+   itself. (Reconciled 2026-08-28 during quorum revision: this line previously said routing was
+   "also at iteration 0," contradicting the Queue's listing of docs-1 as its own 1-iteration item
+   after docs-0. The Queue is correct — docs-1 carries an open scope question, below, that must not
+   gate ratification.)
+2. **Then**: work the queue through the inner loop (design-doc → sprint-plan → execute → evaluate),
+   one sprint-sized item per iteration, recording routing evidence every time.
+
+## The bar — what "the website is up to date" means (RATIFY with Mark at iteration 0)
+
+Mark selected all seven clauses attended on 2026-08-28; clauses 5-7 are his additions.
+
+- **Clause 1 — Code/docs drift.** No page contradicts the shipped binary. Feature status pages match
+  actual implementation, version constants are current, and design docs that moved
+  `planned/` → `implemented/` are reflected on the site. The `docs-sync` skill's
+  `audit_design_docs.sh` / `check_versions.sh` are the instruments — use them.
+- **Clause 2 — Examples compile and run.** Every `.ail` under `examples/` still passes
+  `make verify-examples`, and every site page importing one via raw-loader resolves. A published
+  snippet that no longer runs is worse than no snippet: it teaches wrong syntax to both humans and
+  the models we benchmark. Website examples are IMPORTED from `examples/`, never inlined — a page
+  with an inline code block is itself a clause-2 defect.
+- **Clause 3 — Site build health.** `make docs-build` green, `Deploy Documentation to GitHub Pages`
+  passing, no broken internal links, no orphaned pages unreachable from the nav.
+- **Clause 4 — New features get pages.** Shipped features with no documentation page at all are
+  tracked and closed. Read `CHANGELOG.md` and the release history against the nav; the gap is the
+  work. This is the only generative clause — scope one page per iteration, not a batch.
+- **Clause 5 — Concision and anti-sprawl.** *(Mark, 2026-08-28.)* The site is organised and
+  categorised, and says each thing **once**. Redundant pages are merged or deleted, not left to rot
+  beside their replacement; overlapping guides are consolidated; the nav reflects a real taxonomy
+  rather than accretion order. **Deletion is in scope for this clause** — it is the only clause
+  whose work is usually *removal*, and the loop must not quietly substitute "add a clarifying note"
+  for "delete the duplicate". A page that exists only because nobody dared remove it fails this
+  clause.
+- **Clause 6 — Benchmark report maintenance.** *(Mark, 2026-08-28.)* The published benchmark
+  surface is current and honest: `docs/static/benchmarks/{latest,os/latest,os/history}.json` and the
+  pages that render them. **Beware the known traps, which are documented and must not be
+  rediscovered**: os-rolling data has been stale-but-plausible before (check dates *first*, a low
+  broad pass-rate is usually frozen pre-fix data and not a regression); baselines are NOT poolable
+  across the three local-model boundaries (07-21..08-03 untuned flags, 08-13 budgets+num_ctx,
+  08-17 ollama 0.32.1→0.32.14); and v0.30.0 cost data is INVALID (reasoning tokens unrecorded).
+  This clause maintains the *report*; it does not re-run or re-bank evals, and it takes no rig lock.
+- **Clause 7 — Doc-related requests are answered.** *(Mark, 2026-08-28.)* The mission owns its own
+  inbox and works it: doc-related GitHub issues on `sunholo-data/ailang`, and `ailang messages`
+  requests routed to the **`docs-mission`** inbox.
+  **This clause has no delivery mechanism (trigger) yet — building one is queue item docs-1, not an
+  assumption baked into this charter.**
+
+  **Verified before being written down** (2026-08-28, both rc=0, run live against prod Firestore,
+  not simulated):
+  ```
+  export AILANG_MESSAGES_STORE=gcp AILANG_MESSAGES_PROJECT=ailang-multivac
+
+  # 1. send to a scratch inbox (simulating externally-originated traffic)
+  ailang messages send docs-quorum-test-scratch "iteration-0 quorum premise check..." \
+    --title "docs-mission premise check 20260828T063048Z" --from "docs-quorum-probe"
+  # => Message sent to 'docs-quorum-test-scratch' (ID: inbox_1787898648354_20138c15)
+
+  # 2. forward it to docs-mission — NOTE: flags must come BEFORE the message id, or you get
+  #    "Error: --to flag is required"
+  ailang messages forward --to docs-mission --reason "quorum premise verification" \
+    inbox_1787898648354_20138c15
+  # => Forwarded message from 'docs-quorum-test-scratch' to 'docs-mission'
+
+  # 3. confirm arrival with the CORRECT canonical-store read command (see this repo's root
+  #    CLAUDE.md — cited explicitly here so this clause doesn't leave it implicit):
+  ailang messages list --inbox docs-mission --unread --json
+  # => returned the forwarded message; acked as test cleanup
+  ```
+  Controls run alongside: a known-positive read (`--inbox "pkg:sunholo/ailang_parse"` returned a
+  real unread message) and a known-negative read (a made-up inbox name returned `null`) — so the
+  read instrument is confirmed not vacuously empty either way.
+
+  This confirms `ailang messages send <inbox>` takes a free-form inbox name (`docs-mission` needs
+  no registration) and `ailang messages forward --to <inbox> <id>` works — both **already-existing
+  CLI verbs, verified with no `internal/`/`cmd/` change involved**. What is NOT built is a
+  **trigger**: something that decides *when* to call `forward` for doc-related traffic sitting in
+  `public-feedback`, `pkg:<vendor>/<name>`, or GitHub issues. Public feedback dispatch has never
+  worked end-to-end (36/36 failures since 2026-04-27, ailang#900), so a trigger must **poll** those
+  sources — it cannot assume anything currently pushes traffic anywhere. See docs-1 in the Queue for
+  scope. The canonical store is prod Firestore; a bare `ailang messages list` (no env vars) reads
+  local SQLite and will show an empty, reassuring, wrong inbox.
+
+## Guardrails (mission-specific; the skill's Standing Rules always apply on top)
+
+- **Blast radius is `docs/`, `examples/`, `README.md`, `CHANGELOG.md`, plus `tools/`
+  (non-`internal/`, non-`cmd/`).** This is a **POLICY** guardrail — a rule this mission follows,
+  enforced by the loop reading it here. Widened from `tools/launchd/*` to `tools/*` on 2026-08-28
+  (Mark, attended — commit `29a467cac`) to unblock docs-1's inbox-routing trigger.
+
+  **⚠ CORRECTION 2026-08-28 (attended) — an earlier version of this bullet said the blast radius was
+  "enforced mechanically at the planner gate by `MISSION_PLANNER_ALLOWLIST`". That was FALSE, it was
+  authored by a human, and it cost the mission real work before anyone checked it.** Two facts,
+  each measured with a discriminating control:
+
+  1. **`MISSION_PLANNER_ALLOWLIST` is not a write gate and never was.** It appears in exactly two
+     places in the whole repo — `derive-planner-lane.sh` and the driver's `export` — and nowhere
+     else; there is no write-scope enforcement in `sprint-executor` at all. What it decides is
+     **which model may PLAN the work**: every declared path inside the list → the cheap pinned
+     planner; anything outside → `opus fail-closed:path-not-in-codex-allowlist`. A path outside the
+     list is *expensive to plan*, never *impossible to edit*.
+  2. **`docs/*` is NOT single-level.** These are `case` glob patterns, not shell pathname
+     expansion, so `*` matches `/`. Measured: `docs/docs/intro.mdx` routes to
+     `codex:gpt-5.6-luna declared:codex-ok`, while the `internal/` control is denied in the same
+     run. Nested pages under `docs/docs/**` and `docs/src/**` were always reachable.
+
+  **How this propagated, because the mechanism matters more than the fact.** The false sentence was
+  written into this charter by a human; iteration 1 read it, believed it, deferred DOCS-2-01 and
+  DOCS-2-02 as mechanically impossible, and then opened decision `D-2` **citing this very bullet as
+  its evidence**. A charter is read as ground truth by every iteration, so an unverified mechanical
+  claim in it does not merely mislead once — it becomes self-citing, and the loop cannot tell it
+  from a measurement. **Rule: a claim in this charter about what a mechanism DOES must carry the
+  command that demonstrates it, or must not be stated.** Where a restriction is a judgement rather
+  than a mechanism, say "policy" — as this bullet now does.
+  `internal/**` and `cmd/**` remain denied — if an item genuinely needs a change there, that is a
+  **V1 backlog item, not a docs item** — file it across and move on. Do not widen the allowlist
+  further to make an item fit; the allowlist is the definition of this mission's scope, not an
+  obstacle to it.
+- **No designer on Fable.** The shared skill's designer rotation is
+  `claude:claude-fable-5 → pi:ollama/deepseek-v4-flash:0731-cloud` (kimi removed fleet-wide
+  2026-08-28, V1 charter D-48); this mission seeds the rotation at sonnet (see Routing policy) and
+  must not fall to the Fable entry. Fable is reserved for high-cognition spec synthesis, and docs
+  items are drift repair. Most items here need **no design doc at all** — prefer a Gate-2 reality-check straight
+  into a sprint. If an item truly needs deep design, that is a signal it belongs in V1.
+- **Deleting published pages is an outward-facing change.** Clause 5 makes removal routine, which
+  makes it dangerous. Before deleting or merging a page: check inbound internal links, and leave a
+  redirect where the URL was public. "Nothing links to it" must be *measured*, not assumed — an
+  empty search is a claim, not a fact.
+- **Never re-run or re-bank evals.** Clause 6 maintains the report only. This mission takes **no
+  `rig.lock`** and must never start GPU work; the nightly eval rotation and three sibling missions
+  share that hardware.
+- **Verify before publishing a syntax claim.** Any AILANG syntax that lands on the website must
+  pass `ailang check` first. A wrong claim in published docs is worse than no claim: it trains both
+  readers and the models we benchmark against.
+
+## Routing policy
+
+Uses the **shared** per-role routing from `mission-control`, with this mission's overrides in
+`~/.config/ailang/mission-docs.env` (versioned copy:
+[tools/launchd/mission-env/mission-docs.env](../tools/launchd/mission-env/mission-docs.env)).
+
+The ladder is ordered by **cost type, not model quality** (Mark, attended 2026-08-28): spend the
+subscriptions already paid for, then the flat-rate route, and only reach metered dollars at the last
+rung. Every step down is cheaper in real money than the one above it.
+
+| Rung | Cost type | Lane |
+|---|---|---|
+| 1 | subscription (already paid for) | `claude-sonnet-5` / `codex:gpt-5.6-luna` |
+| 2 | flat-rate (Ollama Cloud pro) | `pi:ollama/<model>:cloud` |
+| 3 | metered, cheapest available | `pi:openrouter/<same weights>` |
+
+Rungs 2 and 3 are deliberately **the same weights on two routes**, so exhausting the flat-rate quota
+(whose denominator is unpublished) costs money and never capability.
+
+| Role | Chain | Notes |
+|---|---|---|
+| **Controller** | `claude-sonnet-5` → `codex:gpt-5.6-luna` | The driver's controller ladder speaks only Anthropic model IDs plus ONE codex fallback, so it cannot express rungs 2-3. Down from opus — this is the biggest line item, a long session re-reading a ~3.8k-line skill each fire. |
+| **Designer** | `claude:claude-sonnet-5` (seed) | Seed only: the designer is a skill-side **rotation**, not a chain — the driver has no `MISSION_DESIGNER_FALLBACK`. Seeded off the Fable default. Most docs items need no design doc at all (see Guardrails). |
+| **Planner** | `codex:gpt-5.6-luna` → `pi:ollama/glm-5.3-flash:cloud` → `pi:openrouter/z-ai/glm-5.3-flash` | Starts at rung 1b, **not** sonnet, and that is forced: `derive-planner-lane.sh` Step 0 accepts only `codex:*` or `pi:*`, so a bare `sonnet` pin emits the labeled fail-closed default `opus fail-closed:env-pin` and deliberately runs opus (a documented fail-closed-to-safety default, not a silent one — every exit path emits a distinct reason token precisely so the lane never reads as pinned in the driver log while actually running opus). Drops the fleet's kimi-k3 rung — free on flat-rate, but $3/$15 per M on its OpenRouter twin, i.e. 40x glm-5.3-flash and dearer than gpt-5.6-sol. As the last rung of a cost ladder that is backwards. |
+| **Executor** | `codex:gpt-5.6-luna` → `pi:ollama/glm-5.3-flash:cloud` → `pi:openrouter/z-ai/glm-5.3-flash` | The high-volume role, so the ladder pays most here. The driver dedupes the shared probe, so planner+executor cost one probe. |
+| **Evaluator** | `sonnet` → `pi:ollama/minimax-m3:cloud` → `pi:openrouter/minimax/minimax-m3` | **Deliberately vendor-disjoint from the executor at every rung.** Two reasons, the second structural: (1) on a mission whose generator is cheap on purpose, a cheap judge means nobody catches anything and the loop reports success it did not earn; (2) the executor chain is OpenAI → Z-AI → Z-AI, so an evaluator walking the *same* ladder would share a vendor at every rung — precisely the shared blind spot generator≠judge exists to prevent. |
+
+**Verified before being written down** (2026-08-28, both rc=0): `codex exec --model gpt-5.6-luna`
+returned "ok" on the subscription lane (7,930 tokens); `ollama run glm-5.3-flash:cloud` returned
+"ok". Live OpenRouter prices read the same day — `z-ai/glm-5.3-flash` $0.075/$0.250 per M at
+1,310,720 context. `deepseek/deepseek-v4-flash-0731` is marginally cheaper ($0.060/$0.120) but
+glm-5.3-flash is the newer generation at a trivial delta on this mission's volume; recorded so the
+choice reads as a decision rather than an oversight.
+
+**Metered ceiling**: `$1`/iteration (fleet default is `$5`). Rungs 1-2 are subscription and
+flat-rate, so a fire spending real dollars has already fallen to rung 3 — a low ceiling makes that a
+loud stop instead of a silent bill.
+
 ## STATUS 2026-08-28 — ITERATION 0 RUN: quorum BLOCKED 3x across 2 revisions (1 human-directed mid-flight), **still not ratified** — parked for Mark
 
 First unattended fire of `dev.ailang.mission-docs` (kill switch had been removed since the prior

--- a/design_docs/docs-mission.md
+++ b/design_docs/docs-mission.md
@@ -75,6 +75,51 @@ At Gate 4, after adding your stamp, move the now-4th stamp to the TOP of the arc
 iteration re-reads this charter — unbounded STATUS history is a per-read token tax on the scarcest
 model budget; the append-only history lives in the log + archive.
 
+## STATUS 2026-09-02 — ITERATION 4 (crediting ITERATION 3): docs-5/6/10 landed by an orphaned fire, credited retroactively; docs-1 LANDED after a real evaluator FAIL/fix/PASS cycle
+
+Gate 0: kill switch armed; billing CLEAN; gh `sunholo-voight-kampff`. Main checkout `dev` diverges
+from `origin/dev` by design (9 ahead / 20 behind — attended commits stranded, loop lands via
+worktree→PR; per this file's own note); the pin worktree this loop actually runs from was clean at
+`origin/dev`'s tip throughout. Running skill differs from `origin/dev` (missing heartbeat stamps
+and the attended-ledger-edits section added since) — read the delta, confirmed the pin worktree's
+own scripts (`tools/launchd/mission-heartbeat.sh`, `scripts/mission_decisions.sh`,
+`scripts/mission_answer.sh`) already exist, so followed the newer instructions rather than the
+stale loaded copy. 0 directives on bookkeeping issue `#979` since the watermark (4 comments, none
+allowlisted). Decision ledger valid, 2 rows, both `RESOLVED` — no new ask.
+
+Gate 1: `CI` and `Deploy Documentation to GitHub Pages` both `success` on `origin/dev` HEAD;
+SHA-addressed check-runs showed 16 checks, one non-green (`SonarCloud Code Analysis`), confirmed
+inherited from the parent commit too — V1's domain (repo owner), not actioned.
+
+**PICK: `docs-1`, after crediting a second died-mid-flight fire.** Gate 2 found `docs-5`/`docs-6`/
+`docs-10` all merged on `origin/dev` (PRs #997/#1004/#1010) while the charter still tagged them
+`[NEXT]` — see ITERATION 3's retroactive entry in the log for full detail and re-verification
+(fresh `make verify-examples`: 211/0/6, `check_examples.sh`: 173/2/42, both matching the landing
+PRs' own claimed counts). Also found PR #1016 (`MERGEABLE`) recovering a complete `docs-1` brief +
+sprint plan from a second orphaned worktree; merged it after re-running its one flaky failing check
+(`launchd drivers (bash 3.2)`, unrelated to a 2-file markdown PR, green on re-run — rule 3d).
+
+**Execution**: routed `docs-1` to `codex:gpt-5.6-luna` using the recovered plan verbatim.
+Round-1 delivery (`tools/messaging/docs_inbox_router.sh`) FAILED independent evaluation (sonnet,
+own worktree) 58/100 — a genuinely empty poll result crashed the router instead of reporting
+`checked=0 forwarded=0`, live-reproduced by the evaluator. Fix routed back to the same executor;
+controller independently reproduced both the original crash and the fix with hand-built fixtures
+before re-committing. Round-2 evaluation: PASS 90/100, zero blocking.
+
+**Outcome: LANDED.** [PR #1018](https://github.com/sunholo-data/ailang/pull/1018) squash-merged →
+`e65e96b15`. Polled the merge commit to full CI completion: 15/16 green, the same inherited
+SonarCloud red as Gate 1, not actioned.
+
+**Metered cost this iteration: $0.00** of $1 ceiling — codex and sonnet are both subscription-lane
+per this mission's routing table. Quota buckets: codex (executor, 2 rounds), sonnet (evaluator, 2
+rounds + controller session).
+
+Queue is now empty of `[NEXT]` items; `docs-8` (126 overdue planned docs) is the natural next pick
+once picked up (already unblocked per its own sequencing note) but was not started this iteration
+(Standing rule 1, one backlog item per iteration).
+
+Full record: `design_docs/docs-mission-log.md` §ITERATION 3, §ITERATION 4.
+
 ## STATUS 2026-08-31 — ITERATION 2: recovered a died-mid-flight fire (docs-9 RULED OUT, PR #973 landed); Gate-0 weekly sweep found docs-10
 
 Gate 0: kill switch armed; billing CLEAN; gh `sunholo-voight-kampff`. `dev` == `origin/dev` at
@@ -197,206 +242,6 @@ prescription — worked as documented, not a gap) — below the ≥2-instance ba
 
 Full record: `design_docs/docs-mission-log.md` §ITERATION 1.
 
-## STATUS 2026-08-28 — **BAR RATIFIED ATTENDED**; queue reordered so the next fire touches the website
-
-Mark closed `docs-0` by human decision after reading iteration 0's result. Two changes, both his:
-
-1. **The bar is ratified** — not by a passing quorum, but because the seven clauses are Mark's own
-   attended selection, so a quorum blocking them second-guesses the human it exists to represent.
-   The objections that survived measurement were about **queue items' implementation**, not the bar;
-   they are preserved and re-enter at each item's own design gate, where they are actionable.
-2. **`docs-2` promoted above `docs-1`.** The original ordering was an authoring error that put
-   clause-7 infrastructure ahead of every clause that changes a published page. The measurement that
-   forced this: after a full iteration, **files changed under `docs/` was zero**.
-
-**The mechanism-level lesson, routed to the shared skill rather than to this mission:** charter
-ratification and design review are different jobs. Running a backlog-bearing governance document
-through a design quorum blocks at the wrong gate — the reviewers keep finding new things to say
-about work that has not been designed yet, so each round raises *new* objections instead of
-converging. Three rounds, no convergence, **6 of 9 objections refuted by direct measurement**.
-
-Iteration 0's real yield is kept and was never the ratification: two corrections to the
-human-authored charter (the CI path-filter citation, the fail-closed framing), a refuted
-"silent fallback" claim, and one **fleet-wide** skill fix (`0e341cc57`) — the shared Gate-0
-Current-State block had been reading V1's kill switch, queue and log for *every* non-V1 mission.
-
-## CURRENT GOAL
-
-1. **Iteration 0 (definition)**: ratify the bar below with Mark through the design quorum, then
-   score the backlog against it into `required` / `nice` / `post`. Output: an ordered queue in this
-   doc. Standing up the `docs-mission` inbox-routing **trigger** that clause 7 depends on is queue
-   item **docs-1** (see Queue and clause 7) — a later, separate iteration, not part of iteration 0
-   itself. (Reconciled 2026-08-28 during quorum revision: this line previously said routing was
-   "also at iteration 0," contradicting the Queue's listing of docs-1 as its own 1-iteration item
-   after docs-0. The Queue is correct — docs-1 carries an open scope question, below, that must not
-   gate ratification.)
-2. **Then**: work the queue through the inner loop (design-doc → sprint-plan → execute → evaluate),
-   one sprint-sized item per iteration, recording routing evidence every time.
-
-## The bar — what "the website is up to date" means (RATIFY with Mark at iteration 0)
-
-Mark selected all seven clauses attended on 2026-08-28; clauses 5-7 are his additions.
-
-- **Clause 1 — Code/docs drift.** No page contradicts the shipped binary. Feature status pages match
-  actual implementation, version constants are current, and design docs that moved
-  `planned/` → `implemented/` are reflected on the site. The `docs-sync` skill's
-  `audit_design_docs.sh` / `check_versions.sh` are the instruments — use them.
-- **Clause 2 — Examples compile and run.** Every `.ail` under `examples/` still passes
-  `make verify-examples`, and every site page importing one via raw-loader resolves. A published
-  snippet that no longer runs is worse than no snippet: it teaches wrong syntax to both humans and
-  the models we benchmark. Website examples are IMPORTED from `examples/`, never inlined — a page
-  with an inline code block is itself a clause-2 defect.
-- **Clause 3 — Site build health.** `make docs-build` green, `Deploy Documentation to GitHub Pages`
-  passing, no broken internal links, no orphaned pages unreachable from the nav.
-- **Clause 4 — New features get pages.** Shipped features with no documentation page at all are
-  tracked and closed. Read `CHANGELOG.md` and the release history against the nav; the gap is the
-  work. This is the only generative clause — scope one page per iteration, not a batch.
-- **Clause 5 — Concision and anti-sprawl.** *(Mark, 2026-08-28.)* The site is organised and
-  categorised, and says each thing **once**. Redundant pages are merged or deleted, not left to rot
-  beside their replacement; overlapping guides are consolidated; the nav reflects a real taxonomy
-  rather than accretion order. **Deletion is in scope for this clause** — it is the only clause
-  whose work is usually *removal*, and the loop must not quietly substitute "add a clarifying note"
-  for "delete the duplicate". A page that exists only because nobody dared remove it fails this
-  clause.
-- **Clause 6 — Benchmark report maintenance.** *(Mark, 2026-08-28.)* The published benchmark
-  surface is current and honest: `docs/static/benchmarks/{latest,os/latest,os/history}.json` and the
-  pages that render them. **Beware the known traps, which are documented and must not be
-  rediscovered**: os-rolling data has been stale-but-plausible before (check dates *first*, a low
-  broad pass-rate is usually frozen pre-fix data and not a regression); baselines are NOT poolable
-  across the three local-model boundaries (07-21..08-03 untuned flags, 08-13 budgets+num_ctx,
-  08-17 ollama 0.32.1→0.32.14); and v0.30.0 cost data is INVALID (reasoning tokens unrecorded).
-  This clause maintains the *report*; it does not re-run or re-bank evals, and it takes no rig lock.
-- **Clause 7 — Doc-related requests are answered.** *(Mark, 2026-08-28.)* The mission owns its own
-  inbox and works it: doc-related GitHub issues on `sunholo-data/ailang`, and `ailang messages`
-  requests routed to the **`docs-mission`** inbox.
-  **This clause has no delivery mechanism (trigger) yet — building one is queue item docs-1, not an
-  assumption baked into this charter.**
-
-  **Verified before being written down** (2026-08-28, both rc=0, run live against prod Firestore,
-  not simulated):
-  ```
-  export AILANG_MESSAGES_STORE=gcp AILANG_MESSAGES_PROJECT=ailang-multivac
-
-  # 1. send to a scratch inbox (simulating externally-originated traffic)
-  ailang messages send docs-quorum-test-scratch "iteration-0 quorum premise check..." \
-    --title "docs-mission premise check 20260828T063048Z" --from "docs-quorum-probe"
-  # => Message sent to 'docs-quorum-test-scratch' (ID: inbox_1787898648354_20138c15)
-
-  # 2. forward it to docs-mission — NOTE: flags must come BEFORE the message id, or you get
-  #    "Error: --to flag is required"
-  ailang messages forward --to docs-mission --reason "quorum premise verification" \
-    inbox_1787898648354_20138c15
-  # => Forwarded message from 'docs-quorum-test-scratch' to 'docs-mission'
-
-  # 3. confirm arrival with the CORRECT canonical-store read command (see this repo's root
-  #    CLAUDE.md — cited explicitly here so this clause doesn't leave it implicit):
-  ailang messages list --inbox docs-mission --unread --json
-  # => returned the forwarded message; acked as test cleanup
-  ```
-  Controls run alongside: a known-positive read (`--inbox "pkg:sunholo/ailang_parse"` returned a
-  real unread message) and a known-negative read (a made-up inbox name returned `null`) — so the
-  read instrument is confirmed not vacuously empty either way.
-
-  This confirms `ailang messages send <inbox>` takes a free-form inbox name (`docs-mission` needs
-  no registration) and `ailang messages forward --to <inbox> <id>` works — both **already-existing
-  CLI verbs, verified with no `internal/`/`cmd/` change involved**. What is NOT built is a
-  **trigger**: something that decides *when* to call `forward` for doc-related traffic sitting in
-  `public-feedback`, `pkg:<vendor>/<name>`, or GitHub issues. Public feedback dispatch has never
-  worked end-to-end (36/36 failures since 2026-04-27, ailang#900), so a trigger must **poll** those
-  sources — it cannot assume anything currently pushes traffic anywhere. See docs-1 in the Queue for
-  scope. The canonical store is prod Firestore; a bare `ailang messages list` (no env vars) reads
-  local SQLite and will show an empty, reassuring, wrong inbox.
-
-## Guardrails (mission-specific; the skill's Standing Rules always apply on top)
-
-- **Blast radius is `docs/`, `examples/`, `README.md`, `CHANGELOG.md`, plus `tools/`
-  (non-`internal/`, non-`cmd/`).** This is a **POLICY** guardrail — a rule this mission follows,
-  enforced by the loop reading it here. Widened from `tools/launchd/*` to `tools/*` on 2026-08-28
-  (Mark, attended — commit `29a467cac`) to unblock docs-1's inbox-routing trigger.
-
-  **⚠ CORRECTION 2026-08-28 (attended) — an earlier version of this bullet said the blast radius was
-  "enforced mechanically at the planner gate by `MISSION_PLANNER_ALLOWLIST`". That was FALSE, it was
-  authored by a human, and it cost the mission real work before anyone checked it.** Two facts,
-  each measured with a discriminating control:
-
-  1. **`MISSION_PLANNER_ALLOWLIST` is not a write gate and never was.** It appears in exactly two
-     places in the whole repo — `derive-planner-lane.sh` and the driver's `export` — and nowhere
-     else; there is no write-scope enforcement in `sprint-executor` at all. What it decides is
-     **which model may PLAN the work**: every declared path inside the list → the cheap pinned
-     planner; anything outside → `opus fail-closed:path-not-in-codex-allowlist`. A path outside the
-     list is *expensive to plan*, never *impossible to edit*.
-  2. **`docs/*` is NOT single-level.** These are `case` glob patterns, not shell pathname
-     expansion, so `*` matches `/`. Measured: `docs/docs/intro.mdx` routes to
-     `codex:gpt-5.6-luna declared:codex-ok`, while the `internal/` control is denied in the same
-     run. Nested pages under `docs/docs/**` and `docs/src/**` were always reachable.
-
-  **How this propagated, because the mechanism matters more than the fact.** The false sentence was
-  written into this charter by a human; iteration 1 read it, believed it, deferred DOCS-2-01 and
-  DOCS-2-02 as mechanically impossible, and then opened decision `D-2` **citing this very bullet as
-  its evidence**. A charter is read as ground truth by every iteration, so an unverified mechanical
-  claim in it does not merely mislead once — it becomes self-citing, and the loop cannot tell it
-  from a measurement. **Rule: a claim in this charter about what a mechanism DOES must carry the
-  command that demonstrates it, or must not be stated.** Where a restriction is a judgement rather
-  than a mechanism, say "policy" — as this bullet now does.
-  `internal/**` and `cmd/**` remain denied — if an item genuinely needs a change there, that is a
-  **V1 backlog item, not a docs item** — file it across and move on. Do not widen the allowlist
-  further to make an item fit; the allowlist is the definition of this mission's scope, not an
-  obstacle to it.
-- **No designer on Fable.** The shared skill's designer rotation is
-  `claude:claude-fable-5 → pi:ollama/deepseek-v4-flash:0731-cloud` (kimi removed fleet-wide
-  2026-08-28, V1 charter D-48); this mission seeds the rotation at sonnet (see Routing policy) and
-  must not fall to the Fable entry. Fable is reserved for high-cognition spec synthesis, and docs
-  items are drift repair. Most items here need **no design doc at all** — prefer a Gate-2 reality-check straight
-  into a sprint. If an item truly needs deep design, that is a signal it belongs in V1.
-- **Deleting published pages is an outward-facing change.** Clause 5 makes removal routine, which
-  makes it dangerous. Before deleting or merging a page: check inbound internal links, and leave a
-  redirect where the URL was public. "Nothing links to it" must be *measured*, not assumed — an
-  empty search is a claim, not a fact.
-- **Never re-run or re-bank evals.** Clause 6 maintains the report only. This mission takes **no
-  `rig.lock`** and must never start GPU work; the nightly eval rotation and three sibling missions
-  share that hardware.
-- **Verify before publishing a syntax claim.** Any AILANG syntax that lands on the website must
-  pass `ailang check` first. A wrong claim in published docs is worse than no claim: it trains both
-  readers and the models we benchmark against.
-
-## Routing policy
-
-Uses the **shared** per-role routing from `mission-control`, with this mission's overrides in
-`~/.config/ailang/mission-docs.env` (versioned copy:
-[tools/launchd/mission-env/mission-docs.env](../tools/launchd/mission-env/mission-docs.env)).
-
-The ladder is ordered by **cost type, not model quality** (Mark, attended 2026-08-28): spend the
-subscriptions already paid for, then the flat-rate route, and only reach metered dollars at the last
-rung. Every step down is cheaper in real money than the one above it.
-
-| Rung | Cost type | Lane |
-|---|---|---|
-| 1 | subscription (already paid for) | `claude-sonnet-5` / `codex:gpt-5.6-luna` |
-| 2 | flat-rate (Ollama Cloud pro) | `pi:ollama/<model>:cloud` |
-| 3 | metered, cheapest available | `pi:openrouter/<same weights>` |
-
-Rungs 2 and 3 are deliberately **the same weights on two routes**, so exhausting the flat-rate quota
-(whose denominator is unpublished) costs money and never capability.
-
-| Role | Chain | Notes |
-|---|---|---|
-| **Controller** | `claude-sonnet-5` → `codex:gpt-5.6-luna` | The driver's controller ladder speaks only Anthropic model IDs plus ONE codex fallback, so it cannot express rungs 2-3. Down from opus — this is the biggest line item, a long session re-reading a ~3.8k-line skill each fire. |
-| **Designer** | `claude:claude-sonnet-5` (seed) | Seed only: the designer is a skill-side **rotation**, not a chain — the driver has no `MISSION_DESIGNER_FALLBACK`. Seeded off the Fable default. Most docs items need no design doc at all (see Guardrails). |
-| **Planner** | `codex:gpt-5.6-luna` → `pi:ollama/glm-5.3-flash:cloud` → `pi:openrouter/z-ai/glm-5.3-flash` | Starts at rung 1b, **not** sonnet, and that is forced: `derive-planner-lane.sh` Step 0 accepts only `codex:*` or `pi:*`, so a bare `sonnet` pin emits the labeled fail-closed default `opus fail-closed:env-pin` and deliberately runs opus (a documented fail-closed-to-safety default, not a silent one — every exit path emits a distinct reason token precisely so the lane never reads as pinned in the driver log while actually running opus). Drops the fleet's kimi-k3 rung — free on flat-rate, but $3/$15 per M on its OpenRouter twin, i.e. 40x glm-5.3-flash and dearer than gpt-5.6-sol. As the last rung of a cost ladder that is backwards. |
-| **Executor** | `codex:gpt-5.6-luna` → `pi:ollama/glm-5.3-flash:cloud` → `pi:openrouter/z-ai/glm-5.3-flash` | The high-volume role, so the ladder pays most here. The driver dedupes the shared probe, so planner+executor cost one probe. |
-| **Evaluator** | `sonnet` → `pi:ollama/minimax-m3:cloud` → `pi:openrouter/minimax/minimax-m3` | **Deliberately vendor-disjoint from the executor at every rung.** Two reasons, the second structural: (1) on a mission whose generator is cheap on purpose, a cheap judge means nobody catches anything and the loop reports success it did not earn; (2) the executor chain is OpenAI → Z-AI → Z-AI, so an evaluator walking the *same* ladder would share a vendor at every rung — precisely the shared blind spot generator≠judge exists to prevent. |
-
-**Verified before being written down** (2026-08-28, both rc=0): `codex exec --model gpt-5.6-luna`
-returned "ok" on the subscription lane (7,930 tokens); `ollama run glm-5.3-flash:cloud` returned
-"ok". Live OpenRouter prices read the same day — `z-ai/glm-5.3-flash` $0.075/$0.250 per M at
-1,310,720 context. `deepseek/deepseek-v4-flash-0731` is marginally cheaper ($0.060/$0.120) but
-glm-5.3-flash is the newer generation at a trivial delta on this mission's volume; recorded so the
-choice reads as a decision rather than an oversight.
-
-**Metered ceiling**: `$1`/iteration (fleet default is `$5`). Rungs 1-2 are subscription and
-flat-rate, so a fire spending real dollars has already fallen to rung 3 — a low ceiling makes that a
-loud stop instead of a silent bill.
-
 ## Queue (top = next; tags: [NEXT] [IN-SPRINT] [PARKED] [LANDED] [RULED OUT])
 
 1. `[LANDED]` **docs-0 · ratify this charter — RATIFIED ATTENDED 2026-08-28 (Mark).** Closed by
@@ -439,7 +284,7 @@ loud stop instead of a silent bill.
    the file doesn't have. Kept as `[RULED OUT]` rather than deleted, matching `docs-7`'s
    convention, because the interesting part is the mechanism: a queue item inherited a tool's raw
    `[STALE]` line without checking whether the tool's premise was sound.
-4. `[NEXT]` **docs-5 · clause 2 · examples hygiene — fix the 9 genuinely-failing runnable
+4. `[LANDED]` **docs-5 · clause 2 · examples hygiene — fix the 9 genuinely-failing runnable
    examples.** `block_demo.ail`, `test_module_minimal.ail`, `simple_func_match.ail`,
    `match_arm_block.ail`, `match_in_block.ail`, `nested_match_minimal.ail` have no `main`
    entrypoint (helper/library files being swept as if runnable); `batch_processing.ail` and
@@ -448,7 +293,11 @@ loud stop instead of a silent bill.
    capability-usage comments is a normal sprint. Do NOT touch
    `.claude/skills/docs-sync/scripts/check_examples.sh` itself (see docs-6). Source:
    `docs/docs-sync-findings.md` DOCS-2-05 through DOCS-2-13.
-5. `[NEXT]` **docs-6 · clause 1 · fix `check_examples.sh`'s
+   **Landed by an orphaned "iteration 3" fire that died before Gate 4/5**: `0e8314549`
+   ("docs(examples): docs-5 — add main entrypoints to 7 parser-regression fixtures", #997),
+   credited and re-verified by iteration 4 (see log). `batch_processing.ail`/`cli_args_demo.ail`
+   remain genuinely out of scope (Env-capability gap, not this item's job).
+5. `[LANDED]` **docs-6 · clause 1 · fix `check_examples.sh`'s
    absolute-path bug.** The instrument this mission's whole clause-1/2 sweep depends on has been
    silently over-reporting broken examples (see docs-2's findings, DOCS-2-01). Fixing it means
    editing `.claude/skills/docs-sync/scripts/check_examples.sh`, which sits outside this mission's
@@ -456,7 +305,11 @@ loud stop instead of a silent bill.
    `design-doc-creator/*`). Also folds in DOCS-2-04 (the audit_design_docs.sh vs
    derive_roadmap_versions.sh design-doc population-count mismatch — same script family, same
    scope question).
-6. `[NEXT]` **docs-10 · clause 1 · `make verify-examples` is vacuous on two independent axes —
+   **Landed by the same orphaned "iteration 3" fire**: `95396664b` ("fix(docs-sync): docs-6 —
+   check_examples.sh absolute-path bug + audit scope comments", #1004). Re-verified by iteration 4
+   with a fresh independent run: `173 passed / 2 failed (batch_processing.ail, cli_args_demo.ail —
+   the known Env-capability gap) / 42 skipped`, matching the commit's own claim exactly.
+6. `[LANDED]` **docs-10 · clause 1 · `make verify-examples` is vacuous on two independent axes —
    found by Gate 0's weekly external-issue sweep (2026-08-31), not by this mission's own tooling.**
    Docs-mission's Repo Profile names `make verify-examples` as one of its two verify-profile gates
    ("every published example still verifies"). Two open, unmentioned-anywhere-in-this-charter
@@ -473,6 +326,13 @@ loud stop instead of a silent bill.
    Guardrails' non-write-gate correction — it plans on `opus` rather than the cheap `codex` lane
    (not in `MISSION_PLANNER_ALLOWLIST`), which is a cost note, not a blocker. Sequenced after
    docs-6 since both are fixes to the sweep's own instruments, not to docs content.
+   **Landed by the same orphaned "iteration 3" fire**: `9c5deac58` ("fix(docs-sync): docs-10 —
+   verify-examples vacuous on two axes (#670, #654)", #1010) — indexed pinned `expected.stdout`
+   once in `main()`, compared trailing-newline-insensitively, and added an anti-vacuity floor
+   (atomic counter, race-checked under `--parallel`) that fails loudly if zero comparisons ran.
+   Re-verified by iteration 4 with a fresh independent run of `make verify-examples`:
+   **211 passed, 0 failed, 6 skipped**, manifest validator "193 modules checked, 0 drift" — a real,
+   non-vacuous green, not inherited from the pre-fix instrument.
 7. `[RULED OUT]` **docs-7 · "the mission cannot edit its own published content" — DISSOLVED
    2026-08-28 (attended): the premise was false, measured.** This item asserted that
    `MISSION_PLANNER_ALLOWLIST`'s `docs/*` is a single-level glob excluding `docs/docs/**` and
@@ -492,7 +352,7 @@ loud stop instead of a silent bill.
    not a sprint-executor task, so this can proceed without an allowlist change, just not via the
    automated inner loop. Sequence after docs-6/docs-7 land or are ruled out, since triaging 126
    docs by hand is exactly the kind of large sweep worth doing once against settled tooling.
-9. `[NEXT]` **docs-1 · clause 7 · build the inbox-routing TRIGGER.** `send` and `forward` are
+9. `[LANDED]` **docs-1 · clause 7 · build the inbox-routing TRIGGER.** `send` and `forward` are
    verified working primitives (see clause 7's verification log) — no `internal/`/`cmd/` change is
    needed for those, and this item should not touch Go code. The missing piece is a **trigger**:
    something that periodically decides doc-related traffic exists (in `public-feedback`,
@@ -504,6 +364,19 @@ loud stop instead of a silent bill.
    `tools/messaging/docs_inbox_router.sh` is in scope (see Guardrails). Deliverable: a message sent
    from outside, observed arriving via the verified read command in clause 7, acked. Est. 1
    iteration.
+   **Landed iteration 4**: a died-mid-flight "iteration 3" left a complete brief + sprint plan
+   unlanded (recovered as [PR #1016](https://github.com/sunholo-data/ailang/pull/1016)); iteration
+   4 executed the plan on `codex:gpt-5.6-luna`, producing `tools/messaging/docs_inbox_router.sh`
+   ([PR #1018](https://github.com/sunholo-data/ailang/pull/1018) → `e65e96b15`). Round-1 evaluator
+   (sonnet, independent worktree) FAILED it 58/100: a genuinely empty (valid, zero-item) poll
+   result crashed the router instead of reporting `checked=0 forwarded=0` — the ordinary,
+   most-common case for a low-traffic inbox. Fixed and independently reproduced by the controller
+   both broken (on the round-1 commit) and fixed (on the round-2 commit) with hand-built empty-
+   response fixtures, not taken on the executor's word. Round-2 evaluator PASSED 90/100, zero
+   blocking. CI green on the merge commit itself (`e65e96b15`) except the pre-existing,
+   not-this-mission's-domain `SonarCloud Code Analysis` red (confirmed inherited from the parent
+   commit, V1's territory per Gate 1's repo-ownership scoping). No launchd wiring in this sprint
+   (explicitly out of scope per the brief) — the router runs by hand or under a future job.
 10. `[PARKED]` **docs-3 · clause 6 · benchmark surface audit.** Blocked on nothing, but sequence it
    after docs-2 so the drift picture is known first.
 11. `[PARKED]` **docs-4 · clause 5 · taxonomy pass.** The `docs/docs/guides/` directory holds 40+


### PR DESCRIPTION
## Summary
- Docs-only mission bookkeeping. Credits a died-mid-flight "iteration 3" whose work (docs-5/#997,
  docs-6/#1004, docs-10/#1010) had already merged on `origin/dev` while the charter still tagged
  them `[NEXT]` — re-verified fresh (`make verify-examples`: 211/0/6; `check_examples.sh`:
  173/2/42), queue tags corrected.
- Records iteration 4's own work: recovered and landed `docs-1` (PR #1016 → PR #1018), including a
  real evaluator FAIL (58/100, live-reproduced blocking bug: an empty poll crashed the router)
  → fix → PASS (90/100) cycle.
- Rotates the charter's STATUS block per its own 3-stamp rule (arithmetic-asserted before/after on
  both files, known-present/known-absent controls checked post-edit).
- Overwrites the mission dashboard snapshot.

## Test plan
- [x] Queue row count unchanged (11) before/after the STATUS rotation
- [x] `grep -c "^## STATUS 2026"` on the charter == 3 (invariant holds)
- [x] Moved stamp present in the archive (1), absent from the charter (0)
- [x] All four touched files confirmed NOT gitignored (`git check-ignore -v`, paired with a firing
      known-ignored control) before staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)