### PR TITLE
test(probe): pin the stub refusal branch's own message, behind the bounded arms (motoko row 6r)

### DIFF
--- a/design_docs/planned/m-motoko-stub-refusal-arm-sprint-plan.md
+++ b/design_docs/planned/m-motoko-stub-refusal-arm-sprint-plan.md
@@ -1,0 +1,234 @@
+# Sprint Plan: M-MOTOKO-STUB-REFUSAL-ARM
+
+**Design doc**: [`design_docs/planned/m-motoko-stub-refusal-arm.md`](m-motoko-stub-refusal-arm.md)
+**Sprint JSON**: `.ailang/state/sprints/sprint_m-motoko-stub-refusal-arm.json` (`.ailang/` is gitignored — `.gitignore:82` — so the JSON is deliberately NOT part of the commit; same convention as the row 6n plan)
+**Planned**: 2026-09-02 (motoko mission iteration 33)
+**Base commit**: `373a12d17`, worktree `/Users/voightkampff/dev/sunholo-data/.wt-motoko-iter33-sprint`, branch `sprint/motoko-iter33-test-stub-arm`, clean
+**Target**: v0.34.x · **Risk**: low (one inserted test arm; no production file is modified)
+**Design status**: quorum-cleared under the narrow-refinement carve-out (design doc §"Quorum round 2"). **This plan does not re-open the design.**
+
+---
+
+## 0. How to read this plan
+
+**Two milestones.**
+
+- **M1** inserts exactly one `expect_failure` arm into the test file. It leaves the suite green at 43 arms, so it is an independently committable, bisectable point.
+- **M2** changes no product code. It runs the mutation drill that proves the M1 arm is non-vacuous, and records the evidence in the design doc.
+
+**Platform.** Every base reading in this plan is **darwin/arm64 (macOS 26.5.2), GNU bash 3.2.57(1)-release, arm64-apple-darwin25**, on this rig, with `/usr/sbin` on PATH (`command -p -v lsof` → `/usr/sbin/lsof`, rc=0). **The windows and ubuntu CI legs are unrun locally.** The `launchd drivers (bash 3.2)` CI leg is the only place the runner's behaviour is observable; nothing in this plan may be reported as "verified on CI" from a local green. A run showing far fewer than 42/43 arms is a PATH problem (no real `lsof`), not a code problem.
+
+**Five standing rules for the executor, and they are not optional:**
+
+1. **The executor makes NO git writes.** No `git add`, no `git commit`, no `git checkout`, no `git stash`, no `git clean`, no branch or worktree operation. The worktree is deliberately uncommitted. **The controller commits**, one commit per milestone, after that milestone's acceptance block is green. If an acceptance block goes red, STOP and report — do not proceed to the next milestone.
+2. **Restore mutants from a `cp` backup, never `git checkout --`.** The sprint's own edits are uncommitted, so `git checkout -- <file>` would silently delete them. Every mutation is bracketed by `cp <file> <file>.bak.<tag>` before and `cp <file>.bak.<tag> <file>` after, and every restore is **verified by sha256 equality against the pre-mutation hash**, not assumed.
+3. **Keep every mutant, backup and log under `/tmp`.** Nothing this sprint writes may land in the worktree except the two deliverable edits (`T` in M1, the design doc in M2). `git status --porcelain` is an acceptance criterion in both milestones.
+4. **Capture exit codes without a pipe**: `cmd > /tmp/out 2>&1; rc=$?`. The controller's interactive shell is zsh and the suite is `/bin/bash`; `${PIPESTATUS[0]}` is not to be used anywhere.
+5. **Cumulative snapshot per milestone.** Before running milestone *k*'s acceptance block, copy the current state of `P`, `T` and `DD` into **`.snap/M<k>/`** at the worktree root — cumulative, so `.snap/M2/` holds M1's edit plus M2's. `.snap/` is **not** gitignored (checked: `git check-ignore .snap/` exits 1, and `.gitignore` has no `snap` rule that covers it), so it appears as a single untracked `?? .snap/` line; both `git status` criteria below account for it explicitly. **`.snap/` must never be `git add`ed** — the controller commits only the deliverable files.
+
+Abbreviations used throughout; all worktree-relative paths:
+
+- `P` = `tools/eval/motoko_connection_probe.sh` — **READ-ONLY for this entire sprint.** The design doc's Non-Goal is explicit: no production-semantics change. The only writes to `P` are inside the M2 mutation drill, and they are to `/tmp` **copies**, never to the tree.
+- `T` = `tools/eval/test_motoko_connection_probe.sh` — the **only** file M1 modifies.
+- `DD` = `design_docs/planned/m-motoko-stub-refusal-arm.md` — the only file M2 modifies.
+
+**Where the design doc and this plan disagree: nowhere.** Every claim in the design doc that this plan makes load-bearing was re-measured on this worktree at `373a12d17` and reproduced. Two points the plan *adds* beyond the doc are flagged inline as **NEW MEASUREMENT** (§1, rows B7 and B10-B12).
+
+---
+
+## 1. Baseline — measured on the UNMODIFIED tree at `373a12d17`, this session
+
+Every acceptance command in this plan was run on the unmodified tree before the plan was written, and its base result is recorded beside the criterion. **No criterion in this plan was found red at base.**
+
+Environment at measurement time:
+
+| Fact | Measured |
+|---|---|
+| Worktree base | `373a12d17`, `git status --porcelain` → **0 lines (clean)** |
+| `sw_vers -productVersion` | `26.5.2` |
+| `/bin/bash --version` | GNU bash 3.2.57(1)-release, arm64-apple-darwin25 |
+| `uname -sm` | `Darwin arm64` |
+| `command -v timeout` / `gtimeout` | **neither exists** — see §Bounded waits |
+| load avg / `hw.ncpu` | 39.15 / 39.38 / 39.44 on **16** CPUs — heavily contended during measurement |
+| `command -p -v lsof` | `/usr/sbin/lsof`, rc=0 |
+| sha256 `P` | `f0b5e02493369099f123c42107850fe062bf60d56ccabb2a7e4690d654aabc99` |
+| sha256 `T` | `b0b445897b307d812dcecb0b3130f29f07fc556134fc355ab2cf9bf09ba43cd7` |
+| mode `P` / `T` | `-rwxr-xr-x` / `-rwxr-xr-x` |
+
+### Base measurements table
+
+| # | Command (run at base) | Observed at base |
+|---|---|---|
+| B1 | `/bin/bash -n tools/eval/motoko_connection_probe.sh; echo rc=$?` | rc=0 |
+| B2 | `/bin/bash -n tools/eval/test_motoko_connection_probe.sh; echo rc=$?` | rc=0 |
+| B3 | `/bin/bash tools/eval/test_motoko_connection_probe.sh > /tmp/base.log 2>&1; rc=$?` (no `PROBE_UNDER_TEST`) | **rc=0, 42 `^ok `, 0 `^not ok`, 0 skip lines**, last line `PASS: 42 probe self-test arms ran` |
+| B4 | The same run with `PROBE_UNDER_TEST=<abs path to the tree's own P>` | **byte-equivalent verdict: rc=0, 42 ok, 0 not ok** — so the swap mechanism itself is not what a mutant result measures |
+| B5 | Refusal-branch gate (final arm of B3) | passes; `expected_refusal_branches=28` at `T:763`; counters `grep -c 'instrument_failure "' P` = **20**, `grep -cE '\|\| usage$' P` = **5**, `grep -c 'echo "process-tree discovery' P` = **3**; 20+5+3 = 28 |
+| B6 | `grep -n 'descendant discovery deadline refuses at the caller' T` | `358:` — the existing caller-message arm; its `run_live` continuation is `T:359`. Insertion point is **immediately after `T:359`** |
+| B7 | **M2 mutant** (strip ` (test stub)` from `P:184`, `/tmp` copy, `chmod 755`) run against the **pristine** `T` | **rc=0, 42 ok, 0 not ok** — **the mutant SURVIVES. This is the defect.** Provenance: sha `f0b5e024…` → `df45556c…`, `bash -n` rc=0, mode `-rwxr-xr-x`, `grep -Fc '…(test stub)'` **1 → 0** while `grep -Fc '…(wall clock)'` stays **1**, echo-refusal count stays 3 |
+| B8 | **M3 known-positive control** (strip ` (wall clock)` from `P:189`) against pristine `T` | **rc=1, 32 ok, 1 not ok**; failing arm **by name**: `not ok - descendant discovery refuses on the real wall-clock deadline lacked expected message: process-tree discovery deadline expired (wall clock)`. Provenance: sha → `645fbfc0…`, `bash -n` rc=0, `(wall clock)` count 1 → 0 while `(test stub)` stays 1. **The harness DOES fire for this class of edit; B7's green is a measurement, not a broken instrument.** |
+| B9 | **T3 mutant** (alter the suffix: `(test stub)` → `(stub)` at `P:184`) against pristine `T` | **NEW MEASUREMENT — rc=0, 42 ok, 0 not ok. This mutant ALSO survives.** So the gap is not specific to deletion: any reword of the stub message lands green today. Provenance: sha → `0e7f60cc…`, `bash -n` rc=0, `(test stub)` count 1 → 0, echo-refusal count still 3 (so the count gate cannot catch it either) |
+| B10 | **NEW MEASUREMENT — prototype of the M1 arm** (the exact two lines of §M1 inserted after `T:359` in a `/tmp` copy of `T`) run with `PROBE_UNDER_TEST` = the **pristine** `P` | **rc=0, 43 ok, 0 not ok**, last line `PASS: 43 probe self-test arms ran`. **The proposed arm passes on correct code.** Prototype sha `98d7fe5a…`, `bash -n` rc=0 |
+| B11 | **NEW MEASUREMENT — the same prototype `T` against the B7 (strip) mutant** | **rc=1, 25 ok, 1 not ok**; failing arm **by name**: `not ok - descendant discovery stub refusal carries its own message lacked expected message: process-tree discovery deadline expired (test stub)` |
+| B12 | **NEW MEASUREMENT — the same prototype `T` against the B9 (reword) mutant** | **rc=1, 25 ok, 1 not ok**; same failing arm by name |
+| B13 | `grep -Fq` semantics, re-measured with `E='process-tree discovery deadline expired (test stub)'` | rc=0 on a file containing `E` exactly; **rc=0 on a file containing `E X`** (append-shaped mutants are VACUOUS); rc=1 on `…expired (stub)`; rc=1 on `…expired`. Confirms design-doc V13/T3 |
+| B14 | Tree integrity after the entire drill | sha256 of `P` and `T` **unchanged**; `git status --porcelain` → **0 lines**. The drill wrote nothing into the worktree |
+
+**What B7+B9 vs B10+B11+B12 establish, together:** the suite as it stands is blind to *any* edit to the stub's message (deletion B7, reword B9), and the proposed arm converts both of those from green to a named red (B11, B12) while staying green on correct code (B10). That is the whole sprint, already proven at design time. M1 reproduces it in the tree; M2 re-proves it against the tree's own file rather than a `/tmp` prototype.
+
+**Note on the 25-vs-42 arm counts in B11/B12.** The harness is **fail-fast**: `expect_failure` ends in `exit 1` on both failure paths (`T:161` `unexpectedly succeeded`, `T:166` `lacked expected message`). The first failing arm terminates the suite and every later arm is unreached. So a red run's `ok` count is a *position*, not a coverage number, and 25 < 42 is expected rather than alarming. This is why every mutation criterion below names the **failing arm by name** instead of asserting an exit code or an arm count.
+
+### Bounded waits
+
+There is **no `timeout(1)` and no `gtimeout` on this machine**, so every bound comes from the harness, not from a shell wrapper.
+
+- Short commands (`grep`, `bash -n`, `sed`, `awk`, `cp`, `shasum`, `stat`): the default tool timeout is ample.
+- **Full suite runs**: timed this session at load average ≈ 39 on 16 CPUs — base **53 s** and **52 s**, the B10 prototype (43 arms) **50 s**. Budget ~60 s and run each with an explicit tool timeout of **300000 ms**. The extra arm costs no measurable time (the stub short-circuits before the walk).
+- **The M2 drill runs four suites back to back** (D1 strip-mutant, D2 reword-mutant, D3 wall-clock control, and the A2.1 pristine re-run) ≈ **3–4 minutes** at the timings above. Run the drill as a **single background script that appends to one artifact file**, then poll that artifact inside a bounded `date +%s` loop. Do not run five foreground suites in sequence.
+- **A multi-minute M2 is EXPECTED, not a hang.** None of the arms in this sprint's path are timing-sensitive: the stub short-circuits before the process-tree walk, so the new arm is deterministic and fast.
+
+---
+
+## 2. Milestones
+
+### M1 — test: give the stub refusal branch an arm that asserts its own message
+
+**Design doc**: Goals (Primary); High-Impact Decision (A); Acceptance Criteria AC3.
+**Files**: `T` only. **+2 lines, 0 lines changed, 0 lines deleted.** `P` is not touched.
+
+**The change.** Insert these **exactly two lines** immediately after `T:359` (i.e. after the existing caller-message arm's `run_live` continuation line, and before `expect_failure "lane sampling deadline refuses" …`):
+
+```bash
+expect_failure "descendant discovery stub refusal carries its own message" "process-tree discovery deadline expired (test stub)" \
+  run_live PROBE_TEST_DESCENDANT_FAILURE=1
+```
+
+Byte-exact requirements, all of which the B10 prototype satisfied:
+
+- Line 1 starts at **column 0** (no leading whitespace), matching every other `expect_failure` in the `run_live` block.
+- Line 2 is indented **two spaces**, matching `T:359`.
+- The continuation backslash on line 1 is the **last** character of the line (no trailing space after it) — a trailing space breaks line continuation in bash and would be caught by AC1.1.
+- The arm name is `descendant discovery stub refusal carries its own message`. It must be **distinct** from the existing arm name at `T:358` so a red is attributable; AC1.4 is what enforces that the two arms are separately identifiable in the log.
+- The asserted string is `process-tree discovery deadline expired (test stub)` — character-for-character the string at `P:184`, including the single space before `(`.
+
+**What must NOT change.** `T:358-359` (the existing caller-message arm) stays byte-identical — the design doc's decision (A) is that the new arm sits **BESIDE** it, not in place of it. `T:763` `expected_refusal_branches=28` stays **28**: this change adds a self-test *arm*, not a production refusal *branch*, so the gate's VALUE must not move (its arm NUMBER moves 42 → 43 as a consequence of inserting an arm ahead of it — that is expected and is what AC1.2 reads). `T:319-321` (`run_live`) is untouched. The wall-clock arm (`T:476`) and node-ceiling arm (`T:731`) are far from the insertion point and are untouched.
+
+**Why this is green on its own.** With `PROBE_TEST_DESCENDANT_FAILURE=1` the probe's stderr carries **both** the stub message and the caller wrapper (design doc V7; reproduced end-to-end here by B10, where the new arm passed against the pristine probe). `expect_failure` requires only `rc != 0` plus a fixed-string substring hit anywhere in the captured stderr (`T:151-169`, B13), both of which hold.
+
+**Blast radius, classified BEFORE choosing criteria.** M1 adds one arm and changes no behaviour of any existing arm. The only observable it can move is the suite's **arm count and final line** (42 → 43). It cannot move the refusal-branch gate's value, the probe's parse, or any other arm's verdict. Therefore the narrowest gate that can actually fail for this diff is *the suite's own arm accounting plus a clean green* — AC1.2 — and everything else in the block is a guard against collateral damage.
+
+**Snapshot.** Before running the acceptance block: `mkdir -p .snap/M1 && cp tools/eval/motoko_connection_probe.sh tools/eval/test_motoko_connection_probe.sh design_docs/planned/m-motoko-stub-refusal-arm.md .snap/M1/`.
+
+**Acceptance block** — run all of these; every one must hold. **No criterion here is a static grep for a string in a file** (that shape is the exact defect this sprint exists to remove); every one reads either a parse result, the suite's own runtime output, or the working tree's cleanliness.
+
+| # | Command | **Base (measured)** | Required after M1 |
+|---|---|---|---|
+| A1.1 | `/bin/bash -n tools/eval/test_motoko_connection_probe.sh; echo rc=$?` | rc=0 (B2) | **rc=0** — catches a trailing space after the continuation backslash, an unbalanced quote, or a broken insertion |
+| A1.2 | `/bin/bash tools/eval/test_motoko_connection_probe.sh > /tmp/m1_suite.log 2>&1; rc=$?` then `grep -c '^ok ' /tmp/m1_suite.log`, `grep -c '^not ok' /tmp/m1_suite.log`, `tail -1 /tmp/m1_suite.log` | rc=0, **42** ok, 0 not ok, `PASS: 42 probe self-test arms ran` (B3) | **rc=0, 43 ok, 0 not ok, `PASS: 43 probe self-test arms ran`** — behavioural: the suite RAN and PASSED one more arm. 42 means the arm was not added; 44+ means more than one arm was added |
+| A1.3 | `grep -ci 'skip' /tmp/m1_suite.log` | 0 (B3) | **0** — no arm may be skipped into a false green |
+| A1.4 | `grep -cE '^ok [0-9]+ - descendant discovery stub refusal carries its own message$' /tmp/m1_suite.log` **and** `grep -cE '^ok [0-9]+ - descendant discovery deadline refuses at the caller$' /tmp/m1_suite.log` | **0 and 1** | **1 and 1** — reads the suite's own emitted pass lines, so it proves the new arm EXECUTED and that the pre-existing caller arm is still executing beside it (design doc decision (A): beside, not instead of). Anti-vacuity: a base of 0 for the first and 1 for the second means both counters are live. **`pass_arm` (`T:75-78`) emits `ok $arms - $1`, i.e. the arm NUMBER is present — a pattern written as `^ok - …` matches nothing and would be a vacuous criterion.** In the B10 prototype these lines were `ok 25 - descendant discovery deadline refuses at the caller` and `ok 26 - descendant discovery stub refusal carries its own message` |
+| A1.5 | The refusal-branch gate arm, read out of the same log: `grep -cF 'ok 43 - refusal-branch count still matches the set this suite covers (28)' /tmp/m1_suite.log` | 0 at base — at base the same line reads `ok 42 - … (28)` (B3, B5) | **1** — the gate still passes with the value **28** while its arm NUMBER has moved 42 → 43, which is exactly the design doc's M5 prediction. If it printed `(29)` or reported drift, a production branch was added, which this sprint forbids. Confirmed in the B10 prototype log: `ok 43 - refusal-branch count still matches the set this suite covers (28)` |
+| A1.6 | `shasum -a 256 tools/eval/motoko_connection_probe.sh` | `f0b5e024…aabc99` (B-env) | **unchanged** — the production probe is read-only this sprint (design doc Non-Goal) |
+| A1.7 | `git status --porcelain` | 0 lines (clean — the plan and design doc are committed by the controller before the executor starts) | **exactly 2 lines**, in any order: ` M tools/eval/test_motoko_connection_probe.sh` and `?? .snap/`. **No `.bak`, no `.log`, no mutant copies inside the tree.** Anything else in the list is collateral damage and reds this criterion |
+
+**Commit (CONTROLLER, not executor)**: `test(probe): assert the stub refusal's own message (motoko iter-33, row 6r)`.
+
+---
+
+### M2 — mutation drill: prove the M1 arm is the sole killer, and record it
+
+**Design doc**: Test Plan T1/T2/T3; Acceptance Criteria AC5.
+**Files**: `DD` only (an appended evidence section). **No product code changes.** **Depends on M1.**
+
+This is the load-bearing milestone. M1 without M2 is a plausible-looking arm with no proof it can fail.
+
+**Standing rules for every mutation in this drill** (each is a step the executor must actually perform and record, not a caveat):
+
+1. **Never mutate the tree.** `cp tools/eval/motoko_connection_probe.sh /tmp/iter33/probe.pristine.bak` once, then build every mutant as a **separate file under `/tmp`** and run the suite with `PROBE_UNDER_TEST=<mutant path> /bin/bash tools/eval/test_motoko_connection_probe.sh`. `T:5` is `probe=${PROBE_UNDER_TEST:-$script_dir/motoko_connection_probe.sh}`, so this swaps the probe under test without touching the tree. **`T` itself must NOT be copied out of the tree** — `script_dir` is only used to resolve `$probe`, but running a `/tmp` copy of `T` would resolve `$probe` to a non-existent `/tmp/motoko_connection_probe.sh` unless `PROBE_UNDER_TEST` is also set; keep `T` in place and vary only the probe.
+2. **`chmod 755` every mutant, and prove it.** `sed > file` creates mode **644**, and the suite invokes `"$probe" --classify-fixture …` **directly** at `T:201`. An un-chmod'd mutant therefore reds at the **FIRST** arm (`not ok - classification fixture: missing loopback 127.0.0.1:11434`, ok=0) for its file **mode**, not for the mutation — a false kill. Record `stat -f '%Sp' <mutant>` = `-rwxr-xr-x` for each.
+3. **Prove each mutant LANDED, PARSES, and had its INTENDED EFFECT** before believing its suite verdict:
+   - LANDED: `shasum -a 256` of the mutant **differs** from the pristine hash `f0b5e024…aabc99`.
+   - PARSES: `/bin/bash -n <mutant>; rc=0`.
+   - EXECUTABLE: `stat -f '%Sp'` = `-rwxr-xr-x`.
+   - INTENDED EFFECT, read against the system's own view: the count of the targeted string goes **1 → 0** while the **sibling suffix's count is unchanged at 1**. A mutant where both counts move is a botched `sed`, not an experiment.
+4. **Add-shaped mutants are forbidden** (B13). Under `grep -Fq` a mutant that only *appends* around the asserted substring leaves the substring present and is vacuous. Every mutant below **removes or alters** the asserted substring.
+5. **Read WHICH arm failed, never the exit code alone.** Rules 2 and 4 both produce non-zero exit codes for reasons that are not the mutation.
+6. **Restore from the `cp` backup and prove byte-identity.** After the drill, `cp /tmp/iter33/probe.pristine.bak tools/eval/motoko_connection_probe.sh` **only if the tree hash ever changed** (it should not — the drill only writes to `/tmp`), and in all cases assert `shasum -a 256 tools/eval/motoko_connection_probe.sh` = `f0b5e024…aabc99`. **Never `git checkout -- <file>`**: M1's edit to `T` is uncommitted at drill time and `git checkout` would destroy it.
+
+**The three mutants, with the assertion each must move and the expected blast radius classified in advance:**
+
+| Mutant | Edit (against a `/tmp` copy of `P`) | Effect proof (system's own view) | Expected blast radius | Required verdict |
+|---|---|---|---|---|
+| **D1 = T1/M2 (the defect)** | strip ` (test stub)` — `P:184` becomes `process-tree discovery deadline expired` | `grep -Fc 'expired (test stub)'` **1 → 0**; `grep -Fc 'expired (wall clock)'` **stays 1**; `grep -c 'echo "process-tree discovery'` **stays 3** (so the count gate cannot be the catcher) | The M1 arm only. The caller-message arm at `T:358` asserts `process-tree discovery failed`, which is untouched, so it stays green and the fail-fast harness REACHES the new arm | **rc=1**, and the failing line is exactly `not ok - descendant discovery stub refusal carries its own message lacked expected message: process-tree discovery deadline expired (test stub)`. **Base (B7): this same mutant is rc=0, 42 ok, 0 not ok — it SURVIVES.** The 0→1 flip in that arm's kill status IS the sprint's result |
+| **D2 = T3 (reword)** | alter the suffix — `P:184` becomes `… deadline expired (stub)` | `grep -Fc 'expired (test stub)'` **1 → 0**; `grep -c 'echo "process-tree discovery'` **stays 3** | Same as D1 | Same failing line as D1. **Base (B9): survives, rc=0, 42 ok.** Proves the arm pins the *exact* string, not merely the presence of a suffix |
+| **D3 = T2 (known-positive control)** | strip ` (wall clock)` — `P:189` becomes `process-tree discovery deadline expired` | `grep -Fc 'expired (wall clock)'` **1 → 0**; `grep -Fc 'expired (test stub)'` **stays 1** | The **wall-clock** arm (`T:476`), which sits AFTER the new arm, so under fail-fast the new arm passes first and the wall-clock arm is the catcher | **rc=1**, failing line `not ok - descendant discovery refuses on the real wall-clock deadline lacked expected message: process-tree discovery deadline expired (wall clock)`. **Base (B8): identical verdict.** This is the control that shows the harness's ability to red for this class of edit is unchanged by M1 — a mutant that must NOT be attributed to the new arm |
+
+**Mutants deliberately NOT run, and why** (design doc T4/T5, upheld verbatim from `gemini-3-1-pro` round 2): removing the stub branch entirely (T4) and rewording the caller wrapper (T5) both red the **caller-message arm at `T:358` first**, which `exit 1`s and aborts the suite **before the new arm executes**. The mutation is still caught, but the new arm is not the catcher, so these produce no information about M1 and would only invite a mis-attribution. `-skip`-style "everything else stayed green" inverse arms are **not expressible in this shell harness** at all — there is no way to run the remaining arms after a failure — which is why every row above names the expected FAILING ARM BY NAME rather than asserting an exit code or a residual arm count.
+
+**Recording step.** Append a `## Mutation Evidence (executed, motoko iteration 33)` section to `DD` containing, per mutant: the sed expression, the pristine and mutant sha256, the `bash -n` rc, the mode, the 1→0 effect count with its unchanged sibling, the suite rc, and **the verbatim failing line**. Also record the pristine re-run (see A2.1) and the tree-integrity check. Do not restate predictions — record only what was observed.
+
+**Snapshot.** Before running the acceptance block: `mkdir -p .snap/M2 && cp tools/eval/motoko_connection_probe.sh tools/eval/test_motoko_connection_probe.sh design_docs/planned/m-motoko-stub-refusal-arm.md .snap/M2/` (cumulative: `.snap/M2/`'s copy of `T` already contains M1's edit, and `.snap/M1/` is left in place).
+
+**Acceptance block:**
+
+| # | Command | **Base (measured)** | Required after M2 |
+|---|---|---|---|
+| A2.1 | Re-run the suite against the **pristine** probe **after** the whole drill: `PROBE_UNDER_TEST="$PWD/tools/eval/motoko_connection_probe.sh" /bin/bash tools/eval/test_motoko_connection_probe.sh > /tmp/m2_pristine.log 2>&1; rc=$?` | rc=0, 42 ok (B4 — the swap mechanism is itself neutral) | **rc=0, 43 ok, 0 not ok**, `PASS: 43 probe self-test arms ran`. The drill left nothing behind |
+| A2.2 | D1 verdict: `grep -cF 'not ok - descendant discovery stub refusal carries its own message lacked expected message: process-tree discovery deadline expired (test stub)' /tmp/m2_d1.log` | **0** (B7: at base this mutant produced ZERO `not ok` lines at all — the defect). Note `expect_failure` emits `not ok - $name …` with **no** arm number, unlike `pass_arm` | **1**, and D1's suite rc=1 |
+| A2.3 | D2 verdict: the same `grep -cF` against `/tmp/m2_d2.log` | **0** (B9: survives at base) | **1**, and D2's suite rc=1 |
+| A2.4 | D3 control verdict: `grep -cF 'not ok - descendant discovery refuses on the real wall-clock deadline lacked expected message: process-tree discovery deadline expired (wall clock)' /tmp/m2_d3.log` **and** `grep -cE '^ok [0-9]+ - descendant discovery stub refusal carries its own message$' /tmp/m2_d3.log` | 1 and 0 (B8 — at base the second pattern cannot match, the arm does not exist yet) | **1 and 1** — the wall-clock arm is the `not ok`, and the new arm appears in D3's log as a PASS. This is the attribution check: D3 must NOT be killed by the new arm |
+| A2.5 | Mutant hygiene, per mutant: sha256 ≠ pristine; `/bin/bash -n <mutant>` rc=0; `stat -f '%Sp'` = `-rwxr-xr-x`; targeted count 1→0 with the sibling count unchanged at 1 | n/a (drill-internal) | all hold for D1, D2, D3. **Any mutant failing this is discarded and rebuilt — its suite verdict is not evidence** |
+| A2.6 | Tree integrity: `shasum -a 256 tools/eval/motoko_connection_probe.sh` | `f0b5e024…aabc99` | **`f0b5e024…aabc99` — byte-identical.** Restore, if ever needed, came from `/tmp/iter33/probe.pristine.bak`, never from `git checkout` |
+| A2.7 | `git status --porcelain` | 0 lines | **exactly 3 lines**, in any order: ` M tools/eval/test_motoko_connection_probe.sh` (M1), ` M design_docs/planned/m-motoko-stub-refusal-arm.md` (M2's evidence section), and `?? .snap/`. **No `.bak`, no `.log`, no mutant copies in the tree** — the drill writes only to `/tmp` |
+
+**Commit (CONTROLLER, not executor)**: `docs(motoko): record the stub-refusal arm's mutation evidence (row 6r)`.
+
+---
+
+## 3. Success metrics
+
+| Metric | Base | Target |
+|---|---|---|
+| Suite arms passing | 42 | **43** |
+| Suite `not ok` | 0 | **0** |
+| `expected_refusal_branches` | 28 | **28 (unchanged)** |
+| Mutants that survive an edit to the stub message | **2 of 2** (strip B7, reword B9) | **0 of 2** |
+| Known-positive control still attributed correctly | wall-clock arm (B8) | wall-clock arm, **not** the new arm |
+| Production files modified | — | **0** (`P` untouched) |
+| LOC | — | **+2** in `T`, plus an evidence section in `DD` |
+
+**No example file is required.** This is a test-harness change to a shell self-test; it adds no AILANG language feature, so the CLAUDE.md "every language feature needs `examples/feature_name.ail`" rule does not apply. No CHANGELOG or website change is warranted either — nothing user-facing moves.
+
+---
+
+## 4. Risks
+
+| # | Risk | Likelihood | Mitigation |
+|---|---|---|---|
+| R1 | Executor inserts the arm at the wrong offset (e.g. after `T:358` instead of `T:359`), splitting the existing arm from its `run_live` continuation | low | A1.1 (`bash -n`) catches a severed continuation; A1.4 catches a missing or renamed caller arm; the exact insertion point and byte-exact text are given in §M1 |
+| R2 | Executor "helpfully" replaces the caller-message arm instead of adding beside it | low | A1.4's second counter (`^ok - descendant discovery deadline refuses at the caller$` = 1) reds. The design doc's decision (A) is explicit that the arms are complementary |
+| R3 | A mutation drill step reds for file MODE rather than for the mutation, and is misread as a kill | **medium — this has already happened once on this rig** | Rule 2 of §M2 plus A2.5: `chmod 755` and record `stat -f '%Sp'`; and A2.2/A2.3 match the failing line **by name**, so a mode failure (which reds at the classification-fixture arm) cannot satisfy them |
+| R4 | An add-shaped mutant is used and produces a vacuous green | low | Rule 4 plus B13's measurement; all three mutants remove or alter the substring |
+| R5 | Rig contention (load avg ≈ 39 on 16 CPUs at planning time) stretches the drill and a suite run is misread as hung | medium | §Bounded waits: ~40 s per run measured, 5 runs ≈ 3–5 min, run in background and poll the artifact in a bounded loop. There is no `timeout(1)` on this machine |
+| R6 | Concurrent edit collides in the `run_live` arm block (`T:330-363`) | low | Design doc §Conflict Surface: the insertion point is inside that block; any concurrent add/remove/reorder there, or a change to `run_live` at `T:319-321`, conflicts. `P` is untouched, so it has no collision surface this sprint |
+| R7 | Local green is mistaken for CI green | medium | §0 Platform: all readings are darwin/arm64 bash 3.2.57. Windows and ubuntu legs are unrun locally; the `launchd drivers (bash 3.2)` CI leg is the only observation of the runner |
+
+---
+
+## 5. Residuals — found, and deliberately left
+
+- **Queue row 6o** — the SIGKILL-escalation group form and the `REAL_LSOF` PATH assertion. Out of scope; not touched.
+- **Queue row 6p** — deriving the node ceiling from an in-test stimulus. Out of scope; not touched.
+- **The wall-clock arm's accepted structural weakness** (it can die on the arm cap rather than on a message mismatch under a full de-race revert) is documented in `T`'s own comment and is not re-litigated. The new stub-message arm has no such weakness: the stub short-circuits before the walk.
+- **The row 6n plan's static-grep acceptance criteria** (`m-motoko-discovery-arm-discriminating-refusal-sprint-plan.md`, AC A1.3/A1.4/A1.5 etc.) are exactly the shape this sprint is replacing. They are historical record and are **not** edited by this sprint; the point is that after M1 the `(test stub)` string is held by a behavioural arm rather than by that grep. Retro-fitting the row 6n plan's other static greps into behavioural arms is a separate, larger piece of work and is **not** attempted here.
+- **`expect_failure` cannot express "the rest of the suite stayed green"** because it `exit 1`s on first failure. A harness change that collected failures instead of aborting would make inverse assertions expressible — genuinely useful, and genuinely out of scope for a two-line sprint. Recorded as a residual, not planned.
+
+---
+
+## 6. Handoff
+
+**Executor**: follow §0's five standing rules literally. M1 then M2, in order. Stop and report on the first red acceptance criterion.
+**Controller**: commits, one per milestone, after that milestone's acceptance block is green.
+
+**SPRINT_PLAN_PATH**: `design_docs/planned/m-motoko-stub-refusal-arm-sprint-plan.md`
+**SPRINT_JSON_PATH**: `.ailang/state/sprints/sprint_m-motoko-stub-refusal-arm.json`

--- a/design_docs/planned/m-motoko-stub-refusal-arm.md
+++ b/design_docs/planned/m-motoko-stub-refusal-arm.md
@@ -241,3 +241,20 @@ was first ratified for this mission at iteration 29. Fixes applied, VERBATIM whe
 discriminate different strings. Under fail-fast ordering it cannot be. That claim now rests on V13/V14 —
 the controller's two-arm behavioural measurement — which is a measurement rather than a prediction, so the
 argument is stronger than it was, not weaker.
+
+## Mutation Evidence (executed, motoko iteration 33)
+
+Executed on darwin/arm64 against pristine probe sha256
+`f0b5e02493369099f123c42107850fe062bf60d56ccabb2a7e4690d654aabc99`. Every mutant was a separate `/tmp`
+copy, was made executable before the suite ran, and altered or removed the asserted substring rather than
+appending around it.
+
+| Mutant | Construction and hygiene | Observed effect | Suite verdict |
+|---|---|---|---|
+| D1 — strip test-stub suffix | `sed 's/process-tree discovery deadline expired (test stub)/process-tree discovery deadline expired/'`; sha256 `df45556cebcf36d32f0bea658d0130f43e3bed193f78c5d7957822c78889643c` (different from pristine); `/bin/bash -n` rc=0; mode `-rwxr-xr-x` | `(test stub)` count 1→0; `(wall clock)` stayed 1; echo-refusal count stayed 3 | rc=1, 25 `ok`, 1 `not ok`; `not ok - descendant discovery stub refusal carries its own message lacked expected message: process-tree discovery deadline expired (test stub)` |
+| D2 — reword test-stub suffix | `sed 's/process-tree discovery deadline expired (test stub)/process-tree discovery deadline expired (stub)/'`; sha256 `0e7f60cca36c85cff372f0b8794b3643b613a952a6eabe27bc6809d0a541815b` (different from pristine); `/bin/bash -n` rc=0; mode `-rwxr-xr-x` | `(test stub)` count 1→0; `(wall clock)` stayed 1; echo-refusal count stayed 3 | rc=1, 25 `ok`, 1 `not ok`; `not ok - descendant discovery stub refusal carries its own message lacked expected message: process-tree discovery deadline expired (test stub)` |
+| D3 — strip wall-clock suffix (known-positive control) | `sed 's/process-tree discovery deadline expired (wall clock)/process-tree discovery deadline expired/'`; sha256 `645fbfc044c72a09530757228bfbd3a81cbbcccac5e82609b17fef77e2583942` (different from pristine); `/bin/bash -n` rc=0; mode `-rwxr-xr-x` | `(wall clock)` count 1→0; `(test stub)` stayed 1; echo-refusal count stayed 3 | rc=1, 33 `ok`, 1 `not ok`; the new arm first passed as `ok 26 - descendant discovery stub refusal carries its own message`, then the control failed as `not ok - descendant discovery refuses on the real wall-clock deadline lacked expected message: process-tree discovery deadline expired (wall clock)` |
+
+After the drill, the suite was re-run with `PROBE_UNDER_TEST` pointing at the pristine tree probe: rc=0,
+43 `ok`, 0 `not ok`, final line `PASS: 43 probe self-test arms ran`. The tree probe sha256 was still
+`f0b5e02493369099f123c42107850fe062bf60d56ccabb2a7e4690d654aabc99`, so no restore was needed.

--- a/design_docs/planned/m-motoko-stub-refusal-arm.md
+++ b/design_docs/planned/m-motoko-stub-refusal-arm.md
@@ -1,6 +1,6 @@
 # M-MOTOKO-STUB-REFUSAL-ARM: pin the `(test stub)` refusal message behaviourally, symmetric with the other two branches
 
-**Status**: NEW — awaiting design quorum. One sprint-sized item, ~1 iteration.
+**Status**: LANDED 2026-09-02 (motoko iteration 33). Quorum: BLOCKED r1 (3/3), BLOCKED r2 (2 reject / 1 pass), resolved under the narrow-refinement carve-out. One sprint-sized item, ~1 iteration.
 **Target**: v0.34.x (next motoko iteration)
 **Priority**: P1 (loop-health — a hunk with no killer; the `(test stub)` suffix is held by a static grep and by nothing behavioural)
 **Estimated**: 1 iteration (~1-2 hours implementation + mutation validation)
@@ -258,3 +258,43 @@ appending around it.
 After the drill, the suite was re-run with `PROBE_UNDER_TEST` pointing at the pristine tree probe: rc=0,
 43 `ok`, 0 `not ok`, final line `PASS: 43 probe self-test arms ran`. The tree probe sha256 was still
 `f0b5e02493369099f123c42107850fe062bf60d56ccabb2a7e4690d654aabc99`, so no restore was needed.
+
+## Arm PLACEMENT — corrected after the evaluation, and this is the iteration's real finding
+
+The arm as first written sat immediately after the caller-message arm at `:358`, i.e. **ahead of every
+wall-clock-bounded arm in the suite**. The independent evaluator filed that as its one BLOCKING finding:
+adding a `run_live` arm there is one more fork/exec before the 4-second `refusing live path refuses with the
+control-void message` arm and before `production run_lane fixture readiness`, so under host contention it
+nudges those arms toward their bounds. It reproduced one of the controller's two intermittent reds
+**verbatim**, including the underlying `INSTRUMENT FAILURE: lane treatment exceeded 4s sampling deadline`,
+in its own worktree at load 39.1-39.5 (base 5/5 clean, arm-at-26 4/5).
+
+**Measured three ways, one probe, interleaved, five rounds** — variants driven identically via
+`PROBE_UNDER_TEST` so the only variable is the test file:
+
+| variant | arm position | result |
+|---|---|---|
+| A — base, no new arm | — | **5/5 green**, 42 ok |
+| B — arm after the caller arm (`:360`) | 26 of 43 | **4/5 green**; the red is `not ok - production run_lane fixture readiness failed (outer_rc=82)` |
+| C — arm after the node-ceiling arm | 42 of 43 | **5/5 green**, 43 ok |
+
+Pooled across this measurement, the controller's earlier runs and the evaluator's independent A/B:
+**base 0 reds in 17 runs, arm-at-26 4 reds in 19, arm-at-42 0 reds in 5.**
+
+**The disposition is C, and the reason is a mechanism rather than a rate.** With the arm placed after every
+wall-clock-bounded arm, those arms begin at the same wall-clock offset as they do at base, so the mechanism
+the evaluator identified is **unreachable by construction** — which is worth more than winning a
+significance argument on a 4-of-19 sample. The move costs nothing: the suite is 43 ok, and the D1 mutant
+still reds with the new arm as the sole failing arm by name (`rc=1`, 41 ok).
+
+**What this costs the doc's earlier argument, stated rather than hidden.** The BESIDE decision said the new
+arm sits *immediately after* the caller-message arm. Adjacency turns out to buy nothing: the evaluator
+established that under the fail-fast harness any mutant that reds the caller arm masks the later one
+regardless of distance, so the two arms were never independent in ordering terms, only in *what they
+assert*. BESIDE-not-INSTEAD-OF still holds and is still right — two distinct strings, two distinct pins —
+but "beside" now means "both present", not "adjacent".
+
+**And the honest residual: moving the arm does NOT make the suite flake-free.** One C-shaped run during
+setup also hit `production run_lane fixture readiness failed`. Placement removes one contributor to a
+pre-existing fragility whose real fix is row 6p's — derive these arms' bounds from a stimulus measured
+in-test rather than from wall-clock constants calibrated on a quiet machine. That is not this row's work.

--- a/design_docs/planned/m-motoko-stub-refusal-arm.md
+++ b/design_docs/planned/m-motoko-stub-refusal-arm.md
@@ -1,0 +1,243 @@
+# M-MOTOKO-STUB-REFUSAL-ARM: pin the `(test stub)` refusal message behaviourally, symmetric with the other two branches
+
+**Status**: NEW — awaiting design quorum. One sprint-sized item, ~1 iteration.
+**Target**: v0.34.x (next motoko iteration)
+**Priority**: P1 (loop-health — a hunk with no killer; the `(test stub)` suffix is held by a static grep and by nothing behavioural)
+**Estimated**: 1 iteration (~1-2 hours implementation + mutation validation)
+**Dependencies**: Row 6r of the motoko mission queue. No new dependency; the two shell files are self-contained and the suite is hermetic. This doc is the direct successor of the row 6n arc (`m-motoko-discovery-arm-discriminating-refusal.md` + its sprint plan), which introduced the three distinct messages and the wall-clock/node-ceiling arms but explicitly left the stub's message unasserted.
+
+## Problem Statement
+
+`tools/eval/motoko_connection_probe.sh` has three refusal branches inside `descendant_pids()`:
+
+| probe line | branch | message |
+|---|---|---|
+| 184 | test-only `PROBE_TEST_DESCENDANT_FAILURE=1` | `process-tree discovery deadline expired (test stub)` |
+| 189 | real in-loop wall clock | `process-tree discovery deadline expired (wall clock)` |
+| 197 | node ceiling | `process-tree discovery exceeded $MAX_TREE_NODES nodes` |
+
+The caller collapses every one of them (probe:220) into `instrument_failure "process-tree discovery failed"`.
+
+Branches (2) and (3) each have a self-test arm asserting **their own** discriminating message:
+- test:476 asserts `process-tree discovery deadline expired (wall clock)`
+- test:731 asserts `process-tree discovery exceeded 3 nodes`
+
+Branch (1) does **not**. The only arm that drives it — test:358-359,
+`expect_failure "descendant discovery deadline refuses at the caller" "process-tree discovery failed" run_live PROBE_TEST_DESCENDANT_FAILURE=1` —
+asserts the **caller's** wrapper message, not the stub's. So the `(test stub)` suffix, whose entire purpose is to make a stubbed refusal
+distinguishable from a real one in a log, is held by nothing behavioural. The only thing holding its text is a **static grep** in the row 6n
+sprint plan's acceptance table (`m-motoko-discovery-arm-discriminating-refusal-sprint-plan.md` line 155, AC A1.3: `grep -Fc 'process-tree
+discovery deadline expired (test stub)'` → 1) — a claim about the file's text rather than about behaviour. The row 6n design doc itself
+self-discloses this: *"The stub's message is never directly asserted (arm :357 asserts the caller wrapper), so changing it is safe."*
+
+**Impact:** a future edit that strips or rewords the `(test stub)` suffix lands green (measured — M2 below). The loop's own rule says a hunk
+with no killer is a finding rather than a failure; this row exists to give the hunk a killer.
+
+## Goals
+
+**Primary Goal:** Give branch (1) a self-test arm that asserts its **own** discriminating message
+`process-tree discovery deadline expired (test stub)`, the symmetric treatment branches (2) and (3) already have, so the `(test stub)`
+suffix is pinned behaviourally and the M2 mutant (strip the suffix) reds the suite.
+
+**Secondary Goal:** Keep the three branches symmetric and the refusal-branch-count gate honest: adding a self-test **arm** must not move
+`expected_refusal_branches` (28); only adding a **production branch** would.
+
+**Non-Goal (scope discipline):** no production-semantics change to the probe. The stub still returns 1 and the caller still collapses it to
+`process-tree discovery failed`. This row does **not** touch the neighbouring queue rows (see Residuals).
+
+## High-Impact Decision
+
+### (A) Add a stub-message arm, sitting BESIDE the existing caller-message arm — chosen
+
+The controller's lean is (A), and I agree. Option (B) — declaring the branch behaviourally unpinned in a code comment — would name the gap
+where a reader meets it, but it would not give the hunk a killer: the M2 mutant would still land green, and the `(test stub)` suffix would
+still be held by nothing. (A) converts the static grep into a behavioural assertion, makes all three branches symmetric, and is cheap — the
+stub short-circuits before the walk, so the new arm is deterministic and fast (no timing sensitivity, no flake surface).
+
+**The new arm sits BESIDE, not in place of, the existing caller-message arm at :358.** The two assert two different strings on the same
+stderr and each can fail for a reason the other cannot:
+
+| arm | drives | asserts | can fail for (unique to it) |
+|---|---|---|---|
+| :358 "descendant discovery deadline refuses at the caller" (existing) | `run_live PROBE_TEST_DESCENDANT_FAILURE=1` | `process-tree discovery failed` | the caller stops collapsing a `descendant_pids` failure into that wrapper — e.g. the `if ! pids=$(descendant_pids ...)` guard in `sample_tree` is removed and the probe proceeds with an empty pid scope, reddening `assert_pid_scope` with a *different* message; or the wrapper string is reworded. Does **not** fail if the stub's message text changes. |
+| NEW "descendant discovery stub refusal carries its own message" | `run_live PROBE_TEST_DESCENDANT_FAILURE=1` | `process-tree discovery deadline expired (test stub)` | the stub's own message text changes — the `(test stub)` suffix is stripped (M2), or the message is reworded. Does **not** fail if the caller stops refusing (the stub message is still emitted to stderr before the caller's behaviour). |
+
+Concretely, if the caller's guard is removed, the probe still exits 1 (via `assert_pid_scope` → `invalid empty or malformed pid scope: ${pids:-<empty>}` — the exact string carries a `: <pids-or-empty>` suffix, V15), so
+stderr still carries `process-tree discovery deadline expired (test stub)` and the new arm stays green while the caller-message arm reds.
+Conversely, if the stub's message is stripped, the caller-message arm stays green while the new arm reds. They are complementary, not
+redundant; replacing one with the other would lose a distinct pin.
+
+**First-party basis for "stderr carries BOTH strings":** established by direct reproduction (see Verification Log V7) — with
+`PROBE_TEST_DESCENDANT_FAILURE=1` the probe's stderr contains both `process-tree discovery deadline expired (test stub)` (count 1) and
+`INSTRUMENT FAILURE: process-tree discovery failed` (count 1). So a single `expect_failure` asserting the stub message is well-formed.
+
+**Refusal-branch-count gate (M5):** `expected_refusal_branches=28` at test:763 counts **production** refusal branches in the probe
+(`instrument_failure "` = 20, `|| usage$` = 5, `echo "process-tree discovery` = 3). This design adds a self-test **arm** in the test file
+only; it adds no production branch, so the count stays 28 and the gate (arm 42) keeps passing. Adding a production branch would move it; this
+design does not.
+
+## Verification Log
+
+Every row below is a claim about the codebase's current state, the command that produced it, and its observed output. Rows labelled
+**controller-measured** are first-party measurements taken by the controller in this session (2026-09-02) and are cited as such; all other
+rows I ran myself on this unmodified worktree (HEAD `7292ec780`).
+
+| # | Claim | Command | Observed output |
+|---|---|---|---|
+| V1 | Baseline suite is green: 42 arms, 0 failures, rc=0, no skips. | `/bin/bash tools/eval/test_motoko_connection_probe.sh > /tmp/m1_base.log 2>&1; echo rc=$?; grep -c '^ok ' /tmp/m1_base.log; grep -c '^not ok' /tmp/m1_base.log; tail -1 /tmp/m1_base.log; grep -ci '/skip/i' /tmp/m1_base.log` | rc=0; `^ok ` = 42; `^not ok` = 0; last line `PASS: 42 probe self-test arms ran`; skip = 0. (Controller-measured M1 agrees: rc=0, 42 ok, 0 not ok.) |
+| V2 | The M2 mutant — strip `(test stub)` from branch (1) only — survives: suite stays green. | controller-measured M2: mutant LANDED (sha256 `f0b5e0249336` → `df45556cebcf`), PARSES (`bash -n` rc=0), effect asserted (`grep -Fc 'expired (test stub)'` 1→0 while `grep -Fc 'expired (wall clock)'` stays 1). | rc=0, 42 ok, 0 not ok. **The mutant survives — this is the defect.** |
+| V3 | The same-scope known-positive control — strip `(wall clock)` from branch (2) only — reds the suite on the wall-clock arm by name. | controller-measured M3: mutant LANDED (`f0b5e0249336` → `645fbfc044c7`), PARSES, effect 1→0 on that suffix only. | rc=1, 32 ok, 1 not ok; failing arm by name: `not ok - descendant discovery refuses on the real wall-clock deadline lacked expected message: process-tree discovery deadline expired (wall clock)`. So the harness CAN red for exactly this class of edit; M2's green is a measurement, not a broken instrument. M2 and M3 differ in exit code (0 vs 1) — no false symmetry. |
+| V4 | Instrument trap: `sed > file` creates mode 644, and the suite invokes `"$probe" --classify-fixture ...` directly at test:201, so an un-chmod'd mutant reds at the FIRST arm for its file mode, not for the mutation. | controller-measured M4; I additionally verified the direct invocation and the repo file mode: `sed -n '198,203p' tools/eval/test_motoko_connection_probe.sh`; `stat -f '%Sp %N' tools/eval/motoko_connection_probe.sh` | test:201 is `"$probe" --classify-fixture "$tmp_dir/or_ips" "$tmp_dir/lsof.fixture"`; repo probe mode is `-rwxr-xr-x` (755). Any mutation drill must `chmod 755` the mutant and read WHICH arm failed, never the exit code alone. |
+| V5 | `expected_refusal_branches` is 28 and the gate passes at baseline. | `grep -n 'expected_refusal_branches' tools/eval/test_motoko_connection_probe.sh`; `grep -c 'instrument_failure "' tools/eval/motoko_connection_probe.sh`; `grep -cE '\|\| usage$' tools/eval/motoko_connection_probe.sh`; `grep -c 'echo "process-tree discovery' tools/eval/motoko_connection_probe.sh` | `expected_refusal_branches=28` at test:763; counts 20 + 5 + 3 = 28. The gate (arm 42) passes as part of V1. (Controller-measured M5 agrees.) |
+| V6 | The three branches and the caller collapse exist at the stated lines with the stated messages. | `grep -n 'process-tree discovery deadline expired (test stub)\|process-tree discovery deadline expired (wall clock)\|process-tree discovery exceeded\|instrument_failure "process-tree discovery failed"' tools/eval/motoko_connection_probe.sh` | 184 `(test stub)`; 189 `(wall clock)`; 197 `exceeded $MAX_TREE_NODES nodes`; 220 `instrument_failure "process-tree discovery failed"`. |
+| V7 | With `PROBE_TEST_DESCENDANT_FAILURE=1`, the probe's stderr carries BOTH the stub message and the caller wrapper. | Hermetic live-path reproduction (coreutils symlinked into a scratch `bin/`, stub `uname`/`dig`/`pgrep`/`lsof`/`ailang-stub`, `env PATH="$T/bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=4 PROBE_TEST_DESCENDANT_FAILURE=1 PROBE_STUB_STATE="$T/lane" /bin/bash tools/eval/motoko_connection_probe.sh treatment control "$T/out.json"`), then `grep -Fc` on captured stderr. | probe rc=1; stderr contains `process-tree discovery deadline expired (test stub)` (count 1) and `INSTRUMENT FAILURE: process-tree discovery failed` (count 1). |
+| V8 | The existing caller-message arm at :358-359 asserts the caller wrapper, not the stub message. | `sed -n '358,359p' tools/eval/test_motoko_connection_probe.sh` | `expect_failure "descendant discovery deadline refuses at the caller" "process-tree discovery failed" \` / `  run_live PROBE_TEST_DESCENDANT_FAILURE=1` |
+| V9 | The wall-clock arm (test:476) and node-ceiling arm (test:731) assert their own messages. | `grep -n 'real wall-clock deadline\|node-count ceiling' tools/eval/test_motoko_connection_probe.sh` | 476 `expect_failure "descendant discovery refuses on the real wall-clock deadline" "process-tree discovery deadline expired (wall clock)"`; 731 `expect_failure "descendant discovery refuses on the node-count ceiling" "process-tree discovery exceeded 3 nodes"` |
+| V10 | Both shell files parse cleanly at base. | `bash -n tools/eval/motoko_connection_probe.sh; echo rc=$?`; `bash -n tools/eval/test_motoko_connection_probe.sh; echo rc=$?` | rc=0; rc=0. |
+| V11 | The probe file's sha256 matches the controller's M2 baseline hash. | `shasum -a 256 tools/eval/motoko_connection_probe.sh` | `f0b5e02493369099f123c42107850fe062bf60d56ccabb2a7e4690d654aabc99` (matches controller's `f0b5e0249336`). |
+| V12 | The static grep that currently holds the `(test stub)` text lives in the row 6n sprint plan's acceptance table. | `sed -n '140,170p' design_docs/planned/m-motoko-discovery-arm-discriminating-refusal-sprint-plan.md` | AC A1.3: `grep -Fc 'process-tree discovery deadline expired (test stub)' tools/eval/motoko_connection_probe.sh` → base 0, required after M1 **1**. |
+| V13 | `expect_failure` matches with `grep -Fq -- "$expected" "$tmp_dir/stderr"` — a fixed-string SUBSTRING match over the ENTIRE captured stderr file, not a last-line match and not a structured field. | `sed -n '151,169p' tools/eval/test_motoko_connection_probe.sh` | `expect_failure() { local name=$1 expected=$2 rc; shift 2; run_bounded "$tmp_dir/stdout" "$tmp_dir/stderr" "$ARM_CAP_SECS" -- "$@"; rc=$?; ... if ! grep -Fq -- "$expected" "$tmp_dir/stderr"; then echo "not ok - $name lacked expected message: $expected" >&2; ... }` — the matcher is `grep -Fq -- "$expected" "$tmp_dir/stderr"`. |
+| V14 | Behavioural, the stronger arm: an `expect_failure` asserting the stub's message PASSES on correct code and REDS on the M2 defect. | controller-measured (2026-09-02), throwaway test-side mutant run before routing: (arm 1) test file with the caller-message arm's expected string swapped to `process-tree discovery deadline expired (test stub)`, run against the PRISTINE probe; (arm 2) the SAME mutated test file run against the stripped-suffix probe (M2). | arm 1 → rc=0, 42 ok, 0 not ok (the assertion passes on correct code). arm 2 → rc=1, 24 ok, 1 not ok, failing arm by name: `not ok - descendant discovery deadline refuses at the caller lacked expected message: process-tree discovery deadline expired (test stub)`. Outcomes DIFFER (rc 0 vs 1) — a discriminating measurement, not a false symmetry. Together they establish that an `expect_failure` asserting the stub's message both passes on correct code and reds on the defect — exactly what the new arm must do. |
+| V15 | `assert_pid_scope` exists, is called, and its refusal message carries a `: ${pids:-<empty>}` suffix. | `grep -n "assert_pid_scope" tools/eval/motoko_connection_probe.sh`; `grep -n "invalid empty or malformed pid scope" tools/eval/motoko_connection_probe.sh`; controls in the same call: `grep -c "instrument_failure" tools/eval/motoko_connection_probe.sh`; negative control `grep -c "assert_zzz_scope" tools/eval/motoko_connection_probe.sh` | 208 `assert_pid_scope() {`; 223 `assert_pid_scope "$pids"`; 210 `[[ "$pids" =~ ^[0-9]+(,[0-9]+)*$ ]] || instrument_failure "invalid empty or malformed pid scope: ${pids:-<empty>}"`. Controls: `instrument_failure` count = 21 (known-positive); `assert_zzz_scope` = 0 (negative). The zeros in this family are measurements, not a broken pattern. |
+| V16 | The refusal-branch gate's anti-vacuity floor exists and `expected_refusal_branches=28`. | `grep -n "expected_refusal_branches=28" tools/eval/test_motoko_connection_probe.sh`; `grep -n "refusal-branch gate" tools/eval/test_motoko_connection_probe.sh`; `grep -n "counter matched nothing" tools/eval/test_motoko_connection_probe.sh` | `expected_refusal_branches=28` at test:763; `[[ -f "$probe" ]]` asserted at test:766 BEFORE any counter runs; anti-vacuity floor at test:771-774: `if (( actual_instrument_failures == 0 || actual_usage_refusals == 0 || actual_echo_refusals == 0 )); then echo "not ok - refusal-branch counter matched nothing; instrument failure, not a verdict" >&2; exit 1; fi`. |
+
+**Empty/negative-result controls:** V2's "mutant survives" is a negative result (no red) — it is a controller-measured first-party run, not an
+inference, and it is paired with V3, the same-scope known-positive control that proves the harness fires for exactly this class of edit.
+V5's "no production branch added" is a design claim, not a measurement; the gate's own anti-vacuity floor (test:771-774, V16) refuses a zero
+counter, so a broken counter cannot silently pass. V15's `assert_zzz_scope` = 0 is a negative control paired with the known-positive `instrument_failure` = 21, so the zeros in that family are measurements, not a broken pattern.
+
+## Test Plan
+
+Each row names the mutation it kills and the observable it reads. For each I state whether it is predicted to be a SOLE killer or a member
+of a larger red set. **Every mutation drill must `chmod 755` the mutant copy and read WHICH arm failed, never the exit code alone (M4).**
+The suite is run as `PROBE_UNDER_TEST=<mutant copy> /bin/bash tools/eval/test_motoko_connection_probe.sh` so the probe is swapped without
+touching the tree.
+
+**THE HARNESS IS FAIL-FAST, AND THAT ORDERS THIS TABLE** (`gemini-3-1-pro`, round 2, upheld). `expect_failure`
+ends in `exit 1` on both of its failure paths (test:161 `unexpectedly succeeded`, test:166 `lacked expected message`), so the
+first failing arm terminates the suite and every later arm is UNREACHED. The controller's own readings prove it rather than
+assume it: V3 stops at 32 ok and V14 at 24 ok, both out of a 42-arm baseline. Since the new arm is inserted immediately AFTER
+the caller-message arm at :358, any mutant that reds the caller arm masks the new one. This does not weaken T1 — T1's mutant
+leaves the caller arm green, so the new arm is reached and is its sole killer — but it does mean a "both arms red" or "the
+other arm stays green" prediction is unobservable in this harness, and the rows below say so.
+
+| # | Mutation (named) | Observable it reads | Predicted killer(s) |
+|---|---|---|---|
+| T1 | **M2 — strip `(test stub)` from branch (1) only** (probe:184 → `process-tree discovery deadline expired`). This is the defect. | The NEW stub-message arm reds: `not ok - ... lacked expected message: process-tree discovery deadline expired (test stub)`. The caller-message arm (:358) stays green (it asserts `process-tree discovery failed`, unchanged); the refusal-branch count stays 28 (echo count still 3). | **SOLE killer** — the new arm is the only arm that reads the `(test stub)` string. This is the row's whole point. |
+| T2 | **M3 — strip `(wall clock)` from branch (2) only** (probe:189). Known-positive control, controller-measured. | The wall-clock arm (test:476) reds by name. The new stub-message arm stays green. | Not the new arm's killer — the wall-clock arm is the sole killer. Included to prove the harness still fires for this class of edit after my change. |
+| T3 | **Alter the stub message's `(test stub)` suffix** (probe:184 → `process-tree discovery deadline expired (stub)`). This is the substring-breaking form of the reword mutant. The append-shaped form (`... (test stub) X`) is REJECTED: `expect_failure` matches with `grep -Fq` fixed-string substring, so appending text leaves the expected string present and the arm still passes. Measured (controller, 2026-09-02) with E=`process-tree discovery deadline expired (test stub)`: `grep -Fq -- "$E"` rc=0 on a file containing E exactly, rc=0 on a file containing "E X", rc=1 on a file containing "...expired (stub)". A substring assertion is only broken by an edit that REMOVES or ALTERS the expected substring, never by one that ADDS around it. | The NEW stub-message arm reds: `not ok - ... lacked expected message: process-tree discovery deadline expired (test stub)`. Caller-message arm stays green. | **SOLE killer** — only the new arm reads the exact stub string. |
+| T4 | **Remove the stub branch entirely** (delete the `if [[ "${PROBE_TEST_DESCENDANT_FAILURE:-0}" == 1 ]]` block at probe:183-186). | The caller-message arm (:358) reds first with `unexpectedly succeeded` and **aborts the suite before the new arm executes** — `expect_failure` ends in `exit 1` (test:161/166), so the harness is fail-fast and every arm after the first failure is unreached. | **Ordering-masked.** Applying `gemini-3-1-pro`'s round-2 fix verbatim: *"the caller-message arm reds and aborts the suite before the new arm executes (meaning the new arm is not reached, though the mutation is still caught)."* The mutation IS caught; the new arm is simply not the catcher. |
+| T5 | **Alter the caller wrapper's asserted substring** (probe:220 → `instrument_failure "process-tree discovery FAILED"`). The append-shaped form (`... failed (X)`) is rejected for the same reason as T3: it keeps the asserted substring `process-tree discovery failed` present, so `grep -Fq` still matches and the caller arm would not red. | The caller-message arm (:358) reds and **aborts the suite, so the new arm's assertion is never reached** — the same fail-fast ordering as T4. | **Ordering-masked.** Applying `gemini-3-1-pro`'s round-2 fix verbatim: *"the caller-message arm reds and aborts the suite, so the new arm's assertion is never reached."* Note what this costs the doc's earlier argument: T5 can no longer be cited as evidence that the two arms discriminate different strings, because the second arm never runs. That claim now rests on **V13/V14** (the controller's two-arm behavioural measurement) alone, which is a measurement rather than a prediction. |
+| T6 | **Add a production refusal branch** (e.g. a new `echo "process-tree discovery ..."` in `descendant_pids`). | The refusal-branch-count gate reds: `refusal-branch drift: probe has 29 refusal branches, this suite is written for 28`. | Not the new arm's killer — the count gate is the sole killer. Applying `gemini-3-1-pro`'s round-2 fix verbatim: *"correct T6 to note that adding an arm shifts the refusal-branch-count gate from arm 42 to arm 43."* The gate's arm NUMBER moves 42 → 43 because this change inserts one arm ahead of it; the gate's `expected_refusal_branches` VALUE stays 28, because a self-test arm is not a production branch. |
+
+**Add-shaped mutants are vacuous under `grep -Fq`:** every `expect_failure` in this suite matches with `grep -Fq -- "$expected" "$tmp_dir/stderr"` — a fixed-string substring over the entire captured stderr (V13). A mutation that only ADDS text around an asserted substring (e.g. appending ` X`) leaves the expected string present, so the arm still passes; only an edit that REMOVES or ALTERS the expected substring can red it. T3 and T5 were both audited for this shape and rewritten to the substring-breaking form; T1/T2 (strip a suffix) and T4 (remove the branch → `unexpectedly succeeded`) already break the substring or the rc==0 check.
+
+**Which write does each read?** T1/T3 read the stub's own message string (probe:184) — a value set alongside the stub branch, so the new arm
+can fail for the reason it claims. T2 reads the wall-clock string (probe:189). T4 reads the presence of the stub branch itself. T5 reads the
+caller wrapper (probe:220). T6 reads the production-branch count. None of the new arm's assertions observe a value set alongside the
+mechanism it claims to pin.
+
+## Acceptance Criteria
+
+Every command below was run on this **unmodified** worktree and its base result recorded (see Verification Log). A gate already red at base
+would measure the repo, not the change; none of these are.
+
+| # | Command | Base (recorded) | Required after the change |
+|---|---|---|---|
+| AC1 | `bash -n tools/eval/motoko_connection_probe.sh; echo rc=$?` | rc=0 (V10) | rc=0 |
+| AC2 | `bash -n tools/eval/test_motoko_connection_probe.sh; echo rc=$?` | rc=0 (V10) | rc=0 |
+| AC3 | `/bin/bash tools/eval/test_motoko_connection_probe.sh > /tmp/suite.log 2>&1; echo rc=$?; grep -c '^ok ' /tmp/suite.log; grep -c '^not ok' /tmp/suite.log; tail -1 /tmp/suite.log` | rc=0, 42 ok, 0 not ok, `PASS: 42 probe self-test arms ran` (V1) | rc=0, **43 ok** (the new arm adds one), 0 not ok, `PASS: 43 probe self-test arms ran` |
+| AC4 | The refusal-branch-count gate (arm 42, part of the AC3 suite) | passes (V1, V5) | still passes with `expected_refusal_branches=28` unchanged — the change adds a test arm, not a production branch |
+| AC5 | The new arm is the sole killer for the M2 mutant (strip `(test stub)`). | n/a (mutation drill, not a base measurement) | T1 reds the suite with the new arm as the failing arm by name |
+
+AC3's 43-ok count is behavioural (the suite ran and passed one more arm), not a static grep for a string — the static-grep shape is the very
+defect this row exists to fix. AC5 is the mutation drill that proves the new arm is non-vacuous; it is carried in the Test Plan and re-stated
+here as the acceptance gate for the fix's purpose.
+
+## Conflict Surface
+
+Two files are touched: `tools/eval/motoko_connection_probe.sh` (read-only for this change — the new arm is in the test file) and
+`tools/eval/test_motoko_connection_probe.sh` (one new `expect_failure` block inserted immediately after the existing caller-message arm at
+:358-359). The probe file is not modified by this design, so the only collision surface is the test file.
+
+Relevant history on these two files. **PROVENANCE VERIFIED BY COMMAND** (`gpt5-6-sol`, round 2, upheld: *"saying the
+history was “read” is still assertion rather than verification"*). Its own proposed command was run —
+`git show --stat --oneline <sha> -- tools/eval/motoko_connection_probe.sh tools/eval/test_motoko_connection_probe.sh` —
+and the observed output is recorded per row below. Enumeration control: `git log --oneline -6 -- <the two files>` returns
+`f5d031161, 20cce785e, 64ca81852, 4bd58bef6, b4da09b53, fd1fa9e01`, i.e. all three cited SHAs are among the most recent
+commits to touch these files and none is invented. Negative control: the same `git show --stat` for `7292ec780` (HEAD, a
+docs-only commit) lists **no files**, so an empty file list is a measurement and not a broken command.
+
+
+- **#1008 (`64ca81852`, motoko iteration 32)** — VERIFIED: subject `test(probe): make the wall-clock discovery arm assert its own refusal (motoko iter-32, D4) (#1008)`; `motoko_connection_probe.sh` 4 ++--, `test_motoko_connection_probe.sh` 25 +++++-----, 2 files, 22 insertions / 7 deletions. — introduced the three distinct messages (probe:184/189/197), the wall-clock arm asserting its
+  own message, the echo-shaped refusal counter, the suite-scope `PROBE_MAX_TREE_NODES` leak guard, and the `[[ -f "$probe" ]]` assertion. This
+  is the commit that created the current shape and the self-disclosed stub gap.
+- **#1013 (`20cce785e`, V1 iteration 317)** — VERIFIED: subject `fix(ci): give process-tree discovery its own deadline (reconciled onto dev) (#1013)`; `motoko_connection_probe.sh` 9 +++---, `test_motoko_connection_probe.sh` 35 +++----, 2 files, 24 insertions / 20 deletions. — de-raced `run_lane`'s single deadline: added `PROBE_TREE_DISCOVERY_SECS`, moved
+  `expected_refusal_branches` 27→28 (re-derived as 20+5+3), and changed the wall-clock arm's env line and the bounded-termination arm's env
+  line. A concurrent edit to the wall-clock arm's env line or to `expected_refusal_branches` would collide with this history.
+- **#1020 (`f5d031161`, most recent)** — VERIFIED: subject `test(probe): give the process-tree de-race a killer, and guard the new knob at suite scope (#1020)`; `test_motoko_connection_probe.sh` ONLY, 1 file, 51 insertions / 7 deletions — so this commit did **not** touch the probe, which narrows its collision surface to the test file. — gave the de-race a killer (wall-clock arm lane deadline at `ARM_CAP_SECS + 30`, stub driver kept
+  alive for the same duration) and added the suite-scope `PROBE_TREE_DISCOVERY_SECS` leak guard. It also added `PROBE_TEST_PGREP_LOOP_DELAY`
+  to the pgrep stub.
+
+**What a concurrent edit would collide with:** my insertion point is immediately after test:358-359, which is inside the block of
+`run_live`-driven `expect_failure` arms (test:330-363). Any concurrent edit that adds/removes/reorders arms in that block, or that changes
+`run_live`'s env line (test:319-321), would conflict. The wall-clock arm (test:476) and node-ceiling arm (test:731) are far from the
+insertion point and are not touched. The refusal-branch-count gate (test:763-782) is not touched; my change must not move `expected_refusal_branches`. The probe file is untouched, so no collision there.
+
+## Residuals / queue rows this does NOT fix
+
+- **Row 6o** — the SIGKILL-escalation group form and the `REAL_LSOF` PATH assertion. Not touched; out of scope.
+- **Row 6p** — deriving the node ceiling from an in-test stimulus. Not touched; out of scope.
+- The wall-clock arm's accepted structural weakness (it can die on the arm cap rather than on a message mismatch under a full de-race
+  revert) is documented in the test file's own comment and is **not** re-litigated here. The new stub-message arm has no such weakness: the
+  stub short-circuits before the walk, so it is deterministic and fast.
+
+## Platform Honesty
+
+Every local reading in this doc is **darwin/arm64, GNU bash 3.2.57, this rig, with `/usr/sbin` present in PATH** (`command -p -v lsof` →
+`/usr/sbin/lsof`, rc=0). The **windows and ubuntu CI legs are unrun locally**. I do not declare any branch "unreachable" or any ordering
+"impossible" from this one host. The new arm is timing-independent (the stub returns before the walk), so it carries no new platform
+sensitivity; but the suite as a whole still depends on `/usr/sbin` being on PATH for `lsof` (V1's iteration 317 recorded that a shell
+without it dies early at "run_lane fixture arm requires real lsof"), so a run showing far fewer than 42 arms is a PATH problem, not a code
+problem.
+
+## Quorum Verification Log
+
+**Round 1 — BLOCKED 3/3, zero absentees, $0.0628.** Three reviewers (gpt5-6-sol, gemini-3-1-pro, oc-glm-5-2) each raised a PREMISE objection — a claim about the codebase this doc had not established. The controller ran all three rather than forwarding them; two are UPHELD and one is REFUTED. The design direction — option (A), a new arm asserting the stub's own message, sitting BESIDE the existing caller-message arm — was not disputed by any reviewer and is unchanged.
+
+| Reviewer | Objection (one line) | Disposition |
+|---|---|---|
+| gpt5-6-sol | T3's append-shaped mutant (`(test stub)` → `(test stub) X`) is vacuous: `expect_failure` uses `grep -Fq` fixed-string substring match, so appending text leaves the expected string present and the arm still passes. | **UPHELD — defect.** T3 replaced with the substring-breaking `(test stub)` → `(stub)` (measured: `grep -Fq` rc 0 on exact, rc 0 on "E X", rc 1 on "...(stub)"). T5 audited and fixed for the same shape. |
+| gemini-3-1-pro | The "two arms fail independently" claim rested on unverified codebase facts (`assert_pid_scope`, the refusal-branch gate's anti-vacuity floor) with no Verification Log row. | **UPHELD — documentation.** Facts are true but unverified; added V15 (`assert_pid_scope` existence/call-site/exact message with `: ${pids:-<empty>}` suffix + controls) and V16 (anti-vacuity floor at test:771-774, `[[ -f ]]` at :766, `expected_refusal_branches=28` at :763). |
+| oc-glm-5-2 | `expect_failure`'s matching semantics were unverified; the arm might fail if the harness matched only the last line or a structured field. | **REFUTED by measurement.** Source (test:151-169, V13) shows `grep -Fq -- "$expected" "$tmp_dir/stderr"` — a fixed-string substring over the entire stderr file; behavioural arms (V14) show the assertion PASSES on pristine code (rc=0, 42 ok) and REDS on the M2 defect (rc=1, 24 ok, 1 not ok) — a discriminating measurement. |
+
+**Line-citation note:** the controller's round-1 note cited the anti-vacuity floor at test:772-776 and `[[ -f "$probe" ]]` at :767; the measured truth is test:771-774 and :766 (the doc's existing citations were already correct). The Verification Log rows above carry the measured numbers.
+
+## Quorum round 2 and the narrow-refinement carve-out (controller-applied, 2026-09-02)
+
+Round 2 synthesis **BLOCKED**, $0.0875, 3/3 external reviewers present, `.synthesis.absent_reviewers` = `[]`
+(cross-checked: `[.reviewers[]|select(.present==false)|.model]` = `[]`). Verdicts: `gpt5-6-sol` reject,
+`gemini-3-1-pro` reject, **`oc-glm-5-2` pass** — its first pass, having been the round-1 rejecter on
+`expect_failure` semantics, which the controller refuted by measurement.
+
+**Objection SURFACES tracked per round** (V1 iteration 257's rule — the disposition turns on where objections
+land, not on the round count). R1: test-plan mutant validity · verification-log completeness · harness
+semantics. R2: conflict-surface provenance · test-plan fail-fast ordering. The objections are **SPREAD across
+different surfaces, not localised onto one**, so this is not the SPLIT signal that rule describes; and one
+reviewer flipped to pass.
+
+**The revision and the one re-quorum are spent, so the disposition is the NARROW-REFINEMENT CARVE-OUT, not a
+park.** Both surviving objections (a) carry a concrete reviewer-authored `proposed_fix` and (b) dispute no
+design DIRECTION — one is attribution, one is a factual correction to predicted test outcomes. The carve-out
+was first ratified for this mission at iteration 29. Fixes applied, VERBATIM where the reviewer supplied text:
+
+| Reviewer | Objection surface | Disposition |
+|---|---|---|
+| `gpt5-6-sol` | Conflict Surface cited three SHAs without commands or observed outputs | **APPLIED.** Ran the reviewer's own `git show --stat --oneline <sha> -- <the two files>`; each bullet now carries its verified subject and diffstat, with an enumeration control and a negative control. The reviewer's alternative ("remove the unsupported historical attributions") was NOT taken, because the attributions turned out to be true and are useful. |
+| `gemini-3-1-pro` | T4/T5 predict outcomes the fail-fast harness cannot produce; T6's arm number is stale | **APPLIED VERBATIM.** T4 and T5 rewritten in the reviewer's own words as ordering-masked; T6 notes the gate moves arm 42 → 43 while `expected_refusal_branches` stays 28. A new fail-fast preamble was added to the Test Plan, evidenced by `expect_failure`'s two `exit 1` paths and by the controller's own V3/V14 arm counts. |
+| `oc-glm-5-2` | (passed) noted the literal insertion text is not written out | **NOT BLOCKING, and deliberately left to the sprint plan** — the exact `expect_failure` line is an implementation detail the planner and executor own, and AC3/AC5 are what make it non-vacuous. Recorded here so it is not silently dropped. |
+
+**What this costs, stated rather than hidden:** T5 was previously cited as evidence that the two arms
+discriminate different strings. Under fail-fast ordering it cannot be. That claim now rests on V13/V14 —
+the controller's two-arm behavioural measurement — which is a measurement rather than a prediction, so the
+argument is stronger than it was, not weaker.

--- a/tools/eval/test_motoko_connection_probe.sh
+++ b/tools/eval/test_motoko_connection_probe.sh
@@ -357,8 +357,6 @@ expect_failure "empty pid scope fails loudly instead of widening lsof" "invalid 
   run_live PROBE_TEST_PID_SCOPE=
 expect_failure "descendant discovery deadline refuses at the caller" "process-tree discovery failed" \
   run_live PROBE_TEST_DESCENDANT_FAILURE=1
-expect_failure "descendant discovery stub refusal carries its own message" "process-tree discovery deadline expired (test stub)" \
-  run_live PROBE_TEST_DESCENDANT_FAILURE=1
 expect_failure "lane sampling deadline refuses" "exceeded 1s sampling deadline" \
   run_live PROBE_TEST_DRIVER_SLEEP=10 PROBE_TIMEOUT_SECS=1
 expect_failure "bounded termination deadline refuses" "bounded termination deadline" \
@@ -734,6 +732,13 @@ expect_failure "descendant discovery refuses on the node-count ceiling" "process
   env PATH="$live_bin" AILANG_BIN=ailang-stub PROBE_TIMEOUT_SECS=60 PROBE_MAX_TREE_NODES=3 \
     PROBE_TEST_PGREP_LOOP=1 PROBE_STUB_STATE="$tmp_dir/lane-node-limit" \
     /bin/bash "$probe" treatment control "$tmp_dir/node-limit.json"
+
+# Placed AFTER every wall-clock-bounded arm on purpose: this arm costs one more fork/exec, and
+# the judge measured that inserting it EARLIER correlates with downstream 4s-deadline arms
+# tipping over under host contention. Position is the cheapest way to make that mechanism
+# unreachable by construction rather than argue about a rate.
+expect_failure "descendant discovery stub refusal carries its own message" "process-tree discovery deadline expired (test stub)" \
+  run_live PROBE_TEST_DESCENDANT_FAILURE=1
 
 # The D4 ceiling override belongs on the wall-clock discovery arm's own env line and nowhere else. A per-command
 # env assignment never persists into this shell, so this is invariantly quiet on a correct

--- a/tools/eval/test_motoko_connection_probe.sh
+++ b/tools/eval/test_motoko_connection_probe.sh
@@ -357,6 +357,8 @@ expect_failure "empty pid scope fails loudly instead of widening lsof" "invalid 
   run_live PROBE_TEST_PID_SCOPE=
 expect_failure "descendant discovery deadline refuses at the caller" "process-tree discovery failed" \
   run_live PROBE_TEST_DESCENDANT_FAILURE=1
+expect_failure "descendant discovery stub refusal carries its own message" "process-tree discovery deadline expired (test stub)" \
+  run_live PROBE_TEST_DESCENDANT_FAILURE=1
 expect_failure "lane sampling deadline refuses" "exceeded 1s sampling deadline" \
   run_live PROBE_TEST_DRIVER_SLEEP=10 PROBE_TIMEOUT_SECS=1
 expect_failure "bounded termination deadline refuses" "bounded termination deadline" \


### PR DESCRIPTION
## What

Queue row **6r** of the motoko mission: `descendant_pids()` in
`tools/eval/motoko_connection_probe.sh` has three refusal branches. The wall-clock and
node-ceiling branches each had a self-test arm asserting their **own** discriminating message;
the test-only `PROBE_TEST_DESCENDANT_FAILURE` branch did not — the only arm driving it asserted
the *caller's* wrapper `process-tree discovery failed`. So the ` (test stub)` suffix, whose whole
purpose is to tell a stubbed refusal apart from a real one in a log, was held by a static grep in
an old sprint plan and by nothing behavioural.

This adds **one** `expect_failure` arm. The production probe is **not modified**
(sha256 unchanged at `f0b5e024…aabc99`).

## Why it is not vacuous

Measured before the change, on a copy driven via `PROBE_UNDER_TEST`: stripping the suffix left the
suite `rc=0` / 42 ok — the mutant **survived**. The same-scope known-positive control (stripping
` (wall clock)` instead) gave `rc=1` with the wall-clock arm failing by name, so the harness fires
for this class of edit.

After the change, three mutants, each a separate executable copy asserted LANDED (sha256 moved),
PARSING (`bash -n` rc=0), mode 755, and effect-verified against the system's own view:

| mutant | verdict |
|---|---|
| strip ` (test stub)` | `rc=1`, the new arm fails **by name** |
| reword to ` (stub)` | `rc=1`, the new arm fails **by name** |
| strip ` (wall clock)` (control) | `rc=1`, new arm passes first, wall-clock arm fails by name |

Every mutant **alters or removes** the asserted substring rather than appending around it —
`expect_failure` matches with `grep -Fq`, so an append-shaped mutant is vacuous by construction.
That correction came from the design quorum and is measured in the doc.

## Arm placement — the reviewer's finding, and the measurement that answers it

The independent evaluator (sonnet, its own worktree, distinct provider from the codex executor)
returned **PASS 76/100** with one blocking finding: the arm as first written sat **ahead of every
wall-clock-bounded arm**, so it added a fork/exec before the 4s `refusing live path` arm and before
`production run_lane fixture readiness`, nudging them toward their bounds under host contention. It
reproduced one of the controller's two intermittent reds **verbatim**.

Measured three ways against one probe, interleaved, five rounds, test file the only variable:

| variant | arm position | result |
|---|---|---|
| base | — | **5/5 green** |
| arm after the caller arm | 26 of 43 | **4/5 green** |
| arm after the node-ceiling arm | 42 of 43 | **5/5 green** |

Pooled with the controller's earlier runs and the judge's own A/B: base **0 reds in 17**,
arm-at-26 **4 in 19**, arm-at-42 **0 in 5**.

The arm moved behind the bounded arms. The point is the **mechanism**, not the rate — those arms now
start at the same wall-clock offset as at base, so the effect is unreachable by construction rather
than merely unlikely. Cost: none. 43 ok, and the strip mutant still reds with this arm as the sole
failing arm by name.

Adjacency turned out to buy nothing: the harness is fail-fast (`expect_failure` ends in `exit 1`), so
any mutant reddening the caller arm masks the later one at any distance. *Beside-not-instead-of* still
holds — two distinct strings, two distinct pins — it just means "both present", not "adjacent".

**Honest residual:** this does not make the suite flake-free. One run at the new placement also hit the
readiness arm. It removes one contributor to a pre-existing fragility whose real fix is row 6p's —
derive those bounds from a stimulus measured in-test rather than from wall-clock constants calibrated
on a quiet machine.

## Gates

`bash -n` rc=0 both files · full suite `rc=0`, **43 ok**, 0 not ok, `PASS: 43 probe self-test arms ran`
· refusal-branch drift gate green with `expected_refusal_branches` **unchanged at 28** (a self-test arm
is not a production branch; only the gate's own arm number moves 42 → 43).

All local readings are **darwin/arm64, GNU bash 3.2.57**, with `/usr/sbin` on PATH. The windows and
ubuntu legs are unrun locally; `launchd drivers (bash 3.2)` is the only place the runner's behaviour
is observable.

## Provenance

Design quorum BLOCKED twice (r1 3/3 reject, $0.0628; r2 2 reject / 1 pass, $0.0875), zero absentees
both rounds. Every round-1 objection was a *premise* objection and was measured rather than forwarded
— one was refuted outright. The two round-2 survivors carried concrete reviewer-authored fixes and
disputed no design direction, so the narrow-refinement carve-out applied and their fixes are in
verbatim. Designer `pi:ollama/deepseek-v4-flash:0731-cloud`, planner `opus`, executor
`codex:gpt-5.6-sol`, evaluator `sonnet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
