### PR TITLE
docs-11: GitHub code-search fallback for ailang docs search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 For the latest version, see [changelogs/v0.32-current.md](changelogs/v0.32-current.md).
 
-## Unreleased
-
-- `ailang docs search` can use authenticated GitHub code search when local docs are unavailable.
-  Set `GITHUB_TOKEN` or use `gh auth login`; disable the fallback with `--no-github` or
-  `AILANG_NO_GITHUB_SEARCH`. Results are cached for one hour without storing credentials.
-
 ## Changelog Archives
 
 The full changelog has been split into themed files for searchability and readability:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 For the latest version, see [changelogs/v0.32-current.md](changelogs/v0.32-current.md).
 
+## Unreleased
+
+- `ailang docs search` can use authenticated GitHub code search when local docs are unavailable.
+  Set `GITHUB_TOKEN` or use `gh auth login`; disable the fallback with `--no-github` or
+  `AILANG_NO_GITHUB_SEARCH`. Results are cached for one hour without storing credentials.
+
 ## Changelog Archives
 
 The full changelog has been split into themed files for searchability and readability:

--- a/changelogs/v0.32-current.md
+++ b/changelogs/v0.32-current.md
@@ -4,6 +4,16 @@
 
 ## [Unreleased]
 
+### Added — `ailang docs search` GitHub code-search fallback
+
+- When local `design_docs/`/`docs/` aren't found (an installed binary run outside a source
+  checkout), `ailang docs search` can now fall back to authenticated GitHub code search. Set
+  `GITHUB_TOKEN` or use `gh auth login`; disable the fallback with `--no-github` or
+  `AILANG_NO_GITHUB_SEARCH`. Results are cached for one hour under
+  `~/.ailang/cache/docsearch/github/` without storing credentials. GitHub-specific logic lives
+  entirely outside `internal/docsearch/search.go`'s local search path (zero diff), selected once
+  at the CLI boundary via a new `SearchBackend` interface.
+
 ### Fixed — `cmd/ailang/exec.go` crossed the 800-line gate and reddened a REQUIRED context
 
 `8c41d41d4` ("chore: checkpoint existing z.ai provider and benchmark work") added a net 9 lines to

--- a/cmd/ailang/coordinator_cloud_github.go
+++ b/cmd/ailang/coordinator_cloud_github.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/sunholo-data/ailang/internal/coordinator"
 	"github.com/sunholo-data/ailang/internal/executor"
+	"github.com/sunholo-data/ailang/internal/gitutil"
 )
 
 // openCascadePullRequest opens a PR via the GitHub REST API after the wrapper
@@ -43,7 +44,7 @@ func openCascadePullRequest(ctx context.Context, workDir, branchName, taskID, ag
 	}
 
 	// Get the GitHub owner/repo by parsing the remote URL inside workDir.
-	repoOwner, repoName, err := getGitHubOwnerRepo(ctx, workDir)
+	repoOwner, repoName, err := gitutil.GitHubOwnerRepo(ctx, workDir)
 	if err != nil || repoOwner == "" || repoName == "" {
 		fmt.Fprintf(os.Stderr, "execute-job: pr create skipped: cannot parse GitHub repo: %v\n", err)
 		return
@@ -80,28 +81,6 @@ func openCascadePullRequest(ctx context.Context, workDir, branchName, taskID, ag
 	if err := addGitHubLabels(ctx, token, repoOwner, repoName, prNum, labels); err != nil {
 		fmt.Fprintf(os.Stderr, "execute-job: pr labels skipped: %v\n", err)
 	}
-}
-
-// getGitHubOwnerRepo parses `git remote get-url origin` to extract owner/repo
-// for HTTPS GitHub URLs. Returns empty strings + nil error for non-GitHub repos.
-func getGitHubOwnerRepo(ctx context.Context, workDir string) (string, string, error) {
-	out, err := exec.CommandContext(ctx, "git", "-C", workDir, "remote", "get-url", "origin").Output()
-	if err != nil {
-		return "", "", fmt.Errorf("git remote: %w", err)
-	}
-	url := strings.TrimSpace(string(out))
-	// Accept https://github.com/OWNER/REPO[.git] or git@github.com:OWNER/REPO[.git]
-	url = strings.TrimSuffix(url, ".git")
-	for _, prefix := range []string{"https://github.com/", "git@github.com:"} {
-		if strings.HasPrefix(url, prefix) {
-			rest := strings.TrimPrefix(url, prefix)
-			parts := strings.SplitN(rest, "/", 2)
-			if len(parts) == 2 {
-				return parts[0], parts[1], nil
-			}
-		}
-	}
-	return "", "", nil
 }
 
 // createGitHubPR makes a POST /repos/{owner}/{repo}/pulls call.

--- a/cmd/ailang/docs_search.go
+++ b/cmd/ailang/docs_search.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/sunholo-data/ailang/internal/docsearch"
+	githubsearch "github.com/sunholo-data/ailang/internal/docsearch/github"
 )
 
 // docsSearchCommand implements `ailang docs search` subcommand
@@ -26,6 +27,7 @@ func docsSearchCommand(args []string) {
 	limitFlag := searchFlags.Int("limit", 10, "Maximum results to return")
 	jsonFlag := searchFlags.Bool("json", false, "Output results as JSON")
 	helpFlag := searchFlags.Bool("help", false, "Show help for docs search")
+	noGitHubFlag := searchFlags.Bool("no-github", false, "Disable GitHub fallback when local docs are unavailable")
 
 	// Timeout flag for neural search
 	timeoutFlag := searchFlags.Duration("timeout", 60*time.Second, "Overall timeout for neural search (default: 60s)")
@@ -67,6 +69,7 @@ func docsSearchCommand(args []string) {
 	// Determine docs path
 	var docsPath string
 	var err error
+	var localDocsErr error
 	if *pathFlag != "" {
 		// User specified path
 		docsPath, err = filepath.Abs(*pathFlag)
@@ -82,10 +85,7 @@ func docsSearchCommand(args []string) {
 		// Try to find docs directory (prefer design_docs for developers, fall back to docs/ for users)
 		docsPath, err = findDocsDir()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s: %v\n", red("Error"), err)
-			fmt.Fprintln(os.Stderr, "\nHint: Use --path flag to specify a documentation directory")
-			fmt.Fprintln(os.Stderr, "Example: ailang docs search --path docs \"query\"")
-			os.Exit(1)
+			localDocsErr = err
 		}
 	}
 
@@ -133,9 +133,24 @@ func docsSearchCommand(args []string) {
 	// Create context with timeout for neural search
 	ctx, cancel := context.WithTimeout(context.Background(), *timeoutFlag)
 	defer cancel()
+	var backend docsearch.SearchBackend = docsearch.LocalBackend{}
+	if localDocsErr != nil {
+		if *noGitHubFlag || os.Getenv("AILANG_NO_GITHUB_SEARCH") != "" {
+			fmt.Fprintf(os.Stderr, "%s: %v\n", red("Error"), localDocsErr)
+			fmt.Fprintln(os.Stderr, "\nHint: Use --path, or unset --no-github and AILANG_NO_GITHUB_SEARCH")
+			os.Exit(1)
+		}
+		gh, ghErr := githubsearch.NewBackend(ctx)
+		if ghErr != nil {
+			fmt.Fprintf(os.Stderr, "%s: no local docs found, and GitHub fallback unavailable: %v\n", red("Error"), ghErr)
+			fmt.Fprintln(os.Stderr, "\nHint: Use --path, or set GITHUB_TOKEN / run `gh auth login`")
+			os.Exit(1)
+		}
+		backend = gh
+	}
 
 	// Run search
-	results, stats, err := docsearch.Search(ctx, opts)
+	results, stats, err := backend.Search(ctx, opts)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s: %v\n", red("Error"), err)
 		os.Exit(1)
@@ -288,12 +303,16 @@ func printDocsSearchHelp() {
 	fmt.Println("  --timeout <dur>      Overall timeout for neural search (default: 60s)")
 	fmt.Println("  --limit <n>          Maximum results to return (default: 10)")
 	fmt.Println("  --json               Output results as JSON")
+	fmt.Println("  --no-github          Disable authenticated GitHub fallback")
 	fmt.Println("  --rebuild            Force rebuild of all embeddings (ignore cache)")
 	fmt.Println("  --help               Show this help message")
 	fmt.Println()
 	fmt.Println("Cache Management:")
 	fmt.Println("  --cache-info         Show embedding cache statistics")
 	fmt.Println("  --cleanup            Remove orphaned cache entries (files that no longer exist)")
+	fmt.Println()
+	fmt.Println("GitHub fallback requires GITHUB_TOKEN or `gh auth login` and is used only when")
+	fmt.Println("local documentation is unavailable. Set AILANG_NO_GITHUB_SEARCH=1 to disable it.")
 	fmt.Println()
 	fmt.Println("Note: Flags must come BEFORE the query.")
 	fmt.Println()

--- a/docs/docs/guides/cli.md
+++ b/docs/docs/guides/cli.md
@@ -1,0 +1,11 @@
+# CLI guide
+
+## Documentation search
+
+`ailang docs search "query"` searches local `design_docs/` or `docs/` directories first. When
+run outside a source checkout, it can fall back to GitHub code search. GitHub fallback requires
+authentication through `GITHUB_TOKEN` or `gh auth login`; unauthenticated search is not attempted.
+
+Use `--path <dir>` to force a local corpus. Disable the network fallback with `--no-github` or
+`AILANG_NO_GITHUB_SEARCH=1`. GitHub results are cached per query for one hour under
+`~/.ailang/cache/docsearch/github/`; cache entries contain results and metadata only, never tokens.

--- a/internal/docsearch/backend.go
+++ b/internal/docsearch/backend.go
@@ -1,0 +1,16 @@
+package docsearch
+
+import "context"
+
+// SearchBackend answers documentation searches. Implementations are selected
+// by callers before a search is started.
+type SearchBackend interface {
+	Search(context.Context, SearchOptions) ([]SearchResult, SearchStats, error)
+}
+
+// LocalBackend preserves the existing filesystem search implementation.
+type LocalBackend struct{}
+
+func (LocalBackend) Search(ctx context.Context, opts SearchOptions) ([]SearchResult, SearchStats, error) {
+	return Search(ctx, opts)
+}

--- a/internal/docsearch/github/cache.go
+++ b/internal/docsearch/github/cache.go
@@ -1,0 +1,83 @@
+package github
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/sunholo-data/ailang/internal/docsearch"
+)
+
+const cacheTTL = time.Hour
+
+type cacheEntry struct {
+	CreatedAt time.Time                `json:"created_at"`
+	Results   []docsearch.SearchResult `json:"results"`
+	Stats     docsearch.SearchStats    `json:"stats"`
+}
+
+func cacheKey(repo, query, subdir string, limit int) string {
+	digest := sha256.Sum256([]byte(repo + "\x00" + query + "\x00" + subdir + "\x00" + fmt.Sprint(limit)))
+	return hex.EncodeToString(digest[:])
+}
+
+func cachePath(repo, query, subdir string, limit int) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("finding home directory: %w", err)
+	}
+	return filepath.Join(home, ".ailang", "cache", "docsearch", "github", cacheKey(repo, query, subdir, limit)+".json"), nil
+}
+
+func readCache(repo, query, subdir string, limit int, now time.Time) ([]docsearch.SearchResult, docsearch.SearchStats, bool) {
+	path, err := cachePath(repo, query, subdir, limit)
+	if err != nil {
+		return nil, docsearch.SearchStats{}, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, docsearch.SearchStats{}, false
+	}
+	var entry cacheEntry
+	if json.Unmarshal(data, &entry) != nil || entry.CreatedAt.IsZero() || now.Sub(entry.CreatedAt) >= cacheTTL {
+		return nil, docsearch.SearchStats{}, false
+	}
+	return entry.Results, entry.Stats, true
+}
+
+func writeCache(repo, query, subdir string, limit int, results []docsearch.SearchResult, stats docsearch.SearchStats, now time.Time) error {
+	path, err := cachePath(repo, query, subdir, limit)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(cacheEntry{CreatedAt: now, Results: results, Stats: stats})
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".tmp-")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err = tmp.Write(data); err == nil {
+		err = tmp.Close()
+	} else {
+		tmp.Close()
+	}
+	if err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/internal/docsearch/github/github.go
+++ b/internal/docsearch/github/github.go
@@ -1,0 +1,153 @@
+// Package github implements authenticated GitHub code search.
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sunholo-data/ailang/internal/docsearch"
+	"github.com/sunholo-data/ailang/internal/gitutil"
+)
+
+const defaultAPI = "https://api.github.com"
+
+// Backend searches the repository's Markdown files through GitHub.
+type Backend struct {
+	Repo   string
+	Token  string
+	client *http.Client
+	apiURL string
+}
+
+// NewBackend resolves a token and the current repository.
+func NewBackend(ctx context.Context) (*Backend, error) {
+	token := strings.TrimSpace(os.Getenv("GITHUB_TOKEN"))
+	if token == "" {
+		cmd := exec.CommandContext(ctx, "gh", "auth", "token")
+		if out, err := cmd.Output(); err == nil {
+			token = strings.TrimSpace(string(out))
+		}
+	}
+	if token == "" {
+		return nil, fmt.Errorf("GitHub search requires authentication: set GITHUB_TOKEN or run `gh auth login`")
+	}
+	owner, repo, err := gitutil.GitHubOwnerRepo(ctx, ".")
+	if err != nil {
+		return nil, fmt.Errorf("detecting GitHub repository: %w", err)
+	}
+	if owner == "" || repo == "" {
+		return nil, fmt.Errorf("current directory has no GitHub origin; use --path from a local checkout")
+	}
+	return &Backend{Repo: owner + "/" + repo, Token: token, client: &http.Client{Timeout: 10 * time.Second}, apiURL: defaultAPI}, nil
+}
+
+// NewBackendForTest constructs a backend without reading credentials or git.
+func NewBackendForTest(apiURL, repo, token string, client *http.Client) *Backend {
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &Backend{Repo: repo, Token: token, client: client, apiURL: strings.TrimRight(apiURL, "/")}
+}
+
+func (b *Backend) Search(ctx context.Context, opts docsearch.SearchOptions) ([]docsearch.SearchResult, docsearch.SearchStats, error) {
+	stats := docsearch.SearchStats{}
+	if strings.TrimSpace(b.Token) == "" {
+		return nil, stats, fmt.Errorf("GitHub search requires an authentication token")
+	}
+	if !validRepo(b.Repo) {
+		return nil, stats, fmt.Errorf("invalid GitHub repository %q", b.Repo)
+	}
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+	perPage := limit
+	if perPage > 100 {
+		perPage = 100
+	}
+	page := 1
+	var results []docsearch.SearchResult
+	for len(results) < limit {
+		u := strings.TrimRight(b.apiURL, "/") + "/search/code"
+		q := opts.Query + " repo:" + b.Repo
+		if opts.Subdir != "" {
+			q += " path:" + opts.Subdir
+		}
+		v := url.Values{"q": {q}, "per_page": {strconv.Itoa(perPage)}, "page": {strconv.Itoa(page)}}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u+"?"+v.Encode(), nil)
+		if err != nil {
+			return nil, stats, fmt.Errorf("creating GitHub search request: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+b.Token)
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+		resp, err := b.client.Do(req)
+		if err != nil {
+			return nil, stats, fmt.Errorf("GitHub search request failed: %w", err)
+		}
+		body, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			return nil, stats, fmt.Errorf("reading GitHub search response: %w", readErr)
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, stats, statusError(resp, body)
+		}
+		var payload struct {
+			Total int `json:"total_count"`
+			Items []struct {
+				Path    string  `json:"path"`
+				HTMLURL string  `json:"html_url"`
+				Score   float64 `json:"score"`
+			} `json:"items"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			return nil, stats, fmt.Errorf("decoding GitHub search response: %w", err)
+		}
+		for _, item := range payload.Items {
+			results = append(results, docsearch.SearchResult{Path: item.HTMLURL, Title: item.Path, Score: item.Score})
+			if len(results) == limit {
+				break
+			}
+		}
+		stats.TotalDocs = payload.Total
+		if len(payload.Items) < perPage || len(results) >= limit {
+			break
+		}
+		page++
+	}
+	stats.SearchTimeMs = 0
+	return results, stats, nil
+}
+
+func validRepo(repo string) bool {
+	parts := strings.Split(repo, "/")
+	return len(parts) == 2 && parts[0] != "" && parts[1] != "" && !strings.ContainsAny(repo, " ?#")
+}
+
+func statusError(resp *http.Response, body []byte) error {
+	message := strings.TrimSpace(string(body))
+	switch resp.StatusCode {
+	case http.StatusUnauthorized:
+		return fmt.Errorf("GitHub authentication rejected (401); check GITHUB_TOKEN or `gh auth status`")
+	case http.StatusForbidden, http.StatusTooManyRequests:
+		reset := resp.Header.Get("X-RateLimit-Reset")
+		if reset != "" {
+			return fmt.Errorf("GitHub code-search rate limit exceeded; reset at Unix time %s", reset)
+		}
+		return fmt.Errorf("GitHub code-search rate limit exceeded")
+	case http.StatusNotFound:
+		return fmt.Errorf("GitHub repository %s was not found or is inaccessible", message)
+	default:
+		return fmt.Errorf("GitHub code-search API returned HTTP %d: %s", resp.StatusCode, message)
+	}
+}

--- a/internal/docsearch/github/github.go
+++ b/internal/docsearch/github/github.go
@@ -70,6 +70,9 @@ func (b *Backend) Search(ctx context.Context, opts docsearch.SearchOptions) ([]d
 	if limit <= 0 {
 		limit = 10
 	}
+	if results, cachedStats, ok := readCache(b.Repo, opts.Query, opts.Subdir, limit, time.Now()); ok {
+		return results, cachedStats, nil
+	}
 	perPage := limit
 	if perPage > 100 {
 		perPage = 100
@@ -126,6 +129,7 @@ func (b *Backend) Search(ctx context.Context, opts docsearch.SearchOptions) ([]d
 		page++
 	}
 	stats.SearchTimeMs = 0
+	_ = writeCache(b.Repo, opts.Query, opts.Subdir, limit, results, stats, time.Now())
 	return results, stats, nil
 }
 

--- a/internal/docsearch/github/github.go
+++ b/internal/docsearch/github/github.go
@@ -20,6 +20,8 @@ import (
 
 const defaultAPI = "https://api.github.com"
 
+const defaultRepo = "sunholo-data/ailang"
+
 // Backend searches the repository's Markdown files through GitHub.
 type Backend struct {
 	Repo   string
@@ -42,12 +44,16 @@ func NewBackend(ctx context.Context) (*Backend, error) {
 	}
 	owner, repo, err := gitutil.GitHubOwnerRepo(ctx, ".")
 	if err != nil {
-		return nil, fmt.Errorf("detecting GitHub repository: %w", err)
+		owner, repo = "sunholo-data", "ailang"
 	}
 	if owner == "" || repo == "" {
-		return nil, fmt.Errorf("current directory has no GitHub origin; use --path from a local checkout")
+		owner, repo = "sunholo-data", "ailang"
 	}
-	return &Backend{Repo: owner + "/" + repo, Token: token, client: &http.Client{Timeout: 10 * time.Second}, apiURL: defaultAPI}, nil
+	resolvedRepo := owner + "/" + repo
+	if resolvedRepo != defaultRepo {
+		return nil, fmt.Errorf("current directory points to GitHub repository %s; refusing to search it (expected %s); use --path from an AILANG checkout", resolvedRepo, defaultRepo)
+	}
+	return &Backend{Repo: resolvedRepo, Token: token, client: &http.Client{Timeout: 10 * time.Second}, apiURL: defaultAPI}, nil
 }
 
 // NewBackendForTest constructs a backend without reading credentials or git.
@@ -144,6 +150,9 @@ func statusError(resp *http.Response, body []byte) error {
 	case http.StatusUnauthorized:
 		return fmt.Errorf("GitHub authentication rejected (401); check GITHUB_TOKEN or `gh auth status`")
 	case http.StatusForbidden, http.StatusTooManyRequests:
+		if resp.Header.Get("X-RateLimit-Remaining") != "0" {
+			return fmt.Errorf("GitHub code-search API returned HTTP %d: %s", resp.StatusCode, message)
+		}
 		reset := resp.Header.Get("X-RateLimit-Reset")
 		if reset != "" {
 			return fmt.Errorf("GitHub code-search rate limit exceeded; reset at Unix time %s", reset)

--- a/internal/docsearch/github/github_test.go
+++ b/internal/docsearch/github/github_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -130,6 +129,7 @@ func TestStatusErrorOnlyClassifiesZeroRemainingAsRateLimit(t *testing.T) {
 func TestCacheHitMissExpiryIsolationAndNoTokenPersistence(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // os.UserHomeDir() reads USERPROFILE, not HOME, on Windows
 	results := []docsearch.SearchResult{{Path: "a.md", Title: "a", Score: 1}}
 	stats := docsearch.SearchStats{TotalDocs: 1}
 	now := time.Now().UTC()
@@ -149,7 +149,11 @@ func TestCacheHitMissExpiryIsolationAndNoTokenPersistence(t *testing.T) {
 	if _, _, ok := readCache("acme/docs", "q", "guides", 1, now.Add(cacheTTL)); ok {
 		t.Fatal("expired cache entry returned a hit")
 	}
-	data, err := os.ReadFile(filepath.Join(home, ".ailang", "cache", "docsearch", "github", cacheKey("acme/docs", "q", "guides", 1)+".json"))
+	onDiskPath, err := cachePath("acme/docs", "q", "guides", 1)
+	if err != nil {
+		t.Fatalf("cachePath: %v", err)
+	}
+	data, err := os.ReadFile(onDiskPath)
 	if err != nil || strings.Contains(string(data), "test-token") {
 		t.Fatalf("cache contains credential or could not be read: %v", err)
 	}

--- a/internal/docsearch/github/github_test.go
+++ b/internal/docsearch/github/github_test.go
@@ -4,11 +4,60 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sunholo-data/ailang/internal/docsearch"
 )
+
+func TestNewBackendDefaultsOutsideGitRepository(t *testing.T) {
+	dir := t.TempDir()
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldDir) })
+	t.Setenv("GITHUB_TOKEN", "test-token")
+
+	b, err := NewBackend(context.Background())
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+	if b.Repo != defaultRepo {
+		t.Fatalf("Repo = %q, want %q", b.Repo, defaultRepo)
+	}
+}
+
+func TestNewBackendRejectsUnrelatedGitHubRepository(t *testing.T) {
+	dir := t.TempDir()
+	if out, err := exec.Command("git", "-C", dir, "init", "-q").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", dir, "remote", "add", "origin", "https://github.com/acme/other.git").CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %v: %s", err, out)
+	}
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldDir) })
+	t.Setenv("GITHUB_TOKEN", "test-token")
+
+	_, err = NewBackend(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "acme/other") || !strings.Contains(err.Error(), "refusing") {
+		t.Fatalf("NewBackend() error = %v, want explicit unrelated-repository error", err)
+	}
+}
 
 func TestBackendSearchAuthenticatedRequestAndPagination(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -52,6 +101,57 @@ func TestBackendRejectsInvalidRepoAndMissingToken(t *testing.T) {
 	b = NewBackendForTest("http://invalid", "acme/docs", "", nil)
 	if _, _, err := b.Search(context.Background(), docOptions("x", "")); err == nil {
 		t.Fatal("expected token error")
+	}
+}
+
+func TestStatusErrorOnlyClassifiesZeroRemainingAsRateLimit(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		status    int
+		remaining string
+		wantRate  bool
+	}{
+		{"permission denied", http.StatusForbidden, "1", false},
+		{"forbidden rate limit", http.StatusForbidden, "0", true},
+		{"too many requests rate limit", http.StatusTooManyRequests, "0", true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{StatusCode: tt.status, Header: make(http.Header)}
+			resp.Header.Set("X-RateLimit-Remaining", tt.remaining)
+			err := statusError(resp, []byte(`{"message":"denied"}`))
+			gotRate := strings.Contains(err.Error(), "rate limit")
+			if gotRate != tt.wantRate {
+				t.Fatalf("error = %v, rate-limit = %v, want %v", err, gotRate, tt.wantRate)
+			}
+		})
+	}
+}
+
+func TestCacheHitMissExpiryIsolationAndNoTokenPersistence(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	results := []docsearch.SearchResult{{Path: "a.md", Title: "a", Score: 1}}
+	stats := docsearch.SearchStats{TotalDocs: 1}
+	now := time.Now().UTC()
+	if _, _, ok := readCache("acme/docs", "q", "guides", 1, now); ok {
+		t.Fatal("unexpected cache hit before write")
+	}
+	if err := writeCache("acme/docs", "q", "guides", 1, results, stats, now); err != nil {
+		t.Fatal(err)
+	}
+	got, gotStats, ok := readCache("acme/docs", "q", "guides", 1, now.Add(time.Minute))
+	if !ok || len(got) != 1 || gotStats.TotalDocs != 1 {
+		t.Fatalf("cache hit = %v, %v, %v", got, gotStats, ok)
+	}
+	if _, _, ok := readCache("other/docs", "q", "guides", 1, now.Add(time.Minute)); ok {
+		t.Fatal("cache key leaked across repositories")
+	}
+	if _, _, ok := readCache("acme/docs", "q", "guides", 1, now.Add(cacheTTL)); ok {
+		t.Fatal("expired cache entry returned a hit")
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".ailang", "cache", "docsearch", "github", cacheKey("acme/docs", "q", "guides", 1)+".json"))
+	if err != nil || strings.Contains(string(data), "test-token") {
+		t.Fatalf("cache contains credential or could not be read: %v", err)
 	}
 }
 

--- a/internal/docsearch/github/github_test.go
+++ b/internal/docsearch/github/github_test.go
@@ -1,0 +1,60 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sunholo-data/ailang/internal/docsearch"
+)
+
+func TestBackendSearchAuthenticatedRequestAndPagination(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer secret" {
+			t.Errorf("missing auth header")
+		}
+		if r.Header.Get("Accept") != "application/vnd.github+json" {
+			t.Errorf("missing accept header")
+		}
+		if r.URL.Query().Get("q") != "contracts repo:acme/docs path:guides" {
+			t.Errorf("query = %q", r.URL.Query().Get("q"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"total_count":1,"items":[{"path":"guides/a.md","html_url":"https://github.com/acme/docs/blob/main/guides/a.md","score":0.8}]}`))
+	}))
+	defer server.Close()
+	b := NewBackendForTest(server.URL, "acme/docs", "secret", server.Client())
+	results, stats, err := b.Search(context.Background(), docOptions("contracts", "guides"))
+	if err != nil || len(results) != 1 || stats.TotalDocs != 1 {
+		t.Fatalf("results=%v stats=%+v err=%v", results, stats, err)
+	}
+}
+
+func TestBackendErrorsNeverEchoToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"bad token"}`, http.StatusUnauthorized)
+	}))
+	defer server.Close()
+	b := NewBackendForTest(server.URL, "acme/docs", "secret", server.Client())
+	_, _, err := b.Search(context.Background(), docOptions("x", ""))
+	if err == nil || strings.Contains(err.Error(), "secret") || !strings.Contains(err.Error(), "authentication rejected") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBackendRejectsInvalidRepoAndMissingToken(t *testing.T) {
+	b := NewBackendForTest("http://invalid", "bad repo", "secret", nil)
+	if _, _, err := b.Search(context.Background(), docOptions("x", "")); err == nil {
+		t.Fatal("expected repo error")
+	}
+	b = NewBackendForTest("http://invalid", "acme/docs", "", nil)
+	if _, _, err := b.Search(context.Background(), docOptions("x", "")); err == nil {
+		t.Fatal("expected token error")
+	}
+}
+
+func docOptions(query, subdir string) docsearch.SearchOptions {
+	return docsearch.SearchOptions{Query: query, Subdir: subdir, Limit: 10}
+}

--- a/internal/docsearch/github/github_test.go
+++ b/internal/docsearch/github/github_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/sunholo-data/ailang/internal/docsearch"
+	"github.com/sunholo-data/ailang/internal/testutil"
 )
 
 func TestNewBackendDefaultsOutsideGitRepository(t *testing.T) {
@@ -128,8 +129,7 @@ func TestStatusErrorOnlyClassifiesZeroRemainingAsRateLimit(t *testing.T) {
 
 func TestCacheHitMissExpiryIsolationAndNoTokenPersistence(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home) // os.UserHomeDir() reads USERPROFILE, not HOME, on Windows
+	testutil.SetHomeDir(t, home)
 	results := []docsearch.SearchResult{{Path: "a.md", Title: "a", Score: 1}}
 	stats := docsearch.SearchStats{TotalDocs: 1}
 	now := time.Now().UTC()

--- a/internal/gitutil/remote.go
+++ b/internal/gitutil/remote.go
@@ -1,0 +1,28 @@
+// Package gitutil contains small helpers for interrogating Git repositories.
+package gitutil
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// GitHubOwnerRepo parses the origin remote in workDir and returns its GitHub
+// owner and repository. Non-GitHub remotes return empty strings and no error.
+func GitHubOwnerRepo(ctx context.Context, workDir string) (string, string, error) {
+	out, err := exec.CommandContext(ctx, "git", "-C", workDir, "remote", "get-url", "origin").Output()
+	if err != nil {
+		return "", "", fmt.Errorf("git remote: %w", err)
+	}
+	url := strings.TrimSuffix(strings.TrimSpace(string(out)), ".git")
+	for _, prefix := range []string{"https://github.com/", "git@github.com:"} {
+		if strings.HasPrefix(url, prefix) {
+			parts := strings.SplitN(strings.TrimPrefix(url, prefix), "/", 2)
+			if len(parts) == 2 {
+				return parts[0], parts[1], nil
+			}
+		}
+	}
+	return "", "", nil
+}

--- a/internal/gitutil/remote_test.go
+++ b/internal/gitutil/remote_test.go
@@ -1,0 +1,48 @@
+package gitutil
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestGitHubOwnerRepo(t *testing.T) {
+	tests := []struct {
+		name, remote, owner, repo string
+	}{
+		{"https", "https://github.com/acme/docs.git", "acme", "docs"},
+		{"ssh", "git@github.com:acme/docs", "acme", "docs"},
+		{"non-github", "https://gitlab.com/acme/docs.git", "", ""},
+		{"malformed", "git@github.com:acme", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := initRepo(t, tt.remote)
+			owner, repo, err := GitHubOwnerRepo(context.Background(), dir)
+			if err != nil || owner != tt.owner || repo != tt.repo {
+				t.Fatalf("got %q/%q, %v; want %q/%q", owner, repo, err, tt.owner, tt.repo)
+			}
+		})
+	}
+}
+
+func TestGitHubOwnerRepoGitError(t *testing.T) {
+	_, _, err := GitHubOwnerRepo(context.Background(), filepath.Join(t.TempDir(), "missing"))
+	if err == nil {
+		t.Fatal("expected git command error")
+	}
+}
+
+func initRepo(t *testing.T, remote string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if out, err := exec.Command("git", "-C", dir, "init", "-q").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	cmd := exec.Command("git", "-C", dir, "remote", "add", "origin", remote)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %v: %s", err, out)
+	}
+	return dir
+}

--- a/scripts/git_exec_baseline.txt
+++ b/scripts/git_exec_baseline.txt
@@ -1,9 +1,10 @@
 cmd/ailang/chains_diff.go 4
 cmd/ailang/coordinator_browse.go 11
 cmd/ailang/coordinator_cloud.go 14
-cmd/ailang/coordinator_cloud_github.go 2
+cmd/ailang/coordinator_cloud_github.go 1
 cmd/ailang/coordinator_inspect.go 4
 cmd/ailang/coordinator_utils.go 3
 cmd/ailang/messages_send.go 3
 internal/eval_harness/gemini_evaluator_bridge.go 1
+internal/gitutil/remote.go 1
 internal/pkg/gitcache.go 5


### PR DESCRIPTION
## Summary
- Implements `design_docs/planned/v0_29_0/m-dx27-docs-search-github-fallback.md` (docs-mission queue item docs-11), design-ready and D-4-approved by attended ruling 2026-09-07.
- M1: extracts `getGitHubOwnerRepo` into a new shared `internal/gitutil` package (pure refactor, zero behavior change), updates the one call site in `cmd/ailang/coordinator_cloud_github.go`.
- M2: adds a narrow `SearchBackend` interface selected once at the CLI boundary; `LocalBackend` wraps the existing `Search()` **unchanged** (`internal/docsearch/search.go` has zero diff lines, verified by both `git diff --exit-code` and a sha256 match against the pre-sprint file). `internal/docsearch/github` implements an authenticated GitHub code-search backend.
- M3: adds 1-hour, SHA-256-keyed JSON result caching under `~/.ailang/cache/docsearch/github/`, no credentials persisted.
- M4: wires backend selection into `cmd/ailang/docs_search.go` (local docs always preferred; GitHub only when nothing local is found), adds `--no-github` / `AILANG_NO_GITHUB_SEARCH` disable controls, documents it in a new `docs/docs/guides/cli.md` and `CHANGELOG.md`.
- M5: full gate sweep (fmt, lint, boundaries, file-sizes, zero-diff, scoped build+test) green.

## Routing
Executor: `codex:gpt-5.6-luna` (3 bounded runs — first two aborted on flawed/sandboxed gate lists the controller wrote, both corrected in place; the codex sandbox denies loopback socket binds, so `httptest`-based tests read false-negative inside it — the controller independently re-ran the full scoped build+test suite **outside** the sandbox and confirmed all green, including the GitHub-backend httptest suite). Planner: `codex:gpt-5.6-luna`. Commits reconstructed by the controller from the executor's per-milestone `.snap/` snapshots, verified build+test at every milestone boundary (bisectability) and sha256 byte-identity against the executor's final tree.

## Known gap for the evaluator
`internal/docsearch/github/cache.go` (83 lines) has no dedicated unit test — the plan's own acceptance checklist calls for hit/miss/expiry/key-isolation/atomic-publication/credential-non-persistence coverage, and `github_test.go`'s 3 tests only cover the backend's request/pagination/error paths, not the cache. Flagging for independent judgment rather than pre-deciding it.

## Test plan
- [x] `go build ./internal/gitutil/... ./internal/docsearch/... ./cmd/ailang/...` (outside sandbox)
- [x] `go test` on the same scope, including GitHub backend httptest suite (outside sandbox)
- [x] `make fmt-check` / `make lint` / `make check-boundaries` / `make check-file-sizes`
- [x] `git diff --exit-code -- internal/docsearch/search.go` (zero-diff invariant)
- [ ] Independent sprint-evaluator review (next step)

Co-Authored-By: codex gpt-5.6-luna