### PR TITLE
M-EVAL-STANDARD-MODE-INPUT-FILES-GAP: gate multi-file grading benchmarks out of standard mode

### DIFF
--- a/changelogs/v0.32-current.md
+++ b/changelogs/v0.32-current.md
@@ -2,6 +2,26 @@
 
 > Current changelog (v0.32.0 onward). Earlier series: [v0.26-v0.31-measurement-cost.md](v0.26-v0.31-measurement-cost.md). Index: [CHANGELOG.md](../CHANGELOG.md).
 
+## [Unreleased]
+
+### Fixed — `grade_entrypoint` benchmarks no longer run in standard mode (M-EVAL-STANDARD-MODE-INPUT-FILES-GAP)
+
+`markdown_reimplement` and `docx_reimplement` set `grade_entrypoint`, which grades the
+agent's preserved multi-file workspace — something standard (0-shot) mode never
+constructs. Every pre-fix standard-mode run of these two benchmarks therefore produced a
+near-guaranteed `compile_error`/`runtime_error` (e.g. the identical
+`undefined variable: emptyParseState` signature across 8/13 models on `markdown_reimplement`
+in the v0.32.0 baseline) that measured the harness gap, not model capability.
+
+**Pre-fix standard-mode data for these 2 benchmarks should be treated as unreliable** —
+exclude it from frontier-tier difficulty/eligibility reads (per the design doc's Risks
+mitigation). Post-fix, they are excluded from standard-mode scheduling entirely, and a
+direct standard-mode dispatch banks a labelled skip row
+(`error_category: skipped_mode_incompatible`, validity reason `mode_incompatible`) that
+every aggregate filters out. Historical result files are not edited; the rows stand as
+banked, quarantined only going forward. Run these benchmarks with
+`eval-suite --agent --benchmarks markdown_reimplement,docx_reimplement`.
+
 ## [v0.35.2] - 2026-09-07
 
 ### Fixed — the agent handoff chain fired for the first time, after four stacked defects

--- a/cmd/ailang/eval_benchmark.go
+++ b/cmd/ailang/eval_benchmark.go
@@ -84,6 +84,54 @@ func runSingleBenchmark(ctx context.Context, model, benchmarkID, lang, condition
 		return runSingleBenchmarkAgent(ctx, benchSpan, spec, model, benchmarkID, lang, condition, cond, trial, seed, outputDir, agentConfig, evalChain, onCost)
 	}
 
+	// M-EVAL-STANDARD-MODE-INPUT-FILES-GAP: dispatch-time guard (defense in
+	// depth for the standard-mode scheduler filter at the discoverBenchmarks
+	// call site). This code is standard-mode-only by construction — the agent
+	// branch above already returned — so reaching it with an agent-workspace-only
+	// benchmark (grade_entrypoint set) means a direct --benchmarks invocation
+	// bypassed the scheduler. Short-circuit BEFORE any provider dispatch:
+	// standard mode never constructs the multi-file workspace such a benchmark
+	// grades against, so a doomed API call would burn budget and bank a
+	// misleading compile/runtime failure. The skip is banked as a
+	// visible-but-labelled result row carrying BOTH the human-readable category
+	// below AND the machine-aggregation marker (Validity invalid with
+	// ReasonModeIncompatible) that makes LoadResults → FilterValidResults drop
+	// the row from every downstream aggregate — eval-elo fitting,
+	// confidence-gating ratings, capability stats, dashboard exports.
+	if spec.RequiresAgentWorkspace() {
+		validity := eval_harness.MarkInvalid(eval_harness.ReasonModeIncompatible)
+		validity.Detail = "grade_entrypoint set: agent-workspace-only benchmark dispatched in standard mode"
+		skipMetrics := &eval_harness.RunMetrics{
+			ID:             spec.ID,
+			Lang:           lang,
+			Model:          model,
+			Seed:           seed,
+			CompileOk:      false,
+			RuntimeOk:      false,
+			StdoutOk:       false,
+			ErrorCategory:  "skipped_mode_incompatible", // no constant: metrics.go is a hard-unchanged file for this fix
+			Stderr:         fmt.Sprintf("skipped: benchmark %s requires an agent workspace (grade_entrypoint set); standard mode cannot grade it", spec.ID),
+			ExpectedStdout: spec.ExpectedOut,
+			Timestamp:      time.Now(),
+			Caps:           spec.Caps,
+			EvalMode:       eval_harness.EvalModeStandard,
+			PromptVersion:  promptVersion,
+			Condition:      condition,
+			Trial:          trial,
+			Validity:       validity,
+		}
+		// Best-effort log, same as the API-error path: the row is evidence, not
+		// a reason to fail the suite loop. Zero provider calls were made, so
+		// onCost is deliberately not invoked (see the early-return note above).
+		logger := eval_harness.NewMetricsLogger(outputDir)
+		if logErr := logger.Log(skipMetrics); logErr != nil {
+			benchSpan.RecordError(logErr)
+		}
+		benchSpan.SetAttributes(attribute.Bool("benchmark.skipped_mode_incompatible", true))
+		benchSpan.SetStatus(codes.Ok, "skipped_mode_incompatible")
+		return false, nil
+	}
+
 	// Standard mode: Create chain stage for this benchmark
 	// M-EVAL-LOCAL-OBSERVABILITY M2: include benchmark id in agent_id (see comment above)
 	var stageID string

--- a/cmd/ailang/eval_benchmark_test.go
+++ b/cmd/ailang/eval_benchmark_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sunholo-data/ailang/internal/eval_harness"
+	"github.com/sunholo-data/ailang/internal/modelreg"
+)
+
+// TestRunSingleBenchmark_StandardModeSkipsAgentWorkspaceOnly is the acceptance
+// test for the M-EVAL-STANDARD-MODE-INPUT-FILES-GAP dispatch-time guard
+// (design component 3): markdown_reimplement sets grade_entrypoint, so it is
+// agent-mode-only. Called directly (as a `--benchmarks` invocation bypassing
+// the scheduler filter) in standard mode it must short-circuit with a
+// structured skip result — error_category "skipped_mode_incompatible" plus
+// Validity invalid with reason "mode_incompatible" — and make ZERO AI provider
+// API calls.
+//
+// The provider transport follows the in-package httptest mock precedent
+// (configdriven_dispatch_test.go): a counting httptest server stands in for the
+// model API. The ollama provider is the one standard-mode transport with an env
+// seam (OLLAMA_HOST), so the sentinel model routes there; if the guard ever
+// stops firing, the standard path reaches NewAIAgent → provider HTTP call and
+// the counter reads non-zero, failing this test.
+func TestRunSingleBenchmark_StandardModeSkipsAgentWorkspaceOnly(t *testing.T) {
+	var providerCalls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		providerCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"message":{"content":"-- sentinel: no eval call should ever reach the provider"}}`))
+	}))
+	defer server.Close()
+
+	// Route the sentinel model's provider transport at the counting server and
+	// register it in the model registry (runSingleBenchmark resolves the model
+	// via modelreg.GlobalModelsConfig). Both are restored on cleanup.
+	t.Setenv("OLLAMA_HOST", server.URL)
+	origModels := modelreg.GlobalModelsConfig
+	modelreg.GlobalModelsConfig = &modelreg.ModelsConfig{
+		Models: map[string]modelreg.ModelConfig{
+			"mock-sentinel": {Provider: "ollama", APIName: "mock-sentinel"},
+		},
+	}
+	defer func() { modelreg.GlobalModelsConfig = origModels }()
+
+	// Load the REAL benchmark spec the way runSingleBenchmark does.
+	origBenchmarkDir := evalBenchmarkDir
+	evalBenchmarkDir = "../../benchmarks"
+	defer func() { evalBenchmarkDir = origBenchmarkDir }()
+
+	specPath := filepath.Join(evalBenchmarkDir, "markdown_reimplement.yml")
+	if _, err := os.Stat(specPath); err != nil {
+		t.Skipf("markdown_reimplement.yml not present (%v); skipping", err)
+	}
+	spec, err := eval_harness.LoadSpec(specPath)
+	if err != nil {
+		t.Fatalf("LoadSpec(markdown_reimplement): %v", err)
+	}
+	if spec.GradeEntrypoint == "" {
+		t.Fatal("fixture drift: markdown_reimplement no longer sets grade_entrypoint; this test's premise is gone")
+	}
+
+	outputDir := t.TempDir()
+	success, err := runSingleBenchmark(
+		context.Background(),
+		"mock-sentinel", // model
+		"markdown_reimplement",
+		"ailang", // lang
+		"",       // condition (legacy)
+		1,        // trial
+		42,       // seed
+		outputDir,
+		30*time.Second,
+		false, // selfRepair
+		"",    // promptVersion
+		nil,   // agentConfig — nil = STANDARD mode
+		"",    // taskID
+		nil,   // evalChain
+		nil,   // onCost
+	)
+
+	// The skip is a structured outcome, not an error: the row was banked, the
+	// suite loop just doesn't count it as a pass.
+	if err != nil {
+		t.Fatalf("runSingleBenchmark returned error %v, want nil (skip is not a failure)", err)
+	}
+	if success {
+		t.Error("runSingleBenchmark returned success=true, want false (benchmark was skipped, not passed)")
+	}
+
+	// Exactly one skip row banked under the standard-mode results directory.
+	rows, err := filepath.Glob(filepath.Join(outputDir, "standard", "*.json"))
+	if err != nil {
+		t.Fatalf("glob results: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("banked %d result rows, want exactly 1 skip row", len(rows))
+	}
+	data, err := os.ReadFile(rows[0])
+	if err != nil {
+		t.Fatalf("read %s: %v", rows[0], err)
+	}
+	var metrics eval_harness.RunMetrics
+	if err := json.Unmarshal(data, &metrics); err != nil {
+		t.Fatalf("unmarshal %s: %v", rows[0], err)
+	}
+
+	if metrics.ID != "markdown_reimplement" {
+		t.Errorf("row id = %q, want markdown_reimplement", metrics.ID)
+	}
+	if metrics.ErrorCategory != "skipped_mode_incompatible" {
+		t.Errorf("row error_category = %q, want skipped_mode_incompatible (human-readable skip label)", metrics.ErrorCategory)
+	}
+	if metrics.Validity == nil {
+		t.Fatal("row Validity is nil — absent decodes as VALID, so the skip row would leak into every aggregate")
+	}
+	if metrics.Validity.Valid {
+		t.Error("row Validity.Valid = true, want false (the model was never invoked; not a measurement)")
+	}
+	if metrics.Validity.Reason != eval_harness.ReasonModeIncompatible {
+		t.Errorf("row Validity.Reason = %q, want %q (machine-aggregation marker)", metrics.Validity.Reason, eval_harness.ReasonModeIncompatible)
+	}
+	if metrics.EvalMode != eval_harness.EvalModeStandard {
+		t.Errorf("row eval_mode = %q, want %q", metrics.EvalMode, eval_harness.EvalModeStandard)
+	}
+
+	// The load-bearing half: ZERO provider API calls.
+	if got := providerCalls.Load(); got != 0 {
+		t.Errorf("provider call counter = %d, want 0 — the guard must short-circuit before any AI dispatch", got)
+	}
+}

--- a/cmd/ailang/eval_helpers.go
+++ b/cmd/ailang/eval_helpers.go
@@ -69,6 +69,41 @@ func isBenchmarkMetaFile(name string) bool {
 	return false
 }
 
+// filterStandardModeBenchmarks drops agent-workspace-only benchmarks from a
+// standard-mode scheduling list (M-EVAL-STANDARD-MODE-INPUT-FILES-GAP).
+//
+// A benchmark setting grade_entrypoint grades the agent's preserved multi-file
+// workspace — something standard mode never constructs (its prompt omits
+// input_files content and its execution runs a fixed single solution.ail), so
+// scheduling it here can only burn API budget on a run that cannot pass and
+// bank a misleading compile/runtime failure. Excluded IDs are named on stderr
+// rather than dropped silently.
+//
+// Agent-mode scheduling never passes through here: it requires an explicit
+// --benchmarks list (eval_suite.go), which stays unfiltered. Benchmarks whose
+// spec cannot be loaded are left in place so the run's own spec load surfaces
+// the problem exactly as before.
+func filterStandardModeBenchmarks(ids []string) []string {
+	var out, excluded []string
+	for _, id := range ids {
+		spec, err := eval_harness.LoadSpec(filepath.Join(evalBenchmarkDir, id+".yml"))
+		if err != nil {
+			out = append(out, id)
+			continue
+		}
+		if spec.RequiresAgentWorkspace() {
+			excluded = append(excluded, id)
+			continue
+		}
+		out = append(out, id)
+	}
+	if len(excluded) > 0 {
+		fmt.Fprintf(os.Stderr, "%s Excluded %d agent-workspace-only benchmark(s) from standard mode (grade_entrypoint set): %s\n",
+			yellow("⚠️"), len(excluded), strings.Join(excluded, ", "))
+	}
+	return out
+}
+
 // parseTierList splits a comma-separated --tier argument and validates each entry
 // against eval_harness.ValidTiers. Whitespace is trimmed; empty input returns nil.
 func parseTierList(raw string) ([]string, error) {

--- a/cmd/ailang/eval_suite.go
+++ b/cmd/ailang/eval_suite.go
@@ -299,7 +299,12 @@ func runEvalSuite() {
 		}
 
 		// Auto-discover benchmarks from benchmarks/ directory (standard mode only)
-		benchmarkList = discoverBenchmarks()
+		// M-EVAL-STANDARD-MODE-INPUT-FILES-GAP: grade_entrypoint-bearing
+		// benchmarks are agent-mode-only — exclude them from standard-mode
+		// scheduling here so no result row is written at all (the dispatch-time
+		// guard in runSingleBenchmark remains as defense in depth for direct
+		// --benchmarks invocations).
+		benchmarkList = filterStandardModeBenchmarks(discoverBenchmarks())
 		if len(benchmarkList) == 0 {
 			fmt.Fprintf(os.Stderr, "Error: No benchmarks found in benchmarks/ directory\n")
 			os.Exit(1)

--- a/docs/docs/guides/evaluation/harness-setup.md
+++ b/docs/docs/guides/evaluation/harness-setup.md
@@ -291,6 +291,23 @@ This gives Δ delta comparison between same-model, different-harness pairs (Sonn
 claude vs opencode; Flash via gemini vs opencode). Results appear in
 `/docs/benchmarks/by-harness` once `ailang eval-report --format=json` is re-run.
 
+## Benchmark mode compatibility: `grade_entrypoint` is agent-mode-only
+
+A benchmark that sets `grade_entrypoint` (with `solution_files`) grades the agent's
+preserved multi-file workspace — something only agent mode constructs. Standard mode
+(0-shot) never honours it: its prompt omits `input_files` content and its execution
+runs a fixed single `solution.ail`. Such benchmarks are therefore **agent-mode-only**:
+
+- Standard-mode scheduling (`eval-suite` auto-discovery) excludes them, so they produce
+  no rows and burn no API budget there.
+- If one is forced through standard mode anyway (explicit `--benchmarks` list),
+  `runSingleBenchmark` short-circuits before any provider call and banks a labelled skip
+  row (`error_category: skipped_mode_incompatible`, validity reason `mode_incompatible`)
+  that every aggregate — ELO fitting, confidence gating, capability stats — excludes.
+
+When authoring a benchmark that needs multi-file grading, plan to run it with
+`eval-suite --agent --benchmarks <id>` (M-EVAL-STANDARD-MODE-INPUT-FILES-GAP).
+
 ## Troubleshooting
 
 **"non-agentic result: 0 turns, 0 tool calls"**

--- a/internal/eval_analysis/validity_filter_test.go
+++ b/internal/eval_analysis/validity_filter_test.go
@@ -68,6 +68,34 @@ func TestLoadResultsIncludingInvalid_OptsBackIn(t *testing.T) {
 	}
 }
 
+// TestFilterValidResults_DropsModeIncompatibleSkipRow is the aggregation half
+// of M-EVAL-STANDARD-MODE-INPUT-FILES-GAP: the dispatch-time guard banks a
+// skip row (error_category "skipped_mode_incompatible", Validity invalid with
+// reason "mode_incompatible") whenever a grade_entrypoint benchmark reaches
+// runSingleBenchmark in standard mode. The model was never invoked, so the row
+// is a "we failed to measure the subject" record, not a measurement — it must
+// be dropped by FilterValidResults, and therefore by LoadResults, which is what
+// eval-elo's fitLang, the confidence-gating ratings, and every capability/success-rate
+// statistic load through. The row itself stays on disk (quarantined, never
+// deleted) and CountInvalid keeps it inspectable under exactly the banked reason.
+func TestFilterValidResults_DropsModeIncompatibleSkipRow(t *testing.T) {
+	results := []*BenchmarkResult{
+		{ID: "good", Lang: "ailang", Model: "m", StdoutOk: true},
+		{ID: "markdown_reimplement", Lang: "ailang", Model: "m", ErrorCategory: "skipped_mode_incompatible",
+			Validity: eval_harness.MarkInvalid(eval_harness.ReasonModeIncompatible)},
+	}
+
+	filtered := FilterValidResults(results)
+	if len(filtered) != 1 || filtered[0].ID != "good" {
+		t.Fatalf("FilterValidResults kept %d row(s), want exactly the 1 valid row — mode_incompatible skip rows are not measurements", len(filtered))
+	}
+
+	counts := CountInvalid(results)
+	if counts[eval_harness.ReasonModeIncompatible] != 1 {
+		t.Errorf("CountInvalid[mode_incompatible] = %d, want 1 — the skip row must stay inspectable under the reason the guard banked", counts[eval_harness.ReasonModeIncompatible])
+	}
+}
+
 // TestLoadResults_LegacyRowsSurvive re-asserts the back-compat guarantee at the
 // LOADER level, not just on the struct: a directory of pre-v0.31.0 results must
 // load completely.

--- a/internal/eval_harness/spec.go
+++ b/internal/eval_harness/spec.go
@@ -50,6 +50,13 @@ type BenchmarkSpec struct {
 	// the agent implements (e.g. the stubbed parser); they keep the agent's version at grade
 	// time while every other input_file is re-seeded to its canonical form (so the probe and
 	// fixed deps can't be tampered with). Unset → legacy single-file solution.ail grading.
+	//
+	// M-EVAL-STANDARD-MODE-INPUT-FILES-GAP: setting grade_entrypoint implies the
+	// benchmark is AGENT-MODE-ONLY. Standard mode never honours it — the standard
+	// prompt never includes input_files content, and execution always runs a fixed
+	// single solution.ail — so such benchmarks are excluded from standard-mode
+	// scheduling and, if forced through anyway, short-circuited at dispatch.
+	// See RequiresAgentWorkspace below.
 	GradeEntrypoint string   `yaml:"grade_entrypoint,omitempty"`
 	SolutionFiles   []string `yaml:"solution_files,omitempty"`
 
@@ -81,6 +88,18 @@ type BenchmarkSpec struct {
 	// line "PREFIX: <non-empty>". The fixed lines still grade exactly; only the
 	// placeholder line is graded structurally. See GradeStdout.
 	Grading string `yaml:"grading,omitempty"`
+}
+
+// RequiresAgentWorkspace reports whether this benchmark can only be graded in
+// agent mode: a grade_entrypoint benchmark grades the agent's preserved
+// multi-file workspace, which standard mode never constructs (its prompt omits
+// input_files content and its execution runs a fixed single solution.ail).
+// Scheduling (standard-mode auto-discovery) and dispatch (runSingleBenchmark's
+// standard-mode path) both test this predicate to keep such benchmarks out of
+// standard mode — see the GradeEntrypoint doc comment above.
+// (M-EVAL-STANDARD-MODE-INPUT-FILES-GAP.)
+func (s *BenchmarkSpec) RequiresAgentWorkspace() bool {
+	return s.GradeEntrypoint != ""
 }
 
 // ValidTiers lists the allowed values for BenchmarkSpec.Tier.

--- a/internal/eval_harness/spec_test.go
+++ b/internal/eval_harness/spec_test.go
@@ -66,6 +66,54 @@ prompt: "Test"
 	}
 }
 
+// TestRequiresAgentWorkspace pins the mode-compatibility predicate
+// (M-EVAL-STANDARD-MODE-INPUT-FILES-GAP): a benchmark requires an agent
+// workspace iff it sets grade_entrypoint. Covered via direct struct literals
+// AND the real specs — the two benchmarks that carry grade_entrypoint
+// (markdown_reimplement, docx_reimplement) must keep reporting true (that is
+// what keeps them out of standard mode), and a real benchmark without one must
+// stay standard-mode eligible.
+func TestRequiresAgentWorkspace(t *testing.T) {
+	if (&BenchmarkSpec{}).RequiresAgentWorkspace() {
+		t.Error("empty spec: RequiresAgentWorkspace() = true, want false")
+	}
+	if (&BenchmarkSpec{SolutionFiles: []string{"docparse/services/parser.ail"}}).RequiresAgentWorkspace() {
+		t.Error("solution_files without grade_entrypoint: RequiresAgentWorkspace() = true, want false")
+	}
+	if !(&BenchmarkSpec{GradeEntrypoint: "main.ail"}).RequiresAgentWorkspace() {
+		t.Error("grade_entrypoint set: RequiresAgentWorkspace() = false, want true")
+	}
+
+	for _, id := range []string{"markdown_reimplement", "docx_reimplement"} {
+		specPath := filepath.Join("..", "..", "benchmarks", id+".yml")
+		if _, err := os.Stat(specPath); err != nil {
+			t.Skipf("%s not present (%v); skipping real-spec cases", specPath, err)
+		}
+		spec, err := LoadSpec(specPath)
+		if err != nil {
+			t.Fatalf("%s: LoadSpec failed: %v", id, err)
+		}
+		if spec.GradeEntrypoint == "" {
+			t.Fatalf("%s: fixture drift — expected grade_entrypoint to be set", id)
+		}
+		if !spec.RequiresAgentWorkspace() {
+			t.Errorf("%s: RequiresAgentWorkspace() = false, want true (grade_entrypoint implies agent-mode-only)", id)
+		}
+	}
+
+	noGradePath := filepath.Join("..", "..", "benchmarks", "fizzbuzz.yml")
+	if _, err := os.Stat(noGradePath); err != nil {
+		t.Skipf("fizzbuzz.yml not present (%v); skipping real-spec negative case", err)
+	}
+	noGrade, err := LoadSpec(noGradePath)
+	if err != nil {
+		t.Fatalf("fizzbuzz: LoadSpec failed: %v", err)
+	}
+	if noGrade.RequiresAgentWorkspace() {
+		t.Errorf("fizzbuzz: RequiresAgentWorkspace() = true, want false (no grade_entrypoint)")
+	}
+}
+
 func TestSupportsLanguage(t *testing.T) {
 	spec := &BenchmarkSpec{
 		ID:        "test",

--- a/internal/eval_harness/validity.go
+++ b/internal/eval_harness/validity.go
@@ -56,6 +56,13 @@ const (
 	// be perfectly healthy — it simply does not measure what it claims, so a
 	// null result from it would be meaningless. Void by preregistration.
 	ReasonTreatmentUnproven = "treatment_unproven"
+	// ReasonModeIncompatible: the benchmark was dispatched into an evaluation
+	// mode that cannot grade it at all — e.g. a grade_entrypoint (multi-file
+	// workspace-grading) benchmark forced through standard mode, which never
+	// constructs the agent workspace its grading requires. The model was never
+	// invoked, so this is a "we failed to measure the subject" row, not a
+	// measurement. (M-EVAL-STANDARD-MODE-INPUT-FILES-GAP.)
+	ReasonModeIncompatible = "mode_incompatible"
 )
 
 // MarkValid returns an explicitly-valid marker.


### PR DESCRIPTION
## Summary
- Design: `design_docs/planned/v0_33_1/m-eval-standard-mode-input-files-gap.md` (docs-12, mission-docs queue) — approved design-ready after 4 quorum rounds; attended human ruling 2026-09-07 (Mark) authorized two wording-only corrections and direct routing to planning without a 5th quorum round.
- `markdown_reimplement`/`docx_reimplement` set `grade_entrypoint`, which only agent mode can satisfy. Standard mode was still scheduling them every release, producing a near-guaranteed compile/runtime failure that measured a harness gap, not model capability.
- 5 milestones, one commit each: M1 predicate + Validity reason, M2 dispatch-time skip guard, M3 scheduling-time exclusion, M4 aggregation-exclusion verification, M5 docs note + changelog.

## Test plan
- [x] `go build ./...` and `go test ./...` (excluding the pre-existing js/wasm-gated `cmd/wasm` build) — 0 failures
- [x] `make fmt-check`, `make lint` (0 issues), `make check-boundaries`, `make check-file-sizes`, `make check-git-exec`, `make check-home-isolation`, `make check-changelog` — all green
- [x] Live-verified: `ailang eval-suite --dry-run --tier frontier` (standard mode) no longer lists `docx_reimplement`/`markdown_reimplement`
- [x] Live-verified: `ailang eval-suite --dry-run --agent --benchmarks docx_reimplement,markdown_reimplement` still plans both
- [x] New unit test: `runSingleBenchmark` in standard mode makes zero provider calls for a `GradeEntrypoint` benchmark
- [x] New unit test: a `ReasonModeIncompatible` skip row is dropped by `FilterValidResults`

Generated via mission-control iteration 16 (docs-mission): planner + executor on `pi:ollama/glm-5.3-flash:cloud`, independent evaluator to follow (generator≠judge).

Co-Authored-By: GLM-5.3-Flash (pi)