### PR TITLE
Motoko iter38 row 16: the mission-loop workbench arc, and the repair it needed

### DIFF
--- a/changelogs/v0.32-current.md
+++ b/changelogs/v0.32-current.md
@@ -16,6 +16,49 @@ checkpoint blocked every open pull request in the repo.
   `OnTurnStart`, `OnText`, `OnToolUse`, `OnToolResult`, `OnTurnEnd`, `OnError`) move **byte-for-byte**
   into `cmd/ailang/exec_events.go`. `exec.go` 807 → 614, new file 209; the diff of `exec.go` is 193
   deletions and **zero** additions. Same package, no signature, visibility or import-path change.
+### Added — mission configuration can be inspected, staged, and applied from one registry
+
+`M-MISSION-LOOP-WORKBENCH`, Phases 1–2. Mission wiring had lived across six surfaces, with a
+hand-maintained reach table that had already hidden a live fork and configuration drift.
+
+- One TOML entry per mission in `missions/` is parsed with the in-tree BurntSushi/toml. Validation
+  rejects colliding `boot_offset` values and deliberately rejects `[roles]`, naming
+  `M-MODEL-REGISTRY-SINGLE-SOURCE` (`models.yml` via `ailang models role`) as the sole owner of
+  model assignment.
+- **`ailang mission list|doctor|install|apply`** covers the four registered missions. `list`
+  computes reach from the registry; the prose reach table in `mission-control.sh` was deleted and
+  tests prevent either it or registry/driver boot-offset drift from returning.
+- **`install` writes both artifacts only to `*.staged`.** This is a safety boundary: the driver
+  re-sources its installed env on every fire, so an in-place write would change a running schedule
+  without a reload. Env rendering authors only mission name, repo, doc and workdir; role chains,
+  allowlists, PATH, comments and blank lines pass through verbatim.
+- **`doctor` was accepted only after reproducing live-rig failures:** reviewed and installed docs
+  env files disagreed on `MISSION_PLANNER_ALLOWLIST`, two plists supplied a PATH without
+  `/usr/sbin`, and world did not source `pin-root.sh`.
+- **`apply` is the only mutating verb.** It refuses a live pidfile unless forced, never retries on
+  its own, and gives bootout settle, bootstrap and readiness verification 10s, 10s and 15s
+  respectively; a test bounds the worst case at 35s.
+- All four missions were adopted only after staged-versus-installed diffs caught two defects: both
+  launchd streams targeted the driver's own `$LOG`, and an appended bare `MISSION_WORKDIR` would
+  have overwritten the pinned worktree with the source clone. Their discovery on first use is why
+  staging and applying remain separate operations.
+
+### Fixed — the mission workbench repair restored every check left red by the attended landing
+
+The follow-up repair in PR #1055 corrected the Windows, shell, ratchet and test defects from
+`M-MISSION-LOOP-WORKBENCH`; all six originally-red checks were green at its final commit.
+
+- Workdir validation now accepts both POSIX-absolute registry paths and host-absolute fixture paths
+  while rejecting relative paths. The Bash 3.2 launchd job remains shell-only, and its explanation
+  is a make comment rather than a shell no-op; the Go mission suite remains available to `make test`
+  and the explicit `test-mission-registry` hand-run target.
+- `kill_unix.go` had shipped without a build constraint or Windows counterpart. Go does not treat
+  `_unix` as a GOOS suffix, so the package did not compile on Windows. This was found by direct
+  measurement, not a CI log: fixing workdir validation alone would still have left both Windows
+  checks red while appearing to address them. The Windows stub now compiles and fails closed.
+- The repair corrected a test comment that overstated local mutation coverage, skips the driver-copy
+  down-ratchet when sibling rig checkouts are absent, and replaced a slash-only backup `baseName`
+  with `filepath.Base`/`filepath.Join` after Windows exposed the final failure.
 
 ### Added — the fleet can now see how much of a subscription bucket it has spent
 


### PR DESCRIPTION
Motoko mission iteration 38, queue row **16** (bookkeeping, ≤1 iteration).

`.claude/rules/coding-standards.md` requires a CHANGELOG entry per change. `M-MISSION-LOOP-WORKBENCH`
shipped a whole user-facing command surface across two attended windows on 2026-09-05 and got none,
and neither did the repair arc that followed it.

**Measured at base `878939117` before the entry was written:**
`grep -rniE "workbench" changelogs/ CHANGELOG.md` returned **zero**, while
`git log --oneline -3 -- CHANGELOG.md` returned three real commits — so the absence was the
changelog's, not the grep's.

**Row 16's own premise had moved and is corrected here.** The row says a new unreleased section
"would misdescribe both halves" because the top entry is the already-shipped `v0.35.1`. A
`## [Unreleased]` section now exists in `changelogs/v0.32-current.md`, so the entry lands there and
covers the feature and its repair together, as the row asked.

**Independently reviewed.** An evaluator (Agent tool, `sonnet`; the executor was `codex:gpt-5.6-sol`,
so distinct agent, model and provider) verified this entry first-party against the ten commits it
cites, confirmed `ailang mission list|doctor|install|apply` and the four `missions/*.toml` registry
entries both exist, and confirmed the `## [Unreleased]` placement. Its one non-blocking note: the
phrase "all six originally-red checks" traces to the charter's own enumeration of six red check
names (`lint`, the windows pair, `docs-build`/`docs-gate`, `launchd drivers (bash 3.2)`), while PR
#1055's defect table groups them into four rows — the substance is right, the framing is a matter of
which unit you count.

**The executor deviated from the controller's directive on one point and was right:** the directive
quoted M2's "workdir absoluteness is POSIX, not host-dependent", but M8 (`a427154c8`) supersedes it —
a POSIX-only check rejects the fixtures' own Windows temp dirs, so the shipped rule accepts either
form. The entry says what M8 says.

`make check-changelog` passes (index hygiene only — a no-regression check, not evidence the entry is
correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
