### PR TITLE
fix(pipeline): verify compile-cache artifacts against the key that authorizes them (M1 of 4)

### DIFF
--- a/internal/pipeline/cache_artifacts.go
+++ b/internal/pipeline/cache_artifacts.go
@@ -1,0 +1,402 @@
+package pipeline
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/gob"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/sunholo-data/ailang/internal/core"
+	"github.com/sunholo-data/ailang/internal/iface"
+	"github.com/sunholo-data/ailang/internal/types"
+)
+
+const (
+	artifactStampName        = "artifacts.json"
+	artifactCoreName         = "core.gob"
+	artifactCoreTIName       = "coretypeinfo.gob"
+	artifactIfaceName        = "iface.json"
+	artifactConstructorsName = "constructors.json"
+
+	maxArtifactBlobBytes   int64 = 16 << 20
+	maxArtifactStampBytes  int64 = 64 << 10
+	maxModuleArtifactBytes int64 = 32 << 20
+
+	artifactInvalidReason  = "ARTIFACT_INVALID"
+	artifactTooLargeReason = "ARTIFACT_TOO_LARGE"
+)
+
+type artifactStamp struct {
+	Version  string            `json:"version"`
+	ModuleID string            `json:"module_id"`
+	CacheKey string            `json:"cache_key"`
+	SHA256   map[string]string `json:"sha256"`
+}
+
+type artifactLimits struct {
+	blob   int64
+	stamp  int64
+	module int64
+}
+
+func productionArtifactLimits() artifactLimits {
+	return artifactLimits{
+		blob:   maxArtifactBlobBytes,
+		stamp:  maxArtifactStampBytes,
+		module: maxModuleArtifactBytes,
+	}
+}
+
+type artifactReadFile interface {
+	io.Reader
+	Stat() (fs.FileInfo, error)
+	Close() error
+}
+
+type artifactTempFile interface {
+	io.Writer
+	Close() error
+	Name() string
+}
+
+type cacheArtifactIO struct {
+	open       func(string) (artifactReadFile, error)
+	mkdirAll   func(string, fs.FileMode) error
+	writeFile  func(string, []byte, fs.FileMode) error
+	createTemp func(string, string) (artifactTempFile, error)
+	rename     func(string, string) error
+	remove     func(string) error
+}
+
+func productionCacheArtifactIO() cacheArtifactIO {
+	return cacheArtifactIO{
+		open: func(path string) (artifactReadFile, error) {
+			return os.Open(path)
+		},
+		mkdirAll:  os.MkdirAll,
+		writeFile: os.WriteFile,
+		createTemp: func(dir, pattern string) (artifactTempFile, error) {
+			return os.CreateTemp(dir, pattern)
+		},
+		rename: os.Rename,
+		remove: os.Remove,
+	}
+}
+
+type cacheArtifactCodec struct {
+	encodeCore         func(*core.Program) ([]byte, error)
+	encodeCoreTI       func(types.CoreTypeInfo) ([]byte, error)
+	encodeIface        func(*iface.Iface) ([]byte, error)
+	encodeConstructors func(map[string]*ConstructorInfo) ([]byte, error)
+	decodeCore         func([]byte) (*core.Program, error)
+	decodeCoreTI       func([]byte) (types.CoreTypeInfo, error)
+	decodeIface        func([]byte) (*iface.Iface, error)
+	decodeConstructors func([]byte) (map[string]*ConstructorInfo, error)
+}
+
+func productionCacheArtifactCodec() cacheArtifactCodec {
+	return cacheArtifactCodec{
+		encodeCore: func(program *core.Program) ([]byte, error) {
+			var buf bytes.Buffer
+			err := gob.NewEncoder(&buf).Encode(program)
+			return buf.Bytes(), err
+		},
+		encodeCoreTI: func(info types.CoreTypeInfo) ([]byte, error) {
+			var buf bytes.Buffer
+			err := gob.NewEncoder(&buf).Encode(info)
+			return buf.Bytes(), err
+		},
+		encodeIface:        marshalIfaceFull,
+		encodeConstructors: marshalConstructors,
+		decodeCore: func(data []byte) (*core.Program, error) {
+			var program core.Program
+			err := gob.NewDecoder(bytes.NewReader(data)).Decode(&program)
+			return &program, err
+		},
+		decodeCoreTI: func(data []byte) (types.CoreTypeInfo, error) {
+			var info types.CoreTypeInfo
+			err := gob.NewDecoder(bytes.NewReader(data)).Decode(&info)
+			return info, err
+		},
+		decodeIface:        unmarshalIfaceFull,
+		decodeConstructors: unmarshalConstructors,
+	}
+}
+
+type cacheArtifactError struct {
+	Reason     string
+	Stage      string
+	Path       string
+	Scope      string
+	LimitBytes int64
+	Err        error
+}
+
+func (e *cacheArtifactError) Error() string {
+	if e.Err == nil {
+		return fmt.Sprintf("%s: %s", e.Reason, e.Path)
+	}
+	return fmt.Sprintf("%s: %s: %v", e.Reason, e.Path, e.Err)
+}
+
+func (e *cacheArtifactError) Unwrap() error { return e.Err }
+
+func artifactFailure(stage, path string, err error) error {
+	return &cacheArtifactError{
+		Reason: artifactInvalidReason,
+		Stage:  stage,
+		Path:   path,
+		Err:    err,
+	}
+}
+
+func artifactTooLarge(stage, path, scope string, limit int64) error {
+	return &cacheArtifactError{
+		Reason:     artifactTooLargeReason,
+		Stage:      stage,
+		Path:       path,
+		Scope:      scope,
+		LimitBytes: limit,
+		Err:        fmt.Errorf("artifact exceeds %s byte limit", scope),
+	}
+}
+
+type encodedArtifact struct {
+	name string
+	data []byte
+}
+
+func (cs *CacheStore) encodeArtifacts(moduleID string, cm *CachedModule) ([]encodedArtifact, error) {
+	encoders := []struct {
+		name string
+		fn   func() ([]byte, error)
+	}{
+		{artifactCoreName, func() ([]byte, error) { return cs.artifactCodec.encodeCore(cm.Core) }},
+		{artifactCoreTIName, func() ([]byte, error) { return cs.artifactCodec.encodeCoreTI(cm.CoreTI) }},
+		{artifactIfaceName, func() ([]byte, error) { return cs.artifactCodec.encodeIface(cm.Iface) }},
+		{artifactConstructorsName, func() ([]byte, error) { return cs.artifactCodec.encodeConstructors(cm.Constructors) }},
+	}
+
+	artifacts := make([]encodedArtifact, 0, len(encoders))
+	var accepted int64
+	for _, encoder := range encoders {
+		data, err := encoder.fn()
+		path := filepath.Join(cs.moduleArtifactDir(moduleID), encoder.name)
+		if err != nil {
+			return nil, artifactFailure("encoding", path, err)
+		}
+		if err := cs.checkArtifactSize("encoding", path, "blob", int64(len(data)), &accepted); err != nil {
+			return nil, err
+		}
+		artifacts = append(artifacts, encodedArtifact{name: encoder.name, data: data})
+	}
+	return artifacts, nil
+}
+
+func (cs *CacheStore) checkArtifactSize(stage, path, fileScope string, size int64, accepted *int64) error {
+	remaining := cs.artifactLimits.module - *accepted
+	limit, scope := bindingArtifactLimit(cs.artifactLimits.blob, remaining, fileScope)
+	if fileScope == "stamp" {
+		limit, scope = bindingArtifactLimit(cs.artifactLimits.stamp, remaining, fileScope)
+	}
+	if size > limit {
+		return artifactTooLarge(stage, path, scope, limit)
+	}
+	*accepted += size
+	return nil
+}
+
+func bindingArtifactLimit(fileLimit, remaining int64, fileScope string) (int64, string) {
+	if remaining < 0 {
+		remaining = 0
+	}
+	if fileLimit <= remaining {
+		return fileLimit, fileScope
+	}
+	return remaining, "module"
+}
+
+func (cs *CacheStore) storeArtifacts(moduleID, cacheKey string, cm *CachedModule) error {
+	if cacheKey == "" {
+		return artifactFailure("encoding", cs.moduleArtifactDir(moduleID), fmt.Errorf("empty cache key"))
+	}
+	artifacts, err := cs.encodeArtifacts(moduleID, cm)
+	if err != nil {
+		return err
+	}
+
+	digests := make(map[string]string, len(artifacts))
+	var accepted int64
+	for _, artifact := range artifacts {
+		accepted += int64(len(artifact.data))
+		sum := sha256.Sum256(artifact.data)
+		digests[artifact.name] = hex.EncodeToString(sum[:])
+	}
+	stampData, err := json.MarshalIndent(artifactStamp{
+		Version:  cacheKeyVersion,
+		ModuleID: moduleID,
+		CacheKey: cacheKey,
+		SHA256:   digests,
+	}, "", "  ")
+	stampPath := filepath.Join(cs.moduleArtifactDir(moduleID), artifactStampName)
+	if err != nil {
+		return artifactFailure("encoding", stampPath, err)
+	}
+	if err := cs.checkArtifactSize("encoding", stampPath, "stamp", int64(len(stampData)), &accepted); err != nil {
+		return err
+	}
+
+	modDir := cs.moduleArtifactDir(moduleID)
+	if err := cs.artifactIO.mkdirAll(modDir, 0o755); err != nil {
+		return artifactFailure("publication", modDir, err)
+	}
+	for _, artifact := range artifacts {
+		path := filepath.Join(modDir, artifact.name)
+		if err := cs.artifactIO.writeFile(path, artifact.data, 0o644); err != nil {
+			return artifactFailure("publication", path, err)
+		}
+	}
+
+	tmp, err := cs.artifactIO.createTemp(modDir, ".artifacts-*.tmp")
+	if err != nil {
+		return artifactFailure("publication", stampPath, err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = cs.artifactIO.remove(tmpPath) }
+	if n, writeErr := tmp.Write(stampData); writeErr != nil || n != len(stampData) {
+		if writeErr == nil {
+			writeErr = io.ErrShortWrite
+		}
+		_ = tmp.Close()
+		cleanup()
+		return artifactFailure("publication", tmpPath, writeErr)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return artifactFailure("publication", tmpPath, err)
+	}
+	if err := cs.artifactIO.rename(tmpPath, stampPath); err != nil {
+		cleanup()
+		return artifactFailure("publication", stampPath, err)
+	}
+	return nil
+}
+
+func (cs *CacheStore) loadArtifacts(moduleID, expectedCacheKey string) (*CachedModule, error) {
+	modDir := cs.moduleArtifactDir(moduleID)
+	stampPath := filepath.Join(modDir, artifactStampName)
+	var accepted int64
+	stampData, err := cs.readBoundedArtifact(stampPath, cs.artifactLimits.stamp, "stamp", &accepted)
+	if err != nil {
+		return nil, err
+	}
+	var stamp artifactStamp
+	if err := json.Unmarshal(stampData, &stamp); err != nil {
+		return nil, artifactFailure("verification", stampPath, err)
+	}
+	if expectedCacheKey == "" || stamp.Version != cacheKeyVersion || stamp.ModuleID != moduleID || stamp.CacheKey != expectedCacheKey {
+		return nil, artifactFailure("verification", stampPath, fmt.Errorf("stamp authorization mismatch"))
+	}
+	if err := validateArtifactDigests(stamp.SHA256); err != nil {
+		return nil, artifactFailure("verification", stampPath, err)
+	}
+
+	artifacts := make(map[string][]byte, 4)
+	for _, name := range artifactPayloadNames() {
+		path := filepath.Join(modDir, name)
+		data, readErr := cs.readBoundedArtifact(path, cs.artifactLimits.blob, "blob", &accepted)
+		if readErr != nil {
+			return nil, readErr
+		}
+		artifacts[name] = data
+	}
+	for _, name := range artifactPayloadNames() {
+		sum := sha256.Sum256(artifacts[name])
+		if hex.EncodeToString(sum[:]) != stamp.SHA256[name] {
+			return nil, artifactFailure("verification", filepath.Join(modDir, name), fmt.Errorf("SHA-256 mismatch"))
+		}
+	}
+
+	program, err := cs.artifactCodec.decodeCore(artifacts[artifactCoreName])
+	if err != nil {
+		return nil, artifactFailure("decoding", filepath.Join(modDir, artifactCoreName), err)
+	}
+	coreTI, err := cs.artifactCodec.decodeCoreTI(artifacts[artifactCoreTIName])
+	if err != nil {
+		return nil, artifactFailure("decoding", filepath.Join(modDir, artifactCoreTIName), err)
+	}
+	ifc, err := cs.artifactCodec.decodeIface(artifacts[artifactIfaceName])
+	if err != nil {
+		return nil, artifactFailure("decoding", filepath.Join(modDir, artifactIfaceName), err)
+	}
+	constructors, err := cs.artifactCodec.decodeConstructors(artifacts[artifactConstructorsName])
+	if err != nil {
+		return nil, artifactFailure("decoding", filepath.Join(modDir, artifactConstructorsName), err)
+	}
+	return &CachedModule{Core: program, CoreTI: coreTI, Iface: ifc, Constructors: constructors}, nil
+}
+
+func (cs *CacheStore) readBoundedArtifact(path string, fileLimit int64, fileScope string, accepted *int64) ([]byte, error) {
+	remaining := cs.artifactLimits.module - *accepted
+	limit, scope := bindingArtifactLimit(fileLimit, remaining, fileScope)
+	file, err := cs.artifactIO.open(path)
+	if err != nil {
+		return nil, artifactFailure("verification", path, err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, artifactFailure("verification", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		_ = file.Close()
+		return nil, artifactFailure("verification", path, fmt.Errorf("not a regular file"))
+	}
+	if info.Size() > limit {
+		_ = file.Close()
+		return nil, artifactTooLarge("verification", path, scope, limit)
+	}
+	data, readErr := io.ReadAll(io.LimitReader(file, limit+1))
+	closeErr := file.Close()
+	if readErr != nil {
+		return nil, artifactFailure("verification", path, readErr)
+	}
+	if closeErr != nil {
+		return nil, artifactFailure("verification", path, closeErr)
+	}
+	if int64(len(data)) > limit {
+		return nil, artifactTooLarge("verification", path, scope, limit)
+	}
+	*accepted += int64(len(data))
+	return data, nil
+}
+
+func validateArtifactDigests(digests map[string]string) error {
+	if len(digests) != 4 {
+		return fmt.Errorf("stamp must contain exactly four payload digests")
+	}
+	for _, name := range artifactPayloadNames() {
+		digest, ok := digests[name]
+		if !ok || len(digest) != sha256.Size*2 {
+			return fmt.Errorf("missing or malformed digest for %s", name)
+		}
+		if _, err := hex.DecodeString(digest); err != nil {
+			return fmt.Errorf("malformed digest for %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func artifactPayloadNames() [4]string {
+	return [4]string{artifactCoreName, artifactCoreTIName, artifactIfaceName, artifactConstructorsName}
+}
+
+func (cs *CacheStore) moduleArtifactDir(moduleID string) string {
+	return filepath.Join(cs.dir, "modules", sanitizeModuleID(moduleID))
+}

--- a/internal/pipeline/cache_artifacts_test.go
+++ b/internal/pipeline/cache_artifacts_test.go
@@ -1,0 +1,578 @@
+package pipeline
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sunholo-data/ailang/internal/core"
+	"github.com/sunholo-data/ailang/internal/iface"
+	"github.com/sunholo-data/ailang/internal/types"
+)
+
+func TestCacheArtifacts_Authorization(t *testing.T) {
+	const moduleID = "auth/module"
+	const cacheKey = "caller-computed-key"
+
+	t.Run("valid", func(t *testing.T) {
+		cs := newArtifactTestStore(t)
+		mustStoreArtifacts(t, cs, moduleID, cacheKey, testCachedModule(moduleID, 42))
+		got, err := cs.LoadArtifacts(moduleID, cacheKey)
+		if err != nil {
+			t.Fatalf("valid artifacts rejected: %v", err)
+		}
+		if gotValue := cachedLiteral(t, got); gotValue != 42 {
+			t.Fatalf("cached value = %d, want 42", gotValue)
+		}
+	})
+
+	cases := []struct {
+		name   string
+		mutate func(t *testing.T, cs *CacheStore, stampPath string)
+		key    string
+	}{
+		{"missing_stamp", func(t *testing.T, _ *CacheStore, path string) { mustRemove(t, path) }, cacheKey},
+		{"corrupt_stamp", func(t *testing.T, _ *CacheStore, path string) { mustWriteArtifactTest(t, path, []byte("{")) }, cacheKey},
+		{"wrong_version", mutateStamp(func(stamp *artifactStamp) { stamp.Version = "v3" }), cacheKey},
+		{"empty_stored_key", mutateStamp(func(stamp *artifactStamp) { stamp.CacheKey = "" }), cacheKey},
+		{"wrong_stored_key", mutateStamp(func(stamp *artifactStamp) { stamp.CacheKey = "other" }), cacheKey},
+		{"wrong_expected_key", func(*testing.T, *CacheStore, string) {}, "other"},
+		{"wrong_module", mutateStamp(func(stamp *artifactStamp) { stamp.ModuleID = "other/module" }), cacheKey},
+		{"extra_digest", mutateStamp(func(stamp *artifactStamp) { stamp.SHA256["extra"] = strings.Repeat("0", 64) }), cacheKey},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := newArtifactTestStore(t)
+			mustStoreArtifacts(t, cs, moduleID, cacheKey, testCachedModule(moduleID, 42))
+			stampPath := filepath.Join(cs.moduleArtifactDir(moduleID), artifactStampName)
+			tc.mutate(t, cs, stampPath)
+			if got, err := cs.LoadArtifacts(moduleID, tc.key); err == nil || got != nil {
+				t.Fatalf("unauthorized artifacts loaded: got=%v err=%v", got, err)
+			}
+		})
+	}
+
+	t.Run("sanitized_collision_uses_exact_module_id", func(t *testing.T) {
+		cs := newArtifactTestStore(t)
+		mustStoreArtifacts(t, cs, "a/b", cacheKey, testCachedModule("a/b", 42))
+		if sanitizeModuleID("a/b") != sanitizeModuleID("a__b") {
+			t.Fatal("fixture does not exercise the known directory collision")
+		}
+		if got, err := cs.LoadArtifacts("a__b", cacheKey); err == nil || got != nil {
+			t.Fatalf("colliding module ID loaded another module: got=%v err=%v", got, err)
+		}
+	})
+}
+
+func TestCacheArtifacts_PartialWrite(t *testing.T) {
+	const moduleID = "partial/module"
+	const keyA = "key-a"
+	const keyB = "key-b"
+
+	t.Run("well_formed_blob_substitution_and_missing_digests", func(t *testing.T) {
+		for _, name := range artifactPayloadNames() {
+			t.Run(name, func(t *testing.T) {
+				csA := newArtifactTestStore(t)
+				csB := newArtifactTestStore(t)
+				mustStoreArtifacts(t, csA, moduleID, keyA, testCachedModule(moduleID, 42))
+				mustStoreArtifacts(t, csB, moduleID, keyB, testCachedModule(moduleID, 99))
+				data := mustRead(t, filepath.Join(csB.moduleArtifactDir(moduleID), name))
+				mustWriteArtifactTest(t, filepath.Join(csA.moduleArtifactDir(moduleID), name), data)
+				if got, err := csA.LoadArtifacts(moduleID, keyA); err == nil || got != nil {
+					t.Fatalf("substituted %s was accepted", name)
+				}
+			})
+
+			t.Run("missing_"+name, func(t *testing.T) {
+				cs := newArtifactTestStore(t)
+				mustStoreArtifacts(t, cs, moduleID, keyA, testCachedModule(moduleID, 42))
+				path := filepath.Join(cs.moduleArtifactDir(moduleID), artifactStampName)
+				mutateStamp(func(stamp *artifactStamp) { delete(stamp.SHA256, name) })(t, cs, path)
+				if got, err := cs.LoadArtifacts(moduleID, keyA); err == nil || got != nil {
+					t.Fatalf("stamp missing %s digest was accepted", name)
+				}
+			})
+		}
+	})
+
+	t.Run("encoding_failure_preserves_A", func(t *testing.T) {
+		for _, stage := range artifactPayloadNames() {
+			t.Run(stage, func(t *testing.T) {
+				cs := newArtifactTestStore(t)
+				mustStoreArtifacts(t, cs, moduleID, keyA, testCachedModule(moduleID, 42))
+				injectEncodingFailure(&cs.artifactCodec, stage)
+				if err := cs.StoreArtifacts(moduleID, keyB, testCachedModule(moduleID, 99)); err == nil {
+					t.Fatal("injected encoding failure returned nil")
+				}
+				got, err := cs.LoadArtifacts(moduleID, keyA)
+				if err != nil || cachedLiteral(t, got) != 42 {
+					t.Fatalf("encoding failure disturbed A: got=%v err=%v", got, err)
+				}
+			})
+		}
+	})
+
+	t.Run("publication_interruption_never_authorizes_B", func(t *testing.T) {
+		names := artifactPayloadNames()
+		stages := append(names[:], "stamp_close", "stamp_rename")
+		for _, stage := range stages {
+			t.Run(stage, func(t *testing.T) {
+				cs := newArtifactTestStore(t)
+				mustStoreArtifacts(t, cs, moduleID, keyA, testCachedModule(moduleID, 42))
+				injectPublicationFailure(cs, stage)
+				if err := cs.StoreArtifacts(moduleID, keyB, testCachedModule(moduleID, 99)); err == nil {
+					t.Fatal("injected publication failure returned nil")
+				}
+				if got, err := cs.LoadArtifacts(moduleID, keyB); err == nil || got != nil {
+					t.Fatalf("partial B publication was authorized: got=%v err=%v", got, err)
+				}
+				if got, err := cs.LoadArtifacts(moduleID, keyA); err == nil && cachedLiteral(t, got) != 42 {
+					t.Fatalf("old key decoded mixed/new value %d", cachedLiteral(t, got))
+				}
+			})
+		}
+	})
+
+	cs := newArtifactTestStore(t)
+	mustStoreArtifacts(t, cs, moduleID, keyA, testCachedModule(moduleID, 42))
+	if got, err := cs.LoadArtifacts(moduleID, keyA); err != nil || cachedLiteral(t, got) != 42 {
+		t.Fatalf("untouched A control failed: got=%v err=%v", got, err)
+	}
+}
+
+func TestCacheArtifacts_ReadSnapshot(t *testing.T) {
+	const moduleID = "snapshot/module"
+	const key = "snapshot-key"
+	cs := newArtifactTestStore(t)
+	mustStoreArtifacts(t, cs, moduleID, key, testCachedModule(moduleID, 42))
+
+	other := newArtifactTestStore(t)
+	mustStoreArtifacts(t, other, moduleID, "other-key", testCachedModule(moduleID, 99))
+	replacement := mustRead(t, filepath.Join(other.moduleArtifactDir(moduleID), artifactCoreName))
+	corePath := filepath.Join(cs.moduleArtifactDir(moduleID), artifactCoreName)
+
+	originalOpen := cs.artifactIO.open
+	mutated := false
+	cs.artifactIO.open = func(path string) (artifactReadFile, error) {
+		file, err := originalOpen(path)
+		if err != nil || path != corePath {
+			return file, err
+		}
+		return &afterCloseArtifactFile{artifactReadFile: file, after: func() {
+			if !mutated {
+				mutated = true
+				mustWriteArtifactTest(t, corePath, replacement)
+			}
+		}}, nil
+	}
+
+	got, err := cs.LoadArtifacts(moduleID, key)
+	if err != nil {
+		t.Fatalf("verified snapshot rejected after disk mutation: %v", err)
+	}
+	if value := cachedLiteral(t, got); value != 42 {
+		t.Fatalf("decoded reopened/unverified bytes: got %d, want verified snapshot 42", value)
+	}
+	if !mutated {
+		t.Fatal("test seam did not mutate disk after the verified read")
+	}
+}
+
+func TestCacheArtifacts_ByteLimits(t *testing.T) {
+	if maxArtifactBlobBytes != 16<<20 || maxArtifactStampBytes != 64<<10 || maxModuleArtifactBytes != 32<<20 {
+		t.Fatalf("production limits changed: blob=%d stamp=%d module=%d", maxArtifactBlobBytes, maxArtifactStampBytes, maxModuleArtifactBytes)
+	}
+
+	t.Run("oversized_blob_rejected_by_stat_without_read", func(t *testing.T) {
+		cs := newArtifactTestStore(t)
+		mustStoreArtifacts(t, cs, "limits/module", "limits-key", testCachedModule("limits/module", 42))
+		path := filepath.Join(cs.moduleArtifactDir("limits/module"), artifactCoreName)
+		if err := os.Truncate(path, maxArtifactBlobBytes+1); err != nil {
+			t.Fatalf("create sparse oversized blob: %v", err)
+		}
+		reads := 0
+		originalOpen := cs.artifactIO.open
+		cs.artifactIO.open = func(openPath string) (artifactReadFile, error) {
+			file, err := originalOpen(openPath)
+			if err != nil || openPath != path {
+				return file, err
+			}
+			return &countingArtifactFile{artifactReadFile: file, reads: &reads}, nil
+		}
+		_, err := cs.LoadArtifacts("limits/module", "limits-key")
+		assertArtifactTooLarge(t, err, "blob", maxArtifactBlobBytes)
+		if reads != 0 {
+			t.Fatalf("oversized stat still read payload %d times", reads)
+		}
+	})
+
+	t.Run("stamp_and_aggregate_scopes", func(t *testing.T) {
+		cs := newArtifactTestStore(t)
+		mustStoreArtifacts(t, cs, "limits/module", "limits-key", testCachedModule("limits/module", 42))
+		stampPath := filepath.Join(cs.moduleArtifactDir("limits/module"), artifactStampName)
+		mustWriteArtifactTest(t, stampPath, bytes.Repeat([]byte(" "), int(maxArtifactStampBytes+1)))
+		_, err := cs.LoadArtifacts("limits/module", "limits-key")
+		assertArtifactTooLarge(t, err, "stamp", maxArtifactStampBytes)
+
+		mustStoreArtifacts(t, cs, "limits/module", "limits-key", testCachedModule("limits/module", 42))
+		stampPath = filepath.Join(cs.moduleArtifactDir("limits/module"), artifactStampName)
+		stamp := readArtifactStamp(t, stampPath)
+		for _, name := range []string{artifactIfaceName, artifactConstructorsName} {
+			path := filepath.Join(cs.moduleArtifactDir("limits/module"), name)
+			data := mustRead(t, path)
+			data = append(data, bytes.Repeat([]byte(" "), int(maxArtifactBlobBytes)-len(data))...)
+			mustWriteArtifactTest(t, path, data)
+			sum := sha256.Sum256(data)
+			stamp.SHA256[name] = fmt.Sprintf("%x", sum)
+		}
+		stampData, marshalErr := json.Marshal(stamp)
+		if marshalErr != nil {
+			t.Fatal(marshalErr)
+		}
+		mustWriteArtifactTest(t, stampPath, stampData)
+		_, err = cs.LoadArtifacts("limits/module", "limits-key")
+		assertArtifactTooLarge(t, err, "module", 0)
+	})
+
+	t.Run("limit_reader_uses_extra_byte_sentinel", func(t *testing.T) {
+		cs := newArtifactTestStore(t)
+		cs.artifactLimits = artifactLimits{blob: 4, stamp: 4, module: 8}
+		cs.artifactIO.open = func(string) (artifactReadFile, error) {
+			return newMemoryArtifactFile([]byte("1234"), 4, 0), nil
+		}
+		accepted := int64(0)
+		data, err := cs.readBoundedArtifact("exact", 4, "blob", &accepted)
+		if err != nil || string(data) != "1234" {
+			t.Fatalf("exact limit with clean EOF rejected: data=%q err=%v", data, err)
+		}
+
+		cs.artifactIO.open = func(string) (artifactReadFile, error) {
+			return newMemoryArtifactFile([]byte("12345"), 4, 0), nil
+		}
+		accepted = 0
+		_, err = cs.readBoundedArtifact("grew-after-stat", 4, "blob", &accepted)
+		assertArtifactTooLarge(t, err, "blob", 4)
+	})
+
+	t.Run("regular_files_and_hashes_precede_decode", func(t *testing.T) {
+		cs := newArtifactTestStore(t)
+		mustStoreArtifacts(t, cs, "limits/module", "limits-key", testCachedModule("limits/module", 42))
+		decoded := 0
+		originalDecode := cs.artifactCodec.decodeCore
+		cs.artifactCodec.decodeCore = func(data []byte) (*core.Program, error) {
+			decoded++
+			return originalDecode(data)
+		}
+		ctorPath := filepath.Join(cs.moduleArtifactDir("limits/module"), artifactConstructorsName)
+		mustWriteArtifactTest(t, ctorPath, []byte(`{"corrupt":true}`))
+		if got, err := cs.LoadArtifacts("limits/module", "limits-key"); err == nil || got != nil {
+			t.Fatal("hash-mismatching payload was accepted")
+		}
+		if decoded != 0 {
+			t.Fatalf("decoded %d payloads before every hash passed", decoded)
+		}
+
+		originalOpen := cs.artifactIO.open
+		cs.artifactIO.open = func(path string) (artifactReadFile, error) {
+			file, err := originalOpen(path)
+			if err != nil || filepath.Base(path) != artifactCoreName {
+				return file, err
+			}
+			return &modeArtifactFile{artifactReadFile: file, mode: fs.ModeDir}, nil
+		}
+		if got, err := cs.LoadArtifacts("limits/module", "limits-key"); err == nil || got != nil {
+			t.Fatal("non-regular payload was accepted")
+		}
+	})
+
+	t.Run("oversized_publication_is_non_authorizing", func(t *testing.T) {
+		cs := newArtifactTestStore(t)
+		cs.artifactLimits.blob = 1
+		var warnings bytes.Buffer
+		runtime := &cacheRuntime{store: cs, stderr: &warnings, invalidWarned: make(map[string]bool), writeWarned: make(map[string]bool)}
+		published := runtime.publish("large/module", "large-key", &CacheEntry{CacheKey: "large-key"}, testCachedModule("large/module", 42))
+		if published {
+			t.Fatal("oversized artifact publication reported success")
+		}
+		if _, ok := cs.Lookup("large/module", "large-key"); ok {
+			t.Fatal("oversized artifacts published a manifest entry")
+		}
+		if !strings.Contains(warnings.String(), "CACHE_WRITE_FAILED") || !strings.Contains(warnings.String(), "stage=encoding") {
+			t.Fatalf("missing encoding warning: %q", warnings.String())
+		}
+	})
+
+	t.Run("pipeline_miss_repairs_oversized_blob_then_hits", func(t *testing.T) {
+		root := t.TempDir()
+		t.Chdir(root)
+		t.Setenv("AILANG_CACHE_DIR", "")
+		mustWriteArtifactTest(t, "answer.ail", []byte("module answer\nexport pure func main() -> int = 42\n"))
+		cfg := Config{Mode: ModeCheck}
+		if _, err := runModuleWithCacheDependencies(t.Context(), cfg, Source{Filename: "answer.ail"}, productionCacheDependencies()); err != nil {
+			t.Fatalf("warm compile: %v", err)
+		}
+		cacheDir := filepath.Join(root, ".ailang", "cache", "compile")
+		corePath := filepath.Join(cacheDir, "modules", "answer", artifactCoreName)
+		if err := os.Truncate(corePath, maxArtifactBlobBytes+1); err != nil {
+			t.Fatalf("poison core: %v", err)
+		}
+		var warnings bytes.Buffer
+		deps := cacheDependencies{newStore: NewCacheStore, stderr: &warnings}
+		result, err := runModuleWithCacheDependencies(t.Context(), cfg, Source{Filename: "answer.ail"}, deps)
+		if err != nil || result.Interface == nil {
+			t.Fatalf("oversized cache miss did not compile fresh: iface=%v err=%v", result.Interface, err)
+		}
+		if warning := warnings.String(); !strings.Contains(warning, "CACHE_INVALID module=answer") || !strings.Contains(warning, "reason=ARTIFACT_TOO_LARGE scope=blob") {
+			t.Fatalf("missing overflow diagnostic: %q", warning)
+		}
+
+		decodeCount := 0
+		hitDeps := cacheDependencies{stderr: io.Discard, newStore: func(projectDir string) (*CacheStore, error) {
+			store, openErr := NewCacheStore(projectDir)
+			if openErr == nil {
+				decode := store.artifactCodec.decodeCore
+				store.artifactCodec.decodeCore = func(data []byte) (*core.Program, error) {
+					decodeCount++
+					return decode(data)
+				}
+			}
+			return store, openErr
+		}}
+		if _, err := runModuleWithCacheDependencies(t.Context(), cfg, Source{Filename: "answer.ail"}, hitDeps); err != nil {
+			t.Fatalf("post-repair warm hit: %v", err)
+		}
+		if decodeCount == 0 {
+			t.Fatal("post-repair run did not decode any verified cached core")
+		}
+	})
+}
+
+func newArtifactTestStore(t *testing.T) *CacheStore {
+	t.Helper()
+	t.Setenv("AILANG_CACHE_DIR", "")
+	cs, err := NewCacheStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewCacheStore: %v", err)
+	}
+	return cs
+}
+
+func testCachedModule(moduleID string, value int) *CachedModule {
+	return &CachedModule{
+		Core: &core.Program{
+			Decls: []core.CoreExpr{&core.Lit{CoreNode: core.CoreNode{NodeID: 1}, Kind: core.IntLit, Value: value}},
+			Meta:  map[string]*core.DeclMeta{},
+			Flags: core.ProgramFlags{Lowered: true},
+		},
+		CoreTI: types.CoreTypeInfo{
+			1: &types.TCon{Name: "int"},
+			2: &types.TCon{Name: fmt.Sprintf("fixture-%d", value)},
+		},
+		Iface: &iface.Iface{
+			Module:       moduleID,
+			Schema:       "ailang.iface/v1",
+			Digest:       fmt.Sprintf("digest-%d", value),
+			Exports:      map[string]*iface.IfaceItem{},
+			Constructors: map[string]*iface.ConstructorScheme{},
+			Types:        map[string]*iface.TypeExport{},
+			TypeAliases:  map[string]types.Type{},
+			AliasParams:  map[string][]string{},
+		},
+		Constructors: map[string]*ConstructorInfo{
+			fmt.Sprintf("Fixture%d", value): {
+				TypeName: fmt.Sprintf("Fixture%d", value),
+				CtorName: fmt.Sprintf("Fixture%d", value),
+			},
+		},
+	}
+}
+
+func cachedLiteral(t *testing.T, cm *CachedModule) int {
+	t.Helper()
+	if cm == nil || cm.Core == nil || len(cm.Core.Decls) != 1 {
+		t.Fatalf("invalid cached fixture: %#v", cm)
+	}
+	lit, ok := cm.Core.Decls[0].(*core.Lit)
+	if !ok {
+		t.Fatalf("cached decl type = %T, want *core.Lit", cm.Core.Decls[0])
+	}
+	value, ok := lit.Value.(int)
+	if !ok {
+		t.Fatalf("cached literal value type = %T, want int", lit.Value)
+	}
+	return value
+}
+
+func mustStoreArtifacts(t *testing.T, cs *CacheStore, moduleID, key string, cm *CachedModule) {
+	t.Helper()
+	if err := cs.StoreArtifacts(moduleID, key, cm); err != nil {
+		t.Fatalf("StoreArtifacts: %v", err)
+	}
+}
+
+func mutateStamp(mutate func(*artifactStamp)) func(*testing.T, *CacheStore, string) {
+	return func(t *testing.T, _ *CacheStore, path string) {
+		t.Helper()
+		var stamp artifactStamp
+		if err := json.Unmarshal(mustRead(t, path), &stamp); err != nil {
+			t.Fatalf("read stamp: %v", err)
+		}
+		mutate(&stamp)
+		data, err := json.Marshal(stamp)
+		if err != nil {
+			t.Fatalf("marshal stamp: %v", err)
+		}
+		mustWriteArtifactTest(t, path, data)
+	}
+}
+
+func injectEncodingFailure(codec *cacheArtifactCodec, name string) {
+	fail := func() ([]byte, error) { return nil, os.ErrPermission }
+	switch name {
+	case artifactCoreName:
+		codec.encodeCore = func(*core.Program) ([]byte, error) { return fail() }
+	case artifactCoreTIName:
+		codec.encodeCoreTI = func(types.CoreTypeInfo) ([]byte, error) { return fail() }
+	case artifactIfaceName:
+		codec.encodeIface = func(*iface.Iface) ([]byte, error) { return fail() }
+	case artifactConstructorsName:
+		codec.encodeConstructors = func(map[string]*ConstructorInfo) ([]byte, error) { return fail() }
+	}
+}
+
+func injectPublicationFailure(cs *CacheStore, stage string) {
+	if stage == "stamp_close" {
+		create := cs.artifactIO.createTemp
+		cs.artifactIO.createTemp = func(dir, pattern string) (artifactTempFile, error) {
+			file, err := create(dir, pattern)
+			return &closeFailTempFile{artifactTempFile: file}, err
+		}
+		return
+	}
+	if stage == "stamp_rename" {
+		cs.artifactIO.rename = func(string, string) error { return os.ErrPermission }
+		return
+	}
+	write := cs.artifactIO.writeFile
+	cs.artifactIO.writeFile = func(path string, data []byte, mode fs.FileMode) error {
+		if filepath.Base(path) == stage {
+			return os.ErrPermission
+		}
+		return write(path, data, mode)
+	}
+}
+
+func assertArtifactTooLarge(t *testing.T, err error, scope string, limit int64) {
+	t.Helper()
+	var artifactErr *cacheArtifactError
+	if !errors.As(err, &artifactErr) {
+		t.Fatalf("error type = %T (%v), want cacheArtifactError", err, err)
+	}
+	if artifactErr.Reason != artifactTooLargeReason || artifactErr.Scope != scope {
+		t.Fatalf("overflow = reason %q scope %q, want %q/%q", artifactErr.Reason, artifactErr.Scope, artifactTooLargeReason, scope)
+	}
+	if limit != 0 && artifactErr.LimitBytes != limit {
+		t.Fatalf("overflow limit = %d, want %d", artifactErr.LimitBytes, limit)
+	}
+}
+
+func mustRead(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return data
+}
+
+func mustWriteArtifactTest(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func mustRemove(t *testing.T, path string) {
+	t.Helper()
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove %s: %v", path, err)
+	}
+}
+
+type afterCloseArtifactFile struct {
+	artifactReadFile
+	after func()
+}
+
+func (file *afterCloseArtifactFile) Close() error {
+	err := file.artifactReadFile.Close()
+	file.after()
+	return err
+}
+
+type countingArtifactFile struct {
+	artifactReadFile
+	reads *int
+}
+
+func (file *countingArtifactFile) Read(data []byte) (int, error) {
+	(*file.reads)++
+	return file.artifactReadFile.Read(data)
+}
+
+type modeArtifactFile struct {
+	artifactReadFile
+	mode fs.FileMode
+}
+
+func (file *modeArtifactFile) Stat() (fs.FileInfo, error) {
+	info, err := file.artifactReadFile.Stat()
+	if err != nil {
+		return nil, err
+	}
+	return fakeFileInfo{name: info.Name(), size: info.Size(), mode: file.mode}, nil
+}
+
+type closeFailTempFile struct{ artifactTempFile }
+
+func (file *closeFailTempFile) Close() error {
+	_ = file.artifactTempFile.Close()
+	return os.ErrPermission
+}
+
+type memoryArtifactFile struct {
+	*bytes.Reader
+	info fakeFileInfo
+}
+
+func newMemoryArtifactFile(data []byte, statSize int64, mode fs.FileMode) *memoryArtifactFile {
+	if mode == 0 {
+		mode = 0o644
+	}
+	return &memoryArtifactFile{Reader: bytes.NewReader(data), info: fakeFileInfo{name: "memory", size: statSize, mode: mode}}
+}
+
+func (file *memoryArtifactFile) Stat() (fs.FileInfo, error) { return file.info, nil }
+func (file *memoryArtifactFile) Close() error               { return nil }
+
+type fakeFileInfo struct {
+	name string
+	size int64
+	mode fs.FileMode
+}
+
+func (info fakeFileInfo) Name() string       { return info.name }
+func (info fakeFileInfo) Size() int64        { return info.size }
+func (info fakeFileInfo) Mode() fs.FileMode  { return info.mode }
+func (info fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (info fakeFileInfo) IsDir() bool        { return info.mode.IsDir() }
+func (info fakeFileInfo) Sys() any           { return nil }

--- a/internal/pipeline/cache_artifacts_test.go
+++ b/internal/pipeline/cache_artifacts_test.go
@@ -123,7 +123,9 @@ func TestCacheArtifacts_PartialWrite(t *testing.T) {
 
 	t.Run("publication_interruption_never_authorizes_B", func(t *testing.T) {
 		names := artifactPayloadNames()
-		stages := append(names[:], "stamp_close", "stamp_rename")
+		// "mkdir" covers the module-directory creation guard: without it, discarding
+		// mkdirAll's error leaves the whole package green.
+		stages := append(names[:], "stamp_close", "stamp_rename", "mkdir")
 		for _, stage := range stages {
 			t.Run(stage, func(t *testing.T) {
 				cs := newArtifactTestStore(t)
@@ -241,6 +243,43 @@ func TestCacheArtifacts_ByteLimits(t *testing.T) {
 		mustWriteArtifactTest(t, stampPath, stampData)
 		_, err = cs.LoadArtifacts("limits/module", "limits-key")
 		assertArtifactTooLarge(t, err, "module", 0)
+	})
+
+	t.Run("store_side_aggregate_module_ceiling", func(t *testing.T) {
+		// The read path's aggregate ceiling is covered by stamp_and_aggregate_scopes above;
+		// this arm covers the WRITE path, where checkArtifactSize charges each encoded blob
+		// against the same module budget. Without it, removing the aggregate term from
+		// checkArtifactSize leaves the whole package green.
+		measure := newArtifactTestStore(t)
+		mustStoreArtifacts(t, measure, "aggregate/module", "aggregate-key", testCachedModule("aggregate/module", 42))
+		var total int64
+		var largest int64
+		for _, name := range []string{artifactCoreName, artifactCoreTIName, artifactIfaceName, artifactConstructorsName} {
+			info, err := os.Stat(filepath.Join(measure.moduleArtifactDir("aggregate/module"), name))
+			if err != nil {
+				t.Fatalf("stat %s: %v", name, err)
+			}
+			total += info.Size()
+			if info.Size() > largest {
+				largest = info.Size()
+			}
+		}
+
+		cs := newArtifactTestStore(t)
+		// Every individual blob fits comfortably; only the sum exceeds the module budget.
+		cs.artifactLimits = artifactLimits{blob: largest * 2, stamp: maxArtifactStampBytes, module: total - 1}
+		err := cs.StoreArtifacts("aggregate/module", "aggregate-key", testCachedModule("aggregate/module", 42))
+		if err == nil {
+			t.Fatal("store accepted a module whose blobs collectively exceed the module ceiling")
+		}
+		assertArtifactTooLarge(t, err, "module", 0)
+		var artifactErr *cacheArtifactError
+		if errors.As(err, &artifactErr) && artifactErr.Stage != "encoding" {
+			t.Fatalf("aggregate overflow stage = %q, want encoding", artifactErr.Stage)
+		}
+		if _, ok := cs.Lookup("aggregate/module", "aggregate-key"); ok {
+			t.Fatal("rejected publication still produced a manifest entry")
+		}
 	})
 
 	t.Run("limit_reader_uses_extra_byte_sentinel", func(t *testing.T) {
@@ -460,6 +499,10 @@ func injectPublicationFailure(cs *CacheStore, stage string) {
 	}
 	if stage == "stamp_rename" {
 		cs.artifactIO.rename = func(string, string) error { return os.ErrPermission }
+		return
+	}
+	if stage == "mkdir" {
+		cs.artifactIO.mkdirAll = func(string, fs.FileMode) error { return os.ErrPermission }
 		return
 	}
 	write := cs.artifactIO.writeFile

--- a/internal/pipeline/cache_invalidation_test.go
+++ b/internal/pipeline/cache_invalidation_test.go
@@ -1,11 +1,228 @@
 package pipeline
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
+
+	"github.com/sunholo-data/ailang/internal/core"
 )
+
+func TestCacheArtifacts_Migration(t *testing.T) {
+	if cacheKeyVersion != "v4" {
+		t.Fatalf("cache key version = %q, want v4 migration boundary", cacheKeyVersion)
+	}
+
+	t.Run("v3_manifest_forces_cold_v4_publication", func(t *testing.T) {
+		root := t.TempDir()
+		t.Chdir(root)
+		t.Setenv("AILANG_CACHE_DIR", "")
+		writeCachePipelineSource(t, 99)
+		cfg := Config{Mode: ModeCheck}
+		if _, err := runModuleWithCacheDependencies(t.Context(), cfg, Source{Filename: "answer.ail"}, productionCacheDependencies()); err != nil {
+			t.Fatalf("seed cache: %v", err)
+		}
+
+		manifestPath := filepath.Join(root, ".ailang", "cache", "compile", "manifest.json")
+		manifest := readCacheManifest(t, manifestPath)
+		manifest.Version = "v3"
+		writeCacheManifest(t, manifestPath, manifest)
+
+		var warnings bytes.Buffer
+		result, err := runModuleWithCacheDependencies(t.Context(), cfg, Source{Filename: "answer.ail"}, cacheDependencies{newStore: NewCacheStore, stderr: &warnings})
+		if err != nil || result.Interface == nil || result.Interface.Exports["main"] == nil {
+			t.Fatalf("v3 migration did not compile current source: iface=%v err=%v", result.Interface, err)
+		}
+		migrated := readCacheManifest(t, manifestPath)
+		if migrated.Version != "v4" {
+			t.Fatalf("migrated manifest version = %q, want v4", migrated.Version)
+		}
+		stamp := readArtifactStamp(t, filepath.Join(root, ".ailang", "cache", "compile", "modules", "answer", artifactStampName))
+		if stamp.Version != "v4" || stamp.ModuleID != "answer" {
+			t.Fatalf("migrated stamp = %#v", stamp)
+		}
+	})
+
+	t.Run("current_manifest_with_legacy_unstamped_blobs_misses", func(t *testing.T) {
+		root := t.TempDir()
+		t.Chdir(root)
+		t.Setenv("AILANG_CACHE_DIR", "")
+		writeCachePipelineSource(t, 99)
+		cfg := Config{Mode: ModeCheck}
+		if _, err := runModuleWithCacheDependencies(t.Context(), cfg, Source{Filename: "answer.ail"}, productionCacheDependencies()); err != nil {
+			t.Fatalf("seed cache: %v", err)
+		}
+		stampPath := filepath.Join(root, ".ailang", "cache", "compile", "modules", "answer", artifactStampName)
+		mustRemove(t, stampPath)
+
+		var warnings bytes.Buffer
+		result, err := runModuleWithCacheDependencies(t.Context(), cfg, Source{Filename: "answer.ail"}, cacheDependencies{newStore: NewCacheStore, stderr: &warnings})
+		if err != nil || result.Interface == nil || result.Interface.Exports["main"] == nil {
+			t.Fatalf("unstamped legacy cache did not compile current source: iface=%v err=%v", result.Interface, err)
+		}
+		if !strings.Contains(warnings.String(), "CACHE_INVALID module=answer") {
+			t.Fatalf("legacy miss was silent: %q", warnings.String())
+		}
+		if stamp := readArtifactStamp(t, stampPath); stamp.Version != "v4" {
+			t.Fatalf("repaired stamp version = %q, want v4", stamp.Version)
+		}
+	})
+}
+
+func TestCachePipeline_WriteFailure(t *testing.T) {
+	t.Run("artifact_failure_keeps_fresh_result_and_manifest_unpublished", func(t *testing.T) {
+		root := t.TempDir()
+		t.Chdir(root)
+		t.Setenv("AILANG_CACHE_DIR", "")
+		writeCachePipelineSource(t, 42)
+		var warnings bytes.Buffer
+		var failedStore *CacheStore
+		deps := cacheDependencies{stderr: &warnings, newStore: func(projectDir string) (*CacheStore, error) {
+			store, err := NewCacheStore(projectDir)
+			if err != nil {
+				return nil, err
+			}
+			failedStore = store
+			write := store.artifactIO.writeFile
+			store.artifactIO.writeFile = func(path string, data []byte, mode os.FileMode) error {
+				if filepath.Base(filepath.Dir(path)) == "answer" && filepath.Base(path) == artifactCoreName {
+					return os.ErrPermission
+				}
+				return write(path, data, mode)
+			}
+			return store, nil
+		}}
+
+		result, err := runModuleWithCacheDependencies(t.Context(), Config{Mode: ModeCheck}, Source{Filename: "answer.ail"}, deps)
+		if err != nil || result.Interface == nil || result.Interface.Exports["main"] == nil {
+			t.Fatalf("optional artifact failure became fatal: iface=%v err=%v", result.Interface, err)
+		}
+		if failedStore == nil {
+			t.Fatal("cache factory was not invoked")
+		}
+		if _, ok := failedStore.Lookup("answer", readCacheKeyIfPresent(t, failedStore, "answer")); ok {
+			t.Fatal("failed artifact publication authorized answer in the manifest")
+		}
+		warning := warnings.String()
+		if !strings.Contains(warning, "CACHE_WRITE_FAILED module=answer stage=publication") || !strings.Contains(warning, "using fresh compilation") {
+			t.Fatalf("artifact failure diagnostic = %q", warning)
+		}
+
+		if _, err := runModuleWithCacheDependencies(t.Context(), Config{Mode: ModeCheck}, Source{Filename: "answer.ail"}, productionCacheDependencies()); err != nil {
+			t.Fatalf("restored publication: %v", err)
+		}
+		decoded := 0
+		hitDeps := cacheDependencies{stderr: io.Discard, newStore: func(projectDir string) (*CacheStore, error) {
+			store, openErr := NewCacheStore(projectDir)
+			if openErr == nil {
+				decode := store.artifactCodec.decodeCore
+				store.artifactCodec.decodeCore = func(data []byte) (*core.Program, error) {
+					decoded++
+					return decode(data)
+				}
+			}
+			return store, openErr
+		}}
+		if _, err := runModuleWithCacheDependencies(t.Context(), Config{Mode: ModeCheck}, Source{Filename: "answer.ail"}, hitDeps); err != nil {
+			t.Fatalf("restored warm hit: %v", err)
+		}
+		if decoded == 0 {
+			t.Fatal("restored cache was not used as a verified warm hit")
+		}
+	})
+
+	t.Run("initialization_failure_is_visible_and_nonfatal", func(t *testing.T) {
+		root := t.TempDir()
+		t.Chdir(root)
+		writeCachePipelineSource(t, 42)
+		var warnings bytes.Buffer
+		deps := cacheDependencies{
+			stderr: &warnings,
+			newStore: func(string) (*CacheStore, error) {
+				return nil, errors.New("injected initialization failure")
+			},
+		}
+		result, err := runModuleWithCacheDependencies(t.Context(), Config{Mode: ModeCheck}, Source{Filename: "answer.ail"}, deps)
+		if err != nil || result.Interface == nil || result.Interface.Exports["main"] == nil {
+			t.Fatalf("initialization failure became fatal: iface=%v err=%v", result.Interface, err)
+		}
+		if warning := warnings.String(); !strings.Contains(warning, "CACHE_WRITE_FAILED stage=initialization") {
+			t.Fatalf("initialization failure diagnostic = %q", warning)
+		}
+	})
+
+	t.Run("manifest_save_failure_is_visible_and_nonfatal", func(t *testing.T) {
+		root := t.TempDir()
+		t.Chdir(root)
+		t.Setenv("AILANG_CACHE_DIR", "")
+		writeCachePipelineSource(t, 42)
+		var warnings bytes.Buffer
+		deps := cacheDependencies{stderr: &warnings, newStore: func(projectDir string) (*CacheStore, error) {
+			store, err := NewCacheStore(projectDir)
+			if err == nil {
+				store.writeManifest = func(string, []byte, os.FileMode) error { return os.ErrPermission }
+			}
+			return store, err
+		}}
+		result, err := runModuleWithCacheDependencies(t.Context(), Config{Mode: ModeCheck}, Source{Filename: "answer.ail"}, deps)
+		if err != nil || result.Interface == nil || result.Interface.Exports["main"] == nil {
+			t.Fatalf("manifest save failure became fatal: iface=%v err=%v", result.Interface, err)
+		}
+		if warning := warnings.String(); !strings.Contains(warning, "CACHE_WRITE_FAILED stage=manifest_save") {
+			t.Fatalf("manifest save failure diagnostic = %q", warning)
+		}
+	})
+}
+
+func writeCachePipelineSource(t *testing.T, value int) {
+	t.Helper()
+	data := []byte("module answer\nexport pure func main() -> int = " + strconv.Itoa(value) + "\n")
+	if err := os.WriteFile("answer.ail", data, 0o644); err != nil {
+		t.Fatalf("write pipeline source: %v", err)
+	}
+}
+
+func readCacheManifest(t *testing.T, path string) CacheManifest {
+	t.Helper()
+	var manifest CacheManifest
+	if err := json.Unmarshal(mustRead(t, path), &manifest); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	return manifest
+}
+
+func writeCacheManifest(t *testing.T, path string, manifest CacheManifest) {
+	t.Helper()
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	mustWriteArtifactTest(t, path, data)
+}
+
+func readArtifactStamp(t *testing.T, path string) artifactStamp {
+	t.Helper()
+	var stamp artifactStamp
+	if err := json.Unmarshal(mustRead(t, path), &stamp); err != nil {
+		t.Fatalf("unmarshal artifact stamp: %v", err)
+	}
+	return stamp
+}
+
+func readCacheKeyIfPresent(t *testing.T, store *CacheStore, moduleID string) string {
+	t.Helper()
+	entry, ok := store.manifest.Entries[moduleID]
+	if !ok {
+		return ""
+	}
+	return entry.CacheKey
+}
 
 // TestCacheKey_InvalidatesOnSourceEdit is a regression test for the cache
 // poisoning bug discovered while building M-LAT-BUDGET workloads (April 2026).

--- a/internal/pipeline/cache_key.go
+++ b/internal/pipeline/cache_key.go
@@ -21,7 +21,11 @@ import (
 // (tolerant of new/missing fields), so this is a defensive guard against a
 // same-version dev/worktree build decoding a pre-AliasParams blob and treating a
 // parameterized alias as nullary.
-const cacheKeyVersion = "v3"
+//
+// v3 -> v4 (M-COMPILE-CACHE-UNVERIFIED-ARTIFACTS): executable blobs are
+// authorized by a versioned artifacts.json stamp that binds their hashes to the
+// exact module ID and caller-computed cache key.
+const cacheKeyVersion = "v4"
 
 // ModuleCacheKey computes a deterministic cache key for a module.
 // The key incorporates:

--- a/internal/pipeline/cache_runtime.go
+++ b/internal/pipeline/cache_runtime.go
@@ -1,0 +1,136 @@
+package pipeline
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+type cacheDependencies struct {
+	newStore func(string) (*CacheStore, error)
+	stderr   io.Writer
+}
+
+func productionCacheDependencies() cacheDependencies {
+	return cacheDependencies{newStore: NewCacheStore, stderr: os.Stderr}
+}
+
+type cacheRuntime struct {
+	store         *CacheStore
+	stderr        io.Writer
+	invalidWarned map[string]bool
+	writeWarned   map[string]bool
+}
+
+func newCacheRuntime(projectDir string, deps cacheDependencies) *cacheRuntime {
+	runtime := &cacheRuntime{
+		stderr:        deps.stderr,
+		invalidWarned: make(map[string]bool),
+		writeWarned:   make(map[string]bool),
+	}
+	if runtime.stderr == nil {
+		runtime.stderr = io.Discard
+	}
+	store, err := deps.newStore(projectDir)
+	if err != nil {
+		runtime.warnWrite("initialization", "", cacheRootPath(projectDir), err)
+		return runtime
+	}
+	runtime.store = store
+	return runtime
+}
+
+func cacheRootPath(projectDir string) string {
+	if override := os.Getenv("AILANG_CACHE_DIR"); override != "" {
+		return filepath.Join(override, "compile")
+	}
+	return filepath.Join(projectDir, ".ailang", "cache", "compile")
+}
+
+func (runtime *cacheRuntime) load(moduleID, expectedKey string) (*CachedModule, *CacheEntry, bool) {
+	if runtime == nil || runtime.store == nil {
+		return nil, nil, false
+	}
+	entry, ok := runtime.store.Lookup(moduleID, expectedKey)
+	if !ok {
+		return nil, nil, false
+	}
+	cached, err := runtime.store.LoadArtifacts(moduleID, expectedKey)
+	if err != nil {
+		runtime.warnInvalid(moduleID, err)
+		return nil, entry, false
+	}
+	return cached, entry, true
+}
+
+func (runtime *cacheRuntime) publish(moduleID, cacheKey string, entry *CacheEntry, cached *CachedModule) bool {
+	if runtime == nil || runtime.store == nil {
+		return false
+	}
+	if err := runtime.store.StoreArtifacts(moduleID, cacheKey, cached); err != nil {
+		stage := "publication"
+		var artifactErr *cacheArtifactError
+		if errors.As(err, &artifactErr) && artifactErr.Stage != "" {
+			stage = artifactErr.Stage
+		}
+		runtime.warnWrite(stage, moduleID, artifactErrorPath(err, runtime.store.moduleArtifactDir(moduleID)), err)
+		return false
+	}
+	runtime.store.Store(moduleID, entry)
+	return true
+}
+
+func (runtime *cacheRuntime) save() {
+	if runtime == nil || runtime.store == nil {
+		return
+	}
+	if err := runtime.store.Save(); err != nil {
+		runtime.warnWrite("manifest_save", "", filepath.Join(runtime.store.dir, "manifest.json"), err)
+	}
+}
+
+func (runtime *cacheRuntime) warnInvalid(moduleID string, err error) {
+	if runtime.invalidWarned[moduleID] {
+		return
+	}
+	runtime.invalidWarned[moduleID] = true
+	path := ""
+	reason := artifactInvalidReason
+	scope := ""
+	var limit int64
+	var artifactErr *cacheArtifactError
+	if errors.As(err, &artifactErr) {
+		path = artifactErr.Path
+		reason = artifactErr.Reason
+		scope = artifactErr.Scope
+		limit = artifactErr.LimitBytes
+	}
+	fmt.Fprintf(runtime.stderr, "CACHE_INVALID module=%s path=%s reason=%s", moduleID, path, reason)
+	if scope != "" {
+		fmt.Fprintf(runtime.stderr, " scope=%s limit_bytes=%d", scope, limit)
+	}
+	fmt.Fprintln(runtime.stderr, "; recompiling")
+}
+
+func (runtime *cacheRuntime) warnWrite(stage, moduleID, path string, err error) {
+	key := stage + "\x00" + moduleID
+	if runtime.writeWarned[key] {
+		return
+	}
+	runtime.writeWarned[key] = true
+	fmt.Fprint(runtime.stderr, "CACHE_WRITE_FAILED")
+	if moduleID != "" {
+		fmt.Fprintf(runtime.stderr, " module=%s", moduleID)
+	}
+	fmt.Fprintf(runtime.stderr, " stage=%s path=%s: %v; using fresh compilation\n", stage, path, err)
+}
+
+func artifactErrorPath(err error, fallback string) string {
+	var artifactErr *cacheArtifactError
+	if errors.As(err, &artifactErr) && artifactErr.Path != "" {
+		return artifactErr.Path
+	}
+	return fallback
+}

--- a/internal/pipeline/cache_store.go
+++ b/internal/pipeline/cache_store.go
@@ -1,10 +1,9 @@
 package pipeline
 
 import (
-	"bytes"
-	"encoding/gob"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"time"
@@ -25,8 +24,12 @@ import (
 
 // CacheStore manages the on-disk compilation cache.
 type CacheStore struct {
-	dir      string
-	manifest *CacheManifest
+	dir            string
+	manifest       *CacheManifest
+	artifactIO     cacheArtifactIO
+	artifactCodec  cacheArtifactCodec
+	artifactLimits artifactLimits
+	writeManifest  func(string, []byte, fs.FileMode) error
 }
 
 // CacheManifest tracks cached module compilation state.
@@ -70,7 +73,13 @@ func NewCacheStore(projectDir string) (*CacheStore, error) {
 		return nil, fmt.Errorf("create cache dir: %w", err)
 	}
 
-	cs := &CacheStore{dir: dir}
+	cs := &CacheStore{
+		dir:            dir,
+		artifactIO:     productionCacheArtifactIO(),
+		artifactCodec:  productionCacheArtifactCodec(),
+		artifactLimits: productionArtifactLimits(),
+		writeManifest:  os.WriteFile,
+	}
 	if err := cs.load(); err != nil {
 		// Corrupted cache — start fresh
 		cs.manifest = &CacheManifest{
@@ -102,7 +111,7 @@ func (cs *CacheStore) Save() error {
 		return fmt.Errorf("marshal manifest: %w", err)
 	}
 	path := filepath.Join(cs.dir, "manifest.json")
-	return os.WriteFile(path, data, 0644)
+	return cs.writeManifest(path, data, 0644)
 }
 
 // Clear removes all cache entries.
@@ -133,106 +142,14 @@ type CachedModule struct {
 }
 
 // StoreArtifacts serializes a CachedModule to disk alongside the manifest.
-// Core program is gob-encoded; CoreTypeInfo, Iface, and Constructors are JSON-encoded.
-func (cs *CacheStore) StoreArtifacts(moduleID string, cm *CachedModule) error {
-	modDir := filepath.Join(cs.dir, "modules", sanitizeModuleID(moduleID))
-	if err := os.MkdirAll(modDir, 0755); err != nil {
-		return fmt.Errorf("create module cache dir: %w", err)
-	}
-
-	// 1. Gob-encode core.Program
-	var buf bytes.Buffer
-	enc := gob.NewEncoder(&buf)
-	if err := enc.Encode(cm.Core); err != nil {
-		return fmt.Errorf("gob encode core.Program for %s: %w", moduleID, err)
-	}
-	if err := os.WriteFile(filepath.Join(modDir, "core.gob"), buf.Bytes(), 0644); err != nil {
-		return err
-	}
-
-	// 2. Gob-encode CoreTypeInfo (M-PERF6B: replaced JSON for 3-5x faster deserialization)
-	var ctiBuf bytes.Buffer
-	ctiEnc := gob.NewEncoder(&ctiBuf)
-	if err := ctiEnc.Encode(cm.CoreTI); err != nil {
-		return fmt.Errorf("gob encode CoreTypeInfo for %s: %w", moduleID, err)
-	}
-	if err := os.WriteFile(filepath.Join(modDir, "coretypeinfo.gob"), ctiBuf.Bytes(), 0644); err != nil {
-		return err
-	}
-
-	// 3. JSON-encode Iface (full reconstruction, not just digest)
-	ifaceData, err := marshalIfaceFull(cm.Iface)
-	if err != nil {
-		return fmt.Errorf("marshal Iface for %s: %w", moduleID, err)
-	}
-	if err := os.WriteFile(filepath.Join(modDir, "iface.json"), ifaceData, 0644); err != nil {
-		return err
-	}
-
-	// 4. JSON-encode Constructors
-	ctorData, err := marshalConstructors(cm.Constructors)
-	if err != nil {
-		return fmt.Errorf("marshal Constructors for %s: %w", moduleID, err)
-	}
-	if err := os.WriteFile(filepath.Join(modDir, "constructors.json"), ctorData, 0644); err != nil {
-		return err
-	}
-
-	return nil
+// Core and CoreTypeInfo are gob-encoded; Iface and Constructors are JSON-encoded.
+func (cs *CacheStore) StoreArtifacts(moduleID, cacheKey string, cm *CachedModule) error {
+	return cs.storeArtifacts(moduleID, cacheKey, cm)
 }
 
 // LoadArtifacts deserializes a CachedModule from disk.
-func (cs *CacheStore) LoadArtifacts(moduleID string) (*CachedModule, error) {
-	modDir := filepath.Join(cs.dir, "modules", sanitizeModuleID(moduleID))
-
-	// 1. Gob-decode core.Program
-	coreData, err := os.ReadFile(filepath.Join(modDir, "core.gob"))
-	if err != nil {
-		return nil, fmt.Errorf("read core.gob for %s: %w", moduleID, err)
-	}
-	var prog core.Program
-	dec := gob.NewDecoder(bytes.NewReader(coreData))
-	if err := dec.Decode(&prog); err != nil {
-		return nil, fmt.Errorf("gob decode core.Program for %s: %w", moduleID, err)
-	}
-
-	// 2. Gob-decode CoreTypeInfo (M-PERF6B: replaced JSON for 3-5x faster deserialization)
-	ctiData, err := os.ReadFile(filepath.Join(modDir, "coretypeinfo.gob"))
-	if err != nil {
-		return nil, fmt.Errorf("read coretypeinfo.gob for %s: %w", moduleID, err)
-	}
-	var cti types.CoreTypeInfo
-	ctiDec := gob.NewDecoder(bytes.NewReader(ctiData))
-	if err := ctiDec.Decode(&cti); err != nil {
-		return nil, fmt.Errorf("gob decode CoreTypeInfo for %s: %w", moduleID, err)
-	}
-
-	// 3. JSON-decode Iface
-	ifaceData, err := os.ReadFile(filepath.Join(modDir, "iface.json"))
-	if err != nil {
-		return nil, fmt.Errorf("read iface.json for %s: %w", moduleID, err)
-	}
-	ifc, err := unmarshalIfaceFull(ifaceData)
-	if err != nil {
-		return nil, fmt.Errorf("unmarshal Iface for %s: %w", moduleID, err)
-	}
-
-	// 4. JSON-decode Constructors
-	ctorData, err := os.ReadFile(filepath.Join(modDir, "constructors.json"))
-	if err != nil {
-		return nil, fmt.Errorf("read constructors.json for %s: %w", moduleID, err)
-	}
-	ctors, err := unmarshalConstructors(ctorData)
-	if err != nil {
-		return nil, fmt.Errorf("unmarshal Constructors for %s: %w", moduleID, err)
-	}
-
-	return &CachedModule{
-		Core:         &prog,
-		CoreTI:       cti,
-		Iface:        ifc,
-		Constructors: ctors,
-	}, nil
+func (cs *CacheStore) LoadArtifacts(moduleID, expectedCacheKey string) (*CachedModule, error) {
+	return cs.loadArtifacts(moduleID, expectedCacheKey)
 }
 
 // sanitizeModuleID converts a module ID (e.g., "std/list") to a safe directory name.

--- a/internal/pipeline/cache_store_test.go
+++ b/internal/pipeline/cache_store_test.go
@@ -225,12 +225,12 @@ func TestCacheStore_ArtifactRoundTrip(t *testing.T) {
 	}
 
 	// Store
-	if err := cs.StoreArtifacts("test/module", cm); err != nil {
+	if err := cs.StoreArtifacts("test/module", "round-trip-key", cm); err != nil {
 		t.Fatalf("StoreArtifacts failed: %v", err)
 	}
 
 	// Load
-	got, err := cs.LoadArtifacts("test/module")
+	got, err := cs.LoadArtifacts("test/module", "round-trip-key")
 	if err != nil {
 		t.Fatalf("LoadArtifacts failed: %v", err)
 	}
@@ -363,11 +363,11 @@ func TestCacheStore_ArtifactRoundTrip_DiverseExprTypes(t *testing.T) {
 		Constructors: map[string]*ConstructorInfo{},
 	}
 
-	if err := cs.StoreArtifacts("test/diverse", cm); err != nil {
+	if err := cs.StoreArtifacts("test/diverse", "diverse-key", cm); err != nil {
 		t.Fatalf("StoreArtifacts failed: %v", err)
 	}
 
-	got, err := cs.LoadArtifacts("test/diverse")
+	got, err := cs.LoadArtifacts("test/diverse", "diverse-key")
 	if err != nil {
 		t.Fatalf("LoadArtifacts failed: %v", err)
 	}

--- a/internal/pipeline/pipeline_module.go
+++ b/internal/pipeline/pipeline_module.go
@@ -25,6 +25,10 @@ import (
 
 // runModuleWithContext runs the pipeline for a module with dependencies
 func runModuleWithContext(ctx context.Context, cfg Config, src Source) (Result, error) {
+	return runModuleWithCacheDependencies(ctx, cfg, src, productionCacheDependencies())
+}
+
+func runModuleWithCacheDependencies(ctx context.Context, cfg Config, src Source, cacheDeps cacheDependencies) (Result, error) {
 	// DEBUG: if cfg.TraceDefaulting { fmt.Printf("DEBUG: runModule called for %s\n", src.Filename) }
 	result := Result{
 		PhaseTimings: make(map[string]int64),
@@ -225,13 +229,11 @@ func runModuleWithContext(ctx context.Context, cfg Config, src Source) (Result, 
 	compiledUnits := make(map[string]*CompileUnit)
 
 	// M-PERF6: Load compilation cache for hit/miss tracking
-	var cacheStore *CacheStore
+	var moduleCache *cacheRuntime
 	var cacheHits, cacheMisses int
 	if !cfg.NoCache {
 		projectDir := filepath.Dir(src.Filename)
-		if cs, err := NewCacheStore(projectDir); err == nil {
-			cacheStore = cs
-		}
+		moduleCache = newCacheRuntime(projectDir, cacheDeps)
 	}
 
 	// M-DX11: Variables to capture root module's type checker and debug sink
@@ -247,7 +249,7 @@ func runModuleWithContext(ctx context.Context, cfg Config, src Source) (Result, 
 
 		// M-PERF6: Compute cache key and check for hits
 		var moduleCacheKey string
-		if cacheStore != nil {
+		if moduleCache != nil && moduleCache.store != nil {
 			// Build dep digests from already-compiled dependencies
 			depDigests := make(map[string]string)
 			for _, imp := range mod.Imports {
@@ -274,10 +276,11 @@ func runModuleWithContext(ctx context.Context, cfg Config, src Source) (Result, 
 			// so bugfixes to elaboration / type-checking / op-lowering take effect without
 			// a manual cache nuke. The source hash and dep digests still catch edits.
 			moduleCacheKey = ModuleCacheKey(version.Commit, sourceContent, depDigests)
-			if entry, ok := cacheStore.Lookup(string(modID), moduleCacheKey); ok {
+			cached, entry, verified := moduleCache.load(string(modID), moduleCacheKey)
+			if verified {
 				cacheHits++
-				// M-INCREMENTAL-TYPECHECK: Try to load cached artifacts and skip compilation
-				if cached, loadErr := cacheStore.LoadArtifacts(string(modID)); loadErr == nil {
+				// M-INCREMENTAL-TYPECHECK: Skip only after the artifact stamp and all payloads verify.
+				if cached != nil {
 					if cfg.DebugCompile {
 						fmt.Fprintf(os.Stderr, "[CACHE] %s: SKIP (cached %s ago)\n", modID, time.Since(entry.Timestamp).Truncate(time.Second))
 					}
@@ -292,14 +295,14 @@ func runModuleWithContext(ctx context.Context, cfg Config, src Source) (Result, 
 					compiledUnits[string(modID)] = unit
 					continue
 				}
-				// Fall through to normal compilation if load fails
-				if cfg.DebugCompile {
-					fmt.Fprintf(os.Stderr, "[CACHE] %s: HIT but load failed, recompiling (compiled %s ago)\n", modID, time.Since(entry.Timestamp).Truncate(time.Second))
-				}
 			} else {
 				cacheMisses++
 				if cfg.DebugCompile {
-					fmt.Fprintf(os.Stderr, "[CACHE] %s: MISS\n", modID)
+					if entry != nil {
+						fmt.Fprintf(os.Stderr, "[CACHE] %s: INVALID, recompiling (compiled %s ago)\n", modID, time.Since(entry.Timestamp).Truncate(time.Second))
+					} else {
+						fmt.Fprintf(os.Stderr, "[CACHE] %s: MISS\n", modID)
+					}
 				}
 			}
 		}
@@ -364,17 +367,18 @@ func runModuleWithContext(ctx context.Context, cfg Config, src Source) (Result, 
 		}
 
 		// M-PERF6: Store cache entry after successful compilation
-		if cacheStore != nil && moduleCacheKey != "" {
+		if moduleCache != nil && moduleCache.store != nil && moduleCacheKey != "" {
 			ifaceJSON, _ := unit.Iface.ToNormalizedJSON()
-			cacheStore.Store(string(modID), &CacheEntry{
+			entry := &CacheEntry{
 				CacheKey:      moduleCacheKey,
 				IfaceDigest:   unit.Iface.Digest,
 				IfaceJSON:     ifaceJSON,
 				CompileTimeMs: 0, // TODO: per-module timing
 				Timestamp:     time.Now(),
-			})
-			// M-INCREMENTAL-TYPECHECK: Store full compiled artifacts for skip on next run
-			_ = cacheStore.StoreArtifacts(string(modID), &CachedModule{
+			}
+			// Publish the manifest entry only after all artifacts and their stamp are durable enough
+			// to be reopened and verified. Persistence remains an optional optimization.
+			moduleCache.publish(string(modID), moduleCacheKey, entry, &CachedModule{
 				Core:         unit.Core,
 				CoreTI:       unit.CoreTI,
 				Iface:        unit.Iface,
@@ -419,10 +423,10 @@ func runModuleWithContext(ctx context.Context, cfg Config, src Source) (Result, 
 	link.RegisterAdtModule(modLinker)
 
 	// M-PERF6: Save cache and report stats
-	if cacheStore != nil {
-		_ = cacheStore.Save()
+	if moduleCache != nil && moduleCache.store != nil {
+		moduleCache.save()
 		if cfg.DebugCompile {
-			totalEntries, _ := cacheStore.Stats()
+			totalEntries, _ := moduleCache.store.Stats()
 			fmt.Fprintf(os.Stderr, "[CACHE] Summary: %d hits, %d misses (%d modules cached)\n",
 				cacheHits, cacheMisses, totalEntries)
 		}


### PR DESCRIPTION
## M1 of 4 — the compile cache now verifies the artifacts it executes

The AILANG compile cache verified its **manifest** and never the **artifact blobs it actually
runs**. `LoadArtifacts(moduleID)` received no cache key and checked nothing, while
`pipeline_module.go` wrote the manifest entry unconditionally and discarded the artifact-write
error. A failed artifact write therefore advanced the manifest to the *new* source's key while the
blobs stayed from the *previous* compile — and every later run loaded the stale blobs and skipped
compilation. Defect reported at #1046; design and plan in `design_docs/planned/v0_35_2/`.

Milestone **M1 only**. M2 (loader-owned source identity), M3 (complete cache clearing) and M4
(route/iface invariant) are not in this PR.

### What M1 does

A v4 artifact stamp binds the exact module ID, the caller-computed **expected** cache key and
SHA-256 digests for all four payloads. Blobs are read once under byte ceilings (16 MiB per blob,
64 KiB stamp, 32 MiB aggregate per module, `LimitReader(limit+1)` as the overflow sentinel) and
decoded only after every hash passes. Publication writes the stamp **last** and the manifest entry
**after** the artifacts; optional-persistence failures are reported on stderr instead of discarded.

New: `internal/pipeline/cache_artifacts.go`, `cache_artifacts_test.go`, `cache_runtime.go`.
`cache_key.go` bumps v3 → v4. `cache_store.go` and `pipeline_module.go` delegate rather than grow —
both stay under the 800-line CI ceiling (`pipeline_module.go` is 776).

Adversarial gob hardening, provenance signatures/MACs, fsync, cache GC and cross-process locks are
deliberately **out of scope** and tracked as their own backlog row.

### Verification

Every gate below was re-run by the controller **outside** the executor's sandbox.

- The design's cumulative acceptance gate prints six `M1 PASS` lines. At the parent commit it fails
  with all six names missing and `go returncode=0` — Go's vacuous zero-selected-tests success,
  which the gate correctly rejects. The gate is non-vacuous.
- `go test ./internal/pipeline` whole package `ok` (also `ok` at the parent). Build, vet, gofmt and
  `make check-file-sizes` clean. Note `go build ./...` is red at base on darwin because `cmd/wasm`
  is `//go:build js && wasm`; the narrowed `go build ./internal/... ./cmd/ailang` is the valid gate.
- End-to-end smoke: cold `42`, warm `42` from cache, `99` after editing the source — invalidation
  still correct.

### Independent review

Judge `sonnet` (independent vendor from the codex executor), round 1, **PASS 91/100, zero
blocking**. It reproduced the original defect at the parent commit end-to-end — forcing an
artifact-write failure gives a silent stale `42` on the second run — and confirmed this commit
prints `99` with a visible `CACHE_WRITE_FAILED` diagnostic instead. It independently re-ran all six
plan mutations and all six kill their named test.

Its two non-blocking findings were **reproduced first-party and fixed in the second commit**: the
write-side aggregate module ceiling and the `mkdirAll` guard each survived deletion with the whole
package green. Both new arms were then proven to be the sole killer of the mutation they were
written for, with the source restored byte-identical by `shasum`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
