### PR TITLE
docs(cache): clarify module encoding and park disputed naming direction

### DIFF
--- a/design_docs/planned/v0_36_0/m-cache-module-id-encoding-sprint-plan.md
+++ b/design_docs/planned/v0_36_0/m-cache-module-id-encoding-sprint-plan.md
@@ -1,5 +1,7 @@
 # Sprint Plan: M-CACHE-MODULE-ID-ENCODING
 
+> **Execution blocked (iteration 336, D-57):** quorum rejected the naming-scheme direction after the bounded re-quorum. This is an inherited plan, not current execution authorization. M1–M4 remain pending. Before execution, a human ruling and design gate must settle the scheme, then the planner must synchronize the plan and initial snapshot, replacing the overbroad injectivity claim and correcting the M1 mutation example: `Foo`/`foo` collapse without the suffix; `a/b`/`a__b` do not under the clarified slug.
+
 ## Summary
 
 Replace the compile-artifact cache's illegal and collision-prone module-directory mapping with

--- a/design_docs/planned/v0_36_0/m-cache-module-id-encoding-sprint-plan.md
+++ b/design_docs/planned/v0_36_0/m-cache-module-id-encoding-sprint-plan.md
@@ -4,27 +4,33 @@
 
 ## Summary
 
-Replace the compile-artifact cache's illegal and collision-prone module-directory mapping with
-the approved bounded `m-<slug>-<16hex>` encoding, wire every production and test consumer to the
-one real encoder, prove Windows legality, remove the temporary Windows skip, and pin the existing
-whole-tree clear behavior for both directory schemes.
+The inherited plan proposed replacing the compile-artifact cache's illegal and collision-prone
+module-directory mapping with the bounded `m-<slug>-<16hex>` encoding, wiring every production
+and test consumer to one encoder, proving Windows legality, removing the temporary Windows skip,
+and pinning the existing whole-tree clear behavior for both directory schemes. That direction is
+not currently approved; D-57 must be decided and the design gate and planner resynchronization
+must complete before this summary becomes executable.
 
 **Target:** v0.36.0  
 **Planned at:** 8cd3bc7831e30a1a9f981539bd351acf1d3d70e3 (`std/VERSION` = v0.35.1)  
 **Duration:** 1.2 working days  
-**Milestones:** 4; one green, independently verifiable commit per approved milestone  
+**Milestones:** 4 inherited pending milestones; commit boundaries require post-D-57 approval
+
 **Risk:** Medium; small implementation, but a cross-package fixture and Windows-only filesystem
 evidence make omission risk material  
-**Dependencies:** None  
+**Dependencies:** Human D-57 decision, completed design gate, and planner resynchronization
+
 **Design:** `design_docs/planned/v0_36_0/m-cache-module-id-encoding.md`  
 **Issue:** None
 
 **Initial sprint state:** `design_docs/planned/v0_36_0/m-cache-module-id-encoding-sprint.json`
-contains the four pending milestones. Before execution, copy it to
-`.ailang/state/sprints/sprint_m-cache-module-id-encoding.json` only if that runtime state is
-absent; never overwrite an active sprint. The tracked file is the initial snapshot, not live progress.
+contains the four pending milestones as a blocked historical snapshot. Do not copy it to
+`.ailang/state/sprints/sprint_m-cache-module-id-encoding.json` while blocked. After D-57, the
+design gate, and planner resynchronization are complete, the planner must replace this instruction
+with the authorized initialization procedure. The tracked file is not live progress.
 
-The approved M1–M4 decomposition is preserved. Estimates are deliberately small: M1 0.35 day,
+The inherited M1–M4 decomposition is preserved for historical planning context and is not current
+execution authorization. Estimates were deliberately small: M1 0.35 day,
 M2 0.35 day, M3 0.30 day, and M4 0.20 day. The seven-day repository diff (523 files, 71,516
 insertions, 6,123 deletions) spans unrelated mission lanes and is not a credible velocity sample
 for this single-function change. Approximately 220 changed LOC, mostly tests, is the useful
@@ -32,15 +38,17 @@ forecasting unit.
 
 ## Scope and execution rules
 
-In scope is exactly the approved hybrid encoder, production wiring, the discovered test-surface
+The inherited scope describes the hybrid encoder, production wiring, the discovered test-surface
 tail, Windows legality and real-directory evidence, removal of the temporary Windows skip, and a
-regression guard for `Clear()` sweeping both naming schemes. There is no cache-key version bump,
-stamp-schema change, automatic garbage collection, path canonicalisation change, or adversarial
-cache hardening.
+regression guard for `Clear()` sweeping both naming schemes. It is historical until D-57 selects a
+direction and the design gate and planner resynchronization establish current scope. The inherited
+exclusions were a cache-key version bump, stamp-schema change, automatic garbage collection, path
+canonicalisation change, and adversarial cache hardening.
 
-The executor must close one green commit at each milestone boundary and must not begin the next
-milestone from a red tree. The controller owns all git writes. If implementation requires a scope
-change, stop at the last green boundary and return to design review.
+If execution is authorized after resynchronization, the executor must close one green commit at
+each milestone boundary and must not begin the next milestone from a red tree. The controller owns
+all git writes. If implementation requires a scope change, stop at the last green boundary and
+return to design review.
 
 ## Reality checks
 

--- a/design_docs/planned/v0_36_0/m-cache-module-id-encoding-sprint.json
+++ b/design_docs/planned/v0_36_0/m-cache-module-id-encoding-sprint.json
@@ -1,6 +1,8 @@
 {
   "sprint_id": "m-cache-module-id-encoding",
-  "status": "not_started",
+  "status": "blocked",
+  "blocked_reason": "D-57 requires a human naming-direction decision, followed by design-gate completion and planner resynchronization; do not initialize runtime sprint state or execute any milestone before all three are complete.",
+  "criteria_status": "historical_inherited_not_currently_approved",
   "created": "2026-09-06T04:13:39Z",
   "design_doc": "design_docs/planned/v0_36_0/m-cache-module-id-encoding.md",
   "sprint_plan": "design_docs/planned/v0_36_0/m-cache-module-id-encoding-sprint-plan.md",

--- a/design_docs/planned/v0_36_0/m-cache-module-id-encoding.md
+++ b/design_docs/planned/v0_36_0/m-cache-module-id-encoding.md
@@ -1,8 +1,8 @@
 # M-CACHE-MODULE-ID-ENCODING — replace `sanitizeModuleID`'s broken, non-injective mapping
 
-**Status**: Planned
+**Status**: PARKED — needs-human-review; blocked pending D-57
 **Created**: 2026-09-06
-**Mission**: V1, iteration 334
+**Mission**: V1, iteration 334; iteration-336 design phase parked after round-2 quorum
 **Supersedes queue rows**: `m-cache-sanitize-module-id-windows-colon` (iter-333),
 `m-cache-sanitize-module-id-collision` (iter-328)
 
@@ -16,24 +16,31 @@ every other byte through unchanged. Its sole production consumer is
 
 Two distinct, separately-filed defects, both on this one function, with different severities:
 
-**Defect 1 — Windows: the artifact cache publishes nothing at all (TOTAL PLATFORM OUTAGE).**
-On Windows a module ID is the canonical absolute source path and begins with a drive letter,
-e.g. `C:/Users/runneradmin/AppData/...`. After `sanitizeModuleID` that whole string becomes
-**one** path component `C:__Users__runneradmin__AppData__...` — which contains a **colon**.
+**Defect 1 — Windows: drive-letter IDs produce illegal artifact directory components.**
+For a drive-letter module ID such as `C:/Users/runneradmin/AppData/...`, the old encoder
+produces **one** path component `C:__Users__runneradmin__AppData__...` containing a **colon**.
 Windows forbids `:` in a path component (`< > : " / \ | ? *`, plus ASCII control chars,
 trailing dot/space, and the reserved `CON PRN AUX NUL COM1-9 LPT1-9` names are all illegal —
 and a reserved name stays reserved when followed by an extension: `con.txt` has basename `con`
-and is just as illegal as bare `con`).
-So `StoreArtifacts` fails on every publication, and the M1 diagnostic from
-`m-compile-cache-unverified-artifacts` reports it verbatim on the CI runner:
+and is just as illegal as bare `con`). Publication for such an ID therefore targets an
+illegal component. This is a deduction about the encoding, not a captured Windows execution.
 
-```
+**Reconstructed diagnostic, not a Windows CI transcript:** the following illustration combines
+the verified separator-only encoding and publication diagnostic format with Windows' colon
+restriction. No Windows CI log excerpt of this error was captured. The fetched baseline log
+had no `CACHE_WRITE_FAILED` match (see iteration-336 Verification Log); it does not establish
+how many Windows modules encounter this path or a platform-wide outage.
+
+```text
 CACHE_WRITE_FAILED module=C:/Users/... stage=publication
 path=...\compile\modules\C:__Users__runneradmin__... : ARTIFACT_INVALID
 ```
 
-The whole compile-artifact cache is therefore **non-functional on Windows**. This is
-PRE-EXISTING: `sanitizeModuleID` predates the sprint; the M1 diagnostic only made it audible.
+The proposed M3 Windows publication test must establish runtime behavior for the drive-letter
+fixture. The earlier claim that this text was observed on the CI runner, and the associated
+claim of a measured total-platform outage, are withdrawn. The separator-only encoder itself
+predates this change.
+
 Two tests in `cmd/ailang/serve_api_mcp_surface_test.go` (the callers of
 `requireCompileArtifactCache` at lines 177 and 287) are gated behind a skip that fires on
 Windows **and** an observed-empty manifest (skip branch at line 572). That skip is a temporary
@@ -55,23 +62,24 @@ encoding.
 
 ### Q1c pre-check — case collisions (the trap neither filed row mentions)
 
-macOS APFS and Windows NTFS are case-INSENSITIVE by default. Module IDs are **not**
-case-normalized anywhere: the loader keys modules by the canonical `module.Path`
-(`internal/loader/loader.go:513`) and `validateModuleName`
-(`internal/loader/stdlib_resolver.go:25`) explicitly allows `[a-zA-Z0-9_/-]`. So two module IDs
-differing only in case are byte-distinct and currently legal. On a case-insensitive filesystem
-a byte-injective-but-case-preserving mapping would still collide at the directory level. Any
-chosen scheme must be distinct even after the *filesystem* has case-folded. (Not a correctness
-defect either — the stamp `module_id` backstop still protects — but it is a silent recompile
-churn source that a robust scheme should remove.)
+macOS APFS and Windows NTFS are case-INSENSITIVE by default. The loader keys modules by
+`module.Path` (`internal/loader/loader.go:513`); that assignment does not fold case. Separately,
+`validateModuleName` (`internal/loader/stdlib_resolver.go:25`) allows `[a-zA-Z0-9_/-]` for
+stdlib-style names (scope verified below). The encoder must therefore handle byte-distinct
+case-variant IDs without relying on case-sensitive directory comparison. On a case-insensitive
+filesystem a byte-injective-but-case-preserving mapping would still collide at the directory
+level. The chosen scheme must preserve its collision resistance after filesystem case folding.
+The stamp `module_id` backstop still protects correctness; this is a recompilation-churn source
+that the proposed scheme reduces.
 
 ## Non-goals
 
 - **Not adversarial cache hardening.** We are not defending against a hostile peer who can
   write arbitrary paths under the cache root. That is the separate row
-  `m-cache-artifact-adversarial-decode`. (Note: `validateModuleName` already rejects `..`,
-  null bytes, and only permits `[a-zA-Z0-9_/-]`, but module IDs are resolved absolute paths —
-  see Conflict Surface — so defence in depth remains the adversarial row's job.)
+  `m-cache-artifact-adversarial-decode`. `validateModuleName` rejects `..`, null bytes,
+  and restricts names to `[a-zA-Z0-9_/-]` for stdlib resolution: its sole production caller
+  is `StdlibResolver.ResolveStdlib`. This does not establish validation of all absolute-path
+  module IDs; defence in depth for those remains the adversarial row's job.
 - **No change to the artifact stamp's correctness role.** The exact-`module_id` comparison in
   `LoadArtifacts` stays the ultimate backstop for every collision (case- or otherwise). This
   design reduces collisions; it does not move the correctness boundary.
@@ -86,9 +94,9 @@ Constraint bundle every option must satisfy — every output must be:
 (a) a legal single path component on Windows/macOS/Linux (no `< > : " / \ | ? *`, ASCII
     control, trailing dot/space; and the basename **before the first dot** is not a reserved
     device name — `con.txt` is as illegal as `con`);
-(b) injective over distinct module IDs;
-(c) distinct even after a case-insensitive filesystem folds case;
-(d) bounded well under Windows' 255-char component / 260-char `MAX_PATH` limits;
+(b) collision-resistant, with foreign-module stamps rejected by the existing backstop;
+(c) retain that collision resistance after a case-insensitive filesystem folds case;
+(d) bounded to 57 ASCII bytes per component (the whole path still depends on the cache root);
 (e) deterministic across runs and platforms.
 
 ### Option A — widen the replacement set to all forbidden characters (REJECTED)
@@ -101,46 +109,90 @@ symbol, so `a:b`, `a"b`, `a*b` … all collapse; (3) it does nothing about Windo
 component limit because output length scales with input length, and module IDs are absolute
 paths. Rejected.
 
-### Option B — pure content hash (fixed-length, always legal, injective-in-practice) 
-`encode(id) = sha256(id)[:N]` lowercase hex. Pros: constant output length (independent of a
-long `C:/Users/…` input), inherently legal (hex alphabet), injective in practice (see collision
-argument), and a lowercase-hex alphabet is stable even under a case-insensitive filesystem, so
-two case-variant IDs get distinct lowercase-hex suffixes. Cons: the cache directory becomes
+### Option B — pure content hash (fixed-length, legal, collision-resistant)
+`encode(id) = hex(sha256(id))[:N]` lowercase hex characters. Pros: constant output length (independent of a
+long `C:/Users/…` input), inherently legal (hex alphabet), collision resistance dependent
+on `N`, and a lowercase-hex alphabet stable under filesystem case folding. Case variants
+are hashed as different inputs; hash collisions remain possible. Cons: the cache directory becomes
 *unreadable to a human* — you cannot tell `std/list` from `std/map` at a glance, which makes
 debugging on-disk state materially harder. Pure hash alone would discard all debuggability for
-no correctness gain over a hybrid.
+no correctness gain over a hybrid with the same hash width and stamp backstop.
 
 ### Option C — hybrid: truncated human-readable slug + hash-suffix over the FULL module ID (CHOSEN)
 Keep a shortened, sanitised, truncated slug for human debuggability and append a short
-lowercase-hex digest derived from the **full** module ID for guaranteed distinctness. The slug
-is purely cosmetic: uniqueness must never rest on it (it is truncated and case-folded, so it
-can collide); the suffix is the authority. Detailed in Chosen design.
+lowercase-hex digest derived from the **full** module ID for collision resistance. The slug
+is a readability aid that may also separate some hash collisions, but is lossy; it cannot
+guarantee uniqueness. The existing exact-module-ID stamp check remains the correctness
+authority. Detailed in Chosen design.
 
-**Why C over B:** identical injectivity, identical legality, identical case-safety, identical
-bounded length — and you keep the ability to read which module lives in which directory.
-The cost is a tiny slug-splitting pass that a one-line helper performs. C dominates B.
+**Why C over B at the same 64-bit hash width:** the hybrid keeps a readable module hint
+while preserving the hash-based collision resistance and lowercase alphabet. It costs a slug
+pass and up to 41 additional bytes; the total remains within the chosen 57-byte component cap.
+This is a readability/space tradeoff, not a claim of mathematical injectivity or equivalence
+to a full 256-bit hash.
+
+### Contested alternative from iteration-336 quorum (not adopted; awaiting re-quorum)
+
+Sol proposed a full 256-bit digest and a new `CACHE_DIRECTORY_COLLISION` diagnostic, followed
+by recompilation or selection of a bounded alternate directory. Its objection to the former
+injectivity claim is accepted: no bounded encoding over arbitrary-length IDs can guarantee
+uniqueness, including a full digest. A full digest would improve collision resistance, but
+64 lowercase hex characters already exceed this design's 57-byte component cap before adding
+the prefix or slug. The new diagnostic/alternate-directory behavior would also add production
+semantics beyond the bounded revision. Neither proposal is silently treated as approved or
+unnecessary: they remain contested alternatives, not adopted in the current scope, for the
+independent re-quorum to assess against the corrected contract.
+
+The retained 64-bit scheme explicitly accepts theoretical directory contention/recompilation.
+When an existing artifact stamp belongs to another module, the existing `stamp.ModuleID !=
+moduleID` check rejects it; `cacheRuntime.load` invokes `warnInvalid` (the existing
+`CACHE_INVALID …; recompiling` diagnostic) and the pipeline takes its ordinary compile path.
+This detects foreign-module artifacts at load time; it is not a promise to prevent future
+writes from contending for the same directory. No collision-specific error code or alternate
+path is introduced here. M1's inherited test name `TestEncodeModuleDirName_InjectivityAndDeterminism`
+means separation of its finite fixture set, not a proof of mathematical injectivity.
 
 ## Chosen design
 
 Replace `sanitizeModuleID` with an `encodeModuleDirName(string) string` (new function) computed
-as `"m-" + slug(id) + "-" + hex(sha256(id)[:16])`:
+as `"m-" + slug(id) + "-" + hex(sha256(id))[:16]` (16 hex characters, not 16 digest bytes):
 
 ```go
-// encodeModuleDirName maps a module ID to a legal, injective, case-insensitive-FS-safe
-// single directory component. The unconditional "m-" prefix is the Windows reserved-name
-// guard (see legality). The slug is a truncated readability aid only; the 16-hex-char
-// SHA-256 prefix over the FULL module ID is the uniqueness authority.
+// encodeModuleDirName maps a module ID to a legal, bounded, collision-resistant
+// single directory component whose lowercase alphabet is stable under filesystem case folding.
+// The unconditional "m-" prefix is the Windows reserved-name guard (see legality).
+// The slug is a truncated readability aid only; the 16-hex-char SHA-256 prefix over
+// the FULL module ID is the collision-resistant discriminator.
 func encodeModuleDirName(moduleID string) string {
     sum := sha256.Sum256([]byte(moduleID))
     suffix := hex.EncodeToString(sum[:])[:16]     // 64 bits, lowercase alpha -> case-insensitive-FS safe
     return "m-" + slug(moduleID) + "-" + suffix
 }
 
-// slug lowercases and keeps [a-z0-9_-], mapping every other byte (and any run of them,
-// INCLUDING '.') to '_'. Then it trims leading/trailing '_' so no component ends in an
-// underscore run. Finally it truncates to 38 bytes (ASCII-only => safe byte cut).
-func slug(id string) string { /* lower; rune-map; trim; cut at 38 */ }
+// slug processes raw bytes: fold ASCII A-Z to a-z; keep [a-z0-9_-]; replace each
+// other byte with exactly one '_'. Preserve runs. Trim outer '_' BEFORE the 38-byte
+// cut; do not trim again after cutting. Never decode or lowercase Unicode runes.
+func slug(id string) string { /* ASCII byte-map; trim outer '_'; cut at 38 */ }
 ```
+
+**Normative slug algorithm (iteration 336 clarification):**
+
+1. Iterate the original Go string by byte index. For each byte in ASCII `A`–`Z`, add
+   32 to obtain `a`–`z`. Preserve ASCII `a`–`z`, `0`–`9`, `_`, and `-`.
+   Replace every other byte, including `.`, with exactly one ASCII `_`.
+2. Preserve all resulting underscore runs, including adjacent replacements and original
+   underscores. There is no run collapse: `:/` becomes `__`; the two UTF-8 bytes of `é`
+   also become `__`. Do not decode runes, apply Unicode case folding, or normalize the input.
+3. Trim all leading and trailing `_` bytes from the complete mapped string.
+4. Take the first `min(38, length)` bytes of that trimmed string. Do not trim again:
+   truncation can expose a trailing `_`, which is allowed. An empty slug is allowed and
+   produces `m--<16hex>`; no placeholder is substituted.
+5. Compute the suffix independently over the full, original string bytes, before any of
+   these slug transformations. Append the first 16 lowercase hex characters of SHA-256.
+
+This resolves the inherited design/plan ambiguity in favor of the sprint plan's per-byte,
+runs-allowed mapping. The hybrid shape, prefix, hash width, and 57-byte bound are unchanged.
+The reference calculation in the iteration-336 Verification Log pins the order and fixtures.
 
 - **Output shape**: `m-<slug>-<16hex>`, e.g. `m-std_list-d9997702a41d1e11`.
 - **Max component length**: 2 (`m-`) + 38 (slug cap) + 1 (dash) + 16 (suffix) = **57 chars**,
@@ -158,17 +210,21 @@ func slug(id string) string { /* lower; rune-map; trim; cut at 38 */ }
   the whole component, which starts with `m-`. **Choice**: we drop `.` rather than keep it. The
   prefix alone would suffice, but dropping `.` (i) removes the hazard a second, independent
   way, (ii) makes the trailing-dot rule moot (nothing to trim), and (iii) costs nothing in
-  readability — `validateModuleName` permits no `.` in module names, and dots in absolute-path
+  readability — `validateModuleName` permits no `.` in stdlib-style names, and dots in absolute-path
   IDs are directory-name noise. The suffix alphabet is `[0-9a-f]`; no forbidden byte survives
   either part. The slug never ends in `.` or space because neither is in its alphabet.
-- **(b) injectivity in practice**: distinct module IDs map to distinct 16-hex-char (64-bit)
-  suffixes with overwhelmingly high probability. Birthday bound: collision probability ≈
+- **(b) collision resistance, not injectivity**: distinct module IDs map to distinct 16-hex-char (64-bit)
+  suffixes with high probability under the non-adversarial, uniformly distributed digest
+  model. Birthday bound: collision probability ≈
   n² / 2⁶⁵; at n = 10⁶ directory entries that is ≈ 3e-8. If two IDs ever did collide the
-  suffix would agree, but the slug additionally differs for every pair that differs within
-  their first 38 characters, so the real distinguishing width is larger than 64 bits for
-  realistic IDs. A collision, even if one occurred, degrades to the existing stamp-backstop
-  recompile, never to a wrong program (Q3).
-- **(c) case-collision safe**: `slug` is lowercased and the suffix is lowercase hex over the
+  suffix would agree, and different final slugs can still distinguish that pair. Distinct input
+  prefixes need not yield distinct slugs: case folding, replacement, trimming, and truncation
+  are lossy. A collision, even if one occurred, degrades to the existing stamp-backstop
+  recompile, never to a wrong program (Q3). For arbitrary-length inputs, a bounded output
+  space cannot be injective. A theoretical hash collision together with equal final slugs
+  can still cause directory contention and repeated recompilation. This proposal reduces
+  that risk; it does not eliminate it or introduce collision-specific diagnostics.
+- **(c) case-fold-stable alphabet**: `slug` is lowercased and the suffix is lowercase hex over the
   **original bytes**. `Foo` and `foo` produce different lowercase-hex suffixes
   (`1cbec737f863e492` vs `2c26b46b68ffc68f`), so the two directories remain distinct even on
   an APFS/NTFS case-insensitive volume, because the *alphabet* of the differing part has no
@@ -176,15 +232,15 @@ func slug(id string) string { /* lower; rune-map; trim; cut at 38 */ }
 - **(d) bounded**: 57 chars max.
 - **(e) deterministic**: a pure function of `moduleID`; identical on every run and platform.
 
-Worked examples (suffix = first 16 hex of SHA-256 over the raw module ID; the `m-` prefix
-does not enter the hash, so the suffixes are unchanged from round 1):
+Worked examples (recomputed in iteration 336 using the normative byte algorithm above;
+suffix = first 16 hex of SHA-256 over the raw module ID; the `m-` prefix does not enter the hash):
 
 | module ID | slug (38 cap, lower, mapped) | resulting directory component |
 |---|---|---|
 | `std/list` | `std_list` | `m-std_list-d9997702a41d1e11` |
 | `a/b` | `a_b` | `m-a_b-c14cddc033f64b9d` |
 | `a__b` | `a__b` | `m-a__b-63e5c1c455d01d5c` |
-| `C:/Users/runneradmin/x` | `c_users_runneradmin_x` | `m-c_users_runneradmin_x-81fb5218f110e3cc` (no colon ⇒ legal on Windows) |
+| `C:/Users/runneradmin/x` | `c__users_runneradmin_x` | `m-c__users_runneradmin_x-81fb5218f110e3cc` (no colon ⇒ legal on Windows) |
 | `con` | `con` | `m-con-1143da2bc54c495c` (basename `m-con-…`, never `con`) |
 | `con.txt` | `con_txt` | `m-con_txt-d3bde286fd271ed6` (legal: no dot survives, and the basename before any dot starts with `m-`, not `con`) |
 | `CON.txt` | `con_txt` (same slug as `con.txt`) | `m-con_txt-09c8cc7edcae01ac` (legal for the same reason; distinct from `con.txt` via the suffix) |
@@ -192,10 +248,11 @@ does not enter the hash, so the suffixes are unchanged from round 1):
 | `COM1.any` | `com1_any` | `m-com1_any-bdd82f44de519430` (legal: basename before any dot is `m-com1_any-…`, never `COM1`) |
 | `Foo` / `foo` | `foo` / `foo` (same slug) | `m-foo-1cbec737f863e492` / `m-foo-2c26b46b68ffc68f` (distinct even case-folded) |
 
-Defect 1 fixed: the colon is gone (every component is `m-` + `[a-z0-9_-]` + `-` + lowercase
+Expected Defect 1 encoding correction: the colon is gone (every component is `m-` + `[a-z0-9_-]` + `-` + lowercase
 hex) and no reserved basename can appear before a dot because there is no dot and the
-component starts with `m-`. Defect 2 fixed: `a/b` and `a__b` now map to distinct dirs.
-Case trap closed: `Foo`/`foo` separate.
+component starts with `m-`. The measured Defect 2 pair `a/b` and `a__b` maps to distinct
+directories, as does the case-variant pair `Foo`/`foo`. These are exact fixture results,
+not proof that all possible module IDs map to distinct directories.
 
 ## Conflict Surface
 
@@ -285,8 +342,13 @@ under the new scheme. Bumping the version would be harmless but redundant; we do
   `stamp.ModuleID != moduleID`) remains the correctness backstop and is **unchanged**; the
   stamp schema (`artifactStamp`, `cache_artifacts.go:35-40`: `Version`, `ModuleID`, `CacheKey`,
   `SHA256`) keeps the same fields and does **not** move.
-- Nothing outside `internal/pipeline` reads the `modules/<component>` directory layout
-  (verified by grep). No external contract changes.
+- The `cmd/ailang` test fixture **does** construct the `modules/<component>` layout:
+  `compileArtifactDir` at `serve_api_mcp_surface_test.go:601-604` duplicates the old encoder,
+  and callers at lines 179 and 289 use its path. M2 must migrate this fixture to the real
+  encoder, as already required by the Conflict Surface and sprint plan. The call-site grep
+  for `moduleArtifactDir` does not establish the absence of consumers outside the package.
+  The earlier blanket outside-pipeline claim is withdrawn; the intended compatibility
+  boundary preserves stamp/manifest formats while changing this on-disk directory layout.
 
 ## Milestones
 
@@ -295,11 +357,12 @@ production-code mutation it kills.
 
 ### M1 — introduce `encodeModuleDirName` + pure unit tests (no production wiring yet)
 Add the new function and a `_test.go` table test exercising only the *function*: determinism,
-injectivity over the worked-example set (`std/list`, `a/b` vs `a__b`, `Foo` vs `foo`), and
+exact separation over the worked-example set (`std/list`, `a/b` vs `a__b`, `Foo` vs `foo`), and
 bounded length (≤ 57).
 - Acceptance test `TestEncodeModuleDirName_InjectivityAndDeterminism` (unit, table-driven).
-- **Mutation killed**: delete the `-<hex>` suffix computation (make output just `slug(id)`).
-  This table instantly turns red (`a/b` vs `a__b`, and `Foo` vs `foo`, become equal). This
+- **Mutation killed**: delete the `-<hex>` suffix computation (return `"m-" + slug(id)`, retaining the prefix).
+  This table instantly turns red (`Foo` and `foo` become equal; `a/b` and `a__b` retain
+  distinct slugs under the runs-preserved algorithm). This
   mutation is killed by M1's own code — M1's test is not vacuous for M1 because M1 introduces
   both.
 
@@ -378,6 +441,34 @@ sees why a version bump was *not* needed for the encoding change.
 
 ## Verification Log
 
+### Iteration-336 source-attribution proof (post-round-2; no design revision)
+
+Sol's alternative proof was reproduced exactly for its eight named source files. The original
+worktree `/Users/voightkampff/dev/sunholo-data/.wt-v1-iter334` returned
+`c2a9d8fb4abfadb472a5c05461f10a506f4a8013` from `git rev-parse HEAD`.
+In `/Users/voightkampff/.ailang-driver-pin/.wt-v1-iter336`, `pwd`, `git rev-parse HEAD`, and
+`git status --short` returned, respectively:
+
+```text
+/Users/voightkampff/.ailang-driver-pin/.wt-v1-iter336
+e30904f71d59b8a6b93f10c3b8d77bc28bce4f48
+ M design_docs/planned/v0_36_0/m-cache-module-id-encoding.md
+```
+
+Exact source-comparison command, run in the iteration-336 worktree:
+
+```sh
+git diff --exit-code c2a9d8fb4abfadb472a5c05461f10a506f4a8013..e30904f71d59b8a6b93f10c3b8d77bc28bce4f48 -- internal/pipeline/cache_store.go internal/pipeline/cache_artifacts.go internal/pipeline/cache_runtime.go internal/pipeline/pipeline_module.go internal/pipeline/cache_key.go internal/loader/loader.go internal/loader/stdlib_resolver.go cmd/ailang/serve_api_mcp_surface_test.go
+```
+
+Observed: **exit 0, no output**. These eight files are identical between the recorded commits;
+the current status additionally shows the only working-tree change is this design document.
+The positive identity controls are the two successful commit resolutions and the current
+`pwd`/status output. This ties inherited observations about the eight named files to the
+reviewed source snapshot; it does not claim equivalence for other files or convert round 2
+into a pass. The historical Verification Log remains intact below.
+
+
 Every codebase claim below was produced by the command shown; controls run where required per
 R2. `$R` = repo root `/Users/voightkampff/dev/sunholo-data/.wt-v1-iter334`.
 
@@ -403,12 +494,123 @@ R2. `$R` = repo root `/Users/voightkampff/dev/sunholo-data/.wt-v1-iter334`.
 | **R2/controller, found while measuring oc-glm-5-2's objection**: a hand-rolled duplicate of the encoding exists in ANOTHER package and does not call `sanitizeModuleID` | `grep -rn 'Split.*"__"\|TrimPrefix.*modules\|Replace.*"__"' --include='*.go' internal/ cmd/` | `cmd/ailang/serve_api_mcp_surface_test.go:602:	name := strings.NewReplacer("/", "__", "\\\\", "__").Replace(moduleID)` (plus two unrelated Firestore-id hits in `internal/server/auth/workspace.go`, which are the known-present control that the pattern fires). This is a SECOND implementation of the directory encoding and breaks silently when the encoding changes. |
 | **R2/gemini-3-1-pro**: `Clear()` DOES reset the manifest, so M4's test assertion is sound (measured by the controller, transcribed) | `sed -n '117,132p' internal/pipeline/cache_store.go` | `cs.manifest = &CacheManifest{ Version: cacheKeyVersion, Entries: make(map[string]*CacheEntry) }` then `if err := cs.Save(); err != nil { return fmt.Errorf("save empty compilation cache manifest: %w", err) }` then `cs.artifactIO.removeAll(filepath.Join(cs.dir, "modules"))`. The reviewer's conditional ("if `Clear()` does not actually clear the manifest") is REFUTED: it resets the in-memory manifest AND persists it, before removing the artifact tree. M4's test needs no weakening. |
 | `cacheKeyVersion` guards blob format, currently `v4` | `sed -n '1,35p' internal/pipeline/cache_key.go` | `const cacheKeyVersion = "v4"`; header comment: "bumped when the cache format changes, invalidating all entries" |
-| `validateModuleName` allows mixed-case `[a-zA-Z0-9_/-]` (case not normalised) | `sed -n '25,79p' internal/loader/stdlib_resolver.go` | `validPattern := regexp.MustCompile(\`^[a-zA-Z0-9_/-]+$\`)`; suspicious list also rejects `c:`, `C:`, UNC |
+| `validateModuleName` allows mixed-case `[a-zA-Z0-9_/-]` for stdlib resolution | `sed -n '25,79p' internal/loader/stdlib_resolver.go` | `validPattern := regexp.MustCompile(\`^[a-zA-Z0-9_/-]+$\`)`; suspicious list also rejects `c:`, `C:`, UNC |
 | Modules keyed by canonical `module.Path` | `sed -n '486,513p' internal/loader/loader.go` | `// Store with canonical ID (module.Path), not input path` `modules[module.Path] = module` |
 | Windows skip branch + its two callers exist in serve test | `grep -n "requireCompileArtifactCache\|sanitizeModuleID" cmd/ailang/serve_api_mcp_surface_test.go` | callers at lines 177 and 287; `sanitizeModuleID` comment refs at 542, 549; skip at 572 |
 | **Negative control** (R2): a fabricated symbol is absent, with a known-present control in the same breath | `grep -rn "fabricatedSymbolDefinitelyAbsentXYZ" --include=*.go . \| wc -l` then `grep -rln "sanitizeModuleID" --include=*.go .` | first output `0`; positive control returns `./cmd/ailang/serve_api_mcp_surface_test.go`, `./internal/pipeline/cache_store.go`, `./internal/pipeline/cache_artifacts_test.go`, `./internal/pipeline/cache_artifacts.go` (4 files) — the same 4-file set shown in the call-site row, so the search instrument is known-good. No admissible "found nothing" claim was made without this control. |
 
+### Iteration 336 clarification — measured 2026-09-06
+
+Commands in this subsection ran from
+`/Users/voightkampff/.ailang-driver-pin/.wt-v1-iter336`. These measurements clarify the
+proposed algorithm; they are not evidence that the production encoder is implemented.
+
+| Claim | Command | Observed output |
+|---|---|---|
+| Q3 has an outside-pipeline layout consumer requiring the already-planned M2 migration | `sed -n '601,604p' cmd/ailang/serve_api_mcp_surface_test.go` and `rg -n 'compileArtifactDir' cmd/ailang/serve_api_mcp_surface_test.go` | Body: `name := strings.NewReplacer("/", "__", "\\", "__").Replace(moduleID)` followed by `return filepath.Join(cacheRoot, "compile", "modules", name)`. Callers at 179 and 289; definition at 601. This positive evidence replaces the former negative claim. |
+| M2 already owns the real-encoder migration | `sed -n '175,195p' design_docs/planned/v0_36_0/m-cache-module-id-encoding-sprint-plan.md` | Work items explicitly expose the real encoder through a narrow test-visible API and replace `compileArtifactDir`'s `strings.NewReplacer` copy with a call to it; a matching copy is insufficient. |
+| All worked examples, ASCII/UTF-8 byte handling, empty slug, and trim-before-cut order | Reference command below | Full output below: all 11 inherited suffixes match; the Windows slug has **two** underscores after `c`; the trim/cut fixture ends its 38-byte slug with `_` and produces a 57-byte component. |
+
+Additional revision measurements after iteration-336 quorum round 1:
+
+| Claim | Command | Observed output |
+|---|---|---|
+| `CacheEntry` and `CacheManifest` have no dedicated directory-name/path fields | `sed -n '/type CacheEntry struct/,/}/p' internal/pipeline/cache_store.go` and `sed -n '/type CacheManifest struct/,/}/p' internal/pipeline/cache_store.go` | Complete entry fields: `CacheKey string`, `IfaceDigest string`, `IfaceJSON []byte`, `CompileTimeMs int64`, `Timestamp time.Time`; manifest fields: `Version string`, `Entries map[string]*CacheEntry`. The complete bodies are the negative evidence; the present `CacheKey` and `Entries` fields are positive controls proving the reads reached both schemas. |
+| `validateModuleName` is invoked by stdlib resolution; it is not established as a guard for every absolute-path ID | `rg -n 'validateModuleName\(' . --glob '*.go'` and `sed -n '147,170p' internal/loader/stdlib_resolver.go` | Production definition at `stdlib_resolver.go:25`, sole non-test call at `:163`, inside `StdlibResolver.ResolveStdlib(moduleName string)` before removing the `std/` prefix. Remaining hits are in `stdlib_resolver_test.go` and `stdlib_entry_path_test.go`; the definition and production call are positive controls for the absence of other production callers. |
+| Loader map assignment uses the stored module path directly | `sed -n '486,513p' internal/loader/loader.go` | `// Store with canonical ID (module.Path), not input path` followed by `modules[module.Path] = module`. This verifies the assignment, not a universal claim about all upstream path normalization. |
+| Validator restrictions apply to that stdlib-style name input | `sed -n '25,79p' internal/loader/stdlib_resolver.go` | Body rejects `strings.Contains(name, "..")` and null bytes, uses `^[a-zA-Z0-9_/-]+$`, then checks `filepath.IsAbs(name)` and suspicious patterns. |
+| Captured baseline log does not establish the illustrated Windows diagnostic | `rg -n 'CACHE_WRITE_FAILED' /tmp/v1-iter336-windows-base.log` then positive control `rg -n -m 1 'Runner Image' /tmp/v1-iter336-windows-base.log` | First query: no matches. Positive control: `2:2026-09-06T01:49:01.8360088Z ##[group]Runner Image Provisioner`. Controller supplied this log from job `101410083473`; no runtime error transcript is claimed. |
+| Existing foreign-module stamp rejection routes to the existing invalid-cache diagnostic and recompilation | `sed -n '295,310p' internal/pipeline/cache_artifacts.go`, `sed -n '52,66p' internal/pipeline/cache_runtime.go`, `sed -n '82,115p' internal/pipeline/cache_runtime.go`, and `sed -n '269,298p' internal/pipeline/pipeline_module.go` | Stamp comparison includes `stamp.ModuleID != moduleID` and returns `artifactFailure("verification", stampPath, fmt.Errorf("stamp authorization mismatch"))`. Load error calls `runtime.warnInvalid(moduleID, err)` and returns `(nil, entry, false)`. `warnInvalid` prints `CACHE_INVALID module=%s path=%s reason=%s` and `; recompiling` (deduplicated per module). The pipeline's unverified branch increments misses and falls through; the cached-unit `continue` is inside the verified branch. |
+
+Reference command (stdlib-only calculation, no repository files written):
+
+```sh
+python3 - <<'PYTHON'
+import hashlib
+ids = ['std/list', 'a/b', 'a__b', 'C:/Users/runneradmin/x', 'con', 'con.txt', 'CON.txt', 'nul.log', 'COM1.any', 'Foo', 'foo', '', '///', '__A__', 'aéB', '__' + 'A' * 37 + '/B__']
+for module_id in ids:
+    raw = module_id.encode('utf-8')
+    lowered = bytes(b + 32 if 65 <= b <= 90 else b for b in raw)
+    mapped = bytes(b if 97 <= b <= 122 or 48 <= b <= 57 or b in (95, 45) else 95 for b in lowered)
+    slug = mapped.strip(b'_')[:38].decode('ascii')
+    component = 'm-' + slug + '-' + hashlib.sha256(raw).hexdigest()[:16]
+    print(repr(module_id), repr(slug), component, len(component))
+PYTHON
+```
+
+Observed output (input, slug, component, component byte length):
+
+```text
+'std/list' 'std_list' m-std_list-d9997702a41d1e11 27
+'a/b' 'a_b' m-a_b-c14cddc033f64b9d 22
+'a__b' 'a__b' m-a__b-63e5c1c455d01d5c 23
+'C:/Users/runneradmin/x' 'c__users_runneradmin_x' m-c__users_runneradmin_x-81fb5218f110e3cc 41
+'con' 'con' m-con-1143da2bc54c495c 22
+'con.txt' 'con_txt' m-con_txt-d3bde286fd271ed6 26
+'CON.txt' 'con_txt' m-con_txt-09c8cc7edcae01ac 26
+'nul.log' 'nul_log' m-nul_log-c0294fbf8537502a 26
+'COM1.any' 'com1_any' m-com1_any-bdd82f44de519430 27
+'Foo' 'foo' m-foo-1cbec737f863e492 22
+'foo' 'foo' m-foo-2c26b46b68ffc68f 22
+'' '' m--e3b0c44298fc1c14 19
+'///' '' m--732c4e9711639ed1 19
+'__A__' 'a' m-a-6530635bd09a76b6 20
+'aéB' 'a__b' m-a__b-a65e5ade07551d5e 23
+'__AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/B__' 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_' m-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_-753374029f5ccda0 57
+```
+
 ## Quorum verification log
+
+### Iteration 336 round 2 — BLOCKED; design phase PARKED pending D-57
+
+Artifact read in full with `cat /tmp/v1-iter336-quorum-r2/*.json`:
+`/tmp/v1-iter336-quorum-r2/m-cache-module-id-encoding-2026-09-06T05-47-18Z.json`.
+Observed synthesis: **blocked**, two rejects, one pass, no absent reviewers; total cost
+**$0.13907585**. The controller recorded an in-session pass; this did not override the
+reviewer rejections. Round 1 plus round 2 cost **$0.28068117**. No third design revision or
+third quorum is being performed in this phase.
+
+| Reviewer | Recorded verdict / request | Disposition |
+|---|---|---|
+| `gpt5-6-sol` | **reject**: inherited verification comes from another worktree without source-identity proof; proposed either remeasurement or the exact eight-file commit diff. | Reproduced the proposed eight-file diff: exit 0, no output; both commit hashes and current worktree status are recorded at the start of Verification Log. This applies only the requested attribution proof and does not change the blocked verdict. |
+| `gemini-3-1-pro` | **pass**, with a request to make M2's artificial mismatched-stamp fixture explicit now that the natural pair separates. | Preserved as review advice for any authorized continuation; no implementation instruction is changed in this parking disposition. |
+| `oc-glm-5-2` | **reject**: disputes the full-prefix slug's readability value; requests either a basename-plus-parent redesign with new fixtures or dropping the slug for pure hashing. | This disputes the design direction. Neither alternative is adopted here, and the narrow-refinement carve-out cannot close it. Escalated to D-57; encoder direction remains unchanged and implementation is parked. |
+
+Two factual qualifications to GLM's reasoning are recorded without treating them as approval:
+under the normative byte algorithm, **one** `/` or `\` byte maps to **one** `_`; two separators
+map to `__`, as do the two UTF-8 bytes of `é`. Its single-separator-to-two-underscores premise
+is incorrect. Also, lossy mapping does not logically imply zero readability: the measured
+`C:/Users/runneradmin/x` fixture retains `c__users_runneradmin_x`. This illustrates a limited
+readable prefix, not demonstrated usability for the production path distribution. Neither
+qualification satisfies GLM's requested alternatives or overrides its direction rejection.
+
+**D-57 decision requested:** keep the hybrid with explicitly limited readable-prefix value
+(recommended), choose pure hashing, or redesign around basename plus parent directory.
+The default is **PARK**: no production code, no M1 execution, and no direction change until
+a human ruling. This paragraph records the pending decision, not a human answer. The earlier
+round-1 text referring to an upcoming re-quorum is retained as history; this round-2 parking
+status supersedes it. The controller owns the decision ledger and further routing.
+
+
+### Iteration 336 round 1 — blocked; bounded revision pending re-quorum
+
+Artifact read in full:
+`/tmp/v1-iter336-quorum-r1/m-cache-module-id-encoding-2026-09-06T05-39-39Z.json`
+(command: `cat /tmp/v1-iter336-quorum-r1/*.json`). Observed synthesis: **blocked**, two
+rejects, one pass, no absent reviewers; total cost **$0.14160532**. The controller's recorded
+in-session pass did not override either rejection. This revision does not claim a new verdict.
+
+| Reviewer | Recorded verdict and objection | Bounded revision / remaining disagreement |
+|---|---|---|
+| `gpt5-6-sol` | **reject**: bounded lossy slug plus 64-bit suffix cannot satisfy injectivity; requests verification of Windows observation, full SHA-256 and explicit collision handling. | Replaced impossible uniqueness guarantees with collision resistance and finite-fixture separation; explicitly accepts theoretical contention/recompilation. Withdrew captured-Windows-outage claim. Full-256/new-diagnostic proposal is recorded as a contested alternative above, **not adopted**, awaiting independent re-quorum. |
+| `gemini-3-1-pro` | **reject**: missing `CacheEntry` schema inspection leaves the migration premise unverified. | Read both complete structs and logged fields with positive controls; neither stores a dedicated directory-name/path field. |
+| `oc-glm-5-2` | **pass**, with objection to unverified captured Windows diagnostic and catch about validator scope. | Adopted its option (b): label diagnostic an inferred reconstruction with no captured CI excerpt; fetched baseline had no diagnostic match. Verified the sole production validator caller is stdlib resolution and qualified all associated scope claims. |
+
+The normative M1 suffix-removal mutation now returns `"m-" + slug(id)`, retaining the prefix.
+The algorithm, 38-byte slug cap, 16-hex-character suffix, and 57-byte total cap are unchanged.
+No production code or new diagnostic is introduced by this revision.
+
+### Historical iteration-334 quorum record
 
 **Round 1 (2026-09-06): 3 reviewers, 3 rejects. Design direction (hybrid slug + hash) undisputed
 by all three; blocked on one substantive defect and one shared verification debt.**

--- a/docs/sprint-retros/iter336-cache-module-id-encoding-quorum/round1.json
+++ b/docs/sprint-retros/iter336-cache-module-id-encoding-quorum/round1.json
@@ -1,0 +1,63 @@
+{
+  "doc": "/Users/voightkampff/.ailang-driver-pin/.wt-v1-iter336/design_docs/planned/v0_36_0/m-cache-module-id-encoding.md",
+  "iso_ts": "2026-09-06T05:39:39Z",
+  "reviewers": [
+    {
+      "model": "gpt5-6-sol",
+      "cost_usd": 0.07405500000000001,
+      "tokens_in": 12957,
+      "tokens_out": 309,
+      "present": true,
+      "result": {
+        "verdict": "reject",
+        "strongest_objection": "The chosen 64-bit hash suffix does not satisfy the document’s hard injectivity requirement. A bounded 57-byte, lossy slug-plus-64-bit-hash mapping over arbitrary module-ID strings must have collisions; the doc simultaneously calls it “injective,” “guaranteed distinct,” and only “injective in practice.” Therefore Defect 2 is made improbable, not fixed, and the claimed equivalence with pure hashing is false.",
+        "catch": "Reconcile constraints (b) and (d), which are mathematically incompatible for unbounded module IDs, and stop describing truncated SHA-256 as injective. Also verify the asserted observed Windows outage and drive-letter module-ID behavior directly; the log only confirms that a diagnostic string exists in source, not that the quoted CI failure occurred.",
+        "proposed_fix": "Replace requirement (b) with “collision-resistant, with collisions explicitly detected and handled,” use the full 256-bit lowercase SHA-256 digest if the 64-character component fits the path budget, and revise all “injective,” “guaranteed distinctness,” and “Defect 2 fixed” claims accordingly. Add a deterministic collision path: when an existing stamp has a different module_id, emit an explicit CACHE_DIRECTORY_COLLISION diagnostic and recompile or select a bounded alternate directory without silently overwriting/churning. Add verification-log rows showing the actual Windows module ID reaching moduleArtifactDir and the observed publication failure on Windows."
+      },
+      "landed": null
+    },
+    {
+      "model": "gemini-3-1-pro",
+      "cost_usd": 0.030643999999999998,
+      "tokens_in": 14344,
+      "tokens_out": 163,
+      "present": true,
+      "result": {
+        "verdict": "reject",
+        "strongest_objection": "The document claims that the manifest (CacheManifest and CacheEntry) is independent of the directory encoding and needs no schema change, but it never verifies this premise by inspecting the CacheEntry struct. If CacheEntry explicitly stores the encoded directory name or path, changing the encoding will corrupt the manifest or break path resolution for existing entries.",
+        "catch": "Missing verification of the CacheEntry struct schema to prove it does not store directory paths or encoded names.",
+        "proposed_fix": "Add a Verification Log row running `sed -n '/type CacheEntry struct/,/}/p' internal/pipeline/cache_store.go` to confirm its fields are strictly independent of the directory encoding."
+      },
+      "landed": null
+    },
+    {
+      "model": "oc-glm-5-2",
+      "cost_usd": 0.03690632,
+      "tokens_in": 12980,
+      "tokens_out": 5738,
+      "present": true,
+      "result": {
+        "verdict": "pass",
+        "strongest_objection": "The Problem section quotes a specific Windows CI error message ('CACHE_WRITE_FAILED module=C:/Users/... stage=publication path=...\\compile\\modules\\C:__Users__runneradmin__... : ARTIFACT_INVALID') as observed on the CI runner, but the Verification Log only confirms the string 'CACHE_WRITE_FAILED' exists in test fixtures — there is no log row showing this error was actually produced by a real Windows CI run. The deduction from verified premises (colon passes through encoder; colon illegal on Windows) is sound, but the specific quoted diagnostic is an unverified runtime observation presented as fact.",
+        "catch": "The doc uses validateModuleName (in stdlib_resolver.go) to claim defence-in-depth against '..' and null bytes for all module IDs, but validateModuleName likely only governs stdlib-style names, not the absolute-path module IDs that are the doc's primary subject. If absolute-path IDs bypass validateModuleName, the 'already rejects' framing overstates the existing protection. Verify whether validateModuleName is applied to absolute-path module IDs or only to stdlib resolution, and qualify the Non-goals bullet accordingly.",
+        "proposed_fix": "Add a Verification Log row that either (a) runs the two serve_api_mcp_surface_test.go callers on a Windows runner and captures the actual CACHE_WRITE_FAILED output, or (b) explicitly marks the quoted CI error as an inferred reconstruction with the note: 'The exact diagnostic string is reconstructed from the verified facts that sanitizeModuleID passes ':' through and Windows rejects ':' in path components; no Windows CI log excerpt was captured.' Additionally, qualify the Non-goals bullet to read: 'validateModuleName (in stdlib_resolver.go) rejects .., null bytes, and restricts to [a-zA-Z0-9_/-] for stdlib-style names; absolute-path module IDs may not pass through this validator — defence in depth for those remains the adversarial row's job.'"
+      },
+      "landed": null
+    }
+  ],
+  "controller_in_session": {
+    "verdict": "pass",
+    "note": "Bounded clarification preserves existing plan per-byte ASCII semantics, fixes contradictory Windows example and Q3 consumer claim. Existing hybrid design direction retained; M1 remains unwired pure encoder. Astra authored revision so Sol occupies OpenAI seat under interim independence workaround."
+  },
+  "synthesis": {
+    "verdict": "blocked",
+    "blocking_objections": [
+      "gpt5-6-sol: The chosen 64-bit hash suffix does not satisfy the document’s hard injectivity requirement. A bounded 57-byte, lossy slug-plus-64-bit-hash mapping over arbitrary module-ID strings must have collisions; the doc simultaneously calls it “injective,” “guaranteed distinct,” and only “injective in practice.” Therefore Defect 2 is made improbable, not fixed, and the claimed equivalence with pure hashing is false.",
+      "gemini-3-1-pro: The document claims that the manifest (CacheManifest and CacheEntry) is independent of the directory encoding and needs no schema change, but it never verifies this premise by inspecting the CacheEntry struct. If CacheEntry explicitly stores the encoded directory name or path, changing the encoding will corrupt the manifest or break path resolution for existing entries."
+    ],
+    "absent_reviewers": [],
+    "total_cost_usd": 0.14160532,
+    "total_tokens_in": 40281,
+    "total_tokens_out": 6210
+  }
+}

--- a/docs/sprint-retros/iter336-cache-module-id-encoding-quorum/round2.json
+++ b/docs/sprint-retros/iter336-cache-module-id-encoding-quorum/round2.json
@@ -1,0 +1,63 @@
+{
+  "doc": "/Users/voightkampff/.ailang-driver-pin/.wt-v1-iter336/design_docs/planned/v0_36_0/m-cache-module-id-encoding.md",
+  "iso_ts": "2026-09-06T05:47:18Z",
+  "reviewers": [
+    {
+      "model": "gpt5-6-sol",
+      "cost_usd": 0.08411,
+      "tokens_in": 14710,
+      "tokens_out": 352,
+      "present": true,
+      "result": {
+        "verdict": "reject",
+        "strongest_objection": "The premise verification is not tied to the reviewed codebase. Most repository claims were measured in `$R=/Users/voightkampff/dev/sunholo-data/.wt-v1-iter334`, while the requested document and later checks are under `/Users/voightkampff/.ailang-driver-pin/.wt-v1-iter336`. The doc provides no commit hashes or diff proving that the relevant files are identical across those worktrees, so the iter-334 observations do not verify current iter-336 APIs, call sites, line references, or behavior.",
+        "catch": "Verify every implementation-dependent claim against the exact iter-336 worktree, especially the sole-consumer/call-site claims, miss-to-recompile control flow, stamp comparison, `Clear()` behavior, manifest schema, version semantics, and Windows skip/duplicate encoder locations.",
+        "proposed_fix": "Replace the iter-334 Verification Log with commands run from `/Users/voightkampff/.ailang-driver-pin/.wt-v1-iter336`, and add a header row recording `pwd`, `git rev-parse HEAD`, and `git status --short`. Alternatively, record both worktree commit hashes and a command such as `git diff --exit-code \u003citer334-commit\u003e..\u003citer336-commit\u003e -- internal/pipeline/cache_store.go internal/pipeline/cache_artifacts.go internal/pipeline/cache_runtime.go internal/pipeline/pipeline_module.go internal/pipeline/cache_key.go internal/loader/loader.go internal/loader/stdlib_resolver.go cmd/ailang/serve_api_mcp_surface_test.go`; only reuse old observations if that diff proves the relevant sources unchanged."
+      },
+      "landed": null
+    },
+    {
+      "model": "gemini-3-1-pro",
+      "cost_usd": 0.035228,
+      "tokens_in": 16312,
+      "tokens_out": 217,
+      "present": true,
+      "result": {
+        "verdict": "pass",
+        "strongest_objection": "The closest concern is a minor test implementation ambiguity in M2: since `a/b` and `a__b` are explicitly separated by the new encoding, they no longer collide organically on disk. Retaining the stamp-backstop assertion in the same test requires artificially simulating a collision (e.g., manually placing a mismatched stamp into the new directory) rather than relying on natural pipeline contention.",
+        "catch": "In M2, explicitly clarify how the test fixture should trigger the stamp-backstop failure now that the natural directory collision between `a/b` and `a__b` is eliminated.",
+        "proposed_fix": "In M2, append to the rewrite instruction: '... then (b) keep the stamp-backstop assertion that a stamp from one module is refused under the other (by having the fixture artificially write a mismatched artifact stamp into the separated directory, since the new encoding prevents them from organically colliding).' "
+      },
+      "landed": null
+    },
+    {
+      "model": "oc-glm-5-2",
+      "cost_usd": 0.01973785,
+      "tokens_in": 14751,
+      "tokens_out": 584,
+      "present": true,
+      "result": {
+        "verdict": "reject",
+        "strongest_objection": "The slug algorithm drops `.` and maps every non-`[a-z0-9_-]` byte to `_`, but this means a UTF-8 multibyte character like `é` produces two consecutive `_` bytes — indistinguishable from a path separator `/` or `\\` which also produce `__`. The worked example confirms this: `aéB` → slug `a__b` (23 bytes), identical to what `a//b` or `a\\\\b` would produce. Combined with the 38-byte truncation and the fact that the slug feeds into no collision-resistant structure (only the 64-bit hash does), the slug provides zero debuggability value for any module ID containing non-ASCII or path-separator-dense inputs — the exact class of absolute-path IDs (e.g. `C:/Users/runneradmin/AppData/...`) that motivated Defect 1. The doc claims the slug is a 'readability aid' but never verifies that it actually aids readability for the production module ID distribution, which the Verification Log confirms are absolute paths on Windows runners.",
+        "catch": "The slug's collision behavior under the normative algorithm is self-contradictory with its stated purpose. The doc says the slug 'may also separate some hash collisions' (Option C rationale) but the algorithm guarantees that multibyte UTF-8 sequences and path separators produce identical slug bytes, so for the exact class of IDs this design targets (Windows absolute paths with separators), the slug is maximally lossy. No test in M1–M4 asserts that a human can distinguish two different absolute-path module IDs by their slugs alone. The design's core tradeoff (slug readability vs. pure hash) is unverified for the production input distribution.",
+        "proposed_fix": "Either (a) restrict the slug to a deterministic, collision-resistant encoding of the path's final two components (basename + parent dir) rather than the full path — preserving debuggability for the common case without claiming the slug separates hash collisions it provably cannot — and add an M1 test asserting that two distinct absolute-path IDs from the Windows fixture set produce distinct slugs; or (b) drop the slug entirely (Option B) and accept the pure-hash readability cost, which the doc already acknowledges is the mathematically honest choice. If (a) is chosen, add a Verification Log row showing the slug output for the full `C:/Users/runneradmin/AppData/Local/...` fixture path from the Windows runner, not the truncated `C:/Users/runneradmin/x` proxy, and confirm a human can identify the module from the slug."
+      },
+      "landed": null
+    }
+  ],
+  "controller_in_session": {
+    "verdict": "pass",
+    "note": "Revised specification accurately limits the bounded 64-bit directory suffix to collision resistance, retains existing exact-ID stamp validation and recompilation, and records the stronger hash/new diagnostic proposal as contested. Independent reviewers must decide whether the corrected existing direction is acceptable; no objection is overridden."
+  },
+  "synthesis": {
+    "verdict": "blocked",
+    "blocking_objections": [
+      "gpt5-6-sol: The premise verification is not tied to the reviewed codebase. Most repository claims were measured in `$R=/Users/voightkampff/dev/sunholo-data/.wt-v1-iter334`, while the requested document and later checks are under `/Users/voightkampff/.ailang-driver-pin/.wt-v1-iter336`. The doc provides no commit hashes or diff proving that the relevant files are identical across those worktrees, so the iter-334 observations do not verify current iter-336 APIs, call sites, line references, or behavior.",
+      "oc-glm-5-2: The slug algorithm drops `.` and maps every non-`[a-z0-9_-]` byte to `_`, but this means a UTF-8 multibyte character like `é` produces two consecutive `_` bytes — indistinguishable from a path separator `/` or `\\` which also produce `__`. The worked example confirms this: `aéB` → slug `a__b` (23 bytes), identical to what `a//b` or `a\\\\b` would produce. Combined with the 38-byte truncation and the fact that the slug feeds into no collision-resistant structure (only the 64-bit hash does), the slug provides zero debuggability value for any module ID containing non-ASCII or path-separator-dense inputs — the exact class of absolute-path IDs (e.g. `C:/Users/runneradmin/AppData/...`) that motivated Defect 1. The doc claims the slug is a 'readability aid' but never verifies that it actually aids readability for the production module ID distribution, which the Verification Log confirms are absolute paths on Windows runners."
+    ],
+    "absent_reviewers": [],
+    "total_cost_usd": 0.13907585,
+    "total_tokens_in": 45773,
+    "total_tokens_out": 1153
+  }
+}


### PR DESCRIPTION
The cache module-ID design claimed injectivity and contained ambiguous slug examples. This revision specifies the byte mapping, verifies all 16 examples, and records the existing exact-ID stamp backstop and its limits.

Two complete quorum rounds still reject the naming direction. The design and inherited plan are parked pending D-57; no production code or milestone is executed. Raw reviewer artifacts are retained. Independent MiniMax reviewed exact head b2f31b154f2024fa1494092b1f37ff018030fcc8: PASS for documentation and the park decision, raw score 14/15 in the documentation category; implementation categories are N/A. This does not approve the naming direction or authorize M1. The inherited plan mutation example remains an explicitly flagged future planner correction. The [raw report](https://github.com/sunholo-data/ailang/blob/374d8a4217358721b2bb2ad7fe52b7be5c93377d/docs/sprint-retros/iter336-cache-module-id-encoding-evaluation.md) and [controller qualifications](https://github.com/sunholo-data/ailang/blob/374d8a4217358721b2bb2ad7fe52b7be5c93377d/docs/sprint-retros/iter336-cache-module-id-encoding-controller-addendum.md) are banked with iteration336 mission bookkeeping.

Validation: baseline make build, make test (8,242 top-level Go PASS events across 123 packages), make lint (0 issues), and pipeline tests passed. These are baseline results, not proof of a shipped encoder.
