### PR TITLE
fix(launchd): bound the WHOLE notice drain, not just each row (M3)

### DIFF
--- a/tools/launchd/mission-control.sh
+++ b/tools/launchd/mission-control.sh
@@ -143,13 +143,25 @@ log() { echo "[$(date '+%F %H:%M:%S')] $*" | tee -a "$LOG"; }
 # A notice that still cannot be sent is KEPT, not dropped, so an outage costs a delay
 # rather than the record.
 _mc_drain_notices() {
-  local spool tmp line ts title body sent=0 kept=0
+  local spool tmp line ts title body sent=0 kept=0 deferred=0 drain_start remaining lineno=0 total=0 DRAIN_BUDGET
   spool="$STATE_DIR/mission-${MISSION_NAME}-notice-spool.tsv"
   [ -s "$spool" ] || return 0
   tmp="${spool}.draining.$$"
   mv "$spool" "$tmp" 2>/dev/null || return 0
+  drain_start=$(date +%s)
+  DRAIN_BUDGET="${MISSION_DRAIN_BUDGET:-90}"
+  total=$(wc -l < "$tmp" | tr -d ' ')
   while IFS="$(printf '\t')" read -r ts title body; do
+    lineno=$((lineno + 1))
     [ -z "${title:-}" ] && continue
+    remaining=$(( DRAIN_BUDGET - ( $(date +%s) - drain_start ) ))
+    if [ "$remaining" -le $(( NOTIFY_TIMEOUT + 2 )) ]; then
+      sed -n "${lineno},\$p" "$tmp" >> "$spool"
+      rm -f "$tmp"
+      deferred=$(( total - sent - kept ))
+      log "notice spool: deferred ${deferred} row(s), aggregate budget ${DRAIN_BUDGET}s exhausted"
+      return 0
+    fi
     if _mc_bounded "$NOTIFY_TIMEOUT" env AILANG_MESSAGES_STORE=gcp AILANG_MESSAGES_PROJECT="${AILANG_MESSAGES_PROJECT:-ailang-multivac}" \
        ailang messages send controlplane "[spooled $ts] $body" --title "$title" --from "$MSG_FROM"; then
       sent=$((sent + 1))

--- a/tools/launchd/test_driver_notify.sh
+++ b/tools/launchd/test_driver_notify.sh
@@ -421,6 +421,49 @@ else
 fi
 rm -rf "$_dn_spool" "$_dn_tr" "$_dn_outf"
 
+# (4b) large-backlog drain: 5-row spool + hanging ailang + aggregate budget -> whole
+# drain bounded, 1 attempt, 4 deferred. Outer 30s. Instrument hygiene: the driver log
+# (MC_TRACE_FILE) is the ONLY thing asserted; the bounded helper's job-control stderr
+# lands in the run_bounded output file, never the trace file.
+_dl_spool=$(mktemp -d)
+for _i in 1 2 3 4 5; do printf 'TS\tTitle%s\tBody%s\n' "$_i" "$_i" >> "$_dl_spool/mission-v1-notice-spool.tsv"; done
+_dl_tr=$(mktemp); _dl_att=$(mktemp); _dl_outf=$(mktemp); _dl_beg=$(date +%s)
+run_bounded 30 "$_dl_outf" env MC_TRACE_FILE="$_dl_tr" MC_ATTEMPT_FILE="$_dl_att" \
+  STUB_HANG_AILANG=1 MISSION_NOTIFY_TIMEOUT=2 MISSION_DRAIN_BUDGET=8 \
+  /bin/bash -c '
+    set -uo pipefail
+    . "$MC_BND"
+    NOTIFY_TIMEOUT="${MISSION_NOTIFY_TIMEOUT:-30}"
+    log() { printf "LOG:%s\n" "$*" >> "$MC_TRACE_FILE"; }
+    MISSION_NAME=v1; MISSION_REPO=sunholo-data/ailang; MSG_FROM=mission-control
+    STATE_DIR="$1"
+    . "$2"
+    _mc_drain_notices
+    echo "DRAIN_RC:$?"
+  ' _ "$_dl_spool" "$LAB/drain.sh"
+_dl_rc=$?; _dl_elapsed=$(( $(date +%s) - _dl_beg ))
+_dl_rows=0; [ -f "$_dl_spool/mission-v1-notice-spool.tsv" ] && _dl_rows=$(wc -l < "$_dl_spool/mission-v1-notice-spool.tsv" | tr -d ' ')
+_dl_attn=$(cat "$_dl_att" 2>/dev/null || echo 0)
+_dl_log="$(cat "$_dl_tr" 2>/dev/null || true)"
+if [ "$_dl_rc" = "124" ]; then
+  bad "drain: whole drain returns within aggregate budget and preserves unattempted rows" "outer 30s watchdog tripped - aggregate budget removed"
+else
+  _dl_good=1
+  [ "$_dl_elapsed" -le 15 ] || _dl_good=0
+  [ "$_dl_rows" -eq 5 ] || _dl_good=0
+  [ "$_dl_attn" -eq 1 ] || _dl_good=0
+  if [ "$_dl_good" -eq 1 ]; then
+    ok "drain: whole drain returns within aggregate budget and preserves unattempted rows"
+  else
+    bad "drain: whole drain returns within aggregate budget and preserves unattempted rows" "elapsed=${_dl_elapsed}s rows=$_dl_rows attempts=$_dl_attn rc=$_dl_rc"
+  fi
+fi
+case "$_dl_log" in
+  *"deferred 4 row(s), aggregate budget 8s exhausted"*) ok "drain: deferred-drain diagnostic names deferred row count";;
+  *) bad "drain: deferred-drain diagnostic names deferred row count" "$(printf '%s' "$_dl_log"|tr '\n' '|')";;
+esac
+rm -rf "$_dl_spool" "$_dl_tr" "$_dl_att" "$_dl_outf"
+
 # (5) hanging gh comment: ailang healthy, gh hangs -> bounded cutoff, WARNING, exit 0.
 _gh_tr=$(mktemp); _gh_outf=$(mktemp); _gh_sp=$(mktemp -d); _gh_beg=$(date +%s)
 run_bounded 15 "$_gh_outf" env MC_TRACE_FILE="$_gh_tr" STUB_HANG_GH=1 MISSION_NOTIFY_TIMEOUT=2 \


### PR DESCRIPTION
M3 of `m-launchd-notify-subshell-observation` — V1 mission iteration 349. M1/M2 landed via #1082.

## The defect, confirmed first-party at `ead709c31`

`_mc_drain_notices` is called once, in the driver's **preflight** — the one phase with no deadline behind it but the 6-hour `HARD_TIMEOUT`. It bounds **each row's** send at `NOTIFY_TIMEOUT` and leaves **the loop** unbounded. The spool is unbounded by construction: `notice-spool` has exactly two references (one read, one append), with no size cap, no row cap and no rotation. So an N-row spool of hanging sends costs `N × (NOTIFY_TIMEOUT + overhead)` inside that phase, and the stall watchdog cannot rescue it — the driver logs that early kill is DISABLED in exactly that situation, and a drain making slow progress is not "no progress" anyway.

Live on the rig right now: three spool files (v1 3 rows, motoko 1, world 1).

## The fix

`MISSION_DRAIN_BUDGET` (default `90`) caps the whole drain. Before each row the loop requires `DRAIN_BUDGET - elapsed > NOTIFY_TIMEOUT + 2`; when it does not, the current row **and every still-unattempted row** are appended back to the spool unchanged, the drain logs `notice spool: deferred <k> row(s), aggregate budget <B>s exhausted`, and returns 0. **No notice is dropped** — an outage costs a delay, not the record. The existing failed-row re-append path is untouched.

## Measurements (all first-party by the controller, not the executor)

| gate | result |
|---|---|
| suite at base `ead709c31` | `38 passed, 0 failed`, rc=0 |
| suite after the fixture, before the fix | `38 passed, 2 failed`, rc=1 |
| suite after the fix | `40 passed, 0 failed`, rc=0 |
| determinism (2 runs) | identical |
| `make test-launchd-drivers` | rc=0, 244s |
| `grep -c MISSION_DRAIN_BUDGET mission-control.sh` | 0 → **1** |

> **Correction (V1 iteration 349, controller + independent judge, both first-party).** The row
> above originally read `0 → 2`. The actual count at `abaa190f2` is **1** (control: `NOTIFY_TIMEOUT`
> reads 7 in the same file, so the grep fires). The plan's acceptance criterion is `≥1`, so it is
> still satisfied — but the number in this table was wrong, and it was written by the author of the
> change. Found by the round-1 judge (`sonnet`, PASS 88/100, zero blocking) and reproduced by the
> controller before this edit.

Mutation sweep, 4/4 killed their **named** assertion:

| mutation | victim | result |
|---|---|---|
| remove the remaining-budget guard before each row | `drain: whole drain returns within aggregate budget…` | KILLED |
| drop the deferred-drain diagnostic log line | `drain: deferred-drain diagnostic names deferred row count` | KILLED |
| suppress re-appending a FAILED drain row | `production: hanging drain send is cut off and row retained` | KILLED |
| delete the top-level preflight drain invocation | `wiring: exactly one preflight drain call` | KILLED |

## Instrument note

The previous attempt's two assertions failed for a reason that was **not** about the production code: they read a buffer the bounded helper's job-control stderr also wrote to, so they matched `Terminated: 15` chatter instead of the driver log. The lab now asserts on `MC_TRACE_FILE` only, with the helper's stderr going to a separate file.

## Not in this PR

M4 (the full 11-row M1–M3 mutation sweep, verification-only, no diff) — the executor lane hit `wall_timeout` at 1751s partway through it. The 4 M3-anchored mutations above were run by the controller; the remaining M1/M2 rows are requeued.

The seven non-D-60 notify call sites remain out of scope (`M-LAUNCHD-NOTIFY-REMAINING-BOUNDING`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
