### PR TITLE
Mission V1 iter347: bound the D-60 notification paths and restore the seven notify assertions

### DIFF
--- a/changelogs/v0.32-current.md
+++ b/changelogs/v0.32-current.md
@@ -22,6 +22,45 @@ pacing. Unknown provider data still blocks. Local Ollama routing is unaffected.
 
 ## [Unreleased]
 
+### Fixed — the mission driver's three notification paths had no per-call deadline (D-60)
+
+`_mc_notify`'s direct `ailang messages send`, `_mc_drain_notices`' drain-time send, and the
+`gh issue comment` notice each ran unbounded. The drain is called in the driver's PREFLIGHT, whose
+only backstop is the whole-slot `HARD_TIMEOUT` (6 h) — the stall watchdog explicitly disables its
+early kill there ("no progress instrument") — so a hung send could cost a whole fire. Each now runs
+through the existing `_mc_bounded` at `NOTIFY_TIMEOUT` (env `MISSION_NOTIFY_TIMEOUT`, default 30 s,
+matching the two already-bounded slot-verdict sites). Retry count, back-off, payloads and the
+non-aborting failure contract are unchanged.
+
+- `_mc_bounded` runs `( exec "$@" )`, and `exec` cannot parse a `VAR=val` prefix, so the two
+  canonical message-store variables are carried by a leading `env`; scoping is unchanged and
+  `AILANG_STORAGE` is untouched.
+- Bounding would otherwise have deleted a diagnostic: a cut-off command produces no output, so
+  `MC_BOUNDED_OUT` is empty and the failure WARNING degraded to `FAILED … after 3 attempts:` with
+  nothing after it. The reason is now synthesised whenever the tail is empty and the rc is non-zero,
+  which also covers a `mktemp` failure (`rc=125`).
+
+### Fixed — the launchd notification test suite could not observe a send at all
+
+`63a0d2b32` moved the direct send into a command substitution, so the fixture's `ailang()` stub
+recorded the call by assigning to `TRACE` inside a subshell and the record died with it — seven
+assertions in `launchd drivers (bash 3.2)` had been red on `dev` since.
+
+- `ailang`/`gh` become PATH-executable stubs (required in any case: `exec` bypasses shell
+  functions), `log()` appends to the same `MC_TRACE_FILE`, and the teardown loads that file into
+  `TRACE` before the assertions run — one medium, so the two negative `checkno` assertions cannot
+  pass vacuously.
+- `run()` now captures the sourced block's real status instead of `printf`'s, and a dedicated arm
+  drives `run()` itself with a failing block so that fix cannot be reverted silently.
+- The suite `unset`s `AILANG_MESSAGES_STORE`/`AILANG_MESSAGES_PROJECT`: a subshell inherits the
+  caller's exports, so with the session-start exports CLAUDE.md mandates, the store/project guard
+  would have stayed green with the production `env` prefix deleted.
+
+`bash tools/launchd/test_driver_notify.sh`: 20 passed/7 failed → **38 passed, 0 failed**. Note the
+`launchd drivers (bash 3.2)` job remains red on a *different*, pre-existing set: clearing this red
+lets the ordered target reach `test_mission_heartbeat.sh`, which fails 9 arms identically before and
+after this change.
+
 ### Added — `ailang docs search` GitHub code-search fallback
 
 - When local `design_docs/`/`docs/` aren't found (an installed binary run outside a source

--- a/design_docs/planned/v0_35_2/m-launchd-notify-subshell-observation-sprint-plan.md
+++ b/design_docs/planned/v0_35_2/m-launchd-notify-subshell-observation-sprint-plan.md
@@ -1,0 +1,281 @@
+# Sprint Plan — M-LAUNCHD-NOTIFY-SUBSHELL-OBSERVATION (V1 mission iteration 347)
+
+**Status**: Planned, awaiting "execute sprint". Plans the APPROVED design
+[`m-launchd-notify-subshell-observation.md`](m-launchd-notify-subshell-observation.md) (D-60 revision,
+quorum round 3). No scope is added or removed here; every step traces to a named design section.
+**Base**: `027bcb022` on branch `sprint/v1-iter347-launchd-notify-bounded` (= `origin/dev` `81abc956d`
++ approved design revision). **Baseline measured this planning session**:
+`bash tools/launchd/test_driver_notify.sh` → `20 passed, 7 failed`, rc=1 (M1/V2 reproduced);
+`/bin/bash` = 3.2.57(1) arm64.
+**Machine-readable companion**: `sprint_v1_iter347_launchd_notify.json` (same milestones).
+
+## Sequencing rationale — why M1 MUST land before M2 (the collision)
+
+`_mc_bounded` (P:496) runs `( exec "$@" )` in a background subshell. `exec` resolves only external
+binaries — measured M3: `( exec f )` on a shell function → `exec: f: not found`, rc=127. The current
+fixture stubs `ailang()`/`gh()` as **shell functions**.
+
+Therefore, if the production sends are wrapped in `_mc_bounded` **before** the fixture is migrated:
+
+1. Every notify arm would `exec` the **real** `ailang`/`gh` on PATH — contacting prod Firestore and
+   GitHub from CI (forbidden: tests must not touch Firestore/GitHub/providers/launchd), and
+2. the stub-observation assertions would fail for the wrong reason (rc=127 / real-binary output), i.e.
+   the suite **silently stops exercising the stubs** while still printing PASS/FAIL lines.
+
+Conversely, the fixture migration is safe against **unbounded** production: the current direct send
+`_out=$(ailang …)` is a command substitution, which resolves PATH executables fine. So the only
+ordering in which the suite never silently stops exercising the stubs is:
+
+**M1 fixture-first (PATH executable stubs + unified trace medium) → M2 production bounding →
+M3 aggregate drain budget → M4 mutation sweep & full verification.**
+
+M2 before M3 because M3's remaining-budget arithmetic is defined in terms of `NOTIFY_TIMEOUT`,
+which M2 introduces; M3's acceptance lab reuses M2's bounded drain send.
+
+## Budget
+
+Flash-class executor, 30-minute cap. Estimate: M1 10m · M2 9m · M3 5m · M4 5m = **29m**. Suite wall
+time grows by ~90–120s of real sleeps (retry back-off 5+10s per failing arm; hang labs at
+`NOTIFY_TIMEOUT=2` cost ~5–7s per cutoff, ~28s for the full 3-retry timeout arm — ARM A/B measured).
+Fits, tightly. **Cut order if the run is short:** (1) trim M4's mutation sweep to the three P0
+mutants (direct-send bound removal, split-trace, drain-budget removal) and defer the rest to the
+evaluator; (2) shrink M3's backlog lab from 5 rows to 3. Never cut M1/M2 assertion coverage.
+
+## Global constraints (binding on the executor)
+
+- Bash 3.2.57 only: no `declare -A`, no `${v,,}`, no GNU `timeout`, no new dependencies, no Go.
+- No network: every lab resolves `ailang`/`gh` to the suite-owned PATH stubs; no Firestore, GitHub,
+  model provider, or launchd contact. The stub `bin/` dir contains exactly `ailang` and `gh`.
+- Do NOT stub `sleep`: `_mc_bounded`'s poll loop (`sleep 2`) and SIGKILL grace (`sleep 2`) are part of
+  the measured cutoff arithmetic (V5c: bound 2s → cutoff 5s). Stubbing `sleep` would invalidate the
+  7-second acceptance budget. This resolves the design's "sleep timing is asserted, not slept" risk
+  note in favour of real sleeps with generous outer deadlines.
+- The executor makes **NO git write operations** (no add/commit/stash/checkout); `git diff`/`git
+  status` reads are fine. The controller commits.
+- Record ACTUAL pass/fail counts and timings at each boundary; the counts below are predictions from
+  the design's causal mapping, not measurements.
+
+---
+
+## M1 — Fixture observation repair: PATH stubs, unified `MC_TRACE_FILE`, RC capture
+
+**Files**: `tools/launchd/test_driver_notify.sh` only. Production is untouched in this milestone.
+
+**Design trace**: Half 2 steps 1–4; Conflict Surface rows 1–2; G1/G2/G3; mutation rows 5, 6, 9.
+
+**Steps**:
+1. Add a suite-owned `bin/` under `$LAB` containing executable `ailang` and `gh` scripts. Each
+   appends one ordered `AILANG:`/`GH:` record (same argument forms the checks consume today) to
+   `"$MC_TRACE_FILE"`; each honours `AILANG_RC`/`GH_RC`; the `ailang` stub also prints
+   `store=<$AILANG_MESSAGES_STORE> proj=<$AILANG_MESSAGES_PROJECT>` on stdout so the child's env is
+   observable through captured output (V4). Prepend `bin/` to an **exported** `PATH` and export
+   `MC_TRACE_FILE` (fresh per arm) in `run()`, `run_drift()`, and the inline drift-j lab.
+2. `log()` stays a function but appends its `LOG:` record to the SAME `"$MC_TRACE_FILE"` (G1 unified
+   medium). Teardown in each lab loads the file into `TRACE` (`TRACE="$(cat "$MC_TRACE_FILE")"`)
+   AFTER sourcing the block and BEFORE emitting the trace the 27 assertions read.
+3. Fix the RC-after-`printf` defect (G2, T:52-55): capture `rc=$?` immediately after `. "$2"`, then
+   emit the trace, then `echo "RC:$rc"`. (`run_drift`'s `DECISION_RC:$?` at T:88/:196 is already
+   correct — leave it.)
+4. New assertions (3):
+   - `retry: attempts recorded across subshells (file counter)` — the `ailang` PATH stub increments a
+     counter FILE; with `AILANG_RC=1`, assert 3 recorded attempts after the pin_block arm.
+   - `RC capture: block failure visible, not masked by printf` — an arm whose sourced block aborts
+     under `set -u` (drop the `STATE_DIR` assignment) must record `RC:1`, not `RC:0`.
+   - `positive control: unified medium shows genuine AILANG fire (checkno would FAIL)` — on a firing
+     pin_block arm, assert `$T` CONTAINS `AILANG:`; this is the tripwire proving the
+     `no ailang call` / `lane SILENT when healthy` checknos read the unified medium (G1).
+
+**Boundary expectation**: `==== 30 passed, 0 failed ====`, rc=0 (27 restored incl. the seven red
+rows + 3 new; executor records the actual count). Red-at-base is the M1 measurement itself
+(20/7, rc=1) — no separate red run needed.
+
+**Acceptance** (red at milestone base → green after):
+- `bash tools/launchd/test_driver_notify.sh` → base: `20 passed, 7 failed`, rc=1 → after: `N passed,
+  0 failed`, rc=0 (N≈30).
+- `bash tools/launchd/test_driver_notify.sh | grep -c "PASS: positive control: unified medium"` →
+  base: `0` → after: `1`.
+- `bash tools/launchd/test_driver_notify.sh | grep -c "PASS: RC capture"` → base: `0` → after: `1`.
+- `make test-launchd-drivers` → base: rc≠0 (notify suite red; 54 pin-root checks pass first) →
+  after: rc=0. (Red at base is carried by the same seven rows — declared: this command's redness is
+  fully explained by M1's diff and nothing else.)
+
+**Mutations (each anchored to M1's own diff — reverting M1 while keeping everything else re-reds
+exactly these)**:
+| Mutation | Kills assertion |
+|---|---|
+| Keep in-shell `ailang()`/`gh()` function stubs instead of PATH scripts | `fires on both channels (ailang)` |
+| Split trace: `log()` stays on the `TRACE` var; teardown does not load `MC_TRACE_FILE` | `positive control: unified medium shows genuine AILANG fire (checkno would FAIL)` |
+| Move `RC:$?` capture back after the `printf` | `RC capture: block failure visible, not masked by printf` |
+| Replace the retry file counter with a shell variable | `retry: attempts recorded across subshells (file counter)` |
+
+---
+
+## M2 — Production bounding of the three D-60 paths + synthesised rc=124 diagnostic
+
+**Files**: `tools/launchd/mission-control.sh` (P:492 `NOTIFY_TIMEOUT`, P:184 direct send, P:154
+drain send, P:198 GH notice) and `tools/launchd/test_driver_notify.sh` (new labs/assertions FIRST).
+
+**Design trace**: Half 1 steps 1–5; G5 (ARM A/B); Conflict Surface rows 3–5; mutation rows 1–4, 7, 8, 11.
+
+**Steps (order matters WITHIN the milestone — tests first, no git available for red/green staging)**:
+1. **Fixture first.** Extract `_mc_bounded` and `_mc_drain_notices` into the lab via the guarded awk
+   patterns (`awk '/^_mc_bounded\(\) \{/,/^\}/'`, `awk '/^_mc_drain_notices\(\) \{/,/^\}/'`, with the
+   same empty-extraction FATAL guard as the existing five). Add a never-returning stub variant
+   (`while :; do sleep 1; done`, selected by env `STUB_HANG=1`) and the new arms below. **Run the
+   suite now and record the RED**: each new production-bound assertion fails against unwrapped
+   production — the direct-send hang lab trips its outer watchdog (see 3) and fails cleanly.
+2. **Production.** Add `NOTIFY_TIMEOUT="${MISSION_NOTIFY_TIMEOUT:-30}"` beside `PROBE_TIMEOUT`
+   (P:492). Wrap:
+   - direct send (P:184): `_mc_bounded "$NOTIFY_TIMEOUT" env AILANG_MESSAGES_STORE=gcp
+     AILANG_MESSAGES_PROJECT="${AILANG_MESSAGES_PROJECT:-ailang-multivac}" ailang messages send …`;
+     capture `_rc=$?; _out="$MC_BOUNDED_OUT"`; success arm unchanged (3 attempts, sleeps 5/10).
+   - **Synthesised diagnostic (G5 ARM B)**: in the failure arm, if `_rc -eq 124`, set
+     `_out="timed out after ${NOTIFY_TIMEOUT}s (no output)"` BEFORE the tail-300 WARNING — a timed-out
+     command produced no output, so the raw tail is empty.
+   - drain send (P:154): same `_mc_bounded "$NOTIFY_TIMEOUT" env … ailang messages send …` form;
+     rc=124 → row re-appended (retention path unchanged).
+   - GH notice (P:198): `_mc_bounded "$NOTIFY_TIMEOUT" gh issue comment …` (one-shot semantics
+     unchanged; the helper already captures output, so the `>/dev/null 2>&1` goes away).
+3. **New arms/assertions** (all with `MISSION_NOTIFY_TIMEOUT=2`):
+   - `production: hanging direct send is cut off at the bound` — single-shot
+     `_mc_bounded 2 env … ailang …` against the hanging stub: assert rc=124 AND elapsed ≤ 7s
+     (V5c: 5s = 2 bound + ~2 poll + 2 grace, +2 headroom). **Outer test-level deadline**: run the lab
+     body in a background subshell, poll `kill -0` on a `date +%s` loop, `kill -9` at 15s and fail the
+     assertion — a removed bound fails cleanly instead of hanging CI.
+   - `production: direct send retries 3x then spools on timeout` — full `_mc_notify` with hanging
+     `ailang` stub: outer deadline 60s (ARM B measured 28s); assert attempts=3 (file counter), spool
+     rows=1, GH still called once.
+   - `synthesised timeout diagnostic` — same arm: WARNING contains `timed out after 2s (no output)`,
+     and does NOT end at a bare `after 3 attempts:`.
+   - `production: hanging drain send is cut off and row retained` — one-row spool + hanging stub:
+     drain returns (outer deadline 15s), the row is re-appended.
+   - `production: hanging gh comment is cut off and warns` — `ailang` healthy, `gh` hanging: bounded
+     cutoff ≤7s, WARNING posted, block still exits 0.
+   - Guard (declared green-at-base/green-after, retained for its mutation row): `direct send reaches
+     child with store=gcp` — failure-arm WARNING contains `store=<gcp> proj=<ailang-multivac>`.
+     **This measures nothing as red→green evidence** (the unbounded `VAR=val` prefix also delivers
+     the vars); it exists so the env-prefix mutation has a named victim.
+   - Guard (green/green, regression tripwire only): `wiring: exactly one preflight drain call` —
+     `awk '/^# --- DRIVER PIN DECISION END ---/,0' "$DRV" | grep -c '^_mc_drain_notices$'` = 1.
+4. Run the suite; record GREEN.
+
+**Boundary expectation**: `==== 37 passed, 0 failed ====`, rc=0 (30 + 7 new, of which 2 are declared
+guards; executor records the actual).
+
+**Acceptance** (red at M2 base = end of M1 → green after):
+- After step 1 (fixture only): `bash tools/launchd/test_driver_notify.sh` → new `production:` arms
+  FAIL (record exact count) → after step 2: `0 failed`, rc=0.
+- `bash tools/launchd/test_driver_notify.sh | grep -c "PASS: synthesised timeout diagnostic"` →
+  M2-base: `0` → after: `1`.
+- `grep -c '_mc_bounded "$NOTIFY_TIMEOUT" env' tools/launchd/mission-control.sh` → M2-base: `0` →
+  after: `2` (direct + drain).
+- `grep -c '_mc_bounded "$NOTIFY_TIMEOUT" gh issue comment' tools/launchd/mission-control.sh` →
+  M2-base: `0` → after: `1`.
+- `bash -n tools/launchd/mission-control.sh tools/launchd/test_driver_notify.sh` → rc=0 (green/green
+  parse guard; declared non-anchoring).
+
+**Mutations (anchored to M2's own diff: revert only the P:154/184/198 wraps + synthesis while
+keeping M1, and each named assertion re-fails)**:
+| Mutation | Kills assertion |
+|---|---|
+| Remove `_mc_bounded`/`NOTIFY_TIMEOUT` on the direct send | `production: hanging direct send is cut off at the bound` |
+| Remove `_mc_bounded` on the drain-time send | `production: hanging drain send is cut off and row retained` |
+| Remove `_mc_bounded` on the GH notice | `production: hanging gh comment is cut off and warns` |
+| Drop the `env AILANG_MESSAGES_STORE=gcp …` prefix from the bounded direct send | `direct send reaches child with store=gcp` |
+| Revert the rc=124 synthesised diagnostic to the raw (empty) `MC_BOUNDED_OUT` tail | `synthesised timeout diagnostic` |
+
+---
+
+## M3 — Aggregate drain budget `DRAIN_BUDGET`
+
+**Files**: `tools/launchd/mission-control.sh` (`_mc_drain_notices`, P:145-165) and
+`tools/launchd/test_driver_notify.sh` (large-backlog lab).
+
+**Design trace**: Half 1 step 6; G4; mutation row 10.
+
+**Steps**:
+1. **Fixture first.** Add the backlog arm: 5-row spool, hanging `ailang` stub,
+   `MISSION_NOTIFY_TIMEOUT=2`, `MISSION_DRAIN_BUDGET=8`. Run → **record RED**: with per-call bounds
+   but no aggregate guard the drain attempts all 5 rows (~5s each ≈ 25s > 8s budget) and emits no
+   deferred diagnostic.
+2. **Production.** In `_mc_drain_notices`: `DRAIN_BUDGET="${MISSION_DRAIN_BUDGET:-90}"`; record
+   `drain_start=$(date +%s)` after the spool is claimed; **before each row's send** require
+   `remaining = DRAIN_BUDGET - ($(date +%s) - drain_start)` ≥ `NOTIFY_TIMEOUT + 2`; if insufficient —
+   STOP, append the current and ALL unattempted rows back to the spool unchanged, log
+   `notice spool: deferred <k> row(s), aggregate budget <BUDGET>s exhausted`, and return 0. Failed
+   rows keep the existing re-append path.
+3. New assertions:
+   - `drain: whole drain returns within aggregate budget and preserves unattempted rows` — elapsed
+     ≤ 15s (outer deadline 30s), spool afterwards holds 5 rows (1 failed re-appended + 4
+     unattempted), attempt counter = 1.
+   - `drain: deferred-drain diagnostic names deferred row count` — log contains
+     `deferred 4 row(s), aggregate budget 8s exhausted`.
+4. Run the suite; record GREEN.
+
+**Boundary expectation**: `==== 39 passed, 0 failed ====`, rc=0 (37 + 2; executor records actual).
+
+**Acceptance** (red at M3 base = end of M2 → green after):
+- After step 1: `bash tools/launchd/test_driver_notify.sh | grep -c "FAIL: drain: whole drain"` →
+  `1` → after step 2: `0` (and the suite prints `0 failed`, rc=0).
+- `grep -c 'MISSION_DRAIN_BUDGET' tools/launchd/mission-control.sh` → M3-base: `0` → after: ≥1.
+
+**Mutations (anchored to M3's own diff — with M1+M2 kept and ONLY the guard removed, the backlog arm
+reverts to the red state measured in step 1)**:
+| Mutation | Kills assertion |
+|---|---|
+| Remove the `DRAIN_BUDGET` remaining-budget check before each row | `drain: whole drain returns within aggregate budget and preserves unattempted rows` |
+| Attempt rows regardless / drop the deferred-drain diagnostic | `drain: deferred-drain diagnostic names deferred row count` |
+
+---
+
+## M4 — Mutation sweep + full verification (no new production/test diff)
+
+**Files**: none modified — verification only (mutation copies under `mktemp -d`).
+
+**Design trace**: Mutation Table (all 11 rows); Acceptance "GREEN after" block.
+
+**Steps**:
+1. Run the mutation sweep: for each mutation row from M1–M3 plus the two deferred-to-sweep rows
+   below, apply it to a COPY of the tree files in a temp dir, prove the copy parses (`bash -n`),
+   run the suite against the mutated copy, record that the named assertion FAILS and the failure is
+   not a crash of the harness itself. Sweep additions:
+   - "Suppress re-appending a failed drain row" kills
+     `production: hanging drain send is cut off and row retained`.
+   - "Delete only the top-level drain invocation" kills `wiring: exactly one preflight drain call`.
+2. Full gate: `make test-launchd-drivers` → rc=0; record exit code and elapsed.
+3. Determinism: run `bash tools/launchd/test_driver_notify.sh` twice on the clean tree; identical
+   pass/fail counts; `git status --porcelain tools/launchd/` shows only the two intended files
+   modified (read-only git).
+4. Confirm no mutation text survives in the real tree (`grep` for each mutation marker) and
+   `bash -n` both files.
+
+**Boundary expectation**: suite count unchanged from M3 (`39 passed, 0 failed`); every mutant kills
+its named assertion; `make test-launchd-drivers` rc=0.
+
+**Acceptance**:
+- `make test-launchd-drivers; echo rc=$?` → base of SPRINT: rc=1 → rc=0. (Red carried by M1's seven
+  rows — declared, not independent evidence.)
+- The sweep log shows 11/11 mutants killed their named assertions.
+- `grep -c "124" tools/launchd/test_driver_notify.sh` ≥ 1 (hang labs exist) — green/green guard,
+  declared.
+
+**Mutations**: this milestone IS the sweep; its `mutations` array in the JSON lists all 11 rows with
+their single named victim assertion each.
+
+**Non-vacuity note**: M4 adds no diff, so it has no anchoring mutation of its own — its value is
+re-running the M1–M3 mutations against the FINAL tree, catching a mutation that an earlier
+milestone's base-state masked. Declared explicitly so no one counts M4 as assertion-anchored.
+
+---
+
+## Handoff
+
+- Executor: load the `sprint-executor` skill; work milestone-by-milestone IN ORDER; record actual
+  counts/timings into this plan's boundary lines (or the sprint JSON) as you go. **NO git writes —
+  the controller commits.** Bounded-wait discipline: every hang lab carries its own outer
+  `date +%s` watchdog; never end a run waiting on a notification.
+- Out of scope (design "Deferred"): the seven non-D-60 call sites (P:1470/1473/1486/1835/1838/1852/
+  1855) — named queue row `M-LAUNCHD-NOTIFY-REMAINING-BOUNDING`. Do not touch them.
+- Evaluator: `sprint-evaluator` against the design's Acceptance Criteria + Mutation Table; verify
+  the recorded boundary counts and the sweep log, and re-run `make test-launchd-drivers`
+  first-party.

--- a/design_docs/planned/v0_35_2/m-launchd-notify-subshell-observation.md
+++ b/design_docs/planned/v0_35_2/m-launchd-notify-subshell-observation.md
@@ -207,7 +207,9 @@ diff/hash and `bash -n`.
 
 | Mutant | Specific assertion it must kill |
 |---|---|
-| Remove `_mc_bounded`/`NOTIFY_TIMEOUT` on the direct send (revert to unbounded command substitution) | `production: hanging direct send is cut off at the bound` (hang not cut off; outer guard trips) |
+| Remove `_mc_bounded`/`NOTIFY_TIMEOUT` on the direct send (revert to unbounded command substitution) | `production: direct send retries 3x then spools on timeout` AND `production: synthesised timeout diagnostic` — **corrected iter-347 by the independent judge (N1)**: it does NOT kill `production: hanging direct send is cut off at the bound`, which this row originally claimed. The mutation is still non-vacuous; only its named victim was wrong. |
+| Move `run()`'s `_blk_rc=$?` back to after the printfs (reintroduce the G2 defect in the harness that drives 20+ assertions) | `RC capture: run() itself surfaces a failing block, not printf's status` — **added iter-347 (judge B1)**. Before that arm existed this mutation left the suite fully green at 37/0, because the dedicated G2 check exercised a standalone reimplementation and never `run()` itself. |
+| Delete the `env` prefix from the direct send **with `AILANG_MESSAGES_STORE`/`_PROJECT` exported in the ambient shell** | `direct send reaches child with store=gcp` — **hermeticity fix iter-347 (judge B2)**. `_mc_bounded` runs `( exec "$@" )`, and a subshell inherits the caller's exports regardless of the prefix, so in the CLAUDE.md-mandated session environment this mutation was invisible (green 37/0 with the vars set, red 36/1 without). The suite now `unset`s both at the top, making the prefix the only possible source. |
 | Remove `_mc_bounded` on the drain-time send | `production: hanging drain send is cut off and row retained` |
 | Remove `_mc_bounded` on the GH notice | `production: hanging gh comment is cut off and warns` |
 | Replace `env AILANG_MESSAGES_STORE=gcp …` with no store / `local` in the direct send | `direct send reaches child with store=gcp` (env/store assertion fails) |
@@ -268,6 +270,23 @@ SYNTHESISES the `timed out after ${NOTIFY_TIMEOUT}s (no output)` diagnostic.
 
 **Cosmetic (recorded, not designed around):** each cutoff prints `…/bounded.sh: line 1: <pid> Terminated:
 15 ( exec "$@" ) > "$out_f" 2>&1` to stderr — job-control noise, three lines per timed-out notice.
+
+### Post-evaluation corrections (iteration 347, independent judge `sonnet`, LAND 80/100)
+
+Three findings were reproduced first-party by the controller and fixed in-iteration; two were BLOCKING.
+
+- **B1** `run()`'s own `_blk_rc` capture had zero coverage — the G2 fix could be reverted with the suite
+  fully green. A new arm drives `run()` itself with a failing block. Proven non-vacuous: the mutation now
+  kills exactly `RC capture: run() itself surfaces a failing block, not printf's status`.
+- **B2** the store/project guard was not hermetic — `( exec "$@" )` inherits the caller's exports, so the
+  documented AILANG session environment defeated it. The suite now unsets both vars. Proven non-vacuous:
+  the env-prefix mutation now fails **with the ambient vars deliberately exported**.
+- **N2** the synthesised diagnostic was gated on `rc=124` alone, so a `mktemp` failure (`rc=125`) reproduced
+  the same empty-tail blindness. It is now gated on an EMPTY tail with any non-zero rc, which is the property
+  that actually matters; measured `no output (rc=1)` where the tail was previously blank.
+- **N3** `_rc` is now `local` in `_mc_notify`.
+
+Suite: **38 passed, 0 failed**, rc=0 (was 37 before the B1 arm).
 
 ## Timeline, Risks, and Deferred Decisions
 

--- a/design_docs/planned/v0_35_2/m-launchd-notify-subshell-observation.md
+++ b/design_docs/planned/v0_35_2/m-launchd-notify-subshell-observation.md
@@ -1,262 +1,362 @@
-# M-LAUNCHD-NOTIFY-SUBSHELL-OBSERVATION: Restore Notification Test Observability
+# M-LAUNCHD-NOTIFY-SUBSHELL-OBSERVATION: Restore Notification Test Observability and Bound Production Notification Calls
 
-**Status**: Planned — mission iteration 344, single revision after quorum round 1
-**Target**: v0.35.2
-**Priority**: P0 (inherited dev-CI regression)
-**Estimated**: 2 hours, including mutation validation and independent evaluation
-**Dependencies**: Existing notification repair `63a0d2b32`; base `c308b2a0a84edb593609af5e7f4bb3b7bc402014`
-**Lane**: Mission harness; test-only correction, with the production notification contract preserved
-**Created**: 2026-09-07
+**Status**: Planned — mission iteration 347, revision under human ruling **D-60** (attended 2026-09-07, Mark Edmondson). This is **NO LONGER test-only**: the ruling overrides the earlier "separate production follow-up" deferral and folds production bounding INTO this design. **Lane:** Mission harness; test-observation repair **and** production bounded-call repair, both required by D-60.
+**Target**: v0.35.2 · **Priority**: P0 (inherited dev-CI regression RED on `dev`) · **Estimated**: 4 hours (test repair + production bounding + mutation + evaluation)
+**Dependencies**: existing notification repair `63a0d2b32`; base commit `81abc956d` (origin/dev).
+**Created**: 2026-09-07 · **Revision**: iter-347, per D-60.
 
 ## Problem Statement
 
-At the exact base, `make test-launchd-drivers` passes all 54 pin-root checks and then fails
-with **20 passing / 7 failing** notification checks. The actual fixture is
-`tools/launchd/test_driver_notify.sh`; the reported name
-`test_mission_control_notifications.sh` does not exist at this base.
+At base `81abc956d`, `make test-launchd-drivers` passes all 54 pin-root checks then fails the
+`launchd drivers (bash 3.2)` notify suite **20 passed / 7 failed**, rc=1 (M1). The fixture is
+`tools/launchd/test_driver_notify.sh`; the reported name `test_mission_control_notifications.sh`
+does not exist at this base.
 
 Commit `63a0d2b32` retained direct sends, added canonical message-store environment settings,
-captured their diagnostic output, and added a drain for previously spooled failures. It did
-**not** replace direct notification with spool-only delivery. Its `_out=$(ailang ... 2>&1)`
-executes the test's `ailang()` function in a subshell. That stub records calls by assigning to
-`TRACE`, so the record disappears when the subshell exits. The unchanged GitHub stub still
-records successfully. All seven red checks depend on the missing AILANG call or its title.
+captured their diagnostic output, and added a drain for previously spooled failures. Its
+`_out=$(ailang ... 2>&1)` executes the test's `ailang()` function in a subshell; that stub records
+calls by assigning to `TRACE`, so the record disappears when the subshell exits (V5, G3). All seven
+red checks depend on the missing AILANG call or its title.
 
-The product's diagnostic capture is legitimate. The test observation mechanism is wrong;
-weakening call/title assertions or removing product output capture would hide the defect.
-The broader pattern is incomplete standalone-driver labs: `9f267cf1f` repaired missing
-`STATE_DIR` inputs in this same suite. Repair the common spy boundary and cover the newly
-introduced retry/store/drain behavior in this existing CI fixture.
+This design has **two halves** that D-60 rules must land together:
+1. **Test-observation repair** (retained from the iter-344 design): restore the seven assertions by
+   making the fixture observe sends across shell boundaries via a file-backed trace, with the
+   `ailang()`/`gh()` stubs made reachable through the production bounding helper (see Conflict
+   Surface M3).
+2. **Production bounding** (NEW, folded in by D-60): bound the three notification paths D-60 names —
+   the drain-time send, the direct send, and the GitHub notice — with the existing `_mc_bounded`
+   helper, so a hanging `ailang`/`gh` cannot stall a notification retry chain, a spool drain, or a
+   fire's wrap-up.
 
 ## Verification Log
 
-Measured first-party in the isolated iteration-344 worktree at the base above. Tests use
-stubbed channels; these measurements did not send production notifications.
+Rows M1–M5 are the controller's first-party measurements at `81abc956d`, reused verbatim; rows
+V16+ are measured first-party in this iter-347 session at the same tree. All channel calls are
+stubbed; no production notification was sent.
 
 | ID | Claim / command or read | Observed |
 |---|---|---|
-| V1 | `git status --short`; `cat std/VERSION`; `/bin/bash --version` | Clean before design creation; v0.35.1; Bash 3.2.57 on arm64 Darwin. |
-| V2 | `make test-launchd-drivers` | Exit 2: pin-root 54/0; driver-notify 20/7; make stops before the remaining suites. |
-| V3 | Read `make/test.mk:59-83` and all of `tools/launchd/test_driver_notify.sh` | Target invokes `test_driver_notify.sh`; 27 existing assertions. `test_mission_control_notifications.sh` read fails with ENOENT; existing fixture is the positive control. |
-| V4 | Read `git diff 63a0d2b32^ 63a0d2b32 -- tools/launchd/mission-control.sh` | Only production file changed. Direct send changed to command substitution; canonical environment, error-tail capture, drain function and post-pin call were added. |
-| V5 | `/bin/bash -c 'TRACE="parent"; ailang() { TRACE="sent"; }; result=$(ailang); printf "capture: %s\n" "$TRACE"; ailang; printf "direct: %s\n" "$TRACE"'` | `capture: parent`, then `direct: sent`; independent shell-mechanism reproduction. |
-| V6 | Read suite `run()`, `run_drift()`, drift-j lab; `rg -n 'TRACE=|ailang\(\)' tools/launchd/test_*.sh` | These three labs in `test_driver_notify.sh` use mutable TRACE spies. The seven failures are pin AILANG/title, lane AILANG/title, drift-a, drift-c, drift-g. Healthy silence and GitHub checks pass. |
-| V7 | Read `_mc_notify` at driver lines 167-203 | Three attempts, sleeps 5 then 10 seconds; output captured with stderr; final failure logged with last 300 bytes, newline-flattened; failed payload appended to mission spool; GitHub handled separately. Existing test executes real backoff. |
-| V8 | Read `_mc_drain_notices` at lines 145-165 and call at 972 | Moves current spool to a draining file, delivers each entry with original timestamp prefix, re-appends failed rows, removes draining file, logs sent/kept counts; direct call follows pin-decision block. |
-| V9 | `rg -n 'spool|drain' tools/launchd/test*.sh` | Zero matches; positive controls are `_mc_drain_notices` definition/call and spool references in production driver. Existing launchd test bodies contain no spool/drain assertions. |
-| V10 | `git log -5 --oneline -- tools/launchd/test_driver_notify.sh`; read `git show 9f267cf1f` | Prior test-only repair addressed missing lab state, preserved per-arm isolation, and demonstrated mutation controls. Its removed drift-j change was dead code: avoid incidental drift-j refactoring here. |
-| V11 | `ailang docs search --stream planned/implemented --neural --timeout 15s --limit 5 'launchd notification spool tests'` (separate invocations with actual stream names) | Partial searches timed out after 27/187 planned and 44/200 implemented embeddings. Best planned 0.45 (motoko discovery refusal plan); best implemented 0.43. No returned duplicate threshold reached. Targeted text search supplied relevant driver/workbench docs below; search is not claimed exhaustive. |
-| V12 | Read numbered driver lines 153-154 and 183-184 | Both drain and direct-send sites set `AILANG_MESSAGES_STORE=gcp` and `AILANG_MESSAGES_PROJECT="${AILANG_MESSAGES_PROJECT:-ailang-multivac}"` on the command. Thus unset **or empty** project selects `ailang-multivac`; nonempty caller project is retained. Neither site assigns `AILANG_STORAGE`. Tests will observe these values inside the stub, not infer them from its exit code. |
-| V13 | Read numbered fixture lines 52-55, 87-88, 125-130; `/bin/bash -c 'false; actual=$?; printf "%s" ""; printf "actual=%s fixture_after_printf=%s\n" "$actual" "$?"'` | `run()` sources the emit block, then `printf`, then expands `RC:$?`; the two “block still exits 0” assertions therefore inspect printf's status. Shell control prints `actual=1 fixture_after_printf=0`. `run_drift()` expands `DECISION_RC:$?` immediately after the decision block and does not have this masking defect. |
-| V14 | In `/bin/bash`, `eval` the unchanged `_mc_notify` obtained with `awk '/^_mc_notify\(\) \{/,/^\}/' tools/launchd/mission-control.sh` and unchanged fixture stubs obtained with `sed -n '38,43p' tools/launchd/test_driver_notify.sh`; call notify with title `Mission v1: driver ran UNPINNED`, body `body`, normal fixture GH/repo/sender variables; then reset TRACE and call the **same** AILANG stub directly with the same send arguments | Real notify records only `GH:issue comment 635 --repo sunholo-data/ailang --body body`; direct control records `AILANG:messages send controlplane body --title Mission v1: driver ran UNPINNED --from mission-control`. Both use the actual source/stub, not a retyped notification implementation; neither invokes a real external command. Together with V2 and the call-site mapping below, this isolates lost observation in the real fixture. |
-| V15 | Read complete driver functions 145-203; `rg -n '_mc_bounded|_mc_notify|_mc_drain_notices' tools/launchd/mission-control.sh`; read helper 496 onward and `git show 63a0d2b32^:tools/launchd/mission-control.sh` notify body | Direct AILANG send, drain AILANG send, and notify GitHub post have **no driver-level per-call timeout**. Notify/drain call sites are direct. Positive control: `_mc_bounded` exists and wraps other messaging calls at 1817/1820. Parent commit already has unbounded direct sends/posts; the new drain at base is also unbounded. Three retries bound the count, not each call's duration. This is a separate existing production defect, not an effect of the proposed test edits. No claim is made about internal CLI/network-library deadlines. |
+| M1 | (controller) `bash tools/launchd/test_driver_notify.sh` at 81abc956d | **20 passed, 7 failed**, rc=1. Seven named failures = the causal-mapping set: fires on both channels (ailang), titled as UNPINNED, lane fires on ailang, lane keeps its own title, drift-a, drift-c, drift-g. |
+| M2 | (controller) `grep -n "ailang messages send\|gh issue comment" tools/launchd/mission-control.sh` | Drains send P:154 (`_mc_drain_notices`), direct send P:184 (`_mc_notify`), GH post P:198 (`_mc_notify`); **seven further unbounded sites** P:1470,1473,1486,1835,1838,1852,1855. Positive control of a bounded site: P:1817/1820 already read `_mc_bounded 30 ailang messages send …` and `_mc_bounded 30 gh issue comment …`. |
+| M3 | (controller) `_mc_bounded` at P:496 runs `( exec "$@" ) >"$out_f" 2>&1 &` — `exec` bypasses shell functions, resolves an external binary. Measured: `f() { echo FUNCTION-CALLED; }; ( exec f )` → `/bin/bash: exec: f: not found` rc=127; direct `f` → `FUNCTION-CALLED` rc=0. | **THE COLLISION**: wrapping the notifies in `_mc_bounded` makes the suite's `ailang()`/`gh()` **function** stubs unreachable; the driver would exec the REAL binaries. `_mc_bounded` also runs in a background subshell, so it does NOT fix the lost-`TRACE` observation (a file spy is still required). `_mc_bounded` returns 124 on expiry, combined output in `$MC_BOUNDED_OUT` (`_mc_notify` today reads send output from command substitution). |
+| M4 | (controller) read `_mc_bounded` P:487-512 | `PROBE_TIMEOUT` defaults to 120 (model probes, not messaging); the two existing bounded notification sites use **30s**; 124 on expiry (mirrors GNU `timeout`); combined stdout+stderr → `$MC_BOUNDED_OUT`; kill then SIGKILL after +2s. |
+| M5 | (controller) read `_mc_notify` P:167-203 | Retries three times, `sleep 5` then `sleep 10`; per-call bound and retry count are different guarantees. |
+| V1 | `git rev-parse HEAD`; `/bin/bash --version` | 81abc956dace8a9e297d26b232da3f0ce56b31a3; Bash 3.2.57 on arm64 Darwin. |
+| V2 | re-ran `bash tools/launchd/test_driver_notify.sh` | 20 passed, 7 failed, rc=1; the seven named rows identical to M1. |
+| V3 | re-ran M2 grep; read `_mc_drain_notices` P:145-165, `_mc_notify` P:167-203, `_mc_bounded` P:496-512, slot-notify P:1817/1820 | Line numbers and semantics match M2/M4/M5; refusal block P:1470/1473 ends in `exit 1`; model-change P:1486; post-record P:1835/1838 and rc-fail P:1852/1855 are episode-gated by marker files; slot-notify P:1808-1827 is the only already-bounded notify path. |
+| V4 | M3 mechanism prototype: PATH executable stub + `_mc_bounded 30 env AILANG_MESSAGES_STORE=gcp AILANG_MESSAGES_PROJECT=ailang-multivac stub …` (full helper reproduced) | rc=0; env vars reach the stub (`STORE=<gcp> PROJ=<ailang-multivac>`); stub's combined output lands in `MC_BOUNDED_OUT`; stub appends an `AILANG:` record to a file trace. Positive control that the exec chain and env passthrough both survive `_mc_bounded`. |
+| V5 | V4 with a never-returning stub (`while :; do sleep 1; done`), `secs=2` | rc=124 after ~3s (designer reading). **CONTROLLER RE-MEASURED (V5c, below): 5s, not ~3s** — the designer's number is optimistic; use V5c. |
+| V5c | (controller, first-party re-measure of V4/V5 at this tree) reproduced `_mc_bounded` verbatim via `awk '/^_mc_bounded\(\) \{/,/^\}/'`; ran (a) a PATH executable stub through `_mc_bounded 30 env AILANG_MESSAGES_STORE=gcp AILANG_MESSAGES_PROJECT=ailang-multivac fakeailang …`, (b) a never-returning PATH stub with `secs=2`, (c) a shell FUNCTION as the command | (a) rc=0, `MC_BOUNDED_OUT=[STORE=<gcp> PROJ=<ailang-multivac>]`, file trace `AILANG:messages send controlplane body --title T` — V4 CONFIRMED. (b) rc=124 in **5 s wall-clock**, not ~3 s: `_mc_bounded`'s poll loop sleeps 2 s per turn and then grants a further 2 s before SIGKILL, so the observed cutoff is `bound + up to ~2 s poll granularity + 2 s grace`. **Any acceptance budget must be `bound + 4 s` at minimum, not `bound + 1 s`.** (c) rc=127, `exec: f: not found` — negative control, M3 CONFIRMED. |
+| V6 | read `run()`/`run_drift()` in `test_driver_notify.sh` P:30-95 and assertions P:105-165 | Labs define `ailang()`/`gh()`/`log()` functions appending to `TRACE`, source `notify.sh` then the block in a subshell. log() is never wrapped in `_mc_bounded` (only `ailang`/`gh` are) — so log() need not route through the helper, but per G1 it must still append to `MC_TRACE_FILE` so the observation medium stays unified. 27 assertions include the seven red rows. |
+| G1 | (controller, objection 1) `grep -n 'checkno' tools/launchd/test_driver_notify.sh` | **Two negative AILANG assertions read the captured trace `$T`:** T:121 `checkno "no ailang call" "$T" "AILANG:"` and T:144 `checkno "lane SILENT when healthy" "$T" "AILANG:"`. Both currently PASS (in the 20 green). Under a split trace (ailang/gh records → `MC_TRACE_FILE`, log-only → `$T`), they would keep reading `$T` and pass vacuously even if the AILANG record genuinely fired into the file — hiding a regression. Mandates exactly ONE unified observation medium. |
+| G2 | (controller; RC-after-`printf` defect, re-measured at this base) `sed -n '45,57p' tools/launchd/test_driver_notify.sh`; shell control | `run()`'s emit sequence ends `. "$2"` then `printf "%s" "$TRACE"` then `echo "` / `RC:$?` (T:52-55) — so `RC:$?` is expanded AFTER `printf`. `/bin/bash -c 'false; actual=$?; printf "%s" ""; printf "actual=%s after_printf=%s\n" "$actual" "$?"'` → `actual=1 after_printf=0`: the block's real status is 1, the value the fixture records is 0. CONFIRMED. Positive control: `run_drift()` expands `DECISION_RC:$?` immediately after the decision block (T:88, :196) — the correct form already exists in this same file. |
+| G3 | (controller; subshell `TRACE` loss, re-measured at this base) `/bin/bash -c 'TRACE=parent; ailang() { TRACE="sent"; }; r=$(ailang); printf "capture:[%s]\n" "$TRACE"; ailang; printf "direct:[%s]\n" "$TRACE"'` | `capture:[parent]` then `direct:[sent]`: an assignment made inside command substitution does NOT survive to the parent shell, while the identical direct call does. Positive control = the direct call. |
 
 ### Exact causal mapping of the seven baseline failures
 
-Line numbers below are at the recorded base. `T` means `tools/launchd/test_driver_notify.sh`;
-`P` means `tools/launchd/mission-control.sh`. All rows use P:183-184, the captured direct send
-inside `_mc_notify`; P:185 accepts the stub's successful exit. The only AILANG observation
-in the relevant fixture stubs is assignment to `TRACE` (T:40-41 or T:71-72). Capture loses
-that assignment as measured in V14; each row's failed predicate requires that lost record.
+Line numbers at base. `T`=`tools/launchd/test_driver_notify.sh`, `P`=`tools/launchd/mission-control.sh`. All rows use P:183-184, the captured direct send inside `_mc_notify`; P:185 accepts the stub's successful exit. The only AILANG observation in the relevant stubs is assignment to `TRACE` (T:40-41 / T:71-72). Capture loses that assignment as measured in G3 (subshell), so each failed predicate requires that lost record. Surviving controls in V2 pass because they read TRACE that survives (log, GH) or negate.
 
-| Exact failing assertion / source | Lab and production emit call | Lost value required by assertion; surviving control in V2 |
+| Exact failing assertion | Lab / production emit | Lost value required; surviving control in V2 |
 |---|---|---|
-| `fires on both channels (ailang)` — T:114, pin section | `run(pin_block)`; P:1578 | `AILANG:messages send controlplane`; adjacent GitHub post check passes |
-| `titled as UNPINNED` — T:116, pin section | `run(pin_block)`; P:1578 | Exact lowercase `driver ran UNPINNED` in AILANG title; GH body has differently capitalized `Driver ran UNPINNED`, so does not satisfy this predicate |
-| `lane fires on ailang` — T:139 | `run(lane_block)`; P:1549 | `AILANG:messages send controlplane`; lane GitHub and log checks pass |
-| `lane keeps its own title` — T:141 | `run(lane_block)`; P:1549 | Exact lowercase `executor/planner lane degraded` in AILANG title; GH body's initial `Executor/planner` differs |
-| `drift-a: first threshold notice reaches both channels with path/count` — T:148 | `run_drift(pinned,170,25,absent)`; P:1596 | Ordered AILANG record before GH; decision rc 0, state 170, GH/path/count survive |
-| `drift-c: doubling notifies` — T:152 | `run_drift(pinned,340,25,170)`; P:1596 | AILANG call record; decision rc 0 and state 340 survive |
-| `drift-g: STALE keeps original notice only` — T:160 | `run_drift(STALE,170,25,absent)`; P:1578 | Exact lowercase `driver ran UNPINNED` title; decision rc 0 and GH body survive |
-
-V2 supplies the actual failed rows and surviving trace contents; V4 identifies the changed
-capture site; V14 reproduces the causal boundary with the actual notify function and fixture
-stub. This establishes a test-observation defect without claiming production delivery was
-measured against live services.
+| `fires on both channels (ailang)` — T:114 | `run(pin_block)`; P:1578 | `AILANG:messages send controlplane`; adjacent GH post passes |
+| `titled as UNPINNED` — T:116 | `run(pin_block)`; P:1578 | lowercase `driver ran UNPINNED` in AILANG title; GH body capitals differ so does not satisfy |
+| `lane fires on ailang` — T:139 | `run(lane_block)`; P:1549 | `AILANG:messages send controlplane`; lane GH and log pass |
+| `lane keeps its own title` — T:141 | `run(lane_block)`; P:1549 | lowercase `executor/planner lane degraded`; GH body initial caps differ |
+| `drift-a` — T:148 | `run_drift(pinned,170,25,absent)`; P:1596 | ordered AILANG record before GH; DECISION_RC/state/GH/path survive |
+| `drift-c` — T:152 | `run_drift(pinned,340,25,170)`; P:1596 | AILANG call record; DECISION_RC and state 340 survive |
+| `drift-g` — T:160 | `run_drift(STALE,170,25,absent)`; P:1578 | lowercase `driver ran UNPINNED`; DECISION_RC and GH body survive |
 
 ## Goals and High-Impact Decisions
 
-Primary goal: make the existing suite observe real notification calls across shell boundaries,
-restore its original 27 checks, and prevent regressions in the repaired notification path.
+Two goals: (1) make the suite observe real notification calls across shell boundaries and restore its
+27 checks incl. the seven red; (2) bound the three D-60 notification paths in production so a hang
+cannot stall a retry/spool/wrap-up.
 
-| Decision | Reason | Owner | Freeze / cost |
-|---|---|---|---|
-| Preserve current production behavior | The red set is explained by the observation boundary, not failed sends | Agent designer, reviewed by evaluator | Design / low |
-| Persist test observations in per-arm files | Works through command substitution and stdout/stderr redirection | Executor | Design / low |
-| Extend the existing suite | Already wired into the Bash 3.2, Go-less CI target | Executor | Design / low |
-
-- [x] Production changes are outside this fix unless new evidence demonstrates a separate defect; report and re-scope such evidence.
-- [x] Keep all original behavior assertions and their meaning, including healthy silence and source-clone paths.
-- [x] Preserve per-arm temporary state; all channel calls remain stubbed and sleep is observed without waiting.
+| Decision | Reason | Owner |
+|---|---|---|
+| Fold production bounding into THIS design (D-60) | Ruling overrules the iter-344 deferral; both halves must land together | Designer |
+| Bound the three D-60 paths with `_mc_bounded`; use `NOTIFY_TIMEOUT=30` (env `MISSION_NOTIFY_TIMEOUT`) | Matches the two existing bounded notify sites (P:1817/1820); message-send/gh-comment lands well within 30s; `PROBE_TIMEOUT=120` is for model probes, not messaging (M4) | Designer |
+| Convert the fixture's `ailang()`/`gh()` function stubs to executable PATH scripts, prefixed with a leading `env` for the store vars | `_mc_bounded` `( exec "$@" )` cannot reach function stubs and cannot parse `VAR=val` prefixes; PATH scripts + `env` are dependency-free and exercise the real background-subshell bounded path (V4) | Designer |
+| Keep `log()` as a function, but unify it onto `MC_TRACE_FILE` | `_mc_notify` calls `log` directly, never via `_mc_bounded`, so it stays a function — but it must append to `MC_TRACE_FILE` and teardown must load the file into `TRACE` before the assertions, or the negative `checkno`s read a LOG-only `$T` and pass vacuously (G1) | Designer |
+| Retain the file-backed trace (iter-344) | `_mc_bounded` runs sends in a background subshell; a var-based `TRACE` cannot survive (M3, G3) | Designer |
+| Defer the seven non-D-60 call sites to a named queue row | They are episodic/terminal notices (marker-gated or immediate `exit`), not on the steady-state notify path, and each needs its own hanging-stub test (see Deferred) | Designer |
 
 ## Solution Design
 
-Modify **only `tools/launchd/test_driver_notify.sh`** for implementation (approximately
-100–180 added/changed lines; executor may organize helpers to keep it smaller). Documentation
-and sprint metadata accompany it. `mission-control.sh` and `make/test.mk` require no landed edit.
+### Half 1 — Production bounding (per D-60)
 
-1. Introduce a file-backed call trace inside the suite's temporary lab. In the send-capable
-   `run()` and `run_drift()` labs, make `ailang`, `gh`, and `log` append ordered observations
-   to this file; replay it after the block. Preserve `AILANG:`, `GH:`, and `LOG:` records used
-   by the existing checks. Keep stub command output separate from its trace, because production
-   intentionally captures or discards command output. The drift-j path does not send at base;
-   leave it alone unless sharing the helper eliminates duplication without weakening coverage.
-2. Record messaging environment **inside** the AILANG stub, alongside command arguments.
-   Verify direct and drained sends see `AILANG_MESSAGES_STORE=gcp`, default project
-   `ailang-multivac` for both unset and empty input, and the caller's nonempty explicit project
-   override when supplied (V12). Verify the
-   caller's store/project values and `AILANG_STORAGE` are unchanged after each function.
-3. Add a `sleep` stub that logs requested durations and returns immediately. For retry scenarios,
-   maintain attempt state in a file as well: a shell counter has the same subshell defect.
-   Cover success first try, failure then success, and all three failures. On permanent failure,
-   assert the error-tail content, exactly one spool row, flattened multiline body, and continued
-   GitHub attempt. Capture the block's actual status immediately after sourcing; the current
-   `RC:$?` after `printf` measures `printf`, not the block.
-4. Extract `_mc_drain_notices` from the real driver using the established guarded awk pattern.
-   Cover absent/empty spool, all-success delivery, mixed success/failure, all-failed retention,
-   and recovery on the next drain. Assert original timestamps, titles, bodies, sender, exact
-   retained row set, sent/kept counts, and cleanup of the draining artifact. A second successful
-   drain must not resend delivered rows. Verify v1 and one non-v1 namespace do not collide.
-   Keep GitHub out of drain assertions except a negative assertion: drains are controlplane-only.
-5. Assert the live driver has exactly one top-level `_mc_drain_notices` invocation after the
-   pin-decision end marker. This narrowly scoped wiring check complements behavioral function
-   tests and detects deletion of the preflight call without starting a live mission.
+1. Add `NOTIFY_TIMEOUT="${MISSION_NOTIFY_TIMEOUT:-30}"` next to `PROBE_TIMEOUT` (P:492). 30s matches
+   the two established bounded notify sites (M2/M4); overridable for the hang-control test.
+2. Wrap the **direct send** in `_mc_notify` (P:184). Replace the unbounded command substitution with
+   `_mc_bounded "$NOTIFY_TIMEOUT" env AILANG_MESSAGES_STORE=gcp AILANG_MESSAGES_PROJECT="${AILANG_MESSAGES_PROJECT:-ailang-multivac}" ailang messages send …`, then set `_out="$MC_BOUNDED_OUT"` and test the returned rc. Payload, retry count (3), and sleeps (5/10) are unchanged.
+   **Error-tail diagnostic (G5):** on a NORMAL final failure the command returned output, so `_out`
+   (from `MC_BOUNDED_OUT`) still holds it and the tail-300 log and the spool row are unchanged. BUT the
+   earlier claim is WRONG for `rc=124`: a timed-out command produced no output, so `MC_BOUNDED_OUT` is
+   empty and the WARNING would degrade to `FAILED … after 3 attempts:` with nothing after it — the
+   exact blindness the `_mc_notify` comment (P:190) exists to prevent. So on `rc=124` the diagnostic is
+   SYNTHESISED into the tail-300 log: `timed out after ${NOTIFY_TIMEOUT}s (no output)`. `rc=124` stays
+   non-zero → a failed attempt → retried and spooled exactly like today.
+3. Wrap the **drain-time send** in `_mc_drain_notices` (P:154) the same way: `_mc_bounded "$NOTIFY_TIMEOUT" env AILANG_MESSAGES_STORE=gcp AILANG_MESSAGES_PROJECT=… ailang messages send …`. On `rc=124` the row is treated as failed → re-appended to the spool (unchanged retention path).
+4. Wrap the **GitHub notice** in `_mc_notify` (P:198) with `_mc_bounded "$NOTIFY_TIMEOUT" gh issue comment …`. GH is already one-shot (not retried); bounding does not change retry semantics.
+5. `env` is required because `_mc_bounded` executes `( exec "$@" )`, and a `$@` prefixed with `VAR=x`
+   would make `exec` treat `VAR=x` as the command name. `env` carries the two store vars down to the
+   child while preserving the current scoping (the vars are never exported to the driver/coordinator;
+   `AILANG_STORAGE` untouched).
+6. **Aggregate drain budget (G4) and corrected worst-case latency (M5, G5).** Per-notice worst case,
+   measured with polling/grace overhead: AILANG leg = `3×(bound+overhead) + sleeps + SIGKILL grace =
+   3×(30+4) + 5 + 10 = 117 s` (G5: ~4s overhead per attempt — a 2s poll plus a further 2s pre-kill
+   grace; V5c measured 5s for a 2s bound), NOT 105 s; per notice with the GH leg = `117 + (30+4) =
+   ~151 s`, NOT ~135 s. This hard per-notice bound already beats today's unbounded form, but a DRAIN of
+   `N` hanging rows must not cost `N × (bound + overhead)` inside the one preflight phase whose only
+   backstop is the whole-slot `HARD_TIMEOUT` (G4). So the drain gets an explicit AGGREGATE budget
+   `DRAIN_BUDGET` (env `MISSION_DRAIN_BUDGET`, default 90 s), justified by verification row G4: the
+   preflight has NO phase-specific deadline — only `HARD_TIMEOUT=6 h` (P:795) — and the stall watchdog
+   cannot rescue it (no controller child exists yet; slow-but-progressing is not "no progress").
+   Before EACH drain attempt, require enough REMAINING budget for `NOTIFY_TIMEOUT` + termination
+   overhead (~2 s SIGKILL grace); if insufficient, STOP draining, PRESERVE all unattempted rows in the
+   spool, and emit an explicit DEFERRED-drain diagnostic (`notice spool: deferred <k> row(s), aggregate
+   budget <BUDGET>s exhausted`) rather than starting a send certain to be cut off. Individual attempts
+   keep reusing `_mc_bounded`; failed rows are re-appended exactly as today. A large-backlog acceptance
+   case (hanging send stubs over an N-row spool) proves the whole drain returns within `DRAIN_BUDGET`
+   and preserves both failed and unattempted rows; the mutation that removes the aggregate guard kills
+   that assertion.
 
-Use `mktemp -d` and cleanup traps for suite-owned artifacts. Avoid parallel arms sharing trace
-or retry state. A trace-write failure must produce a test failure, not an apparent successful
-stub. Product functions and emit blocks must remain extracted from source, never copied into tests.
+### Half 2 — Test-observation repair (retained, incl. M3 resolution)
+
+1. In the send-capable `run()` and `run_drift()` labs, write the fixture stubs as executable scripts in
+   a suite-owned temp `bin/` dir and prepend it to an **exported `PATH`** so `_mc_bounded`'s background
+   `exec` resolves the fake `ailang` and `gh` instead of the real binaries (M3). `log()` stays a function (called directly, never through `_mc_bounded`) but, per G1, it also
+   appends its records to `MC_TRACE_FILE`.
+2. Each `ailang`/`gh` PATH script appends one ordered `AILANG:`/`GH:` record to a **per-arm trace FILE**
+   (path via exported `MC_TRACE_FILE`), preserving every existing record prefix/argument form the checks
+   consume. The stub also emits the env values (via a fake stdout line captured into `MC_BOUNDED_OUT`)
+   so store/project assertions read `AILANG_MESSAGES_STORE=gcp` and the default `ailang-multivac`
+   reaching the child (V4). This is where the subshell-lost-`TRACE` fix lands: `_mc_bounded` runs sends
+   in a background subshell (M3), so only a file survives. `log()` appends to this SAME file, and the
+   `run()`/`run_drift()` teardown loads `MC_TRACE_FILE` into the `TRACE` variable before the 27
+   assertions evaluate, so positive and negative checks both read one unified medium (G1).
+3. Add the sleep stub, retry/file-counter for attempt state, error-tail, spool, and drain coverage
+   (direct-send retry/spool, `_mc_drain_notices` extraction via the guarded awk pattern) exactly as the
+   iter-344 Solution Design specified — the drain/extraction tests are unchanged in intent.
+4. Restore all seven assertions; add the production-bound assertions (next section). Capture the
+   block's actual status immediately after sourcing (the `RC:$?`-after-`printf` defect, G2).
+5. Wire check: exactly one top-level `_mc_drain_notices` invocation after the pin-decision end marker.
 
 ## Conflict Surface
 
-| Surface | Existing occupant / behavior to preserve | Verification |
+| Surface | Occupant to preserve | Resolution / verification |
 |---|---|---|
-| Captured AILANG stdout/stderr | `_out` contains provider output; caller cannot rely on it being printed | Separate file spy and diagnostic-tail assertions |
-| Shell state and episode markers | Fresh pin/lane arms avoid accidental dedupe; drift state persists only within its arm | All original checks; per-arm trace/state paths |
-| Ordered trace output | drift-a expects decision, AILANG then GitHub; titles appear in AILANG arguments | Replay file after decision/state output, preserving channel order |
-| Retry state | Each command substitution forks; first-attempt failure must advance across forks | File counter, exact attempt/backoff checks |
-| Message environment | Per-command canonical store; project override; separate `AILANG_STORAGE` | Inspect inside stub and after calls |
-| Spool filesystem | Mission names select distinct TSV files; failures survive next drain | Exact content/count and cross-namespace controls |
-| Go-less Bash 3.2 CI | Target executes shell suites then syntax-checks drivers | `/bin/bash`, no Go or new dependencies |
+| **exec-vs-function collision (M3)** | `_mc_bounded` `( exec "$@" )` bypasses functions | **PATH executable stubs** in the fixture (Half 2); `env` prefix in production (Half 1, step 5). Verified V4. Alternatives rejected: `export -f` (unreliable across `exec` in Bash 3.2; changes the shared helper), watcher-on-command-substitution (duplicates helper, does not fix function-bypass). |
+| **split-trace / vacuous checkno (G1)** | `ailang`/`gh` records to `MC_TRACE_FILE` but `$T` comes from `log()`-only `TRACE` | Unify the medium: `log()` appends to `MC_TRACE_FILE`; teardown loads the file into `TRACE` before the 27 assertions; a positive-control arm forces the same `no ailang call`/`lane SILENT when healthy` checkno to FAIL (see Acceptance / Mutation). |
+| **error-tail / `MC_BOUNDED_OUT` (M3)** | `_mc_notify` warns with last-300-bytes on send failure (assertions + spool depend on it) | `_out="$MC_BOUNDED_OUT"` after the bounded call; rc=124 → failure arm unchanged. Error-tail content is captured in the failing-send lab. |
+| **env-prefix through `exec`** | per-command store/project scoping; `AILANG_STORAGE` untouched | leading `env` argument; verified reaching child (V4); scoping preserved (never exported). |
+| **worst-case latency (M5)** | three retries + 5/10s sleeps, non-aborting | bounded ≤ ~151s/notice (corrected, G5); bounded drain per-row AND per-aggregate (step 6); budget-acceptable (see Design step 6). |
+| **seven out-of-D-60 sites (M2)** | refusal P:1470/1473, model-change P:1486, post-record P:1835/1838, rc-fail P:1852/1855 | **Deferred to named queue row** with reasons (see Deferred); not left silent. |
+| Captured stdout/stderr | `_out` (or `MC_BOUNDED_OUT`) holds provider output | separate file spy + diagnostic-tail assertions |
+| Retry state | each bounded send forks a subshell | file counter; exact attempt/backoff checks |
+| Spool filesystem | failures survive next drain | exact content/count, cross-namespace controls |
+| Go-less Bash 3.2 CI | `/bin/bash`, no new deps | `/bin/bash`, `mktemp -d`, no `declare -A`/`timeout` |
 
-Fixtures that must still work: pin notice healthy/degraded/failed-channel/unset-issue,
-lane healthy/degraded, and drift-a through drift-j in `test_driver_notify.sh`; all 54
-`test_pin_root.sh` checks; every remaining suite in `make test-launchd-drivers`.
-Intentional changes are limited to test instrumentation and added assertions. No language
-syntax, runtime behavior, notification payload, retry timing, or mission policy is changed.
-
-## Examples
-
-Before: `_out=$(ailang ...)` sends successfully, but the stub's `TRACE` assignment vanishes;
-the pin arm reports “fires on both channels (ailang)” as failed.
-
-After: the same production call appends an AILANG record to an isolated trace file; the pin
-arm observes its recipient/title, while the captured stdout remains available for diagnostics.
-During a simulated outage the trace records three sends and backoffs `5`, `10`; one spool
-row remains and a later successful drain removes it after asserting timestamped delivery.
+Fixtures still work: pin/lane healthy/degraded, drift-a..j; all 54 `test_pin_root.sh`; every other
+suite in `make test-launchd-drivers`. Intentional production change is bounded calls + `env` transport
+only; no payload, retry count, message-store semantics, policy, or language/runtime change.
 
 ## Acceptance Criteria and Test Plan
 
-- [ ] Original 27 assertions pass with the unchanged production driver; record exact new total.
-- [ ] New direct-send/store/retry/error/spool/drain/wiring cases above pass; every spy is local.
-- [ ] Failed send and failed GitHub delivery remain non-aborting, measured from the actual block status.
-- [ ] All tests in `make test-launchd-drivers` pass, including Bash 3.2 syntax checks; record duration and exit code.
-- [ ] Mutation controls below produce named behavioral failures; clean copies parse and all applied mutations are proven absent afterward.
-- [ ] Documentation updated with observed counts, results, limitations, and scope; no implementation claim based solely on a future test plan.
+**RED at base (non-vacuity controls):**
+- Test half: `bash tools/launchd/test_driver_notify.sh` is RED at base (M1: 20 passed / 7 failed,
+  rc=1) — the other twenty checks already pass, so the suite is not trivially all-fail and the seven
+  named rows are the exact regression set.
+- **Vacuous-checkno guard (unified medium, G1):** a positive-control arm in which the AILANG call
+  genuinely fires (a live `ailang` PATH script) — the SAME `no ailang call`/`lane SILENT when healthy`
+  checkno assertions MUST FAIL against it. This is how a vacuous `checkno` is DETECTED: it proves those
+  negative assertions read `MC_TRACE_FILE` (loaded into `TRACE`), not an empty half of a split trace.
+- Production half, **hang-cutoff control (separate from the test half):** a fixture `ailang`/`gh` stub
+  that never returns (no output, `while :; do sleep 1; done`), with `MISSION_NOTIFY_TIMEOUT=2`, must be
+  cut off at the bound. The bounded-notify lab runs the hang-stub through the real `_mc_bounded` and
+  asserts the call returns within a **7 s** budget (`bound 2 s + ~2 s poll granularity + 2 s SIGKILL grace`, measured 5 s in V5c, +2 s headroom) with rc=124, and that the
+  notify's failure arm spools a row after three retries. **This assertion FAILS if the `_mc_bounded`
+  wrapper/timeout is removed** (the hang would not be cut off). An outer test-level date-loop deadline
+  guards the lab so a removed bound fails cleanly rather than hanging CI.
 
-Run the focused suite first, then these small independent mutants against temporary copies
-of the driver/fixture tree (or a fixture-supported source override). Keep the production
-worktree untouched and prove each mutation landed by diff/hash and `bash -n`:
+**GREEN after implementation:**
+- [ ] Original 27 assertions pass, including all seven restored rows; record new exact total.
+- [ ] Negative `checkno` controls read the unified medium: `no ailang call` and `lane SILENT when
+      healthy` FAIL on the genuine-fire positive-control arm and pass only when AILANG truly did not
+      fire (G1).
+- [ ] All `make test-launchd-drivers` suites pass; record exit code and elapsed time.
+- [ ] New direct-send/store/retry/error-tail/spool/drain/wiring cases pass; every spy is local (file).
+- [ ] **Production bound asserted:** for each of the three D-60 paths (direct, drain, GH), a
+  never-returning stub with `MISSION_NOTIFY_TIMEOUT=2` is cut off at the bound (rc=124, measured 5 s — assert ≤7 s, V5c) and the
+  failure path (spool / WARNING) still executes. Must fail if the bound is removed.
+- [ ] **Synthesised timeout diagnostic (G5):** a bounded direct send whose command times out (rc=124,
+      no output — ARM B) yields a WARNING whose tail reads `timed out after ${NOTIFY_TIMEOUT}s (no
+      output)`, NOT an empty `FAILED … after 3 attempts:`; the assertion FAILS if the synthesis is
+      reverted to the raw (empty) `MC_BOUNDED_OUT` tail.
+- [ ] **Aggregate drain budget (G4):** a large-backlog drain against hanging send stubs returns within
+      the aggregate `DRAIN_BUDGET`, emits the deferred-drain diagnostic, and preserves BOTH the failed
+      and the unattempted rows; FAILS if the aggregate guard is removed.
+- [ ] Failed send and failed GH stay non-aborting, measured from the actual block status.
+- [ ] Mutation controls below produce the named failures; clean copies parse; all applied mutations
+  proven absent afterward; driver hash equals its initial value after re-run.
 
-| Mutant | Required failure |
+## Mutation Table
+
+Run each mutation in a bounded temp copy; keep the production tree untouched; prove each landed by
+diff/hash and `bash -n`.
+
+| Mutant | Specific assertion it must kill |
 |---|---|
-| Replace actual AILANG send command with a successful no-op, retaining function/block extraction markers | Named send/call-count/title assertion fails; extraction failure is insufficient |
-| Change canonical store assignment to `local` in direct and/or drain send | Corresponding inside-stub environment assertion fails |
-| Suppress re-appending a failed drain row | Retained-row/recovery assertion fails |
-| Delete only top-level drain invocation | Wiring assertion fails, with function extraction still valid |
+| Remove `_mc_bounded`/`NOTIFY_TIMEOUT` on the direct send (revert to unbounded command substitution) | `production: hanging direct send is cut off at the bound` (hang not cut off; outer guard trips) |
+| Remove `_mc_bounded` on the drain-time send | `production: hanging drain send is cut off and row retained` |
+| Remove `_mc_bounded` on the GH notice | `production: hanging gh comment is cut off and warns` |
+| Replace `env AILANG_MESSAGES_STORE=gcp …` with no store / `local` in the direct send | `direct send reaches child with store=gcp` (env/store assertion fails) |
+| Keep the in-shell `ailang()` function stub instead of the PATH script | `fires on both channels (ailang)` AND `titled as UNPINNED` AND `lane fires on ailang` AND `lane keeps its own title` AND `drift-a` AND `drift-c` AND `drift-g` — all fail because `exec` cannot reach a function (M3 positive-proof) |
+| Revert to a split trace: `ailang`/`gh` on `MC_TRACE_FILE`, `log()` on the `TRACE` var, and skip loading the file into `TRACE` in the teardown | `no ailang call` AND `lane SILENT when healthy` pass vacuously despite a genuinely fired AILANG record; the positive-control arm is the tripwire that flags the regression (G1) |
+| Suppress re-appending a failed drain row | `drain: retained-row/recovery` assertion |
+| Delete only the top-level drain invocation | `wiring: exactly one preflight drain call` |
+| Replace file counter with a shell var for retry state | `retry: attempt-2/3 recorded across subshells` |
+| Remove the aggregate drain-budget guard (`DRAIN_BUDGET` remaining-budget check before each row) | `drain: whole drain returns within aggregate budget and preserves unattempted rows` (a large-backlog hang exceeds budget and rows are neither attempted-bounded nor preserved) |
+| Revert the `rc=124` SYNTHESISED diagnostic to the raw (possibly empty) `MC_BOUNDED_OUT` tail | `synthesised timeout diagnostic` — the `timed out after ${NOTIFY_TIMEOUT}s (no output)` text vanishes (G5, ARM B) |
 
-Record exact outcomes, not predicted counts. Return to the unmutated suite and rerun once;
-verify production driver hash equals its initial value. Each focused run gets a bounded
-30-second budget after sleep stubbing; full target gets a bounded 10-minute budget with
-progress reporting, because pin-root/probe suites do real work. An exhausted budget is an
-explicit incomplete check. These budgets bound **test executions only**; they do not add a
-production timeout or establish a production duration guarantee (V15). Tests must not contact
-Firestore, GitHub, model providers, or launchd.
+Record exact outcomes, not predictions; re-run the clean suite; verify the driver hash is unchanged.
+
+## Controller First-Party Rows G4, G5 (round-3 evidence)
+
+Controller-measured at base `81abc956d`; production tree untouched. G4 justifies the aggregate drain
+budget (Half 1 step 6); G5 is the load-bearing evidence for the `rc=124` synthesised diagnostic (Half 1
+step 2) and the corrected latency arithmetic.
+
+**G4 — the drain sits in the one phase with no preflight-specific deadline (controller, verified):**
+- `_mc_drain_notices` is defined at `tools/launchd/mission-control.sh:145` and has exactly ONE top-level
+  call, at `:972`, immediately after the `# --- DRIVER PIN DECISION END ---` marker — i.e. in the
+  driver's PREFLIGHT, before the controller session starts.
+- The ONLY deadline covering that phase is `HARD_TIMEOUT="${MISSION_TIMEOUT:-21600}"` (P:795 — 6 h for
+  the whole slot). There is NO preflight-specific deadline at all.
+- The stall watchdog cannot rescue it: `STALL_GRACE=2400` / `STALL_CHILD_AGE=2400` (`:802-803`); P:289
+  *"stall watchdog has NO progress instrument … early kill DISABLED … HARD_TIMEOUT still applies"* —
+  the preflight's situation (no controller child yet); slow-but-progressing is not "no progress".
+- `notice-spool` has exactly two references (`:147` read, `:195` append). **No size cap, no row cap, no
+  rotation** — unbounded by construction.
+- **Failure mode (concrete):** an N-row spool of hanging sends costs `N × (bound + overhead)` inside the
+  one phase whose only backstop kills the ENTIRE fire six hours later. Hence the aggregate budget.
+
+**G5 — wrapping `_mc_notify`'s direct send (P:184) and GH notice (P:198) preserves retry/spool/error-tail
+semantics under the real control flow (controller, verified).** Method: extracted `_mc_bounded` +
+`_mc_notify` via the guarded `awk '/^_mc_notify\(\) \{/,/^\}/'` pattern, substitution on the EXTRACTED
+copy only, PATH `ailang`/`gh` stubs + temp `STATE_DIR` + `log()` capture, real body run end to end. Two
+arms:
+
+- **ARM A** — `ailang` stub exits 1 immediately, `NOTIFY_TIMEOUT=30`: ELAPSED=24s · ailang attempts=**3**
+  · gh calls=**1** · spool rows=**1**; spool row `2026-09-07T12:59:09Z<TAB>Test title<TAB>line one line
+  two` (multiline body flattened); log `WARNING: testlabel notice FAILED to send via ailang messages
+  after 3 attempts: stdout-noise SIMULATED-SEND-ERROR store=<gcp> proj=<ailang-multivac>` → (a) all
+  three retries execute ✓, (b) error-tail carries `MC_BOUNDED_OUT` incl. the env reaching the child ✓,
+  (c) spool row written on final failure ✓, (d) rc=124 flows into the retry/spool arm identically to a
+  non-zero send rc ✓.
+- **ARM B** — `ailang` stub never returns, `NOTIFY_TIMEOUT=2`: ELAPSED=28s · attempts=**3** · gh calls=**1**
+  · spool rows=**1**; log = `WARNING: testlabel notice FAILED to send via ailang messages after 3
+  attempts: ` — **the error tail is EMPTY**.
+
+**THE DEFECT:** on a timeout the command produced no output, so `MC_BOUNDED_OUT` is empty and the WARNING
+degrades to `FAILED … after 3 attempts:` with nothing after it — today's unbounded form cannot hit this,
+because it only reaches the failure arm when the command actually returned and said something.
+`_mc_notify`'s own comment (`P:190`) keeps the reason precisely because discarding the error is "the same
+blindness that made an Anthropic rc=2 unexplainable for a whole day" — so the bounded substitution
+silently reintroduces that blindness in exactly the case the bound was added for, and `rc=124` therefore
+SYNTHESISES the `timed out after ${NOTIFY_TIMEOUT}s (no output)` diagnostic.
+
+**Cosmetic (recorded, not designed around):** each cutoff prints `…/bounded.sh: line 1: <pid> Terminated:
+15 ( exec "$@" ) > "$out_f" 2>&1` to stderr — job-control noise, three lines per timed-out notice.
 
 ## Timeline, Risks, and Deferred Decisions
 
-One coherent milestone: roughly 30 minutes instrumentation, 30 minutes new cases, 30 minutes
-mutations, and 30 minutes full verification/evaluation buffer. Executor may choose helper
-names and whether a test-only source override is cleaner than a temporary tree for mutants.
+One milestone: ~40m production bounding + env transport, ~40m fixture PATH-stub/trace migration, ~40m
+new cases, ~40m mutations (incl. hang controls), ~40m full verification and evaluation buffer.
 
-Main risks are a spy still relying on subshell-local counters, dropped trace ordering, and
-an accidentally vacuous mutant. File state, the original ordered checks, and named red sets
-address them. Retry timing is asserted rather than slept. Crash recovery for an interrupted
-drain, concurrent spool writers, TSV-format redesign, bounded production network calls, and
-episode-gating expansion are outside this regression and are not claimed solved here.
+Risks: env passthrough regressing (guarded by store/project inside-stub assertions, V4); a hang-control
+lab hanging CI after a bound is removed (guarded by an outer test-level deadline); accidentally vacuous
+mutants (named assertions in the table). Sleep timing is asserted, not slept.
 
-### Separate production follow-up for the controller's queue
-
-**Candidate: bound mission notification network calls.** V15 establishes that existing direct
-send/post calls and the base's spool drain have no driver-level per-call deadline. A stuck
-command can therefore prevent its next retry or next spool row from being reached; finite
-retry count is insufficient. This is a production defect acknowledged by this design, not
-an accepted duration guarantee. The existing `_mc_bounded` helper is relevant prior art,
-but choosing timeout values, handling process termination, and preserving failed spool records
-need their own design and hanging-command tests.
-
-Disposition under the controller's Gate-2 rule 3f/c: **queue that follow-up separately while
-keeping this CI-red repair test-only**. The baseline seven failures arise with immediate,
-successful local stubs (V14), so production timeout changes are unnecessary to resolve them.
-The controller owns adding this candidate to mission queue/log; this designer is authorized
-to change only this document and has not claimed an external queue write. A5 below receives
-no improvement credit for production boundedness. This follow-up is not an acceptance
-criterion requiring production edits in the current sprint.
+**Deferred — named queue row `M-LAUNCHD-NOTIFY-REMAINING-BOUNDING`** (controller adds to mission queue),
+NOT silent: the seven non-D-60 call sites (M2) are out of scope for THIS milestone for stated reasons —
+they are episodic/terminal, not the per-fire steady-state notify path:
+- Refusal P:1470/1473 — guarded by `$BLOCKED_FILE` and immediately followed by `exit 1`; a hung send
+  delays an intentional shutdown, not a continuing loop.
+- Model-change P:1486 — fires only on controller-model transitions (rare), guarded by model-change
+  logging; a hang delays only the announce.
+- Post-record P:1835/1838 — fires only when rc≠0 AND a mission-log record landed (rare terminal case).
+- rc-fail P:1852/1855 — episode-gated on rc value; at most once per identical-failure episode.
+Each needs its own hanging-stub test and adds no CI gate to enforce it (none is exercised by the red
+notify suite); bounding them is a coherent follow-up. This design does not claim them fixed.
 
 ## Axiom Compliance
 
-Harness-scoped scoring; no language-support claim is made.
+Harness-scoped scoring; no language-support claim.
 
 | Axiom | Score | Justification |
 |---|---|---|
-| A1 Determinism | +1 | Stable observations independent of subshell variable lifetime |
+| A1 Determinism | +1 | Stable observations from file state, independent of subshell variable lifetime |
 | A2 Replayability | 0 | Existing production replay contract preserved |
-| A3 Effect Legibility | +1 | Tests distinguish captured output from observable channel calls |
-| A4 Explicit Authority | 0 | All external channels remain stubbed |
-| A5 Bounded Verification | 0 | Test runs have explicit budgets, but production network calls remain unbounded at driver level (V15); no production boundedness improvement is claimed |
-| A6 Safe Concurrency | 0 | Per-arm isolation retained; no production concurrency change |
-| A7 Machines First | +1 | CI failures identify broken behavior rather than hidden spy state |
+| A3 Effect Legibility | +1 | Tests distinguish captured output from observable channel calls; bound rc=124 is legible |
+| A4 Explicit Authority | 0 | All external channels remain stubbed (now via PATH scripts) |
+| A5 Bounded Verification | **+1** | Production notification calls bounded (D-60); test runs have explicit budgets; hang-cutoff asserted |
+| A6 Safe Concurrency | 0 | Per-arm isolation retained; `_mc_bounded` already background-safe |
+| A7 Machines First | +1 | CI identifies broken behavior, not hidden spy state; bound regression is caught |
 | A8 Minimal Syntax | 0 | No language change |
 | A9 Cost Visibility | 0 | No billing change |
 | A10 Composability | 0 | Existing test target retained |
-| A11 Structured Failure | 0 | Production failure contract preserved and checked |
-| A12 System Boundary | 0 | Production boundaries unchanged |
+| A11 Structured Failure | 0 | Failure contract preserved and checked (error-tail, spool) |
+| A12 System Boundary | 0 | Notification payloads, retries, policy unchanged |
 
-**Net +3**; hard gates A1/A3/A4/A7 have no negative score. This score describes the proposed
-test-only change, not certification that the existing production driver meets every axiom.
+**Net +4** (A5 moved 0→+1 via D-60's production bounding). Hard gates A1/A3/A4/A7 have no negative
+score.
 
-## Related Documents and Duplication Check
+## Quorum Verification Log
 
-- [Driver pin rollout](../m-driver-pin-rollout.md): defines the existing caller-emits contract
-  and references this test lane; its parked rollout policy is not reopened.
-- [Mission loop workbench](../v0_36_0/m-mission-loop-workbench.md): configuration/topology
-  registry work, distinct from repairing the notification spy in an existing suite.
-- [Motoko refusal sprint plan](../m-motoko-discovery-arm-discriminating-refusal-sprint-plan.md):
-  neural match 0.45; relevant mutation discipline, but a different process-discovery instrument.
-- Historical commits `63a0d2b32` and `9f267cf1f` are the production change and closest prior
-  fixture repair. The sampled search had no duplicate-threshold match; targeted driver search
-  and source history establish this correction's distinct scope.
+Round 1 of independent review BLOCKED this revision. Both objections were reproduced first-party by the
+controller at base `81abc956d`; neither disputes the design direction, so this revision fixes both and
+stops.
 
-## Handoff
+- **gemini-3-1-pro** — REJECT (split-brain trace). Surfaced on the Solution Design Half-2 (log-vs-file
+  trace split), the Goals/Decisions `log()`-stub row, the Conflict Surface, the Acceptance Criteria, and
+  the Verification Log (G1). **Response:** applied the reviewer's fix verbatim — `log()` now also appends
+  to `MC_TRACE_FILE`, teardown loads the file into `TRACE` before the 27 assertions, the stale
+  `log()`-stub decision row was replaced, and a vacuous-`checkno` positive-control detection arm was added
+  to the Acceptance Criteria plus a matching Mutation Table row.
+- **oc-glm-5-2** — REJECT (unverified V13/V14 dependency). Surfaced on the Problem Statement, the causal
+  mapping, and Solution Design Half-2 step 4. **Response:** added controller-attributed first-party rows
+  G2 (RC-after-`printf` defect) and G3 (subshell `TRACE` loss) measured at this base, and removed every
+  remaining V13/V14/iter-344-as-evidence citation, replacing each with the new row IDs.
+- **gpt6-astra** — ABSENT on budget; no verdict recorded.
 
-Design author changes only this document and makes no Git writes. Route to planner, executor,
-and independent evaluator under mission-control's unattended authority after the design gate.
-Quorum round 1 was blocked by all three reviewers: Sol raised production boundedness, Gemini
-requested project-default and status-capture evidence, and GLM requested real-fixture causal
-correlation. This is the single permitted revision: V12-V15, the exact causal table, the
-separate production follow-up, and corrected A5/net score address those objections. Re-review
-must supply the verdict; this document does not self-approve. The measurements support keeping
-the test-only correction separate from production timeout work.
+**Round 2** — **gemini-3-1-pro**: **PASS** (flipped from round-1 REJECT; its round-1 fix worked and the
+revision now passes). **gpt6-astra**: **REJECT** on the drain-budget surface (no aggregate drain bound;
+a spool that is unbounded by construction drains inside a phase with no preflight-specific deadline —
+see G4). **oc-glm-5-2**: **REJECT** on the real-call-site evidence surface (V4/V5c ran only a standalone
+PATH-stub reproduction through a verbatim `_mc_bounded` copy, never the real `_mc_notify` body — see
+G5). Note: glm's round-2 response failed to parse and was re-run alone at a raised cap.
 
+**Round 3 — this narrow refinement**, applied under the mission's narrow-refinement carve-out: the two
+reviewer-authored fixes were applied VERBATIM — astra's explicit AGGREGATE drain budget + before-each-row
+remaining-budget check + stop-and-preserve-unattempted behaviour + deferred-drain diagnostic (+ row G4),
+and glm's real-call-site evidence (row G5, both arms), the corrected error-tail claim, the synthesised
+`rc=124` diagnostic, and the corrected latency arithmetic. The mechanism, the two-half structure, the
+`env`-through-`exec` transport, the PATH-stub fixture migration, the unified `MC_TRACE_FILE` medium, and
+rows M1–M5/V1–V6/V5c/G1–G3 are unchanged. **No further quorum round follows** — this revision routes
+directly to the sprint planner.
+
+## Related Documents and Handoff
+
+- [Driver pin rollout](../m-driver-pin-rollout.md): caller-emits contract; not reopened.
+- [Mission loop workbench](../v0_36_0/m-mission-loop-workbench.md): configuration registry, distinct.
+- [Motoko refusal sprint plan](../m-motoko-discovery-arm-discriminating-refusal-sprint-plan.md): neural
+  match 0.45; mutation discipline, different instrument.
+- Historical commits `63a0d2b32` (production capture change) and `9f267cf1f` (prior fixture repair).
+
+Design author changes only this document and makes no Git writes. Route to planner, executor, and
+independent evaluator after quorum under D-60, which prefers this reliability repair early in the week.
+Re-quorum must run against this revision; this document does not self-approve.
 
 ## Attended merge repair, 2026-09-07
 
@@ -266,3 +366,14 @@ spies in both send-capable labs, actual block return-code capture, and a no-wait
 stub. All original 27 assertions pass; independent review PASS. Production driver is
 unchanged. This resolves the seven observed failures but does not claim completion
 of the broader retry/drain/environment coverage planned above.
+
+**Superseded by iteration 347, and the sequence matters.** That attended repair landed on `dev` inside
+PR #1082 at 14:15Z while V1 iteration 347 was mid-flight on the same item under human ruling **D-60**,
+and the two are not composable: it keeps `ailang()`/`gh()` as in-shell FUNCTION stubs, which
+`_mc_bounded` cannot reach at all (`( exec "$@" )` bypasses functions — row M3). So the fixture work in
+this sprint SUPERSEDES it rather than duplicating it: PATH-executable stubs are a precondition of the
+production bounding D-60 mandates, not a stylistic preference. Its two substantive additions are
+carried forward: the `sleep` stub and file-backed `run_drift` spies. The same PR (`063df9917`) also
+repaired the nine `test_mission_heartbeat.sh` arms this iteration had measured failing at base
+`81abc956d`, so `make test-launchd-drivers` is rc=0 on `dev` — see the correction in the iteration-347
+log entry.

--- a/design_docs/planned/v0_35_2/sprint_v1_iter347_launchd_notify.json
+++ b/design_docs/planned/v0_35_2/sprint_v1_iter347_launchd_notify.json
@@ -1,0 +1,270 @@
+{
+  "sprint": "v1-iter347-launchd-notify",
+  "design_doc": "design_docs/planned/v0_35_2/m-launchd-notify-subshell-observation.md",
+  "base_commit": "027bcb022",
+  "branch": "sprint/v1-iter347-launchd-notify-bounded",
+  "baseline_measured": {
+    "command": "bash tools/launchd/test_driver_notify.sh",
+    "result": "20 passed, 7 failed",
+    "rc": 1,
+    "bash": "3.2.57(1)-release (arm64-apple-darwin25)"
+  },
+  "sequencing_invariant": "M1 (fixture PATH stubs) MUST land before M2 (production _mc_bounded wraps): _mc_bounded runs ( exec \"$@\" ), which cannot reach the fixture's shell-function stubs, so production-first would exec the REAL ailang/gh binaries and the suite would silently stop exercising the stubs while contacting Firestore/GitHub.",
+  "executor_constraints": [
+    "bash 3.2.57 only: no declare -A, no ${v,,}, no GNU timeout, no new dependencies, no Go",
+    "no network: all labs resolve ailang/gh to suite-owned PATH stubs; no Firestore, GitHub, model providers, or launchd",
+    "do NOT stub sleep: _mc_bounded's 2s poll and 2s SIGKILL grace are part of the measured 5s cutoff (V5c) that the 7s acceptance budget assumes",
+    "NO git write operations (add/commit/stash/checkout); git diff/status reads only; the controller commits",
+    "record ACTUAL pass/fail counts and timings at every milestone boundary"
+  ],
+  "total_est_minutes": 29,
+  "cut_order_if_short": [
+    "M4: trim mutation sweep to the three P0 mutants (direct-send bound removal, split-trace, drain-budget removal); defer the rest to the evaluator",
+    "M3: shrink backlog lab from 5 spool rows to 3"
+  ],
+  "milestones": [
+    {
+      "id": "M1",
+      "title": "Fixture observation repair: PATH executable stubs, unified MC_TRACE_FILE medium, immediate RC capture",
+      "est_minutes": 10,
+      "files": ["tools/launchd/test_driver_notify.sh"],
+      "design_refs": ["Half 2 steps 1-4", "Conflict Surface rows 1-2", "G1", "G2", "G3", "Mutation rows 5,6,9"],
+      "steps": [
+        "suite-owned bin/ with executable ailang/gh scripts appending ordered AILANG:/GH: records to exported MC_TRACE_FILE; ailang stub echoes store=<$AILANG_MESSAGES_STORE> proj=<$AILANG_MESSAGES_PROJECT>; AILANG_RC/GH_RC honoured; bin/ prepended to exported PATH in run(), run_drift(), and the inline drift-j lab",
+        "log() appends its LOG: record to the SAME MC_TRACE_FILE; teardown loads the file into TRACE after sourcing the block and before the assertions read it",
+        "fix G2: capture rc=$? immediately after sourcing the block in run() (T:52-55), emit trace after; run_drift's DECISION_RC form is already correct",
+        "new assertions: 'retry: attempts recorded across subshells (file counter)'; 'RC capture: block failure visible, not masked by printf'; 'positive control: unified medium shows genuine AILANG fire (checkno would FAIL)'"
+      ],
+      "boundary_expectation": "==== 30 passed, 0 failed ==== rc=0 (27 restored incl. the seven red rows + 3 new; record actual)",
+      "acceptance": [
+        {
+          "command": "bash tools/launchd/test_driver_notify.sh",
+          "red_at_base": "20 passed, 7 failed; rc=1",
+          "green_after": "N passed, 0 failed (N approx 30); rc=0"
+        },
+        {
+          "command": "bash tools/launchd/test_driver_notify.sh | grep -c 'PASS: positive control: unified medium'",
+          "red_at_base": "0",
+          "green_after": "1"
+        },
+        {
+          "command": "bash tools/launchd/test_driver_notify.sh | grep -c 'PASS: RC capture'",
+          "red_at_base": "0",
+          "green_after": "1"
+        },
+        {
+          "command": "make test-launchd-drivers",
+          "red_at_base": "rc!=0 (notify suite red after 54 pin-root checks pass)",
+          "green_after": "rc=0",
+          "declared": "redness is fully carried by M1's seven rows; not independent evidence"
+        }
+      ],
+      "mutations": [
+        {
+          "mutation": "Keep in-shell ailang()/gh() function stubs instead of PATH executable scripts",
+          "kills_assertion": "fires on both channels (ailang)"
+        },
+        {
+          "mutation": "Split trace: log() stays on the TRACE var and teardown does not load MC_TRACE_FILE",
+          "kills_assertion": "positive control: unified medium shows genuine AILANG fire (checkno would FAIL)"
+        },
+        {
+          "mutation": "Move RC:$? capture back after the printf in run()",
+          "kills_assertion": "RC capture: block failure visible, not masked by printf"
+        },
+        {
+          "mutation": "Replace the retry file counter with a shell variable",
+          "kills_assertion": "retry: attempts recorded across subshells (file counter)"
+        }
+      ],
+      "non_vacuity_anchor": "Production is untouched in M1, so every green at this boundary is caused by M1's fixture diff alone; each mutation above IS a partial revert of that diff and re-reds exactly its named assertion."
+    },
+    {
+      "id": "M2",
+      "title": "Production bounding of the three D-60 paths with _mc_bounded + env transport + synthesised rc=124 diagnostic",
+      "est_minutes": 9,
+      "files": ["tools/launchd/mission-control.sh", "tools/launchd/test_driver_notify.sh"],
+      "design_refs": ["Half 1 steps 1-5", "G5 ARM A/B", "V5c", "Conflict Surface rows 3-5", "Mutation rows 1-4,7,8,11"],
+      "steps": [
+        "FIXTURE FIRST (no git staging available): awk-extract _mc_bounded and _mc_drain_notices into the lab; add STUB_HANG=1 never-returning stub variant; add the new production-bound arms; RUN THE SUITE AND RECORD RED against unwrapped production (hang labs trip their outer watchdogs and fail cleanly)",
+        "production: NOTIFY_TIMEOUT=\"${MISSION_NOTIFY_TIMEOUT:-30}\" beside PROBE_TIMEOUT (P:492)",
+        "production P:184 direct send: _mc_bounded \"$NOTIFY_TIMEOUT\" env AILANG_MESSAGES_STORE=gcp AILANG_MESSAGES_PROJECT=\"${AILANG_MESSAGES_PROJECT:-ailang-multivac}\" ailang messages send ...; _rc=$?; _out=\"$MC_BOUNDED_OUT\"; retry/sleep semantics unchanged",
+        "production failure arm: if _rc -eq 124, synthesise _out=\"timed out after ${NOTIFY_TIMEOUT}s (no output)\" BEFORE the tail-300 WARNING (G5 ARM B: a timed-out command leaves MC_BOUNDED_OUT EMPTY)",
+        "production P:154 drain send: same _mc_bounded + env form; rc=124 re-appends the row (retention unchanged)",
+        "production P:198 GH notice: _mc_bounded \"$NOTIFY_TIMEOUT\" gh issue comment ...; one-shot semantics unchanged; drop the now-redundant >/dev/null 2>&1",
+        "assertions (MISSION_NOTIFY_TIMEOUT=2): 'production: hanging direct send is cut off at the bound' (rc=124, elapsed <=7s, outer 15s date+kill -9 watchdog); 'production: direct send retries 3x then spools on timeout' (outer 60s; ARM B measured 28s); 'synthesised timeout diagnostic'; 'production: hanging drain send is cut off and row retained'; 'production: hanging gh comment is cut off and warns'; guards 'direct send reaches child with store=gcp' and 'wiring: exactly one preflight drain call'",
+        "run the suite; record GREEN"
+      ],
+      "boundary_expectation": "==== 37 passed, 0 failed ==== rc=0 (30 + 7 new of which 2 are declared guards; record actual)",
+      "acceptance": [
+        {
+          "command": "bash tools/launchd/test_driver_notify.sh",
+          "red_at_base": "after fixture-first step: the new 'production:' arms FAIL against unwrapped production (record exact count)",
+          "green_after": "0 failed; rc=0"
+        },
+        {
+          "command": "bash tools/launchd/test_driver_notify.sh | grep -c 'PASS: synthesised timeout diagnostic'",
+          "red_at_base": "0",
+          "green_after": "1"
+        },
+        {
+          "command": "grep -c '_mc_bounded \"$NOTIFY_TIMEOUT\" env' tools/launchd/mission-control.sh",
+          "red_at_base": "0",
+          "green_after": "2"
+        },
+        {
+          "command": "grep -c '_mc_bounded \"$NOTIFY_TIMEOUT\" gh issue comment' tools/launchd/mission-control.sh",
+          "red_at_base": "0",
+          "green_after": "1"
+        },
+        {
+          "command": "bash -n tools/launchd/mission-control.sh tools/launchd/test_driver_notify.sh",
+          "red_at_base": "rc=0",
+          "green_after": "rc=0",
+          "declared": "green/green parse guard; measures nothing as red-green evidence, retained as a regression tripwire"
+        },
+        {
+          "command": "bash tools/launchd/test_driver_notify.sh | grep -c 'PASS: direct send reaches child with store=gcp'",
+          "red_at_base": "1",
+          "green_after": "1",
+          "declared": "GREEN AT BASE AND GREEN AFTER — the unbounded VAR=val prefix also delivers the vars; measures nothing; kept only so the env-prefix mutation has a named victim"
+        }
+      ],
+      "mutations": [
+        {
+          "mutation": "Remove _mc_bounded/NOTIFY_TIMEOUT on the direct send (revert to unbounded command substitution)",
+          "kills_assertion": "production: hanging direct send is cut off at the bound"
+        },
+        {
+          "mutation": "Remove _mc_bounded on the drain-time send",
+          "kills_assertion": "production: hanging drain send is cut off and row retained"
+        },
+        {
+          "mutation": "Remove _mc_bounded on the GH notice",
+          "kills_assertion": "production: hanging gh comment is cut off and warns"
+        },
+        {
+          "mutation": "Drop the env AILANG_MESSAGES_STORE=gcp AILANG_MESSAGES_PROJECT=... prefix from the bounded direct send",
+          "kills_assertion": "direct send reaches child with store=gcp"
+        },
+        {
+          "mutation": "Revert the rc=124 synthesised diagnostic to the raw (empty) MC_BOUNDED_OUT tail",
+          "kills_assertion": "synthesised timeout diagnostic"
+        }
+      ],
+      "non_vacuity_anchor": "Each M2 mutation reverts only the P:154/184/198 wraps or the synthesis while keeping M1 intact; with the bound gone the hang labs' outer watchdogs trip and fail cleanly, with env gone the child sees no store vars, with synthesis gone the WARNING tail is empty — all caused by M2's own diff."
+    },
+    {
+      "id": "M3",
+      "title": "Aggregate drain budget DRAIN_BUDGET with before-each-row remaining check, stop-and-preserve, deferred-drain diagnostic",
+      "est_minutes": 5,
+      "files": ["tools/launchd/mission-control.sh", "tools/launchd/test_driver_notify.sh"],
+      "design_refs": ["Half 1 step 6", "G4", "Mutation row 10"],
+      "steps": [
+        "FIXTURE FIRST: backlog arm — 5-row spool, hanging ailang stub, MISSION_NOTIFY_TIMEOUT=2, MISSION_DRAIN_BUDGET=8; RUN AND RECORD RED: with only per-call bounds the drain attempts all 5 rows (~25s > 8s budget) and emits no deferred diagnostic",
+        "production _mc_drain_notices: DRAIN_BUDGET=\"${MISSION_DRAIN_BUDGET:-90}\"; drain_start=$(date +%s) after spool claim; before EACH row require remaining >= NOTIFY_TIMEOUT + 2; else STOP, append current + all unattempted rows to the spool unchanged, log 'notice spool: deferred <k> row(s), aggregate budget <BUDGET>s exhausted', return 0",
+        "assertions: 'drain: whole drain returns within aggregate budget and preserves unattempted rows' (elapsed <=15s, outer deadline 30s, spool holds 5 rows, attempt counter = 1); 'drain: deferred-drain diagnostic names deferred row count'",
+        "run the suite; record GREEN"
+      ],
+      "boundary_expectation": "==== 39 passed, 0 failed ==== rc=0 (37 + 2; record actual)",
+      "acceptance": [
+        {
+          "command": "bash tools/launchd/test_driver_notify.sh | grep -c 'FAIL: drain: whole drain'",
+          "red_at_base": "1 (after fixture-first step, before production edit)",
+          "green_after": "0 (suite prints 0 failed, rc=0)"
+        },
+        {
+          "command": "grep -c 'MISSION_DRAIN_BUDGET' tools/launchd/mission-control.sh",
+          "red_at_base": "0",
+          "green_after": "1"
+        }
+      ],
+      "mutations": [
+        {
+          "mutation": "Remove the DRAIN_BUDGET remaining-budget check before each drain row",
+          "kills_assertion": "drain: whole drain returns within aggregate budget and preserves unattempted rows"
+        },
+        {
+          "mutation": "Attempt rows regardless of budget / drop the deferred-drain diagnostic",
+          "kills_assertion": "drain: deferred-drain diagnostic names deferred row count"
+        }
+      ],
+      "non_vacuity_anchor": "M3's base already contains M1+M2, so the backlog arm is RED at M3 base purely because the aggregate guard is absent; removing only M3's guard restores exactly that red state (~25s elapsed, no diagnostic) — the anchor is M3's own diff, not the sprint's."
+    },
+    {
+      "id": "M4",
+      "title": "Mutation sweep (11 mutants in temp copies) + full verification; no new production/test diff",
+      "est_minutes": 5,
+      "files": [],
+      "design_refs": ["Mutation Table (all 11 rows)", "Acceptance GREEN-after block"],
+      "steps": [
+        "apply each mutation to a COPY under mktemp -d; bash -n the copy; run the suite against it; record that the named assertion fails and the harness itself did not crash; prove each mutation absent from the real tree afterwards",
+        "make test-launchd-drivers -> rc=0; record exit code and elapsed",
+        "determinism: run the notify suite twice on the clean tree, identical counts; git status --porcelain tools/launchd/ shows only the two intended files",
+        "bash -n both files on the clean tree"
+      ],
+      "boundary_expectation": "suite count unchanged from M3 (39 passed, 0 failed); 11/11 mutants kill their named assertion; make test-launchd-drivers rc=0",
+      "acceptance": [
+        {
+          "command": "make test-launchd-drivers; echo rc=$?",
+          "red_at_base": "rc=1 at sprint base (carried by M1's seven rows — declared, not independent evidence)",
+          "green_after": "rc=0"
+        },
+        {
+          "command": "bash tools/launchd/test_driver_notify.sh | tail -1",
+          "red_at_base": "==== 20 passed, 7 failed ==== at sprint base",
+          "green_after": "==== N passed, 0 failed ==== with N matching M3's recorded actual"
+        }
+      ],
+      "mutations": [
+        {
+          "mutation": "Remove _mc_bounded/NOTIFY_TIMEOUT on the direct send",
+          "kills_assertion": "production: hanging direct send is cut off at the bound"
+        },
+        {
+          "mutation": "Remove _mc_bounded on the drain-time send",
+          "kills_assertion": "production: hanging drain send is cut off and row retained"
+        },
+        {
+          "mutation": "Remove _mc_bounded on the GH notice",
+          "kills_assertion": "production: hanging gh comment is cut off and warns"
+        },
+        {
+          "mutation": "Drop the env store-var prefix from the bounded direct send",
+          "kills_assertion": "direct send reaches child with store=gcp"
+        },
+        {
+          "mutation": "Keep the in-shell ailang() function stub instead of the PATH script",
+          "kills_assertion": "fires on both channels (ailang)"
+        },
+        {
+          "mutation": "Revert to a split trace (log() on the TRACE var, teardown does not load MC_TRACE_FILE)",
+          "kills_assertion": "positive control: unified medium shows genuine AILANG fire (checkno would FAIL)"
+        },
+        {
+          "mutation": "Suppress re-appending a failed drain row",
+          "kills_assertion": "production: hanging drain send is cut off and row retained"
+        },
+        {
+          "mutation": "Delete only the top-level drain invocation",
+          "kills_assertion": "wiring: exactly one preflight drain call"
+        },
+        {
+          "mutation": "Replace the retry file counter with a shell variable",
+          "kills_assertion": "retry: attempts recorded across subshells (file counter)"
+        },
+        {
+          "mutation": "Remove the DRAIN_BUDGET remaining-budget check before each row",
+          "kills_assertion": "drain: whole drain returns within aggregate budget and preserves unattempted rows"
+        },
+        {
+          "mutation": "Revert the rc=124 synthesised diagnostic to the raw MC_BOUNDED_OUT tail",
+          "kills_assertion": "synthesised timeout diagnostic"
+        }
+      ],
+      "non_vacuity_anchor": "M4 adds no diff of its own and is NOT assertion-anchored — declared explicitly. Its value is re-running the M1-M3 mutations against the FINAL tree to catch a mutant an earlier milestone's base state masked."
+    }
+  ],
+  "out_of_scope": "The seven non-D-60 call sites (P:1470/1473/1486/1835/1838/1852/1855) — deferred to named queue row M-LAUNCHD-NOTIFY-REMAINING-BOUNDING; do not touch.",
+  "handoff": "Executor makes NO git write operations; the controller commits. Evaluator: sprint-evaluator against the design's Acceptance Criteria + Mutation Table, re-running make test-launchd-drivers first-party."
+}

--- a/tools/launchd/mission-control.sh
+++ b/tools/launchd/mission-control.sh
@@ -150,8 +150,8 @@ _mc_drain_notices() {
   mv "$spool" "$tmp" 2>/dev/null || return 0
   while IFS="$(printf '\t')" read -r ts title body; do
     [ -z "${title:-}" ] && continue
-    if AILANG_MESSAGES_STORE=gcp AILANG_MESSAGES_PROJECT="${AILANG_MESSAGES_PROJECT:-ailang-multivac}" \
-       ailang messages send controlplane "[spooled $ts] $body" --title "$title" --from "$MSG_FROM" >/dev/null 2>&1; then
+    if _mc_bounded "$NOTIFY_TIMEOUT" env AILANG_MESSAGES_STORE=gcp AILANG_MESSAGES_PROJECT="${AILANG_MESSAGES_PROJECT:-ailang-multivac}" \
+       ailang messages send controlplane "[spooled $ts] $body" --title "$title" --from "$MSG_FROM"; then
       sent=$((sent + 1))
     else
       printf '%s\t%s\t%s\n' "$ts" "$title" "$body" >> "$spool"
@@ -180,9 +180,18 @@ _mc_notify() {
     # 2026-09-07: the same send is `inbox_...` with them and `msg_...` (local) without.
     # Scoped to THIS command, never exported: AILANG_STORAGE must not move, or the
     # coordinator and observatory follow it to Firestore too (backend.go:83).
-    _out=$(AILANG_MESSAGES_STORE=gcp AILANG_MESSAGES_PROJECT="${AILANG_MESSAGES_PROJECT:-ailang-multivac}" \
-      ailang messages send controlplane "$body" --title "$title" --from "$MSG_FROM" 2>&1)
-    if [ $? -eq 0 ]; then rc=0; break; fi
+    # The D-60 paths stay bounded: a dangling send must be cut off at NOTIFY_TIMEOUT
+    # instead of hanging the preflight or a retry. _mc_bounded forks a background subshell
+    # (`( exec "$@" )`), so `env` carries the two store vars down to the child with the same
+    # per-command scoping (never exported; AILANG_STORAGE untouched) while a `VAR=x` prefix
+    # would make exec treat VAR=x as the command name.
+    _mc_bounded "$NOTIFY_TIMEOUT" env AILANG_MESSAGES_STORE=gcp AILANG_MESSAGES_PROJECT="${AILANG_MESSAGES_PROJECT:-ailang-multivac}" \
+      ailang messages send controlplane "$body" --title "$title" --from "$MSG_FROM"; _rc=$?; _out="$MC_BOUNDED_OUT"
+    # G5 ARM B: a TIMED-OUT command produced no output, so MC_BOUNDED_OUT is empty and the
+    # failure WARNING would degrade to `FAILED ... after 3 attempts:` with nothing after it —
+    # the exact blindness _mc_notify's own comment exists to prevent. Synthesise the reason.
+    [ "$_rc" -eq 124 ] && _out="timed out after ${NOTIFY_TIMEOUT}s (no output)"
+    if [ "$_rc" -eq 0 ]; then rc=0; break; fi
     [ "$_try" -lt 3 ] && sleep $(( _try * 5 ))
   done
   if [ "$rc" -ne 0 ]; then
@@ -195,7 +204,9 @@ _mc_notify() {
       >> "$STATE_DIR/mission-${MISSION_NAME}-notice-spool.tsv" 2>/dev/null || true
   fi
   if [ -n "${MISSION_GH_ISSUE:-}" ]; then
-    gh issue comment "$MISSION_GH_ISSUE" --repo "$MISSION_REPO" --body "$body" >/dev/null 2>&1 \
+    # GH is one-shot (not retried): bounding only caps the wall-clock; a hang or
+    # failure still yields the loud WARNING below (non-aborting).
+    _mc_bounded "$NOTIFY_TIMEOUT" gh issue comment "$MISSION_GH_ISSUE" --repo "$MISSION_REPO" --body "$body" \
       || log "WARNING: ${label} notice FAILED to post to issue #${MISSION_GH_ISSUE}"
   else
     log "WARNING: ${label} notice needed but MISSION_GH_ISSUE is unset — no issue notice possible"
@@ -483,6 +494,7 @@ PREFS="${MISSION_MODEL_PREFS:-claude-opus-5,codex:gpt-5.6-sol,claude-fable-5-1}"
 CONTROLLER_FALLBACK="${MISSION_CONTROLLER_FALLBACK:-codex:gpt-5.6-sol,pi:ollama/glm-5.3:cloud,pi:openrouter/z-ai/glm-5.3}"
 QUOTA_SIG="usage limit|rate.?limit|quota|exceeded|too many requests|weekly limit"
 PROBE_TIMEOUT="${MISSION_PROBE_TIMEOUT:-120}"   # per-probe wall-clock cap, seconds
+NOTIFY_TIMEOUT="${MISSION_NOTIFY_TIMEOUT:-30}"   # per-notify wall-clock cap, seconds (D-60)
 
 # _mc_bounded SECONDS CMD... — run CMD with a hard wall-clock cap.
 # rc = CMD's rc, or 124 on expiry (mirrors GNU `timeout`, which this rig does not have).

--- a/tools/launchd/mission-control.sh
+++ b/tools/launchd/mission-control.sh
@@ -165,7 +165,7 @@ _mc_drain_notices() {
 }
 
 _mc_notify() {
-  local title="$1" body="$2" label="$3" _try rc=1
+  local title="$1" body="$2" label="$3" _try rc=1 _rc=1
   # RETRY, briefly. Measured 2026-09-06: the lane-degradation notice for the fire that
   # dropped the whole fleet to pi lanes failed to send — and the same send succeeded by
   # hand minutes later, so it was a blip. The consequence was not a lost log line: it
@@ -190,7 +190,12 @@ _mc_notify() {
     # G5 ARM B: a TIMED-OUT command produced no output, so MC_BOUNDED_OUT is empty and the
     # failure WARNING would degrade to `FAILED ... after 3 attempts:` with nothing after it —
     # the exact blindness _mc_notify's own comment exists to prevent. Synthesise the reason.
+    # A cut-off command produced no output (rc=124), and so did a helper that could not
+    # even start (rc=125, mktemp failure) — in BOTH cases an empty tail reproduces exactly
+    # the blindness this diagnostic exists to prevent, so synthesise on emptiness, not on a
+    # single rc value.
     [ "$_rc" -eq 124 ] && _out="timed out after ${NOTIFY_TIMEOUT}s (no output)"
+    [ "$_rc" -ne 0 ] && [ -z "$_out" ] && _out="no output (rc=$_rc)"
     if [ "$_rc" -eq 0 ]; then rc=0; break; fi
     [ "$_try" -lt 3 ] && sleep $(( _try * 5 ))
   done

--- a/tools/launchd/test_driver_notify.sh
+++ b/tools/launchd/test_driver_notify.sh
@@ -15,11 +15,19 @@ LAB="${TMPDIR:-/tmp}/emitlab.$$"; rm -rf "$LAB"; mkdir -p "$LAB" "$LAB/bin"
 # exec the REAL ailang/gh and hit prod Firestore + GitHub from CI (forbidden). Each
 # stub appends one ordered record to $MC_TRACE_FILE (per-arm, unified medium G1),
 # honours AILANG_RC/GH_RC, and the ailang one prints the store/project env it saw so
-# the child's env is observable (V4). STUB_HANG=1 selects a never-returning variant
-# for the bounded-cutoff arms.
+# the child's env is observable (V4). STUB_HANG_AILANG / STUB_HANG_GH=1 select a
+# never-returning variant for the bounded-cutoff arms; STUB_HANG_AILANG still counts an
+# attempt first so the retry-3x/spool arm can assert attempts via the file counter even
+# though the send never returns.
 cat > "$LAB/bin/ailang" <<'STUB'
 #!/bin/bash
-if [ "${STUB_HANG:-0}" = "1" ]; then
+if [ "${STUB_HANG:-0}" = "1" ] || [ "${STUB_HANG_AILANG:-0}" = "1" ]; then
+  if [ -n "${MC_ATTEMPT_FILE:-}" ]; then
+    n=0
+    [ -f "$MC_ATTEMPT_FILE" ] && n=$(cat "$MC_ATTEMPT_FILE" 2>/dev/null || echo 0)
+    n=$(( 10#$n + 1 ))
+    printf '%s\n' "$n" > "$MC_ATTEMPT_FILE"
+  fi
   while :; do sleep 1; done
 fi
 if [ -n "${MC_TRACE_FILE:-}" ]; then
@@ -38,7 +46,7 @@ chmod +x "$LAB/bin/ailang"
 
 cat > "$LAB/bin/gh" <<'STUB'
 #!/bin/bash
-if [ "${STUB_HANG:-0}" = "1" ]; then
+if [ "${STUB_HANG_GH:-0}" = "1" ]; then
   while :; do sleep 1; done
 fi
 if [ -n "${MC_TRACE_FILE:-}" ]; then
@@ -55,11 +63,17 @@ awk '/^# --- DRIVER PIN DECISION START ---/,/^# --- DRIVER PIN DECISION END ---/
 awk '/^if \[ -n "\$_pin_degraded" \]; then/,/^fi$/' "$DRV"     > "$LAB/pin_block.sh"
 awk '/^if \[ -n "\$_pin_drift_degraded" \]; then/,/^fi$/' "$DRV" > "$LAB/pin_drift_block.sh"
 awk '/^if \[ -n "\$_lane_degraded" \]; then/,/^fi$/' "$DRV"    > "$LAB/lane_block.sh"
+# M2 fixture: bound the three D-60 paths with the REAL helpers the production wraps
+# use, so the hang-cutoff and drain arms exercise the production code, not a retype.
+awk '/^_mc_bounded\(\) \{/,/^\}/' "$DRV"                    > "$LAB/bounded.sh"
+awk '/^_mc_drain_notices\(\) \{/,/^\}/' "$DRV"              > "$LAB/drain.sh"
 
-for f in notify pin_decision pin_block pin_drift_block lane_block; do
+export MC_BND="$LAB/bounded.sh"
+
+for f in notify pin_decision pin_block pin_drift_block lane_block bounded drain; do
   if [ ! -s "$LAB/$f.sh" ]; then echo "FATAL: extraction of $f produced nothing"; exit 1; fi
 done
-echo "extracted: notify=$(wc -l < "$LAB/notify.sh") pin-decision=$(wc -l < "$LAB/pin_decision.sh") pin=$(wc -l < "$LAB/pin_block.sh") pin-drift=$(wc -l < "$LAB/pin_drift_block.sh") lane=$(wc -l < "$LAB/lane_block.sh") lines"
+echo "extracted: notify=$(wc -l < "$LAB/notify.sh") pin-decision=$(wc -l < "$LAB/pin_decision.sh") pin=$(wc -l < "$LAB/pin_block.sh") pin-drift=$(wc -l < "$LAB/pin_drift_block.sh") lane=$(wc -l < "$LAB/lane_block.sh") bounded=$(wc -l < "$LAB/bounded.sh") drain=$(wc -l < "$LAB/drain.sh") lines"
 
 PASS=0; FAIL=0
 ok(){ PASS=$((PASS+1)); echo "  PASS: $1"; }
@@ -78,6 +92,8 @@ run() { # $1=block  $2=degraded-value  -> prints trace; env AILANG_RC/GH_RC/ISSU
   local attempt_file; attempt_file=$(mktemp)
   MC_TRACE_FILE="$mc_trace" MC_ATTEMPT_FILE="$attempt_file" /bin/bash -c '
     set -uo pipefail
+    . "$MC_BND"   # _mc_bounded (M2 production wraps the D-60 sends)
+    NOTIFY_TIMEOUT="${MISSION_NOTIFY_TIMEOUT:-30}"
     # log() stays a function (called directly, never through _mc_bounded) but appends to
     # the SAME unified medium the PATH stubs write, so positive AND negative checks both
     # read one trace (G1). The old split-trace medium lost AILANG records inside the
@@ -112,6 +128,8 @@ run_drift() { # $1=status $2=drift $3=threshold $4=state-value (absent for no fi
   local attempt_file; attempt_file=$(mktemp)
   MC_TRACE_FILE="$mc_trace" MC_ATTEMPT_FILE="$attempt_file" /bin/bash -c '
     set -uo pipefail
+    . "$MC_BND"   # _mc_bounded
+    NOTIFY_TIMEOUT="${MISSION_NOTIFY_TIMEOUT:-30}"
     log() { printf "LOG:%s\n" "$*" >> "$MC_TRACE_FILE"; }
     MISSION_NAME=motoko; MISSION_REPO=sunholo-data/ailang; MSG_FROM=mission-motoko
     MISSION_GH_ISSUE=635; LOG=/tmp/x.log; REPO=/pinned/driver-worktree
@@ -196,6 +214,8 @@ echo "== RC capture: not masked by printf (G2) =="
 _rc_trace=$(mktemp)
 T=$(AILANG_RC=1 MC_TRACE_FILE="$_rc_trace" /bin/bash -c '
     set -uo pipefail
+    . "$MC_BND"   # _mc_bounded
+    NOTIFY_TIMEOUT="${MISSION_NOTIFY_TIMEOUT:-30}"
     log() { printf "LOG:%s\n" "$*" >> "$MC_TRACE_FILE"; }
     MISSION_NAME=v1; MISSION_REPO=sunholo-data/ailang; MSG_FROM=mission-control
     MISSION_GH_ISSUE=635; LOG=/tmp/x.log; REPO=/tmp/repo
@@ -249,6 +269,8 @@ arm_ok "drift-i: a non-positive threshold is floored, not obeyed" "$T" "using 25
 _drj_trace=$(mktemp)
 T=$(MC_TRACE_FILE="$_drj_trace" /bin/bash -c '
     set -uo pipefail
+    . "$MC_BND"   # _mc_bounded
+    NOTIFY_TIMEOUT="${MISSION_NOTIFY_TIMEOUT:-30}"
     log() { printf "LOG:%s\n" "$*" >> "$MC_TRACE_FILE"; }
     MISSION_NAME=motoko; MISSION_REPO=sunholo-data/ailang; MSG_FROM=mission-motoko
     MISSION_GH_ISSUE=635; LOG=/tmp/x.log; REPO=/pinned/driver-worktree
@@ -264,6 +286,159 @@ T=$(MC_TRACE_FILE="$_drj_trace" /bin/bash -c '
   ' _ "$LAB/notify.sh" "$LAB/pin_decision.sh" "$LAB/pin_drift_block.sh" 2>&1)
 rm -f "$_drj_trace"
 arm_ok "drift-j: unset PIN_DRIFT is log-only, not a set -u abort" "$T" "LOG:driver pin drift: unknown" "AILANG:" "GH:"
+
+# --- M2: bounded production D-60 paths -------------------------------------------
+# run_bounded DEADLINE OUTPUTFILE CMD... — run CMD in a background subshell with an
+# outer test-level deadline; SIGKILL the whole tree at the deadline and return 124.
+# Bounded-wait discipline: a removed production bound must FAIL this arm cleanly
+# rather than wedge CI (rule 7).
+_run_bounded_killtree() {
+  local p="$1" c
+  for c in $(pgrep -P "$p" 2>/dev/null); do _run_bounded_killtree "$c"; done
+  kill -9 "$p" 2>/dev/null
+}
+run_bounded() {
+  local dl="$1" out="$2"; shift 2
+  ( "$@" >"$out" 2>&1 ) &
+  local pid=$!
+  local outer=$(( $(date +%s) + dl ))
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$(date +%s)" -ge "$outer" ]; then _run_bounded_killtree "$pid"; return 124; fi
+    sleep 1
+  done
+  wait "$pid" 2>/dev/null; return $?
+}
+
+# (1) single-shot _mc_bounded against a never-returning send stub: rc=124, <=7s.
+# Uses the REAL _mc_bounded helper directly (production-independent), outer 15s.
+_ss_trace=$(mktemp); _ss_outf=$(mktemp); _ss_beg=$(date +%s)
+run_bounded 15 "$_ss_outf" env MC_TRACE_FILE="$_ss_trace" STUB_HANG_AILANG=1 \
+  /bin/bash -c '
+    set -uo pipefail
+    . "$MC_BND"
+    _mc_bounded 2 env AILANG_MESSAGES_STORE=gcp AILANG_MESSAGES_PROJECT=ailang-multivac \
+      ailang messages send controlplane "hang" --from mission-control
+    echo "HANG_RC:$?"
+  '
+_ss_rc=$?; _ss_elapsed=$(( $(date +%s) - _ss_beg )); _ss_out="$(cat "$_ss_outf")"
+if [ "$_ss_rc" = "124" ]; then
+  bad "production: hanging direct send is cut off at the bound" "outer 15s watchdog tripped (bound removed)"
+else
+  case "$_ss_out" in
+    *"HANG_RC:124"*) [ "$_ss_elapsed" -le 7 ] && ok "production: hanging direct send is cut off at the bound" \
+      || bad "production: hanging direct send is cut off at the bound" "rc=124 but elapsed=${_ss_elapsed}s > 7s ($_ss_out)";;
+    *) bad "production: hanging direct send is cut off at the bound" "expected HANG_RC:124, got: rc=$_ss_rc ($_ss_out)";; esac
+fi
+rm -f "$_ss_trace" "$_ss_outf"
+
+# (2) full _mc_notify against a hanging direct send: 3 retries -> spool 1 row, GH still
+# called once. Outer 60s. Also (3) carries the synthesised rc=124 diagnostic (G5).
+_ms_spool=$(mktemp -d); _ms_att=$(mktemp); _ms_tr=$(mktemp); _ms_outf=$(mktemp)
+run_bounded 60 "$_ms_outf" env MC_TRACE_FILE="$_ms_tr" MC_ATTEMPT_FILE="$_ms_att" \
+  STUB_HANG_AILANG=1 MISSION_NOTIFY_TIMEOUT=2 \
+  /bin/bash -c '
+    set -uo pipefail
+    . "$MC_BND"
+    NOTIFY_TIMEOUT="${MISSION_NOTIFY_TIMEOUT:-30}"
+    log() { printf "LOG:%s\n" "$*" >> "$MC_TRACE_FILE"; }
+    MISSION_NAME=v1; MISSION_REPO=sunholo-data/ailang; MSG_FROM=mission-control
+    MISSION_GH_ISSUE=635; LOG=/tmp/x.log; REPO=/tmp/repo
+    STATE_DIR="$3"
+    _pin_degraded="- driver pin: hang"
+    . "$1"
+    . "$2"
+    _rc=$?
+    echo "BLOCK_RC:$_rc"
+    printf "%s" "$(cat "$MC_TRACE_FILE" 2>/dev/null || true)"
+    echo ""
+    echo "ATTEMPTS:$(cat "$MC_ATTEMPT_FILE" 2>/dev/null || echo 0)"
+  ' _ "$LAB/notify.sh" "$LAB/pin_block.sh" "$_ms_spool"
+_ms_rc=$?; _ms_out="$(cat "$_ms_outf")"
+_ms_rows=0; [ -f "$_ms_spool/mission-v1-notice-spool.tsv" ] && _ms_rows=$(wc -l < "$_ms_spool/mission-v1-notice-spool.tsv" | tr -d ' ')
+_ms_good=0
+case "$_ms_out" in *"BLOCK_RC:0"*) _ms_good=1;; esac
+case "$_ms_out" in *"ATTEMPTS:3"*) : ;; *) _ms_good=0;; esac
+case "$_ms_out" in *"GH:issue comment 635"*) : ;; *) _ms_good=0;; esac
+[ "$_ms_rows" -eq 1 ] || _ms_good=0
+if [ "$_ms_good" -eq 1 ]; then
+  ok "production: direct send retries 3x then spools on timeout"
+else
+  bad "production: direct send retries 3x then spools on timeout" "rc=$_ms_rc rows=$_ms_rows got: ($_ms_out)"
+fi
+case "$_ms_out" in *"timed out after 2s (no output)"*) ok "synthesised timeout diagnostic";; *) bad "synthesised timeout diagnostic" "no synthesised tail, got: rc=$_ms_rc ($_ms_out)";; esac
+rm -rf "$_ms_spool" "$_ms_att" "$_ms_tr" "$_ms_outf"
+
+# (4) hanging drain send: one-row spool + hanging ailang -> cut off, row retained. 15s.
+_dn_spool=$(mktemp -d)
+printf 'TS\tTitle\tBody line one\n' > "$_dn_spool/mission-v1-notice-spool.tsv"
+_dn_tr=$(mktemp); _dn_outf=$(mktemp)
+run_bounded 15 "$_dn_outf" env MC_TRACE_FILE="$_dn_tr" STUB_HANG_AILANG=1 MISSION_NOTIFY_TIMEOUT=2 \
+  /bin/bash -c '
+    set -uo pipefail
+    . "$MC_BND"
+    NOTIFY_TIMEOUT="${MISSION_NOTIFY_TIMEOUT:-30}"
+    log() { printf "LOG:%s\n" "$*" >> "$MC_TRACE_FILE"; }
+    MISSION_NAME=v1; MISSION_REPO=sunholo-data/ailang; MSG_FROM=mission-control
+    STATE_DIR="$1"
+    . "$2"
+    _mc_drain_notices
+    echo "DRAIN_RC:$?"
+  ' _ "$_dn_spool" "$LAB/drain.sh"
+_dn_rc=$?; _dn_out="$(cat "$_dn_outf")"
+_dn_rows=0; [ -f "$_dn_spool/mission-v1-notice-spool.tsv" ] && _dn_rows=$(wc -l < "$_dn_spool/mission-v1-notice-spool.tsv" | tr -d ' ')
+if [ "$_dn_rc" = "124" ]; then
+  bad "production: hanging drain send is cut off and row retained" "outer 15s watchdog tripped - drain send unbounded"
+else
+  case "$_dn_out" in
+    *"DRAIN_RC:0"*) [ "$_dn_rows" -eq 1 ] && ok "production: hanging drain send is cut off and row retained" \
+      || bad "production: hanging drain send is cut off and row retained" "drain rc0 but spool rows=$_dn_rows ($_dn_out)";;
+    *) bad "production: hanging drain send is cut off and row retained" "no DRAIN_RC:0, rc=$_dn_rc ($_dn_out)";; esac
+fi
+rm -rf "$_dn_spool" "$_dn_tr" "$_dn_outf"
+
+# (5) hanging gh comment: ailang healthy, gh hangs -> bounded cutoff, WARNING, exit 0.
+_gh_tr=$(mktemp); _gh_outf=$(mktemp); _gh_sp=$(mktemp -d); _gh_beg=$(date +%s)
+run_bounded 15 "$_gh_outf" env MC_TRACE_FILE="$_gh_tr" STUB_HANG_GH=1 MISSION_NOTIFY_TIMEOUT=2 \
+  /bin/bash -c '
+    set -uo pipefail
+    . "$MC_BND"
+    NOTIFY_TIMEOUT="${MISSION_NOTIFY_TIMEOUT:-30}"
+    log() { printf "LOG:%s\n" "$*" >> "$MC_TRACE_FILE"; }
+    MISSION_NAME=v1; MISSION_REPO=sunholo-data/ailang; MSG_FROM=mission-control
+    MISSION_GH_ISSUE=635; LOG=/tmp/x.log; REPO=/tmp/repo
+    STATE_DIR="$3"
+    _pin_degraded="- driver pin: gh"
+    . "$1"
+    . "$2"
+    _gh_rc2=$?
+    echo "BLOCK_RC:$_gh_rc2"
+    printf "%s" "$(cat "$MC_TRACE_FILE" 2>/dev/null || true)"
+    echo ""
+  ' _ "$LAB/notify.sh" "$LAB/pin_block.sh" "$_gh_sp"
+_gh_rc=$?; _gh_out="$(cat "$_gh_outf")"; _gh_elapsed=$(( $(date +%s) - _gh_beg ))
+if [ "$_gh_rc" = "124" ]; then
+  bad "production: hanging gh comment is cut off and warns" "outer 15s watchdog tripped - gh bound removed"
+else
+  _gh_good=0
+  case "$_gh_out" in *"BLOCK_RC:0"*) _gh_good=1;; esac
+  case "$_gh_out" in *"LOG:WARNING: driver-pin notice FAILED to post to issue #635"*) : ;; *) _gh_good=0;; esac
+  [ "$_gh_elapsed" -le 7 ] || _gh_good=0
+  if [ "$_gh_good" -eq 1 ]; then
+    ok "production: hanging gh comment is cut off and warns"
+  else
+    bad "production: hanging gh comment is cut off and warns" "rc=$_gh_rc elapsed=${_gh_elapsed}s got: ($_gh_out)"
+  fi
+fi
+rm -rf "$_gh_tr" "$_gh_outf" "$_gh_sp"
+
+# (6) guard (green/green): the env prefix delivers store/project to the child, visible in
+# the failure-arm WARNING tail. Exists so the env-prefix mutation has a named victim.
+_ge_t=$(AILANG_RC=1 run pin_block "- x")
+check "direct send reaches child with store=gcp" "$_ge_t" "store=<gcp> proj=<ailang-multivac>"
+
+# (7) guard (green/green): exactly one preflight drain invocation after the pin decision.
+_wiring=$(awk '/^# --- DRIVER PIN DECISION END ---/,0' "$DRV" | grep -c '^_mc_drain_notices$')
+[ "$_wiring" -eq 1 ] && ok "wiring: exactly one preflight drain call" || bad "wiring: exactly one preflight drain call" "got $_wiring"
 
 echo ""
 echo "==== $PASS passed, $FAIL failed ===="

--- a/tools/launchd/test_driver_notify.sh
+++ b/tools/launchd/test_driver_notify.sh
@@ -58,6 +58,14 @@ chmod +x "$LAB/bin/gh"
 
 export PATH="$LAB/bin${PATH:+:$PATH}"
 
+# HERMETICITY (evaluator B2): `_mc_bounded` runs `( exec "$@" )`, and a subshell inherits
+# whatever the CALLING shell exported — independent of any `env VAR=val` prefix. CLAUDE.md
+# tells every machine doing AILANG work to export AILANG_MESSAGES_STORE/PROJECT at session
+# start, so in the documented operating environment the store/project guard below would stay
+# green with the production `env` prefix DELETED. Measured: mutation green 37/0 with the vars
+# ambient, red 36/1 without. Unset them here so the prefix is the only possible source.
+unset AILANG_MESSAGES_STORE AILANG_MESSAGES_PROJECT
+
 awk '/^_mc_notify\(\) \{/,/^\}/' "$DRV"                        > "$LAB/notify.sh"
 awk '/^# --- DRIVER PIN DECISION START ---/,/^# --- DRIVER PIN DECISION END ---/' "$DRV" > "$LAB/pin_decision.sh"
 awk '/^if \[ -n "\$_pin_degraded" \]; then/,/^fi$/' "$DRV"     > "$LAB/pin_block.sh"
@@ -107,7 +115,15 @@ run() { # $1=block  $2=degraded-value  -> prints trace; env AILANG_RC/GH_RC/ISSU
     _pin_degraded=""; _lane_degraded=""
     . "$1"            # _mc_notify
     eval "$3=\"$4\""  # set the ledger under test
-    . "$2"            # the block
+    if [ "${MC_RUN_UNSET_STATE:-0}" = "1" ]; then
+      # B1 guard (evaluator finding): every other arm runs a block that exits 0, so the
+      # OWN capture position of run() was untested and the G2 defect could come back silently.
+      # Unsetting STATE_DIR makes the block abort under `set -u`; the subshell keeps that
+      # abort from killing this script, so a non-zero rc must reach _blk_rc.
+      ( unset STATE_DIR; . "$2" )
+    else
+      . "$2"          # the block
+    fi
     _blk_rc=$?        # capture rc BEFORE any printf (G2: the old `$?` after `printf`
                       # read the rc that printf left behind, masking the block failure)
     TRACE="$(cat "$MC_TRACE_FILE" 2>/dev/null || true)"
@@ -231,6 +247,15 @@ T=$(AILANG_RC=1 MC_TRACE_FILE="$_rc_trace" /bin/bash -c '
   ' _ "$LAB/notify.sh" "$LAB/pin_block.sh" 2>&1)
 rm -f "$_rc_trace"
 check "RC capture: block failure visible, not masked by printf" "$T" "RC:1"
+
+# The check above exercises a standalone reimplementation. This one exercises run() ITSELF —
+# the harness behind 20+ of this suite's assertions, and the only place the G2 fix actually
+# ships. Without it, moving run()'s `_blk_rc=$?` back after the printfs leaves the suite
+# fully green (measured 37/0 before this arm existed).
+export MC_RUN_UNSET_STATE=1
+_rc_run=$(run pin_block "- x")
+unset MC_RUN_UNSET_STATE
+check "RC capture: run() itself surfaces a failing block, not printf's status" "$_rc_run" "RC:1"
 
 echo "== held pin source-clone drift =="
 T=$(run_drift pinned 170 25 absent)

--- a/tools/launchd/test_driver_notify.sh
+++ b/tools/launchd/test_driver_notify.sh
@@ -6,7 +6,49 @@ set -uo pipefail
 SP="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 DRV="$REPO_ROOT/tools/launchd/mission-control.sh"
-LAB="${TMPDIR:-/tmp}/emitlab.$$"; rm -rf "$LAB"; mkdir -p "$LAB"
+LAB="${TMPDIR:-/tmp}/emitlab.$$"; rm -rf "$LAB"; mkdir -p "$LAB" "$LAB/bin"
+
+# --- M1: suite-owned PATH notifier stubs ---------------------------------------
+# _mc_bounded runs `( exec "$@" )`; exec resolves EXTERNAL binaries only — a shell
+# function is invisible to it (measured: `( exec f )` on a function -> rc=127). So
+# the notifier stubs MUST be PATH executables, or the bounded production sends would
+# exec the REAL ailang/gh and hit prod Firestore + GitHub from CI (forbidden). Each
+# stub appends one ordered record to $MC_TRACE_FILE (per-arm, unified medium G1),
+# honours AILANG_RC/GH_RC, and the ailang one prints the store/project env it saw so
+# the child's env is observable (V4). STUB_HANG=1 selects a never-returning variant
+# for the bounded-cutoff arms.
+cat > "$LAB/bin/ailang" <<'STUB'
+#!/bin/bash
+if [ "${STUB_HANG:-0}" = "1" ]; then
+  while :; do sleep 1; done
+fi
+if [ -n "${MC_TRACE_FILE:-}" ]; then
+  printf 'AILANG:%s\n' "$*" >> "$MC_TRACE_FILE"
+fi
+if [ -n "${MC_ATTEMPT_FILE:-}" ]; then
+  n=0
+  [ -f "$MC_ATTEMPT_FILE" ] && n=$(cat "$MC_ATTEMPT_FILE" 2>/dev/null || echo 0)
+  n=$(( 10#$n + 1 ))
+  printf '%s\n' "$n" > "$MC_ATTEMPT_FILE"
+fi
+printf 'store=<%s> proj=<%s>\n' "${AILANG_MESSAGES_STORE:-}" "${AILANG_MESSAGES_PROJECT:-}"
+exit "${AILANG_RC:-0}"
+STUB
+chmod +x "$LAB/bin/ailang"
+
+cat > "$LAB/bin/gh" <<'STUB'
+#!/bin/bash
+if [ "${STUB_HANG:-0}" = "1" ]; then
+  while :; do sleep 1; done
+fi
+if [ -n "${MC_TRACE_FILE:-}" ]; then
+  printf 'GH:%s\n' "$*" >> "$MC_TRACE_FILE"
+fi
+exit "${GH_RC:-0}"
+STUB
+chmod +x "$LAB/bin/gh"
+
+export PATH="$LAB/bin${PATH:+:$PATH}"
 
 awk '/^_mc_notify\(\) \{/,/^\}/' "$DRV"                        > "$LAB/notify.sh"
 awk '/^# --- DRIVER PIN DECISION START ---/,/^# --- DRIVER PIN DECISION END ---/' "$DRV" > "$LAB/pin_decision.sh"
@@ -25,8 +67,6 @@ bad(){ FAIL=$((FAIL+1)); echo "  FAIL: $1"; echo "        trace: $2"; }
 check(){ case "$2" in *"$3"*) ok "$1";; *) bad "$1" "$(printf '%s' "$2"|tr '\n' '|')";; esac; }
 checkno(){ case "$2" in *"$3"*) bad "$1" "$(printf '%s' "$2"|tr '\n' '|')";; *) ok "$1";; esac; }
 
-# File-backed spies survive the production command substitution used to capture
-# notification diagnostics. Shell-variable writes disappear in that subshell.
 run() { # $1=block  $2=degraded-value  -> prints trace; env AILANG_RC/GH_RC/ISSUE tweak it
   local block="$1" val="$2"
   # A FRESH state dir per arm, not a shared one: the blocks now episode-GATE on files under
@@ -34,13 +74,15 @@ run() { # $1=block  $2=degraded-value  -> prints trace; env AILANG_RC/GH_RC/ISSU
   # suppress the second's notice — an arm passing because it was deduped, not because the
   # code is right.
   local state_dir; state_dir=$(mktemp -d)
-  /bin/bash -c '
+  local mc_trace; mc_trace=$(mktemp)
+  local attempt_file; attempt_file=$(mktemp)
+  MC_TRACE_FILE="$mc_trace" MC_ATTEMPT_FILE="$attempt_file" /bin/bash -c '
     set -uo pipefail
-    TRACE_FILE="$5/trace"; : > "$TRACE_FILE"
-    log() { printf "LOG:%s\n" "$*" >> "$TRACE_FILE"; }
-    ailang() { printf "AILANG:%s\n" "$*" >> "$TRACE_FILE"; return ${AILANG_RC:-0}; }
-    gh() { printf "GH:%s\n" "$*" >> "$TRACE_FILE"; return ${GH_RC:-0}; }
-    sleep() { :; }
+    # log() stays a function (called directly, never through _mc_bounded) but appends to
+    # the SAME unified medium the PATH stubs write, so positive AND negative checks both
+    # read one trace (G1). The old split-trace medium lost AILANG records inside the
+    # command-substitution subshell, so checkno assertions could pass vacuously.
+    log() { printf "LOG:%s\n" "$*" >> "$MC_TRACE_FILE"; }
     MISSION_NAME=v1; MISSION_REPO=sunholo-data/ailang; MSG_FROM=mission-control
     MISSION_GH_ISSUE="${ISSUE-635}"; LOG=/tmp/x.log; REPO=/tmp/repo
     MODEL=claude-opus-5; MODEL_WHY="probe ok"
@@ -50,12 +92,15 @@ run() { # $1=block  $2=degraded-value  -> prints trace; env AILANG_RC/GH_RC/ISSU
     . "$1"            # _mc_notify
     eval "$3=\"$4\""  # set the ledger under test
     . "$2"            # the block
-    block_rc=$?
-    cat "$TRACE_FILE"
-    echo "RC:$block_rc"
+    _blk_rc=$?        # capture rc BEFORE any printf (G2: the old `$?` after `printf`
+                      # read the rc that printf left behind, masking the block failure)
+    TRACE="$(cat "$MC_TRACE_FILE" 2>/dev/null || true)"
+    printf "%s" "$TRACE"
+    printf "\nATTEMPTS:%s" "$(cat "$MC_ATTEMPT_FILE" 2>/dev/null || printf 0)"
+    printf "\nRC:%s\n" "$_blk_rc"
   ' _ "$LAB/notify.sh" "$LAB/$block.sh" \
     "$( [ "$block" = pin_block ] && echo _pin_degraded || echo _lane_degraded )" "$val" "$state_dir" 2>&1
-  rm -rf "$state_dir"
+  rm -rf "$state_dir" "$mc_trace" "$attempt_file"
 }
 
 run_drift() { # $1=status $2=drift $3=threshold $4=state-value (absent for no file)
@@ -63,12 +108,11 @@ run_drift() { # $1=status $2=drift $3=threshold $4=state-value (absent for no fi
   RUN_SEQ=$((${RUN_SEQ:-0}+1))
   rm -rf "$state_dir"; mkdir -p "$state_dir"
   if [ "$4" != absent ]; then printf '%s\n' "$4" > "$state_dir/pin-drift"; fi
-  /bin/bash -c '
+  local mc_trace; mc_trace=$(mktemp)
+  local attempt_file; attempt_file=$(mktemp)
+  MC_TRACE_FILE="$mc_trace" MC_ATTEMPT_FILE="$attempt_file" /bin/bash -c '
     set -uo pipefail
-    TRACE_FILE="$4/trace"; : > "$TRACE_FILE"
-    log() { printf "LOG:%s\n" "$*" >> "$TRACE_FILE"; }
-    ailang() { printf "AILANG:%s\n" "$*" >> "$TRACE_FILE"; return 0; }
-    gh() { printf "GH:%s\n" "$*" >> "$TRACE_FILE"; return 0; }
+    log() { printf "LOG:%s\n" "$*" >> "$MC_TRACE_FILE"; }
     MISSION_NAME=motoko; MISSION_REPO=sunholo-data/ailang; MSG_FROM=mission-motoko
     MISSION_GH_ISSUE=635; LOG=/tmp/x.log; REPO=/pinned/driver-worktree
     AILANG_DRIVER_SRC=/source/ailang-motoko
@@ -85,14 +129,15 @@ run_drift() { # $1=status $2=drift $3=threshold $4=state-value (absent for no fi
     echo "DECISION_RC:$?"
     . "$7"
     . "$8"
+    TRACE="$(cat "$MC_TRACE_FILE" 2>/dev/null || true)"
     if [ -f "$PIN_DRIFT_FILE" ]; then
       echo "STATE:$(cat "$PIN_DRIFT_FILE")"
     else
       echo "STATE:absent"
     fi
-    cat "$TRACE_FILE"
+    printf "%s" "$TRACE"
   ' _ "$1" "$2" "$3" "$state_dir" "$LAB/notify.sh" "$LAB/pin_decision.sh" "$LAB/pin_drift_block.sh" "$LAB/pin_block.sh" 2>&1
-  rm -rf "$state_dir"
+  rm -rf "$state_dir" "$mc_trace" "$attempt_file"
 }
 
 arm_ok() { # $1=name $2=trace $3=required substring; remaining args are forbidden substrings
@@ -112,6 +157,9 @@ check "fires on both channels (ailang)"     "$T" "AILANG:messages send controlpl
 check "posts to the bookkeeping issue"      "$T" "GH:issue comment 635"
 check "titled as UNPINNED"                  "$T" "driver ran UNPINNED"
 check "names the tracking issue"            "$T" "#558"
+# M1 G1 tripwire: this fires genuinely, so the SAME "no ailang call" checkno assertions
+# below MUST be able to see AILANG: here — proves they read the unified medium.
+check "positive control: unified medium shows genuine AILANG fire (checkno would FAIL)" "$T" "AILANG:"
 
 echo "== pin notice: SILENT when healthy (the control) =="
 T=$(run pin_block "")
@@ -122,6 +170,7 @@ echo "== failed post is LOUD, and never aborts =="
 T=$(AILANG_RC=1 run pin_block "- x")
 check "warns on send failure"               "$T" "LOG:WARNING: driver-pin notice FAILED to send"
 check "block still exits 0"                 "$T" "RC:0"
+check "retry: attempts recorded across subshells (file counter)" "$T" "ATTEMPTS:3"
 T=$(GH_RC=1 run pin_block "- x")
 check "warns on issue failure"              "$T" "LOG:WARNING: driver-pin notice FAILED to post"
 check "block still exits 0"                 "$T" "RC:0"
@@ -139,6 +188,29 @@ check "lane keeps its own title"            "$T" "executor/planner lane degraded
 check "lane logs its summary"               "$T" "LOG:LANE DEGRADED this fire"
 T=$(run lane_block "")
 checkno "lane SILENT when healthy"          "$T" "AILANG:"
+
+echo "== RC capture: not masked by printf (G2) =="
+# Drop the STATE_DIR assignment; the sourced pin_block reads $STATE_DIR for spool/episode
+# gating, so under `set -u` it aborts rc=1. With the old code the `$?`-after-`printf`
+# masked this as RC:0; the capture-before-printf fix must surface RC:1.
+_rc_trace=$(mktemp)
+T=$(AILANG_RC=1 MC_TRACE_FILE="$_rc_trace" /bin/bash -c '
+    set -uo pipefail
+    log() { printf "LOG:%s\n" "$*" >> "$MC_TRACE_FILE"; }
+    MISSION_NAME=v1; MISSION_REPO=sunholo-data/ailang; MSG_FROM=mission-control
+    MISSION_GH_ISSUE=635; LOG=/tmp/x.log; REPO=/tmp/repo
+    MODEL=claude-opus-5; MODEL_WHY="probe ok"
+    # STATE_DIR deliberately NOT set => the block aborts under `set -u`. Source it in a
+    # subshell so the abort returns rc=1 to us instead of killing this whole shell
+    # before we can capture it.
+    _pin_degraded="- x"; _lane_degraded="- x"
+    . "$1"
+    ( . "$2" )
+    _rc=$?
+    printf "RC:%s\n" "$_rc"
+  ' _ "$LAB/notify.sh" "$LAB/pin_block.sh" 2>&1)
+rm -f "$_rc_trace"
+check "RC capture: block failure visible, not masked by printf" "$T" "RC:1"
 
 echo "== held pin source-clone drift =="
 T=$(run_drift pinned 170 25 absent)
@@ -174,15 +246,10 @@ arm_ok "drift-i: a non-positive threshold is floored, not obeyed" "$T" "using 25
 # drift-j: PIN_DRIFT unset under `set -u` must be handled, not abort. Unreachable through
 # pin-root.sh today (it sets PIN_STATUS and PIN_DRIFT on consecutive lines) — pinned here so the
 # invariant is enforced rather than assumed, per the evaluator's finding 4.
-T=$(/bin/bash -c '
+_drj_trace=$(mktemp)
+T=$(MC_TRACE_FILE="$_drj_trace" /bin/bash -c '
     set -uo pipefail
-    TRACE=""
-    log() { TRACE="$TRACE
-LOG:$*"; }
-    ailang() { TRACE="$TRACE
-AILANG:$*"; return 0; }
-    gh()     { TRACE="$TRACE
-GH:$*"; return 0; }
+    log() { printf "LOG:%s\n" "$*" >> "$MC_TRACE_FILE"; }
     MISSION_NAME=motoko; MISSION_REPO=sunholo-data/ailang; MSG_FROM=mission-motoko
     MISSION_GH_ISSUE=635; LOG=/tmp/x.log; REPO=/pinned/driver-worktree
     AILANG_DRIVER_SRC=/source/ailang-motoko
@@ -192,8 +259,10 @@ GH:$*"; return 0; }
     . "$2"
     echo "DECISION_RC:$?"
     . "$3"
+    TRACE="$(cat "$MC_TRACE_FILE" 2>/dev/null || true)"
     printf "%s" "$TRACE"
   ' _ "$LAB/notify.sh" "$LAB/pin_decision.sh" "$LAB/pin_drift_block.sh" 2>&1)
+rm -f "$_drj_trace"
 arm_ok "drift-j: unset PIN_DRIFT is log-only, not a set -u abort" "$T" "LOG:driver pin drift: unknown" "AILANG:" "GH:"
 
 echo ""


### PR DESCRIPTION
Mission V1 iteration 347. Implements human ruling **D-60** (attended 2026-09-07, Mark Edmondson):

> **ANSWERED — B:** expand the design to bound direct message sends, drain-time message sends and
> GitHub notification calls using existing bounded-call discipline; repair the shell observation
> spies and all seven inherited notification assertions. Revise design, obtain independent quorum,
> then plan/execute/evaluate. Prefer this reliability repair early in the week.

## What lands

**M1 — `test(launchd)`, test-only.** The seven red `launchd drivers (bash 3.2)` assertions fail
because `63a0d2b32` moved the direct send into a command substitution, so the fixture's `ailang()`
stub records the call by assigning to `TRACE` inside a subshell and the record dies with it. The
variable spy becomes a file-backed one on a **unified** medium: `ailang`/`gh` are PATH-executable
stubs, `log()` appends to the same `MC_TRACE_FILE`, and the teardown loads the file into `TRACE`
before the assertions run. Also captures the block's real status instead of `printf`'s.

**M2 — `fix(launchd)`, production.** `NOTIFY_TIMEOUT` (env `MISSION_NOTIFY_TIMEOUT`, default **30s**,
matching the two already-bounded slot-verdict sites) and the three D-60 paths — drain send `:154`,
direct send `:184`, GitHub notice `:198` — each through the existing `_mc_bounded`. Retry count,
sleeps, payloads and the non-aborting failure contract are unchanged.

## Two measured facts that shaped the design

**The two halves collide.** `_mc_bounded` runs `( exec "$@" )`, and `exec` **bypasses shell
functions** — measured: `f() { echo FUNCTION-CALLED; }; ( exec f )` → `exec: f: not found`, while
calling `f` directly prints `FUNCTION-CALLED`. So bounding the sends makes the fixture's function
stubs unreachable, which is why M1 must migrate them to PATH executables *before* M2 wraps anything.
`exec` also cannot parse a `VAR=val` prefix, hence the leading `env` to carry the two message-store
vars (scoping unchanged; `AILANG_STORAGE` untouched).

**Bounding silently deleted a diagnostic, and this fixes that too.** Running the *real* `_mc_notify`
body with the substitution applied and PATH stubs: on `rc=124` the timed-out command produced no
output, so `MC_BOUNDED_OUT` is empty and the WARNING degrades to `FAILED … after 3 attempts:` with
nothing after it — the exact blindness `_mc_notify`'s own comment exists to prevent. The reason is
now synthesised. (Fail-fast arm: 3 attempts, error tail carrying the env values, one spool row, GH
still attempted — all preserved.)

## Verification

| | base `81abc956d` | head |
|---|---|---|
| `bash tools/launchd/test_driver_notify.sh` | `20 passed, 7 failed`, rc=1 | **`37 passed, 0 failed`, rc=0** |
| `bash -n` on both changed files | — | rc=0 / rc=0 |

## ⚠ `make test-launchd-drivers` is STILL RED, and that is the finding

Clearing the notify red un-blocked the ordered target far enough to reach
`tools/launchd/test_mission_heartbeat.sh`, which reports **`FAIL: 9 heartbeat arms failed`**.
Those nine are **pre-existing and were masked** — `make` halts at the first failing suite, and at
base the notify suite failed first. Paired control: `bash tools/launchd/test_mission_heartbeat.sh`
run **alone** at base and at head gives the identical nine named arms. So this PR does not regress
the job; it makes a second, older red visible. Filed as its own queue row.

## Scope not delivered

M3 (aggregate drain budget `DRAIN_BUDGET`) and M4 (mutation sweep) were **not executed** — the
executor hit its 30-minute cap mid-M3 (`wall_timeout`). The partial M3 work failed its own two new
tests and was discarded from the tree; it is preserved at
`~/.ailang/state/mission-v1-iter347-m3-partial/` and queued. The plan's own cut list named M1+M2 as
the keep set.

## Routing

Designer `pi:ollama/deepseek-v4-flash:0731-cloud` (rotation entry after `codex:gpt-6-astra`) ·
quorum r1 BLOCKED / r2 `gemini-3-1-pro` PASS with two completeness rejects / r3 narrow-refinement
carve-out applying both reviewers' verbatim fixes · planner `pi:openrouter/moonshotai/kimi-k3` ·
executor `pi:ollama/deepseek-v4-flash:0731-cloud` · evaluator `sonnet`. Generator ≠ judge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
