### PR TITLE
fix(pipeline): key the compile cache on the bytes the lexer actually parsed (M2 of 4)

### DIFF
--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -45,15 +45,16 @@ type PackageResolver interface {
 
 // LoadedModule represents a loaded and parsed module
 type LoadedModule struct {
-	Path         string
-	File         *ast.File
-	Imports      []string                 // Module paths this module imports
-	Exports      map[string]*ast.FuncDecl // Export table (for now, just functions)
-	Types        map[string]*ast.TypeDecl // Exported type declarations
-	Constructors map[string]string        // Constructor name -> Type name mapping
-	Core         *core.Program            // Core representation (after elaboration)
-	Iface        *iface.Iface             // Module interface (after type checking)
-	CoreTI       interface{}              // Type info for Core expressions (types.CoreTypeInfo, interface{} to avoid import cycle)
+	Path          string
+	File          *ast.File
+	SourceContent *string                  // Exact source text parsed by the lexer; nil when unavailable
+	Imports       []string                 // Module paths this module imports
+	Exports       map[string]*ast.FuncDecl // Export table (for now, just functions)
+	Types         map[string]*ast.TypeDecl // Exported type declarations
+	Constructors  map[string]string        // Constructor name -> Type name mapping
+	Core          *core.Program            // Core representation (after elaboration)
+	Iface         *iface.Iface             // Module interface (after type checking)
+	CoreTI        interface{}              // Type info for Core expressions (types.CoreTypeInfo, interface{} to avoid import cycle)
 }
 
 // NewModuleLoader creates a new module loader
@@ -282,8 +283,10 @@ func (ml *ModuleLoader) Load(path string) (*LoadedModule, error) {
 		}
 	}
 
-	// Parse file
-	l := lexer.New(string(content), fullPath)
+	// Parse the exact source snapshot retained on the loaded module. The pointer
+	// distinguishes known-empty source from source that was never available.
+	sourceText := string(content)
+	l := lexer.New(sourceText, fullPath)
 	p := parser.New(l)
 	p.SetStrictSyntaxMode(ml.strictSyntaxMode)
 	file := p.ParseFile()
@@ -332,13 +335,14 @@ func (ml *ModuleLoader) Load(path string) (*LoadedModule, error) {
 	// Cache and return with canonical ID
 	canonicalID = CanonicalModuleID(path)
 	loaded := &LoadedModule{
-		Path:         canonicalID, // Store canonical form
-		File:         file,
-		Imports:      imports,
-		Exports:      exports,
-		Types:        types,
-		Constructors: constructors,
-		Core:         nil, // Will be populated by runtime
+		Path:          canonicalID, // Store canonical form
+		File:          file,
+		SourceContent: &sourceText,
+		Imports:       imports,
+		Exports:       exports,
+		Types:         types,
+		Constructors:  constructors,
+		Core:          nil, // Will be populated by runtime
 	}
 	ml.cache[canonicalID] = loaded
 

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/sunholo-data/ailang/std"
 )
 
 func TestIsTempPath(t *testing.T) {
@@ -151,6 +153,56 @@ func TestLoad_EmbeddedStdlibFallback(t *testing.T) {
 		}
 		if loaded1 != loaded2 {
 			t.Error("expected same pointer from cache")
+		}
+	})
+}
+
+func TestCacheSource_ExactSnapshot(t *testing.T) {
+	t.Run("disk bytes", func(t *testing.T) {
+		root := t.TempDir()
+		content := []byte("module exact\n\nexport pure func answer() -> int = 42\n")
+		if err := os.WriteFile(filepath.Join(root, "exact.ail"), content, 0o644); err != nil {
+			t.Fatalf("write source: %v", err)
+		}
+
+		loaded, err := NewModuleLoader(root).Load("exact")
+		if err != nil {
+			t.Fatalf("load disk source: %v", err)
+		}
+		if loaded.SourceContent == nil {
+			t.Fatal("disk source snapshot is unavailable")
+		}
+		if got := *loaded.SourceContent; got != string(content) {
+			t.Fatalf("disk source snapshot = %q, want exact bytes %q", got, content)
+		}
+	})
+
+	t.Run("embedded stdlib bytes", func(t *testing.T) {
+		want, err := std.FS.ReadFile("option.ail")
+		if err != nil {
+			t.Fatalf("read embedded control: %v", err)
+		}
+		ml := NewModuleLoader(t.TempDir())
+		ml.stdlibResolver = &StdlibResolver{
+			searchPaths:   []string{filepath.Join(t.TempDir(), "missing")},
+			negativeCache: make(map[string][]string),
+		}
+
+		loaded, err := ml.Load("std/option")
+		if err != nil {
+			t.Fatalf("load embedded source: %v", err)
+		}
+		if loaded.File == nil {
+			t.Fatal("embedded module has no AST")
+		}
+		if filepath.ToSlash(loaded.File.Path) != "<embedded>/std/option.ail" {
+			t.Fatalf("embedded AST path = %q", loaded.File.Path)
+		}
+		if loaded.SourceContent == nil {
+			t.Fatal("embedded source snapshot is unavailable")
+		}
+		if got := *loaded.SourceContent; got != string(want) {
+			t.Fatalf("embedded source snapshot differs from std.FS bytes")
 		}
 	})
 }

--- a/internal/pipeline/cache_invalidation_test.go
+++ b/internal/pipeline/cache_invalidation_test.go
@@ -12,7 +12,265 @@ import (
 	"testing"
 
 	"github.com/sunholo-data/ailang/internal/core"
+	"github.com/sunholo-data/ailang/internal/eval"
+	"github.com/sunholo-data/ailang/internal/loader"
+	ailruntime "github.com/sunholo-data/ailang/internal/runtime"
+	"github.com/sunholo-data/ailang/internal/version"
 )
+
+func TestCacheSource_ExactSnapshot(t *testing.T) {
+	t.Run("disk changes after load do not change key", func(t *testing.T) {
+		root := t.TempDir()
+		t.Chdir(root)
+		t.Setenv("AILANG_CACHE_DIR", filepath.Join(root, "cache"))
+		source := "module answer\nexport pure func value() -> int = 7\n"
+		if err := os.WriteFile("answer.ail", []byte(source), 0o644); err != nil {
+			t.Fatalf("write source: %v", err)
+		}
+		deps := productionCacheDependencies()
+		afterLoad := func(modules map[string]*loader.LoadedModule) {
+			if err := os.Remove("answer.ail"); err != nil {
+				t.Fatalf("remove source after load: %v", err)
+			}
+		}
+		if _, err := runModuleWithCacheDependencies(t.Context(), Config{Mode: ModeCheck}, Source{Filename: "answer.ail"}, deps, afterLoad); err != nil {
+			t.Fatalf("compile retained snapshot: %v", err)
+		}
+		manifest := readCacheManifest(t, filepath.Join(root, "cache", "compile", "manifest.json"))
+		entry := manifest.Entries["answer"]
+		if entry == nil {
+			t.Fatal("retained disk snapshot produced no cache entry")
+		}
+		if want := ModuleCacheKey(version.Commit, source, nil); entry.CacheKey != want {
+			t.Fatalf("cache key = %q, want retained-source key %q", entry.CacheKey, want)
+		}
+	})
+
+	t.Run("nil bypasses while known empty remains cacheable", func(t *testing.T) {
+		root := t.TempDir()
+		t.Chdir(root)
+		cacheRoot := filepath.Join(root, "cache")
+		t.Setenv("AILANG_CACHE_DIR", cacheRoot)
+		writeCachePipelineSource(t, 42)
+		if _, err := runModuleWithCacheDependencies(t.Context(), Config{Mode: ModeCheck}, Source{Filename: "answer.ail"}, productionCacheDependencies()); err != nil {
+			t.Fatalf("seed cache: %v", err)
+		}
+		manifestPath := filepath.Join(cacheRoot, "compile", "manifest.json")
+		seed := readCacheManifest(t, manifestPath).Entries["answer"]
+		if seed == nil {
+			t.Fatal("seed cache has no answer entry")
+		}
+
+		var warnings bytes.Buffer
+		reads, writes := 0, 0
+		deps := cacheDependencies{
+			stderr: &warnings,
+			newStore: func(projectDir string) (*CacheStore, error) {
+				store, err := NewCacheStore(projectDir)
+				if err != nil {
+					return nil, err
+				}
+				open := store.artifactIO.open
+				store.artifactIO.open = func(path string) (artifactReadFile, error) {
+					if filepath.Base(filepath.Dir(path)) == "answer" {
+						reads++
+					}
+					return open(path)
+				}
+				write := store.artifactIO.writeFile
+				store.artifactIO.writeFile = func(path string, data []byte, mode os.FileMode) error {
+					if filepath.Base(filepath.Dir(path)) == "answer" {
+						writes++
+					}
+					return write(path, data, mode)
+				}
+				return store, nil
+			},
+		}
+		nilSource := func(modules map[string]*loader.LoadedModule) {
+			modules["answer"].SourceContent = nil
+		}
+		if _, err := runModuleWithCacheDependencies(t.Context(), Config{Mode: ModeCheck}, Source{Filename: "answer.ail"}, deps, nilSource); err != nil {
+			t.Fatalf("compile unavailable snapshot: %v", err)
+		}
+		if reads != 0 || writes != 0 {
+			t.Fatalf("nil snapshot touched cache artifacts: reads=%d writes=%d", reads, writes)
+		}
+		if warning := warnings.String(); !strings.Contains(warning, "CACHE_SOURCE_UNAVAILABLE module=answer") {
+			t.Fatalf("nil snapshot diagnostic = %q", warning)
+		}
+		afterNil := readCacheManifest(t, manifestPath).Entries["answer"]
+		if afterNil == nil || afterNil.CacheKey != seed.CacheKey || !afterNil.Timestamp.Equal(seed.Timestamp) {
+			t.Fatalf("nil snapshot changed manifest entry: before=%#v after=%#v", seed, afterNil)
+		}
+
+		emptyRoot := t.TempDir()
+		t.Chdir(emptyRoot)
+		t.Setenv("AILANG_CACHE_DIR", filepath.Join(emptyRoot, "cache"))
+		if err := os.WriteFile("answer.ail", []byte("module answer\nexport pure func value() -> int = 42\n"), 0o644); err != nil {
+			t.Fatalf("write known-empty fixture: %v", err)
+		}
+		warnings.Reset()
+		empty := ""
+		emptyDeps := cacheDependencies{
+			newStore: NewCacheStore,
+			stderr:   &warnings,
+		}
+		emptySource := func(modules map[string]*loader.LoadedModule) {
+			modules["answer"].SourceContent = &empty
+		}
+		if _, err := runModuleWithCacheDependencies(t.Context(), Config{Mode: ModeCheck}, Source{Filename: "answer.ail"}, emptyDeps, emptySource); err != nil {
+			t.Fatalf("compile known-empty snapshot: %v", err)
+		}
+		emptyManifest := readCacheManifest(t, filepath.Join(emptyRoot, "cache", "compile", "manifest.json"))
+		emptyEntry := emptyManifest.Entries["answer"]
+		if emptyEntry == nil || emptyEntry.CacheKey != ModuleCacheKey(version.Commit, "", nil) {
+			t.Fatalf("known-empty snapshot entry = %#v", emptyEntry)
+		}
+		if strings.Contains(warnings.String(), "CACHE_SOURCE_UNAVAILABLE") {
+			t.Fatalf("known-empty snapshot treated as unavailable: %q", warnings.String())
+		}
+	})
+}
+
+func TestCachePipeline_EmbeddedKeys(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+	t.Setenv("HOME", filepath.Join(root, "home"))
+	t.Setenv("AILANG_STDLIB_PATH", filepath.Join(root, "missing-stdlib"))
+	t.Setenv("AILANG_CACHE_DIR", filepath.Join(root, "cache"))
+	if err := os.WriteFile("main.ail", []byte("module main\nexport pure func main() -> int = 1\n"), 0o644); err != nil {
+		t.Fatalf("write entry source: %v", err)
+	}
+
+	var loaded map[string]*loader.LoadedModule
+	deps := productionCacheDependencies()
+	afterLoad := func(modules map[string]*loader.LoadedModule) { loaded = modules }
+	result, err := runModuleWithCacheDependencies(t.Context(), Config{Mode: ModeCheck}, Source{Filename: "main.ail"}, deps, afterLoad)
+	if err != nil {
+		t.Fatalf("compile embedded stdlib: %v", err)
+	}
+	manifest := readCacheManifest(t, filepath.Join(root, "cache", "compile", "manifest.json"))
+	for _, moduleID := range []string{"std/option", "std/result"} {
+		mod := loaded[moduleID]
+		if mod == nil || mod.File == nil {
+			t.Fatalf("loaded module %s = %#v", moduleID, mod)
+		}
+		wantPath := "<embedded>/" + moduleID + ".ail"
+		if got := filepath.ToSlash(mod.File.Path); got != wantPath {
+			t.Fatalf("%s source path = %q, want %q", moduleID, got, wantPath)
+		}
+		if mod.SourceContent == nil || *mod.SourceContent == "" {
+			t.Fatalf("%s retained empty/unavailable embedded content", moduleID)
+		}
+		if len(mod.Imports) != 0 {
+			t.Fatalf("%s unexpected dependencies: %v", moduleID, mod.Imports)
+		}
+		entry := manifest.Entries[moduleID]
+		if entry == nil {
+			t.Fatalf("manifest has no %s entry", moduleID)
+		}
+		want := ModuleCacheKey(version.Commit, *mod.SourceContent, map[string]string{})
+		if entry.CacheKey != want {
+			t.Fatalf("%s key = %q, want %q", moduleID, entry.CacheKey, want)
+		}
+		if empty := ModuleCacheKey(version.Commit, "", map[string]string{}); entry.CacheKey == empty {
+			t.Fatalf("%s embedded key equals empty-source key %q", moduleID, empty)
+		}
+		if result.Modules[moduleID].SourceContent != nil {
+			t.Fatalf("runtime result copied %s source snapshot", moduleID)
+		}
+	}
+}
+
+func TestCachePipeline_SourceEditBehavior(t *testing.T) {
+	t.Run("cache edit and verified warm hit", func(t *testing.T) {
+		root := t.TempDir()
+		t.Chdir(root)
+		t.Setenv("AILANG_CACHE_DIR", filepath.Join(root, "cache"))
+		writeCacheBehaviorSources(t, 2)
+		cfg := Config{Mode: ModeCheck}
+		first, err := runModuleWithCacheDependencies(t.Context(), cfg, Source{Filename: "main.ail"}, productionCacheDependencies())
+		if err != nil {
+			t.Fatalf("compile dependency v1: %v", err)
+		}
+		if got := executePipelineMain(t, first); got != "3" {
+			t.Fatalf("v1 output = %s, want 3", got)
+		}
+
+		writeCacheBehaviorSources(t, 40)
+		second, err := runModuleWithCacheDependencies(t.Context(), cfg, Source{Filename: "main.ail"}, productionCacheDependencies())
+		if err != nil {
+			t.Fatalf("compile dependency v2: %v", err)
+		}
+		if second.Modules["dep"] == nil || second.Modules["dep"].Core == nil {
+			t.Fatal("edited dependency has no updated Core")
+		}
+		if got := executePipelineMain(t, second); got != "41" {
+			t.Fatalf("v2 output = %s, want 41", got)
+		}
+
+		depCoreReads, warmEncodes := 0, 0
+		warmDeps := cacheDependencies{stderr: io.Discard, newStore: func(projectDir string) (*CacheStore, error) {
+			store, openErr := NewCacheStore(projectDir)
+			if openErr == nil {
+				open := store.artifactIO.open
+				store.artifactIO.open = func(path string) (artifactReadFile, error) {
+					if filepath.Base(filepath.Dir(path)) == "dep" && filepath.Base(path) == artifactCoreName {
+						depCoreReads++
+					}
+					return open(path)
+				}
+				encode := store.artifactCodec.encodeCore
+				store.artifactCodec.encodeCore = func(program *core.Program) ([]byte, error) {
+					warmEncodes++
+					return encode(program)
+				}
+			}
+			return store, openErr
+		}}
+		warm, err := runModuleWithCacheDependencies(t.Context(), cfg, Source{Filename: "main.ail"}, warmDeps)
+		if err != nil {
+			t.Fatalf("verified warm compile: %v", err)
+		}
+		if depCoreReads == 0 {
+			t.Fatal("edited dependency was not loaded through a verified warm hit")
+		}
+		if warmEncodes != 0 {
+			t.Fatalf("verified warm run recompiled %d modules", warmEncodes)
+		}
+		if got := executePipelineMain(t, warm); got != "41" {
+			t.Fatalf("warm output = %s, want 41", got)
+		}
+	})
+
+	t.Run("NoCache parity without persistence", func(t *testing.T) {
+		root := t.TempDir()
+		t.Chdir(root)
+		cacheRoot := filepath.Join(root, "cache")
+		t.Setenv("AILANG_CACHE_DIR", cacheRoot)
+		cfg := Config{Mode: ModeCheck, NoCache: true}
+		writeCacheBehaviorSources(t, 2)
+		first, err := runModuleWithCacheDependencies(t.Context(), cfg, Source{Filename: "main.ail"}, productionCacheDependencies())
+		if err != nil {
+			t.Fatalf("NoCache compile v1: %v", err)
+		}
+		if got := executePipelineMain(t, first); got != "3" {
+			t.Fatalf("NoCache v1 output = %s, want 3", got)
+		}
+		writeCacheBehaviorSources(t, 40)
+		second, err := runModuleWithCacheDependencies(t.Context(), cfg, Source{Filename: "main.ail"}, productionCacheDependencies())
+		if err != nil {
+			t.Fatalf("NoCache compile v2: %v", err)
+		}
+		if got := executePipelineMain(t, second); got != "41" {
+			t.Fatalf("NoCache v2 output = %s, want 41", got)
+		}
+		if _, err := os.Stat(filepath.Join(cacheRoot, "compile")); !os.IsNotExist(err) {
+			t.Fatalf("NoCache persisted compile cache: err=%v", err)
+		}
+	})
+}
 
 func TestCacheArtifacts_Migration(t *testing.T) {
 	if cacheKeyVersion != "v4" {
@@ -188,6 +446,38 @@ func writeCachePipelineSource(t *testing.T, value int) {
 	}
 }
 
+func writeCacheBehaviorSources(t *testing.T, depValue int) {
+	t.Helper()
+	dep := []byte("module dep\nexport pure func value() -> int = " + strconv.Itoa(depValue) + "\n")
+	main := []byte("module main\nimport dep (value)\nexport pure func main() -> int = value() + 1\n")
+	if err := os.WriteFile("dep.ail", dep, 0o644); err != nil {
+		t.Fatalf("write dependency: %v", err)
+	}
+	if err := os.WriteFile("main.ail", main, 0o644); err != nil {
+		t.Fatalf("write entry: %v", err)
+	}
+}
+
+func executePipelineMain(t *testing.T, result Result) string {
+	t.Helper()
+	rt := ailruntime.NewModuleRuntime(".")
+	for moduleID, loaded := range result.Modules {
+		if loaded.SourceContent != nil {
+			t.Fatalf("runtime module %s retained source snapshot", moduleID)
+		}
+		rt.PreloadModule(moduleID, loaded)
+	}
+	inst, err := rt.LoadAndEvaluate("main")
+	if err != nil {
+		t.Fatalf("load runtime entry: %v", err)
+	}
+	value, err := ailruntime.CallEntrypoint(rt, inst, "main", []eval.Value{})
+	if err != nil {
+		t.Fatalf("call runtime entry: %v", err)
+	}
+	return value.String()
+}
+
 func readCacheManifest(t *testing.T, path string) CacheManifest {
 	t.Helper()
 	var manifest CacheManifest
@@ -227,13 +517,12 @@ func readCacheKeyIfPresent(t *testing.T, store *CacheStore, moduleID string) str
 // TestCacheKey_InvalidatesOnSourceEdit is a regression test for the cache
 // poisoning bug discovered while building M-LAT-BUDGET workloads (April 2026).
 //
-// The bug: pipeline_module.go fed os.ReadFile(mod.Path) into the cache key,
-// but mod.Path holds the *canonical module ID* ("benchmarks/workloads/warm_eval"),
-// not the on-disk file path. ReadFile silently failed and returned an empty
-// string, so every module that shared the same imports collided on the same
-// cache key. After M-INCREMENTAL-TYPECHECK wired cache hits to skip compilation
-// (commit 4f91d27e, 2026-04-10), this meant edits to .ail files were silently
-// ignored — the runtime kept executing the previously-cached version.
+// The bug: pipeline_module.go reread a path opportunistically at key time and
+// silently used an empty string when that second read failed. A canonical
+// module ID was initially used as the path; even after switching to File.Path,
+// the second read could describe bytes different from the AST. Modules sharing
+// imports could therefore collide or execute stale artifacts. The loader-owned
+// snapshot now binds the cache key to the exact text handed to the lexer.
 //
 // The unit tests in cache_key_test.go and cache_store_test.go BOTH passed
 // throughout: cache_key_test verifies that ModuleCacheKey produces different
@@ -304,8 +593,8 @@ export pure func main() -> int = 99
 	if keyV1 == keyV2 {
 		t.Fatalf("cache poisoning regression: source edit did not change cache key.\n"+
 			"  Both versions hashed to %s.\n"+
-			"  This means ModuleCacheKey received the same sourceContent for both edits, "+
-			"which is the bug fixed in pipeline_module.go (mod.Path → mod.File.Path).\n"+
+			"  This means ModuleCacheKey received the same source snapshot for both edits, "+
+			"which violates the loader-owned source identity contract.\n"+
 			"  See cache_invalidation_test.go header for full incident notes.", keyV1)
 	}
 }

--- a/internal/pipeline/cache_invalidation_test.go
+++ b/internal/pipeline/cache_invalidation_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sunholo-data/ailang/internal/eval"
 	"github.com/sunholo-data/ailang/internal/loader"
 	ailruntime "github.com/sunholo-data/ailang/internal/runtime"
+	"github.com/sunholo-data/ailang/internal/testutil"
 	"github.com/sunholo-data/ailang/internal/version"
 )
 
@@ -144,7 +145,7 @@ func TestCacheSource_ExactSnapshot(t *testing.T) {
 func TestCachePipeline_EmbeddedKeys(t *testing.T) {
 	root := t.TempDir()
 	t.Chdir(root)
-	t.Setenv("HOME", filepath.Join(root, "home"))
+	testutil.SetHomeDir(t, filepath.Join(root, "home"))
 	t.Setenv("AILANG_STDLIB_PATH", filepath.Join(root, "missing-stdlib"))
 	t.Setenv("AILANG_CACHE_DIR", filepath.Join(root, "cache"))
 	if err := os.WriteFile("main.ail", []byte("module main\nexport pure func main() -> int = 1\n"), 0o644); err != nil {

--- a/internal/pipeline/cache_invalidation_test.go
+++ b/internal/pipeline/cache_invalidation_test.go
@@ -99,6 +99,14 @@ func TestCacheSource_ExactSnapshot(t *testing.T) {
 		if warning := warnings.String(); !strings.Contains(warning, "CACHE_SOURCE_UNAVAILABLE module=answer") {
 			t.Fatalf("nil snapshot diagnostic = %q", warning)
 		}
+		// The design says a module without a snapshot bypasses BOTH lookup and
+		// publication -- it must never ATTEMPT to publish, not merely fail to.
+		// Publication with the zero cache key is separately rejected one layer
+		// down by StoreArtifacts, which would emit a write diagnostic here; the
+		// bypass diagnostic must therefore be the only thing on stderr.
+		if warning := warnings.String(); strings.Contains(warning, "CACHE_WRITE_FAILED") {
+			t.Fatalf("nil snapshot attempted publication: stderr = %q", warning)
+		}
 		afterNil := readCacheManifest(t, manifestPath).Entries["answer"]
 		if afterNil == nil || afterNil.CacheKey != seed.CacheKey || !afterNil.Timestamp.Equal(seed.Timestamp) {
 			t.Fatalf("nil snapshot changed manifest entry: before=%#v after=%#v", seed, afterNil)

--- a/internal/pipeline/cache_runtime.go
+++ b/internal/pipeline/cache_runtime.go
@@ -114,6 +114,10 @@ func (runtime *cacheRuntime) warnInvalid(moduleID string, err error) {
 	fmt.Fprintln(runtime.stderr, "; recompiling")
 }
 
+func (runtime *cacheRuntime) warnSourceUnavailable(moduleID string) {
+	fmt.Fprintf(runtime.stderr, "CACHE_SOURCE_UNAVAILABLE module=%s; bypassing compilation cache\n", moduleID)
+}
+
 func (runtime *cacheRuntime) warnWrite(stage, moduleID, path string, err error) {
 	key := stage + "\x00" + moduleID
 	if runtime.writeWarned[key] {

--- a/internal/pipeline/pipeline_module.go
+++ b/internal/pipeline/pipeline_module.go
@@ -28,7 +28,7 @@ func runModuleWithContext(ctx context.Context, cfg Config, src Source) (Result, 
 	return runModuleWithCacheDependencies(ctx, cfg, src, productionCacheDependencies())
 }
 
-func runModuleWithCacheDependencies(ctx context.Context, cfg Config, src Source, cacheDeps cacheDependencies) (Result, error) {
+func runModuleWithCacheDependencies(ctx context.Context, cfg Config, src Source, cacheDeps cacheDependencies, afterLoad ...func(map[string]*loader.LoadedModule)) (Result, error) {
 	// DEBUG: if cfg.TraceDefaulting { fmt.Printf("DEBUG: runModule called for %s\n", src.Filename) }
 	result := Result{
 		PhaseTimings: make(map[string]int64),
@@ -147,6 +147,9 @@ func runModuleWithCacheDependencies(ctx context.Context, cfg Config, src Source,
 		pipelineSpan.RecordError(loadErr)
 		return result, loadErr
 	}
+	if len(afterLoad) > 0 && afterLoad[0] != nil {
+		afterLoad[0](modules)
+	}
 
 	loadSpan.SetAttributes(attribute.Int("modules.count", len(modules)))
 	loadSpan.End()
@@ -250,58 +253,46 @@ func runModuleWithCacheDependencies(ctx context.Context, cfg Config, src Source,
 		// M-PERF6: Compute cache key and check for hits
 		var moduleCacheKey string
 		if moduleCache != nil && moduleCache.store != nil {
-			// Build dep digests from already-compiled dependencies
-			depDigests := make(map[string]string)
-			for _, imp := range mod.Imports {
-				if cu, ok := compiledUnits[imp]; ok && cu.Iface != nil {
-					depDigests[imp] = cu.Iface.Digest
-				}
-			}
-			// Read source from disk for content hash.
-			// mod.Path is the canonical module identity (e.g. "benchmarks/workloads/warm_eval");
-			// the actual disk path lives on mod.File.Path. Using mod.Path here caused
-			// os.ReadFile to fail silently, leaving sourceContent="" so every module that
-			// shared the same imports collided on the same cache key — edits to .ail files
-			// were ignored after the first compile.
-			sourceContent := ""
-			srcPath := mod.Path
-			if mod.File != nil && mod.File.Path != "" {
-				srcPath = mod.File.Path
-			}
-			if srcBytes, err := os.ReadFile(srcPath); err == nil {
-				sourceContent = string(srcBytes)
-			}
-			// Use build commit (from internal/version) as the compiler-identity component
-			// of the cache key. Rebuilding `ailang` at a new commit invalidates cache,
-			// so bugfixes to elaboration / type-checking / op-lowering take effect without
-			// a manual cache nuke. The source hash and dep digests still catch edits.
-			moduleCacheKey = ModuleCacheKey(version.Commit, sourceContent, depDigests)
-			cached, entry, verified := moduleCache.load(string(modID), moduleCacheKey)
-			if verified {
-				cacheHits++
-				// M-INCREMENTAL-TYPECHECK: Skip only after the artifact stamp and all payloads verify.
-				if cached != nil {
-					if cfg.DebugCompile {
-						fmt.Fprintf(os.Stderr, "[CACHE] %s: SKIP (cached %s ago)\n", modID, time.Since(entry.Timestamp).Truncate(time.Second))
-					}
-					unit.Core = cached.Core
-					unit.CoreTI = cached.CoreTI
-					unit.Iface = cached.Iface
-					unit.Constructors = cached.Constructors
-					// Register interface with linker so downstream modules can resolve imports
-					if unit.Iface != nil {
-						modLinker.RegisterIface(unit.Iface)
-					}
-					compiledUnits[string(modID)] = unit
-					continue
-				}
+			if mod.SourceContent == nil {
+				moduleCache.warnSourceUnavailable(string(modID))
 			} else {
-				cacheMisses++
-				if cfg.DebugCompile {
-					if entry != nil {
-						fmt.Fprintf(os.Stderr, "[CACHE] %s: INVALID, recompiling (compiled %s ago)\n", modID, time.Since(entry.Timestamp).Truncate(time.Second))
-					} else {
-						fmt.Fprintf(os.Stderr, "[CACHE] %s: MISS\n", modID)
+				// Build dep digests from already-compiled dependencies
+				depDigests := make(map[string]string)
+				for _, imp := range mod.Imports {
+					if cu, ok := compiledUnits[imp]; ok && cu.Iface != nil {
+						depDigests[imp] = cu.Iface.Digest
+					}
+				}
+				// Use the immutable loader-owned snapshot so the key always describes
+				// the exact bytes parsed into this module's AST.
+				moduleCacheKey = ModuleCacheKey(version.Commit, *mod.SourceContent, depDigests)
+				cached, entry, verified := moduleCache.load(string(modID), moduleCacheKey)
+				if verified {
+					cacheHits++
+					// M-INCREMENTAL-TYPECHECK: Skip only after the artifact stamp and all payloads verify.
+					if cached != nil {
+						if cfg.DebugCompile {
+							fmt.Fprintf(os.Stderr, "[CACHE] %s: SKIP (cached %s ago)\n", modID, time.Since(entry.Timestamp).Truncate(time.Second))
+						}
+						unit.Core = cached.Core
+						unit.CoreTI = cached.CoreTI
+						unit.Iface = cached.Iface
+						unit.Constructors = cached.Constructors
+						// Register interface with linker so downstream modules can resolve imports
+						if unit.Iface != nil {
+							modLinker.RegisterIface(unit.Iface)
+						}
+						compiledUnits[string(modID)] = unit
+						continue
+					}
+				} else {
+					cacheMisses++
+					if cfg.DebugCompile {
+						if entry != nil {
+							fmt.Fprintf(os.Stderr, "[CACHE] %s: INVALID, recompiling (compiled %s ago)\n", modID, time.Since(entry.Timestamp).Truncate(time.Second))
+						} else {
+							fmt.Fprintf(os.Stderr, "[CACHE] %s: MISS\n", modID)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## M2 of 4 — `m-compile-cache-unverified-artifacts`

The compile-cache key was computed from a **second, opportunistic `os.ReadFile`** at key time whose
failure silently defaulted to the empty string. A module whose source had moved, been deleted, or
been supplied from the embedded stdlib was therefore keyed on `""` — colliding with every other
such module. The loader already holds the exact bytes it handed the lexer; now it keeps them.

- `internal/loader` — `LoadedModule` gains an immutable `SourceContent *string`, set once from the
  same buffer given to `lexer.New`. The **pointer** distinguishes a known-empty source from one
  that was never available. The embedded `std.FS` fallback flows through the same buffer.
- `internal/pipeline` — the key site requires `mod.SourceContent != nil` and hashes
  `*mod.SourceContent`; the reread and its empty-string default are gone. A module without a
  snapshot bypasses **both** cache lookup and publication and emits `CACHE_SOURCE_UNAVAILABLE`;
  it is never hashed as `""`. The snapshot is not copied into runtime `LoadedModule`s and not
  serialized into any artifact.

### Verification

All gates re-run by the controller **outside** the executor sandbox:

| Gate | Result |
|---|---|
| `python3 <plan runner> M2` | rc=0 — 6 M1 + 4 M2 `PASS` lines |
| same runner at **base** (control) | rc=1 `('M2', 'missing or skipped', {'TestCacheSource_ExactSnapshot'})` |
| `go test ./internal/loader ./internal/pipeline ./cmd/ailang ./internal/apiserver` | all `ok` |
| `go build ./internal/... ./cmd/ailang` · `gofmt -l` · `go vet` · `make fmt-check` · `make check-file-sizes` | clean |
| end-to-end, binary built from this branch | cold `42` · warm `42` · after edit `99` · warm `99` |

T6/T7/T8 each proven to kill the mutation the plan's table names, by the executor and independently
by the judge. Independent evaluator (`sonnet`, own worktree, generator≠judge by vendor as well as
model): **96/100 PASS, zero blocking findings**.

The judge's one non-blocking finding is fixed in the second commit: anchoring its mutation set to
the diff rather than to the plan's table, it found that deleting `&& moduleCacheKey != ""` from the
publication guard left the **whole `internal/pipeline` package green**. Reproduced first-party. The
system was still safe — M1's `StoreArtifacts` rejects an empty key one layer down — but "bypasses
publication" then means *fails to publish* rather than *never attempts*, and the attempt emits
`CACHE_WRITE_FAILED`. One arm now pins it, proven to be the sole killer of that mutation with the
source restored byte-identical afterwards.

M2 of 4 for the defect reported at #1046. That report stays **open** until M4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
